### PR TITLE
Enable Products M4 for all!

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,10 +2,8 @@
 -----
  
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+- [**] Products M4 features are now available to all. Products M4 features: add a simple/grouped/external product with actions to publish or save as draft.
 - [*] enhancement: Order details screen now shows variation attributes for WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3109]
-
-5.5
------
 - [*] fix: Product detail screen now includes the number of ratings for that product. [https://github.com/woocommerce/woocommerce-ios/pull/3089]
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
  
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
-- [**] Products M4 features are now available to all. Products M4 features: add a simple/grouped/external product with actions to publish or save as draft.
+- [**] Products M4 features are now available to all. Products M4 features: add a simple/grouped/external product with actions to publish or save as draft. [https://github.com/woocommerce/woocommerce-ios/pull/3133]
 - [*] enhancement: Order details screen now shows variation attributes for WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3109]
 - [*] fix: Product detail screen now includes the number of ratings for that product. [https://github.com/woocommerce/woocommerce-ios/pull/3089]
 

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -5,8 +5,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .editProductsRelease4:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease5:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .issueRefunds:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -10,10 +10,6 @@ enum FeatureFlag: Int {
     ///
     case barcodeScanner
 
-    /// Edit products - release 4
-    ///
-    case editProductsRelease4
-
     /// Edit products - release 5
     ///
     case editProductsRelease5

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -287,7 +287,7 @@ private extension SettingsViewController {
 
     /// This is false because there are no ongoing experiments
     func couldShowBetaFeaturesRow() -> Bool {
-        true
+        false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -6,7 +6,7 @@ struct ProductsTopBannerFactory {
     /// - Parameters:
     ///   - isExpanded: whether the top banner is expanded by default.
     ///   - expandedStateChangeHandler: called when the top banner expanded state changes.
-    ///   - onGiveFeedbackButtonPressed: called the give feedbak button is pressed.
+    ///   - onGiveFeedbackButtonPressed: called the give feedback button is pressed.
     ///   - onDismissButtonPressed: called the dismiss button is pressed
     ///   - onCompletion: called when the view controller is created and ready for display.
     static func topBanner(isExpanded: Bool,
@@ -16,45 +16,36 @@ struct ProductsTopBannerFactory {
                           onGiveFeedbackButtonPressed: @escaping () -> Void,
                           onDismissButtonPressed: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
-        let action = AppSettingsAction.loadProductsFeatureSwitch { isFeatureSwitchOn in
-            let title = isFeatureSwitchOn ? Localization.titleWhenRelease4IsEnabled: Localization.title
-            let icon: UIImage = .megaphoneIcon
-            let infoText = isFeatureSwitchOn ? Localization.infoWhenRelease4IsEnabled: Localization.info
-            let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
-                analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .gaveFeedback))
-                onGiveFeedbackButtonPressed()
-            }
-            let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
-                analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .dismissed))
-                onDismissButtonPressed()
-            }
-            let actions = [giveFeedbackAction, dismissAction]
-            let viewModel = TopBannerViewModel(title: title,
-                                               infoText: infoText,
-                                               icon: icon,
-                                               isExpanded: isExpanded,
-                                               topButton: .chevron(handler: expandedStateChangeHandler),
-                                               actionButtons: actions)
-            let topBannerView = TopBannerView(viewModel: viewModel)
-            topBannerView.translatesAutoresizingMaskIntoConstraints = false
-            onCompletion(topBannerView)
+        let title = Localization.title
+        let icon: UIImage = .megaphoneIcon
+        let infoText = Localization.info
+        let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
+            analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .gaveFeedback))
+            onGiveFeedbackButtonPressed()
         }
