### PR TITLE
AsyncDictionaryTests: increase timeout in `testAsyncUpdatesWhereTheFirstOperationFinishesLast`

### DIFF
--- a/WooCommerce/WooCommerceTests/Tools/AsyncDictionaryTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AsyncDictionaryTests.swift
@@ -82,7 +82,7 @@ class AsyncDictionaryTests: XCTestCase {
         }
 
         asyncDictionary.calculate(forKey: key, operation: operation2, onCompletion: onOperation2Completion)
-        waitForExpectations(timeout: 0.1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(asyncDictionary.value(forKey: key), value2)
     }
 }


### PR DESCRIPTION
Part of #1687

While I was running `WooCommerce` unit tests in Xcode 12.0, I noticed that `AsyncDictionaryTests.testAsyncUpdatesWhereTheFirstOperationFinishesLast` started failing consistently (it was failing intermittently in Xcode 11 for me before):

```
✗ testAsyncUpdatesWhereTheFirstOperationFinishesLast, Asynchronous wait failed: Exceeded timeout of 0.1 seconds, with unfulfilled expectations: "Wait for completion callback for the first operation".
```

I was wondering why it hasn't shown up in CI, and noticed that it actually fails on CI but it retries and generally succeeds on the 5th try. This is also why the "Unit Tests" step grew from **4-6 minutes** to **11-12 minutes** after we upgraded CI to use Xcode 12.0:


<img width="1629" alt="Screen Shot 2020-10-30 at 11 23 52 AM" src="https://user-images.githubusercontent.com/1945542/97657357-a3343b00-1aa4-11eb-9e86-2a301884808b.png">

In this PR, the Unit Tests step now takes about 9 minutes (down by ~2-3 minutes) 🎉 It's interesting that it still takes more time for "Build Tests" and "Unit Tests" steps on CI since the Xcode 12 upgrade.

## Changes

Increased the timeout in `AsyncDictionaryTests.testAsyncUpdatesWhereTheFirstOperationFinishesLast` from 0.1 to 1 second. I can't really think of reasons why it takes longer in Xcode 12 though, feel free to share any ideas!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
