### PR TITLE
Text headers on Product price screen are no more clipped with large text sizes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,11 @@
 
 5.4
 -----
+- [*] fix: text headers on Product price screen are no more clipped with large text sizes. [https://github.com/woocommerce/woocommerce-ios/pull/3090]
+
+
+5.4
+-----
 - [*] fix: the footer in app Settings is now correctly centered.
 - [*] fix: Products tab: earlier draft products now show up in the same order as in core when sorting by "Newest to Oldest".
 - [*] enhancement: in product details > price settings, the sale dates can be edited inline in iOS 14 using the new date picker. Also, the sale end date picker editing does not automatically end on changes anymore. [https://github.com/woocommerce/woocommerce-ios/pull/3044]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -260,10 +260,10 @@ extension ProductPriceSettingsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if sections[section].title == nil {
-            return UITableView.automaticDimension
-        }
+        return UITableView.automaticDimension
+    }
 
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         return Constants.sectionHeight
     }
 


### PR DESCRIPTION
## Description
When using a large text size (dynamic type) on the device, the "Price" and "Tax settings" labels on the Product Details > Price screen are getting clipped. Now, they are no more clipped with large text sizes.

## Testing
1. Set the largest text under accessibility on your iPhone.
2. Navigate a product price detail. -> Make sure the headers are no more clipped.

## Screenshots
Note: for my screenshot on the right I used a bigger text size (the maximum available).
| Before            |  After |
:-------------------------:|:-------------------------:
![95467828-d425c200-0975-11eb-9e22-fa95d217d224](https://user-images.githubusercontent.com/495617/97722449-f15c3500-1aca-11eb-8e45-919a5b414520.PNG) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-30 at 16 07 34](https://user-images.githubusercontent.com/495617/97722459-f28d6200-1aca-11eb-95c4-4a2843574c7b.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