-        stores.dispatch(action)
+        let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
+            analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .dismissed))
+            onDismissButtonPressed()
+        }
+        let actions = [giveFeedbackAction, dismissAction]
+        let viewModel = TopBannerViewModel(title: title,
+                                           infoText: infoText,
+                                           icon: icon,
+                                           isExpanded: isExpanded,
+                                           topButton: .chevron(handler: expandedStateChangeHandler),
+                                           actionButtons: actions)
+        let topBannerView = TopBannerView(viewModel: viewModel)
+        topBannerView.translatesAutoresizingMaskIntoConstraints = false
+        onCompletion(topBannerView)
     }
 }
 
 private extension ProductsTopBannerFactory {
     enum Localization {
         static let title =
-            NSLocalizedString("New editing options available",
-                              comment: "The title of the Work In Progress top banner on the Products tab when Products feature switch is disabled.")
-        static let info =
-            NSLocalizedString("You can now edit grouped, external and variable products, change product type and update categories and tags",
-                              comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is disabled.")
-        static let titleWhenRelease4IsEnabled =
             NSLocalizedString("Create products from the app!",
                               comment: "The title of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
-        static let infoWhenRelease4IsEnabled =
+        static let info =
             NSLocalizedString(
                 "It’s now possible to create simple, grouped \nand external products on the go from the Woo app. Not ready yet? Save them as draft!",
                 comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -156,7 +156,6 @@ final class ProductsViewController: UIViewController {
         registerTableViewCells()
 
         updateTopBannerView()
-        observeProductsFeatureSwitchChange()
 
         syncingCoordinator.resynchronize()
     }
@@ -234,31 +233,21 @@ private extension ProductsViewController {
             return button
         }()
 
-        updateNavigationBarRightButtonItems()
+        configureNavigationBarRightButtonItems()
     }
 
-    /// Fetches the feature switch value from app settings and updates its navigation bar right button items.
-    func updateNavigationBarRightButtonItems() {
-        let action = AppSettingsAction.loadProductsFeatureSwitch { [weak self] isFeatureSwitchOn in
-            self?.updateNavigationBarRightButtonItems(isProductsFeatureSwitchOn: isFeatureSwitchOn)
-        }
-        ServiceLocator.stores.dispatch(action)
-    }
-
-    func updateNavigationBarRightButtonItems(isProductsFeatureSwitchOn: Bool) {
+    func configureNavigationBarRightButtonItems() {
         var rightBarButtonItems = [UIBarButtonItem]()
-        if isProductsFeatureSwitchOn {
-            let buttonItem: UIBarButtonItem = {
-                let button = UIBarButtonItem(image: .plusImage,
-                                             style: .plain,
-                                             target: self,
-                                             action: #selector(addProduct(_:)))
-                button.accessibilityTraits = .button
-                button.accessibilityLabel = NSLocalizedString("Add a product", comment: "The action to add a product")
-                return button
-            }()
-            rightBarButtonItems.append(buttonItem)
-        }
+        let buttonItem: UIBarButtonItem = {
+            let button = UIBarButtonItem(image: .plusImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(addProduct(_:)))
+            button.accessibilityTraits = .button
+            button.accessibilityLabel = NSLocalizedString("Add a product", comment: "The action to add a product")
+            return button
+        }()
+        rightBarButtonItems.append(buttonItem)
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.barcodeScanner) {
             let buttonItem: UIBarButtonItem = {
@@ -367,14 +356,6 @@ private extension ProductsViewController {
 // MARK: - Updates
 //
 private extension ProductsViewController {
-    func observeProductsFeatureSwitchChange() {
-        NotificationCenter.default.addObserver(forName: .ProductsFeatureSwitchDidChange, object: nil, queue: nil) { [weak self] _ in
-            guard let self = self else { return }
-            self.updateTopBannerView()
-            self.updateNavigationBarRightButtonItems()
-        }
-    }
-
     /// Fetches products feedback visibility from AppSettingsStore and update products top banner accordingly
     ///
     func updateTopBannerView() {


### PR DESCRIPTION
Fixes #3125 

## Changes

- Removed `editProductsRelease4` feature flag
- Hid experimental features row in settings `SettingsViewController`
- In `ProductsTopBannerFactory`, updated to always show the products tab top banner copy (title & info) for M4 features
- In `ProductsViewController`, removed conditional check for Add Product CTA in the navigation bar right button items. Also removed observation of Products feature switch changes

## Testing

- On `develop` or any other branch, first launch the app and turn off the Products feature switch in Settings > Experimental Features --> there should be no "+" CTA in the Products tab and the top banner does not mention product creation
- On PR branch, launch the app
- Go to the Products tab --> the "+" CTA should be visible even though the feature switch was turned off previously, and the top banner should mention product creation
- Go to Settings --> Experimental Features row should not be visible

## Example screenshots

Products tab | Settings
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-11-11 at 11 26 35](https://user-images.githubusercontent.com/1945542/98762113-e500a200-2411-11eb-9397-bf51b8f50d88.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-11 at 11 26 40](https://user-images.githubusercontent.com/1945542/98762124-e8942900-2411-11eb-85f2-db4d25f42a83.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
