### PR TITLE
[Issue Refund] Pass refund details to RefundConfirmation screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -75,11 +75,10 @@ final class IssueRefundViewModel {
     /// Creates the `ViewModel` to be used when navigating to the page where the user can
     /// confirm and submit the refund.
     func createRefundConfirmationViewModel() -> RefundConfirmationViewModel {
-        let refundItems = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: $1) }
         let details = RefundConfirmationViewModel.Details(order: state.order,
                                                           amount: "\(calculateRefundTotal())",
                                                           refundsShipping: state.shouldRefundShipping,
-                                                          items: refundItems)
+                                                          items: state.refundQuantityStore.refundableItems())
         return RefundConfirmationViewModel(details: details, currencySettings: state.currencySettings)
     }
 }
@@ -190,7 +189,7 @@ extension IssueRefundViewModel {
                                        currencySettings: state.currencySettings)
         }
 
-        let refundItems = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: $1) }
+        let refundItems = state.refundQuantityStore.refundableItems()
         let summaryRow = RefundProductsTotalViewModel(refundItems: refundItems, currency: state.order.currency, currencySettings: state.currencySettings)
 
         return Section(rows: itemsRows + [summaryRow])
@@ -233,7 +232,7 @@ extension IssueRefundViewModel {
     ///
     private func calculateRefundTotal() -> Decimal {
         let formatter = CurrencyFormatter(currencySettings: state.currencySettings)
-        let refundItems = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: $1) }
+        let refundItems = state.refundQuantityStore.refundableItems()
         let productsTotalUseCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)
 
         // If shipping is not enabled, return only the products value
@@ -324,6 +323,12 @@ private extension IssueRefundViewModel {
         ///
         func count() -> Int {
             store.values.reduce(0) { $0 + $1 }
+        }
+
+        /// Returns an array of `RefundableOrderItem` from the internal store
+        ///
+        func refundableItems() -> [RefundableOrderItem] {
+            map { RefundableOrderItem(item: $0, quantity: $1) }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -75,7 +75,12 @@ final class IssueRefundViewModel {
     /// Creates the `ViewModel` to be used when navigating to the page where the user can
     /// confirm and submit the refund.
     func createRefundConfirmationViewModel() -> RefundConfirmationViewModel {
-        RefundConfirmationViewModel(order: state.order, currencySettings: state.currencySettings)
+        let refundItems = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: $1) }
+        let details = RefundConfirmationViewModel.Details(order: state.order,
+                                                          amount: "\(calculateRefundTotal())",
+                                                          refundsShipping: state.shouldRefundShipping,
+                                                          items: refundItems)
+        return RefundConfirmationViewModel(details: details, currencySettings: state.currencySettings)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -34,7 +34,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(previouslyRefundedRow.value, "$147.2319")
     }
 
-    func test_refund_amount_is_property_formatted_with_currency() throws {
+    func test_refund_amount_is_properly_formatted_with_currency() throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .USD,
                                                 currencyPosition: .left,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -33,4 +33,22 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(previouslyRefundedRow.value, "$147.2319")
     }
+
+    func test_refund_amount_is_property_formatted_with_currency() throws {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .left,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+
+        let order = MockOrders().empty()
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "130.3473", refundsShipping: false, items: [])
+
+        // When
+        let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.refundAmount, "$130.35")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -22,7 +22,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         ]
         let order = MockOrders().empty().copy(refunds: refundItems)
 
-        let viewModel = RefundConfirmationViewModel(order: order, currencySettings: currencySettings)
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "0.0", refundsShipping: false, items: [])
+
+        let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
 
         // When
         // We expect the Previously Refunded row to be the first item.


### PR DESCRIPTION
closes #2981

# Why 

This super quick PR connects the `IssueRefund` screen to the `RefundConformation` screen.

# How

- Create a new `Details` struct that contains all the necessary details for creating a refund object.
- Update `refundAmount` property to be formatted from `Details.amount`.

# Testing Steps
- Go to an un-refunded order
- Tap on the Issue Refund button
- Select some items
- Tap next
- See that the "Refund Amount" corresponds to the real amount to refund.

# Screenshots
1st step | 2nd step
---- | ----
<img width="393" alt="1st step" src="https://user-images.githubusercontent.com/562080/97728228-4b470580-1a9f-11eb-80e4-677cdb7604c1.png">|<img width="389" alt="2nd step" src="https://user-images.githubusercontent.com/562080/97728233-4da95f80-1a9f-11eb-9ecd-4ff8f13d7a21.png">

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
