### PR TITLE
Removed error logs on Sentry from ProductFormViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -3,8 +3,6 @@ import UIKit
 import WordPressUI
 import Yosemite
 
-import class AutomatticTracks.CrashLogging
-
 /// The entry UI for adding/editing a Product.
 final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: UIViewController, UITableViewDelegate {
     typealias ProductModel = ViewModel.ProductModel
@@ -607,7 +605,7 @@ private extension ProductFormViewController {
             switch result {
             case .failure(let error):
                 DDLogError("⛔️ Error updating Product: \(error)")
-                CrashLogging.logError(error)
+
                 // Dismisses the in-progress UI then presents the error alert.
                 self?.navigationController?.dismiss(animated: true) {
                     self?.displayError(error: error)
@@ -686,7 +684,6 @@ private extension ProductFormViewController {
                 switch result {
                 case .failure(let error):
                     DDLogError("⛔️ Error deleting Product: \(error)")
-                    CrashLogging.logError(error)
 
                     // Dismisses the in-progress UI then presents the error alert.
                     self.navigationController?.dismiss(animated: true) { [weak self] in


### PR DESCRIPTION
It seems that [we are logging on Sentry](https://sentry.io/share/issue/dc6647450c4d45b896c03b6dd7fb4e88/) some errors when a product is saved or deleted, but they are not useful for us since we are logging just the error messages, which are generic and localized in the store language.

In this PR I removed the `CrashLogging` from `ProductFormViewController`. We discussed it [here](https://a8c.slack.com/archives/C70PAM3RA/p1605022224162900).

I added just you @jaclync as a reviewer since you probably know if there are other reasons to log these messages, that maybe we are ignoring. 

## Testing
- Just CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
