### PR TITLE
Remove References to "master"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -562,7 +562,7 @@ private extension OrderListViewController {
 // MARK: - IndicatorInfoProvider Conformance
 
 // This conformance is not used directly by `OrderListViewController`. We only need this because
-// `Self` is used as a child of `OrdersMasterViewController` which is a
+// `Self` is used as a child of `OrdersTabbedViewController` which is a
 // `ButtonBarPagerTabStripViewController`.
 @available(iOS 13.0, *)
 extension OrderListViewController: IndicatorInfoProvider {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -73,7 +73,7 @@ final class OrderListViewController: UIViewController {
 
     /// Used for looking up the `OrderStatus` to show in the `OrderTableViewCell`.
     ///
-    /// The `OrderStatus` data is fetched from the API by `OrdersMasterViewModel`.
+    /// The `OrderStatus` data is fetched from the API by `OrdersTabbedViewModel`.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = ServiceLocator.storageManager

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -8,7 +8,7 @@ import protocol Storage.StorageManagerType
 ///
 /// This is an incremental WIP. Eventually, we should move all the data loading in here.
 ///
-/// Important: The `OrdersViewController` **owned** by `OrdersMasterViewController` currently
+/// Important: The `OrdersViewController` **owned** by `OrdersTabbedViewController` currently
 /// does not get deallocated when switching sites. This `ViewModel` should consider that and not
 /// keep site-specific information as much as possible. For example, we shouldn't keep `siteID`
 /// in here but grab it from the `SessionManager` when we need it. Hopefully, we will be able to

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Yosemite
 
-/// Encapsulates data management for `OrdersMasterViewController`.
+/// Encapsulates data management for `OrdersTabbedViewController`.
 ///
 final class OrdersMasterViewModel {
 
@@ -30,7 +30,7 @@ final class OrdersMasterViewModel {
 
     /// Start all the operations that this `ViewModel` is responsible for.
     ///
-    /// This should only be called once in the lifetime of `OrdersMasterViewController`.
+    /// This should only be called once in the lifetime of `OrdersTabbedViewController`.
     ///
     func activate() {
         try? statusResultsController.performFetch()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -3,21 +3,21 @@ import Yosemite
 
 /// The root tab controller for Orders.
 ///
-/// This is really just a container for `OrdersMasterViewController` with subtle fixes for the
+/// This is really just a container for `OrdersTabbedViewController` with subtle fixes for the
 /// XLPagerTabStrip bug in landscape. See PR#1851 (https://git.io/Jvzg8) for more information
 /// about the bug.
 ///
 /// If we eventually get XLPagerTabStrip replaced, we can merge this class with
-/// `OrdersMasterViewController`.
+/// `OrdersTabbedViewController`.
 ///
-/// If you need to add additional logic, probably consider adding it to `OrdersMasterViewController`
+/// If you need to add additional logic, probably consider adding it to `OrdersTabbedViewController`
 /// instead if possible.
 ///
 final class OrdersRootViewController: UIViewController {
 
     // MARK: Child view controller
 
-    private lazy var ordersViewController = OrdersMasterViewController(siteID: siteID)
+    private lazy var ordersViewController = OrdersTabbedViewController(siteID: siteID)
 
     // MARK: Subviews
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -11,7 +11,7 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
 
     private lazy var analytics = ServiceLocator.analytics
 
-    private lazy var viewModel = OrdersMasterViewModel(siteID: siteID)
+    private lazy var viewModel = OrdersTabbedViewModel(siteID: siteID)
 
     private let siteID: Int64
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -7,7 +7,7 @@ import struct Yosemite.Note
 
 /// The main Orders view controller that is shown when the Orders tab is accessed.
 ///
-final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
+final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
 
     private lazy var analytics = ServiceLocator.analytics
 
@@ -87,7 +87,7 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
 
 // MARK: - OrdersViewControllerDelegate
 
-extension OrdersMasterViewController: OrderListViewControllerDelegate {
+extension OrdersTabbedViewController: OrderListViewControllerDelegate {
     func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController) {
         viewModel.syncOrderStatuses()
     }
@@ -95,7 +95,7 @@ extension OrdersMasterViewController: OrderListViewControllerDelegate {
 
 // MARK: - Initialization and Loading (Not Reusable)
 
-private extension OrdersMasterViewController {
+private extension OrdersTabbedViewController {
     /// Initialize the tab bar containing the "Processing" and "All Orders" buttons.
     ///
     func configureTabStrip() {
@@ -148,7 +148,7 @@ private extension OrdersMasterViewController {
 
 // MARK: - Creators
 
-extension OrdersMasterViewController {
+extension OrdersTabbedViewController {
     /// Create a `UIBarButtonItem` to be used as the search button on the top-left.
     ///
     func createSearchBarButtonItem() -> UIBarButtonItem {
@@ -253,7 +253,7 @@ extension OrdersMasterViewController {
 
 // MARK: - Localization
 
-private extension OrdersMasterViewController {
+private extension OrdersTabbedViewController {
     enum Localization {
         static let processingTitle = NSLocalizedString("Processing", comment: "Title for the first page in the Orders tab.")
         static let processingEmptyStateMessage =

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersMasterViewController" customModule="WooCommerce" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersTabbedViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="buttonBarView" destination="7lu-ed-U2a" id="CeJ-gT-RxY"/>
                 <outlet property="containerView" destination="VD7-Yu-YwE" id="3vO-sb-eUc"/>
@@ -22,7 +23,7 @@
             <subviews>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="7lu-ed-U2a" customClass="ButtonBarView" customModule="XLPagerTabStrip">
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="pvM-9u-cnp"/>
                     </constraints>
@@ -38,7 +39,8 @@
                     <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                 </scrollView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="rGE-vr-B04"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="1oC-b9-sf9"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="VD7-Yu-YwE" secondAttribute="trailing" id="9vb-3t-PWE"/>
@@ -48,8 +50,12 @@
                 <constraint firstItem="7lu-ed-U2a" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="Zdd-er-iM1"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="7lu-ed-U2a" secondAttribute="trailing" id="lJ7-pc-DWf"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="rGE-vr-B04"/>
             <point key="canvasLocation" x="-317" y="153"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 /// Encapsulates data management for `OrdersTabbedViewController`.
 ///
-final class OrdersMasterViewModel {
+final class OrdersTabbedViewModel {
 
     private lazy var storageManager = ServiceLocator.storageManager
     private lazy var stores = ServiceLocator.stores

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -54,7 +54,7 @@ final class OrdersViewController: UIViewController {
 
     /// Used for looking up the `OrderStatus` to show in the `OrderTableViewCell`.
     ///
-    /// The `OrderStatus` data is fetched from the API by `OrdersMasterViewModel`.
+    /// The `OrderStatus` data is fetched from the API by `OrdersTabbedViewModel`.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = ServiceLocator.storageManager

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -524,7 +524,7 @@ private extension OrdersViewController {
 // MARK: - IndicatorInfoProvider Conformance
 
 // This conformance is not used directly by `OrdersViewController`. We only need this because
-// `Self` is used as a child of `OrdersMasterViewController` which is a
+// `Self` is used as a child of `OrdersTabbedViewController` which is a
 // `ButtonBarPagerTabStripViewController`.
 extension OrdersViewController: IndicatorInfoProvider {
     /// Return `self.title` under `IndicatorInfo`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -8,7 +8,7 @@ import protocol Storage.StorageManagerType
 ///
 /// This is an incremental WIP. Eventually, we should move all the data loading in here.
 ///
-/// Important: The `OrdersViewController` **owned** by `OrdersMasterViewController` currently
+/// Important: The `OrdersViewController` **owned** by `OrdersTabbedViewController` currently
 /// does not get deallocated when switching sites. This `ViewModel` should consider that and not
 /// keep site-specific information as much as possible. For example, we shouldn't keep `siteID`
 /// in here but grab it from the `SessionManager` when we need it. Hopefully, we will be able to

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -103,7 +103,7 @@ private extension AuthenticatedState {
         }
     }
 
-    /// Executed whenever a DotcomError is received (ApplicationLayer). This allows us to have a *Master* error handling flow!
+    /// Executed whenever a DotcomError is received (ApplicationLayer). This allows us to have a *main* error handling flow!
     ///
     func tunnelTimeoutWasReceived(note: Notification) {
         ServiceLocator.analytics.track(.jetpackTunnelTimeout)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 		57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */; };
 		57C503DC23E8C70C00EC0790 /* OrdersTabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersTabbedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */; };
-		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
+		57C503E023E8D4D600EC0790 /* OrdersTabbedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersTabbedViewModel.swift */; };
 		57C5FF7A25091A350074EC26 /* OrderListSyncActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */; };
 		57C5FF7C25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */; };
 		57C5FF7F250925C90074EC26 /* OrderListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7D250925000074EC26 /* OrderListViewModel.swift */; };
@@ -1551,7 +1551,7 @@
 		57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenterTests.swift; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTabbedViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersTabbedViewController.xib; sourceTree = "<group>"; };
-		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
+		57C503DF23E8D4D600EC0790 /* OrdersTabbedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTabbedViewModel.swift; sourceTree = "<group>"; };
 		57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCase.swift; sourceTree = "<group>"; };
 		57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCaseTests.swift; sourceTree = "<group>"; };
 		57C5FF7D250925000074EC26 /* OrderListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListViewModel.swift; sourceTree = "<group>"; };
@@ -4275,7 +4275,7 @@
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */,
 				57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */,
-				57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */,
+				57C503DF23E8D4D600EC0790 /* OrdersTabbedViewModel.swift */,
 				0206483923FA4160008441BB /* OrdersRootViewController.swift */,
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
 				576F92212423C3C0003E5FEF /* OrdersViewModel.swift */,
@@ -5714,7 +5714,7 @@
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,
 				26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */,
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
-				57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */,
+				57C503E023E8D4D600EC0790 /* OrdersTabbedViewModel.swift in Sources */,
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -517,8 +517,8 @@
 		57ABE36824EB048A00A64F49 /* MockSwitchStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */; };
 		57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */; };
 		57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */; };
-		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
-		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
+		57C503DC23E8C70C00EC0790 /* OrdersTabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */; };
+		57C503DE23E8CE0D00EC0790 /* OrdersTabbedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		57C5FF7A25091A350074EC26 /* OrderListSyncActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */; };
 		57C5FF7C25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */; };
@@ -1549,8 +1549,8 @@
 		57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSwitchStoreUseCase.swift; sourceTree = "<group>"; };
 		57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewControllerTests.swift; sourceTree = "<group>"; };
 		57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenterTests.swift; sourceTree = "<group>"; };
-		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
-		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
+		57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTabbedViewController.swift; sourceTree = "<group>"; };
+		57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersTabbedViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
 		57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCase.swift; sourceTree = "<group>"; };
 		57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCaseTests.swift; sourceTree = "<group>"; };
@@ -4273,8 +4273,8 @@
 				CEE006022077D0F80079161F /* Cells */,
 				CE35F1092343E482007B2A6B /* Order Details */,
 				CEE005F52076C4040079161F /* Orders.storyboard */,
-				57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */,
-				57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */,
+				57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */,
+				57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */,
 				57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */,
 				0206483923FA4160008441BB /* OrdersRootViewController.swift */,
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
@@ -5119,7 +5119,7 @@
 				74A95B5821C403EA00FEE953 /* pure-min.css in Resources */,
 				0262DA5423A238460029AF30 /* UnitInputTableViewCell.xib in Resources */,
 				B5BE75DD213F1D3D00909A14 /* OverlayMessageView.xib in Resources */,
-				57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */,
+				57C503DE23E8CE0D00EC0790 /* OrdersTabbedViewController.xib in Resources */,
 				02F4F510237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib in Resources */,
 				45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */,
 				45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */,
@@ -5393,7 +5393,7 @@
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,
 				74460D4222289C7A00D7316A /* StorePickerCoordinator.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
-				57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */,
+				57C503DC23E8C70C00EC0790 /* OrdersTabbedViewController.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,


### PR DESCRIPTION
Ref paaHJt-15h-p2.

This removes some of the references to "master". Mainly by renaming `OrdersMaster*` to `OrdersTabbed*`. 

The remaining are sort of our control but let me know if you have suggestions about what to do with them:

https://github.com/woocommerce/woocommerce-ios/blob/8254985625f91fac207b5039b6add37c0c86d516/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift#L7

https://github.com/woocommerce/woocommerce-ios/blob/a0cf92a3336594d5a161796ef061f7b93a3494ea/CodeGeneration/Models%2BCopiable.swifttemplate#L30

## Testing

Please do a quick regression test and open the Orders tab and make sure it still works like before. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

