### PR TITLE
Order Details > variation details: add missing release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
  
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+- [*] enhancement: Order details screen now shows variation attributes for WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3109]
 
 5.5
 -----


### PR DESCRIPTION
For #2280 

## Changes

I forgot to add release notes in https://github.com/woocommerce/woocommerce-ios/pull/3109 😅  

## Testing

None! no code changes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
