### PR TITLE
Product inventory/SKU settings: add scan CTA to SKU cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -270,10 +270,7 @@ private extension ProductInventorySettingsViewController {
     func configureSKU(cell: TitleAndTextFieldTableViewCell) {
         var cellViewModel = Product.createSKUViewModel(sku: viewModel.sku) { [weak self] value in
             self?.viewModel.handleSKUChange(value) { [weak self] (isValid, shouldBringUpKeyboard) in
-                self?.enableDoneButton(isValid)
-                if shouldBringUpKeyboard {
-                    self?.getSkuCell()?.textFieldBecomeFirstResponder()
-                }
+                self?.handleSKUValidation(isValid: isValid, shouldBringUpKeyboard: shouldBringUpKeyboard)
             }
         }
         switch viewModel.error {
@@ -283,6 +280,15 @@ private extension ProductInventorySettingsViewController {
             break
         }
         cell.configure(viewModel: cellViewModel)
+
+        // Configures accessory view for adding SKU from barcode scanner.
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.barcodeScanner) {
+            let button = UIButton(type: .detailDisclosure)
+            button.applyIconButtonStyle(icon: .scanImage)
+            button.addTarget(self, action: #selector(scanSKUButtonTapped), for: .touchUpInside)
+
+            cell.accessoryView = button
+        }
     }
 
     func configureManageStock(cell: SwitchTableViewCell) {
@@ -322,6 +328,28 @@ private extension ProductInventorySettingsViewController {
         let title = NSLocalizedString("Stock status", comment: "Title of the cell in Product Inventory Settings > Stock status")
         cell.updateUI(title: title, value: viewModel.stockStatus?.description)
         cell.accessoryType = .disclosureIndicator
+    }
+}
+
+// MARK: - SKU Scanner
+//
+private extension ProductInventorySettingsViewController {
+    @objc func scanSKUButtonTapped() {
+    }
+
+    func onSKUBarcodeScanned(barcode: String) {
+        viewModel.handleSKUChange(barcode) { [weak self] (isValid, shouldBringUpKeyboard) in
+            self?.handleSKUValidation(isValid: isValid, shouldBringUpKeyboard: shouldBringUpKeyboard)
+        }
+    }
+}
+
+private extension ProductInventorySettingsViewController {
+    func handleSKUValidation(isValid: Bool, shouldBringUpKeyboard: Bool) {
+        enableDoneButton(isValid)
+        if shouldBringUpKeyboard {
+            getSkuCell()?.textFieldBecomeFirstResponder()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -335,12 +335,7 @@ private extension ProductInventorySettingsViewController {
 //
 private extension ProductInventorySettingsViewController {
     @objc func scanSKUButtonTapped() {
-    }
-
-    func onSKUBarcodeScanned(barcode: String) {
-        viewModel.handleSKUChange(barcode) { [weak self] (isValid, shouldBringUpKeyboard) in
-            self?.handleSKUValidation(isValid: isValid, shouldBringUpKeyboard: shouldBringUpKeyboard)
-        }
+        // TODO-2704: scan barcode for product SKU
     }
 }
 


### PR DESCRIPTION
Part of #2407 

## Changes

This PR adds a scan CTA to the inventory/SKU settings > SKU row without any action.

In `ProductInventorySettingsViewController`:
- Added a scan button to the accessory view of the SKU cell if the feature flag is enabled
- Extracted view model's `handleSKUChange` validation handling to a separate function for future reuse

## Testing

- Go to the products tab
- Tap on a product whose SKU is editable
- Tap on the inventory/SKU row --> there should be a scan CTA in the accessory view of the SKU cell

## Example screenshots

feature flag on | feature flag off
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-11-03 at 14 09 46](https://user-images.githubusercontent.com/1945542/97954548-c6c9ef00-1dde-11eb-9c22-7d63a40ba6a6.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-03 at 14 11 19](https://user-images.githubusercontent.com/1945542/97954553-ca5d7600-1dde-11eb-8dd1-ee104a6b4be6.png)
![Simulator Screen Shot - iPhone 11 - 2020-11-03 at 14 10 10](https://user-images.githubusercontent.com/1945542/97954564-cfbac080-1dde-11eb-9725-1c369b0525d0.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-03 at 14 11 25](https://user-images.githubusercontent.com/1945542/97954567-d0ebed80-1dde-11eb-80e6-d560461d6a76.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
