### PR TITLE
[Hot-fix] Setup notice presenter correctly

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -56,7 +56,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupAuthenticationManager()
         setupCocoaLumberjack()
         setupLogLevel(.verbose)
-        setupNoticePresenter()
         setupPushNotificationsManagerIfPossible()
         setupAppRatingManager()
         setupWormholy()
@@ -83,6 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup the Interface!
         setupMainWindow()
         setupComponentsAppearance()
+        setupNoticePresenter()
 
         // Start app navigation.
         appCoordinator?.start()


### PR DESCRIPTION
fixes #3098

# Why 
While trying to fish the [GridIcon Crash](https://github.com/woocommerce/woocommerce-ios/pull/3059) I missed moving the notice presenter configuration to the correct place.

# How
Move the `setupNoticePresenter()` method from `willFinishLaunchingWithOptions` to `didFinishLaunchingWithOptions` because `setupNoticePresenter()` requires a `presentingViewController` which is set up in the `setupMainWindow()` method

# GIF
![notice](https://user-images.githubusercontent.com/562080/98296390-da14c000-1f80-11eb-89c5-29b7faeff2ac.gif)

# Testing Steps
- Go to an unfulfilled order
- Tap on the "Begin Fulfillment" button
- Tap on the "Mark Order Complete" button
- See that the order is marked as completed and a notice is presented with the `undo` action

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
