### PR TITLE
Order Details > variation details: UI integration

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -74,13 +74,7 @@ public struct OrderItem: Decodable, Hashable {
                         ?? container.decode(String.self, forKey: .name)).strippedHTML
             let allAttributes = (try? container.decodeIfPresent([OrderItemAttribute].self, forKey: .attributes)) ?? []
             // Skips any attribute if the name is `_reduced_stock` because this is a known attribute added by core.
-            attributes = allAttributes.filter { $0.name != "_reduced_stock" }
-
-            // Logs error for unexpected attributes.
-            let unexpectedAttributes = attributes.filter { $0.name.hasPrefix("_") }
-            if unexpectedAttributes.isEmpty == false {
-                DDLogError("⚠️ Unexpected order item attributes: \(unexpectedAttributes)")
-            }
+            attributes = allAttributes.filter { !$0.name.hasPrefix("_") }
         } else {
             name = try container.decode(String.self, forKey: .name).strippedHTML
             attributes = []

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -214,7 +214,7 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(lineItems.count, 2)
 
         let variationLineItem = lineItems[0]
-        // Attribute with `_reduced_stock` name is skipped.
+        // Attributes with `_` prefix in the name are skipped.
         let expectedAttributes: [OrderItemAttribute] = [
             .init(metaID: 6377, name: "Color", value: "Orange"),
             .init(metaID: 6378, name: "Brand", value: "Woo")
@@ -230,7 +230,7 @@ final class OrderMapperTests: XCTestCase {
 
     /// The attributes API support are added in WC version 4.7, and WC version 4.6.1 returns a different structure of order line item attributes.
     func test_OrderLineItem_attributes_are_empty_before_API_support() throws {
-        let order = try XCTUnwrap(mapLoadOrderWithLineItemAttributesBeforeAPISuppportResponse())
+        let order = try XCTUnwrap(mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse())
 
         let lineItems = order.items
         XCTAssertEqual(lineItems.count, 1)
@@ -288,7 +288,7 @@ private extension OrderMapperTests {
 
     /// Returns the OrderMapper output upon receiving `order-with-line-item-attributes-before-API-support`
     ///
-    func mapLoadOrderWithLineItemAttributesBeforeAPISuppportResponse() -> Order? {
+    func mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse() -> Order? {
         return mapOrder(from: "order-with-line-item-attributes-before-API-support")
     }
 }

--- a/Networking/NetworkingTests/Responses/order-with-line-item-attributes.json
+++ b/Networking/NetworkingTests/Responses/order-with-line-item-attributes.json
@@ -90,6 +90,13 @@
                         "display_value": "Woo"
                     },
                     {
+                        "id": 6546,
+                        "key": "_square_item_variation_id",
+                        "value": "aweiotjo",
+                        "display_key": "_square_item_variation_id",
+                        "display_value": "aweiotjo"
+                    },
+                    {
                         "id": 6411,
                         "key": "_reduced_stock",
                         "value": "1",

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -55,7 +55,8 @@ final class AggregateDataHelper {
                 price: item.price,
                 quantity: totalQuantity,
                 sku: item.sku,
-                total: total
+                total: total,
+                attributes: []
             )
         }
 
@@ -69,7 +70,7 @@ final class AggregateDataHelper {
     ///
     static func combineOrderItems(_ items: [OrderItem], with refunds: [Refund]) -> [AggregateOrderItem] {
         guard let refundedProducts = combineRefundedProducts(from: refunds) else {
-            fatalError("Error: attemtpted to calculate aggregate order item data with no refunded products.")
+            fatalError("Error: attempted to calculate aggregate order item data with no refunded products.")
         }
 
         let currency = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
@@ -83,7 +84,8 @@ final class AggregateDataHelper {
                 price: item.price,
                 quantity: item.quantity,
                 sku: item.sku,
-                total: total
+                total: total,
+                attributes: item.attributes
             )
         }
 
@@ -116,7 +118,8 @@ final class AggregateDataHelper {
                 price: item.price,
                 quantity: totalQuantity,
                 sku: item.sku,
-                total: total
+                total: total,
+                attributes: item.attributes
             )
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+import Yosemite
 
 /// This model represents a computed summary of order items.
 /// (order items - refunded order items) = aggregate order item data.
@@ -20,6 +20,8 @@ final class AggregateOrderItem {
     let sku: String?
     var total: NSDecimalNumber
 
+    let attributes: [OrderItemAttribute]
+
     /// Designated initializer.
     ///
     init(productID: Int64,
@@ -28,7 +30,8 @@ final class AggregateOrderItem {
          price: NSDecimalNumber,
          quantity: Decimal,
          sku: String?,
-         total: NSDecimalNumber) {
+         total: NSDecimalNumber,
+         attributes: [OrderItemAttribute]) {
         self.productID = productID
         self.variationID = variationID
         self.name = name
@@ -36,6 +39,7 @@ final class AggregateOrderItem {
         self.quantity = quantity
         self.sku = sku
         self.total = total
+        self.attributes = attributes
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -74,6 +74,23 @@ final class AggregateDataHelperTests: XCTestCase {
 
         XCTAssertEqual(expectedCount, actual.count)
     }
+
+    func test_AggregateOrderItem_has_attributes_from_OrderItem() {
+        // Given
+        let productID: Int64 = 1
+        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Yes")]
+        let orderItems = [MockOrderItem.sampleItem(itemID: 62, productID: productID, quantity: 3, attributes: orderItemAttributes)]
+        let order = MockOrders().empty().copy(items: orderItems)
+        let refundItems = [MockRefunds.sampleRefundItem(productID: productID)]
+        let refunds = [MockRefunds.sampleRefund(items: refundItems)]
+
+        // When
+        let aggregatedOrderItems = AggregateDataHelper.combineOrderItems(order.items, with: refunds)
+
+        // Then
+        XCTAssertEqual(aggregatedOrderItems.count, 1)
+        XCTAssertEqual(aggregatedOrderItems[0].attributes, orderItemAttributes)
+    }
 }
 
 
@@ -121,50 +138,55 @@ private extension AggregateDataHelperTests {
                                        price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
                                        quantity: -2,
                                        sku: "HOODIE-WOO-LOGO",
-                                       total: currencyFormatter.convertToDecimal(from: "-63.00") ?? NSDecimalNumber.zero)
+                                       total: currencyFormatter.convertToDecimal(from: "-63.00") ?? NSDecimalNumber.zero,
+                                       attributes: [])
         expectedArray.append(item0)
         let item1 = AggregateOrderItem(
-                        productID: 21,
-                        variationID: 70,
-                        name: "Ship Your Idea - Blue, XL",
-                        price: currencyFormatter.convertToDecimal(from: "27") ?? NSDecimalNumber.zero,
-                        quantity: -3,
-                        sku: "HOODIE-SHIP-YOUR-IDEA-BLUE-XL",
-                        total: currencyFormatter.convertToDecimal(from: "-81.00") ?? NSDecimalNumber.zero
-                    )
+            productID: 21,
+            variationID: 70,
+            name: "Ship Your Idea - Blue, XL",
+            price: currencyFormatter.convertToDecimal(from: "27") ?? NSDecimalNumber.zero,
+            quantity: -3,
+            sku: "HOODIE-SHIP-YOUR-IDEA-BLUE-XL",
+            total: currencyFormatter.convertToDecimal(from: "-81.00") ?? NSDecimalNumber.zero,
+            attributes: []
+        )
         expectedArray.append(item1)
 
         let item2 = AggregateOrderItem(
-                        productID: 21,
-                        variationID: 71,
-                        name: "Ship Your Idea - Black, L",
-                        price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
-                        quantity: -1,
-                        sku: "HOODIE-SHIP-YOUR-IDEA-BLACK-L",
-                        total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero
-                    )
+            productID: 21,
+            variationID: 71,
+            name: "Ship Your Idea - Black, L",
+            price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
+            quantity: -1,
+            sku: "HOODIE-SHIP-YOUR-IDEA-BLACK-L",
+            total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero,
+            attributes: []
+        )
         expectedArray.append(item2)
 
         let item3 = AggregateOrderItem(
-                        productID: 22,
-                        variationID: 0,
-                        name: "Ninja Silhouette",
-                        price: currencyFormatter.convertToDecimal(from: "18") ?? NSDecimalNumber.zero,
-                        quantity: -1,
-                        sku: "T-SHIRT-NINJA-SILHOUETTE",
-                        total: currencyFormatter.convertToDecimal(from: "-18.00") ?? NSDecimalNumber.zero
-                    )
+            productID: 22,
+            variationID: 0,
+            name: "Ninja Silhouette",
+            price: currencyFormatter.convertToDecimal(from: "18") ?? NSDecimalNumber.zero,
+            quantity: -1,
+            sku: "T-SHIRT-NINJA-SILHOUETTE",
+            total: currencyFormatter.convertToDecimal(from: "-18.00") ?? NSDecimalNumber.zero,
+            attributes: []
+        )
         expectedArray.append(item3)
 
         let item4 = AggregateOrderItem(
-                        productID: 24,
-                        variationID: 0,
-                        name: "Happy Ninja",
-                        price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
-                        quantity: -1,
-                        sku: "HOODIE-HAPPY-NINJA",
-                        total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero
-                    )
+            productID: 24,
+            variationID: 0,
+            name: "Happy Ninja",
+            price: currencyFormatter.convertToDecimal(from: "31.5") ?? NSDecimalNumber.zero,
+            quantity: -1,
+            sku: "HOODIE-HAPPY-NINJA",
+            total: currencyFormatter.convertToDecimal(from: "-31.50") ?? NSDecimalNumber.zero,
+            attributes: []
+        )
         expectedArray.append(item4)
 
         return expectedArray

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -16,7 +16,8 @@ public struct MockOrderItem {
                                   taxClass: String = "",
                                   taxes: [OrderItemTax] = [],
                                   total: String = "0",
-                                  totalTax: String = "0") -> OrderItem {
+                                  totalTax: String = "0",
+                                  attributes: [OrderItemAttribute] = []) -> OrderItem {
         return OrderItem(itemID: itemID,
                          name: name,
                          productID: productID,
@@ -30,6 +31,6 @@ public struct MockOrderItem {
                          taxes: taxes,
                          total: total,
                          totalTax: totalTax,
-                         attributes: [])
+                         attributes: attributes)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -130,7 +130,8 @@ private extension ProductLoaderViewControllerModelTests {
                            price: 1.2,
                            quantity: 3,
                            sku: nil,
-                           total: 3.6)
+                           total: 3.6,
+                           attributes: [])
     }
 
     func makeTopEarnerStatsItem(productID: Int64) -> TopEarnerStatsItem {


### PR DESCRIPTION
Fixes #2280
Fixes #1127 

## Changes 

- Added `attributes: [OrderItemAttribute]` to `AggregateOrderItem` and updated `AggregateDataHelper` (note that refund items do not have attributes support in the API yet)
- `ProductDetailsCellViewModel`:
  - Added `OrderAttributeViewModel` that can be initialized from an `OrderItemAttribute`: I decided to create a separate view model for an attribute, because a refund item is likely having a different model for its attributes when we implement this in the future
  - Localized the subtitle based on the attributes
- In `OrderItem`, updated to filter all attributes with a `_` prefix in the name. Before, we only knew of one (`_reduced_stock`) but I noticed another one from Square plugin (`_square_item_variation_id`). It's possible an actual variation attribute starts with an underscore, but the chance is probably lower than stores having a plugin that injects an attribute
- Updated unit tests

## Testing

### WC store with API support

Prerequisites:
- The store is on WC 4.7.0-rc.1 or above
- The store has two types of orders:
1) The order has not been refunded, and has at least one variation line item
2) The order has several line items including least one variation line item, and at least one **non-variation** line items has been refunded (so that the variation line item is shown in order details)

Testing steps:
- Go to the orders tab
- Tap on order type 1 in the prerequisite (order without refunds) --> the variation line item should show its parent name, and the attributes separated by comma
- Tap on order type 2 in the prerequisite (order with refunds, where `AggregateOrderItem` is used) --> the variation line item should show its parent name, and the attributes separated by comma

### WC store without API support

Prerequisites:
- The store is on WC 4.7.0 or below
- The store has two types of orders:
1) The order has not been refunded, and has at least one variation line item
2) The order has several line items including least one variation line item, and at least one **non-variation** line items has been refunded (so that the variation line item is shown in order details)

- Switch to a store with WC 4.7.0 or below
- Go to the orders tab
- Tap on order type 1 in the prerequisite (order without refunds) --> the variation line item should show the same product details UI as on `develop` without attributes
- Tap on order type 2 in the prerequisite (order with refunds, where `AggregateOrderItem` is used) --> the variation line item should show the same product details UI as on `develop` without attributes

## Example screenshots

The order in the screenshots has 3 line items with 1, 2, and 3 variation attributes.

WC store with API support (4.7.1-rc.1) | WC store without API support (4.6.2)
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 16 19 10](https://user-images.githubusercontent.com/1945542/98516379-6556c400-22a7-11eb-8237-a11ceda6c8d0.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 16 16 39](https://user-images.githubusercontent.com/1945542/98516364-60921000-22a7-11eb-840a-3c1c522d9e69.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
