### PR TITLE
Fix Product Review Push Notification Handling Regressions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -114,11 +114,6 @@ private extension ReviewDetailsViewController {
         entityListener.onUpsert = { [weak self] productReview in
             self?.productReview = productReview
         }
-
-        entityListener.onDelete = { [weak self] in
-            self?.navigationController?.popToRootViewController(animated: true)
-            self?.displayNoteDeletedNotice()
-        }
     }
 
     /// Reports a significant event to the App Rating Manager
@@ -175,15 +170,6 @@ private extension ReviewDetailsViewController {
 // MARK: - Display Notices
 //
 private extension ReviewDetailsViewController {
-
-    /// Displays a Notice onScreen, indicating that the current Review has been deleted from the Store.
-    ///
-    func displayNoteDeletedNotice() {
-        let title = NSLocalizedString("The review has been removed", comment: "Displayed whenever a review that was onscreen got deleted.")
-        let notice = Notice(title: title, feedbackType: .error)
-
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
-    }
 
     /// Displays the Error Notice.
     ///

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -8,6 +8,9 @@ import Storage
 public final class ProductReviewStore: Store {
     private let remote: ProductReviewsRemote
 
+    private lazy var productReviewFromNoteUseCase =
+        RetrieveProductReviewFromNoteUseCase(network: network, derivedStorage: sharedDerivedStorage)
+
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.newDerivedStorage()
     }()
@@ -124,9 +127,7 @@ private extension ProductReviewStore {
     ///
     func retrieveProductReviewFromNote(noteID: Int64,
                                        onCompletion: @escaping (Result<ProductReviewFromNoteParcel, Error>) -> Void) {
-        let useCase = RetrieveProductReviewFromNoteUseCase(network: network,
-                                                           derivedStorage: sharedDerivedStorage)
-        useCase.retrieve(noteID: noteID, completion: onCompletion)
+        productReviewFromNoteUseCase.retrieve(noteID: noteID, completion: onCompletion)
     }
 
     /// Updates the review's approval status


### PR DESCRIPTION
Refs #1810. 

This fixes two regressions for handling Product Review push notifications. 

## Regression A: Review Details page is not shown if the product has not been previously loaded

### To Reproduce

1. Delete the app from the device to reset all the data.
2. Run and log in. Do not open the Products and Reviews tab. 
3. Place the app in the background. 
4. Send a push notification. 
5. Tap on the push notification. 

The review details page will not be shown. 

### Why It Happens

Currently, we load all the information for presenting a Review Details page via this action handler:

https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/Yosemite/Yosemite/Stores/ProductReviewStore.swift#L125-L130

This relied on the fact that API completion blocks are always called regardless of the `Remote` instances being deallocated. However, we changed that behavior in #2879. The `Remote` completion blocks are no longer called if the `Remote` instance has been deallocated. We did that by adding `weak self` in 1b98298:

https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/Networking/Networking/Remote/Remote.swift#L30-L34

This caused a problem in the `RetrieveProductReviewFromNoteUseCase` shown above. Because the `UseCase` is not retained, it gets deallocated right away, and its network calls are essentially _cancelled_. The result is that tapping the push notification will still cause the API calls to be run but [the final completion block](https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L188-L195) will not be called, and so the review details page is never shown by [ReviewsCoordinator](https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift#L64-L94).

### Solution

I fixed this by storing the `UseCase` as an ivar (https://github.com/woocommerce/woocommerce-ios/commit/7896fcb509ad8f76443f7df7f5c787c8a813cde8). I tried to create a unit test to reproduce the scenario but failed. I could not find a way to make the `UseCase` be forcefully deallocated immediately during a unit test scenario. 

## Regression B: The Review Details page is shown but is immediately dismissed

### To Reproduce

1. Load all the products of the site.
1. Terminate the app.
2. Send a Product Review push notification. 
3. Tap on the push notification. 
4. The Review Detail page will be shown. But then it will be dismissed right away and the user will be navigated to the Reviews page.

### Why It Happens

I found this after fixing the first regression. This happens because in https://github.com/woocommerce/woocommerce-ios/pull/2796, we started deleting all the reviews when loading the Reviews list page for the first time. 

https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/Yosemite/Yosemite/Stores/ProductReviewStore.swift#L88-L90

That seemed fine but is causing an issue if the `ReviewDetailsViewController` is presented. The `ReviewDetailsViewController` has special handling for when the underlying `ProductReview` (`NSManagedObject`) has been deleted from the `NSManagedObjectContext`. It dismisses itself when that happens. 

https://github.com/woocommerce/woocommerce-ios/blob/ec6f85b6eeb6d06fb03fe9670a0e5343d3a1b67e/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift#L118-L121

### Solution

I _fixed_ this by removing the `onDelete` handling (e59a526). As far as I can tell, the `onDelete` handling does not seem to be necessary. The `ReviewDetailsViewController` and its buttons like _Spam_ and _Delete_ still seems to work well even if the underlying `NSManagedObject` no longer exists. 

It also shows a misleading notice to the user because the Review could not have been deleted from the site, it was just deleted in the local database. We have a similar problem with Orders https://github.com/woocommerce/woocommerce-ios/issues/2369. 

## Testing

Please follow the **To Reproduce** steps in the sections above. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

