### PR TITLE
Add Tracks event for product image upload error

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -311,6 +311,7 @@ public enum WooAnalyticsStat: String {
     case productImageSettingsAddImagesButtonTapped = "product_image_settings_add_images_button_tapped"
     case productImageSettingsAddImagesSourceTapped = "product_image_settings_add_images_source_tapped"
     case productImageSettingsDeleteImageButtonTapped = "product_image_settings_delete_image_button_tapped"
+    case productImageUploadFailed = "product_image_upload_failed"
 
     // Product Categories Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -314,8 +314,8 @@ public enum WooAnalyticsStat: String {
 
     // Product Categories Events
     //
-    case productCategoriyListLoaded = "product_categories_loaded"
-    case productCategoriyListLoadFailed = "product_categories_load_failed"
+    case productCategoryListLoaded = "product_categories_loaded"
+    case productCategoryListLoadFailed = "product_categories_load_failed"
     case productCategorySettingsDoneButtonTapped = "product_category_settings_done_button_tapped"
     case productCategorySettingsAddButtonTapped = "product_category_settings_add_button_tapped"
     case productCategorySettingsSaveNewCategoryTapped = "add_product_category_save_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
@@ -128,10 +128,10 @@ private extension ProductCategoryListViewModel {
             self?.updateViewModelsArray()
 
             if let error = error {
-                ServiceLocator.analytics.track(.productCategoriyListLoadFailed, withError: error)
+                ServiceLocator.analytics.track(.productCategoryListLoadFailed, withError: error)
                 self?.handleSychronizeAllCategoriesError(error)
             } else {
-                ServiceLocator.analytics.track(.productCategoriyListLoaded)
+                ServiceLocator.analytics.track(.productCategoryListLoaded)
                 self?.syncCategoriesState = .synced
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -150,6 +150,10 @@ final class ProductImageActionHandler {
                                                         return
                                                     }
 
+                                                    if let error = error {
+                                                        ServiceLocator.analytics.track(.productImageUploadFailed, withError: error)
+                                                    }
+
                                                     guard let index = self.index(of: asset) else {
                                                         return
                                                     }


### PR DESCRIPTION
Fixes #3126 

## Changes

- Added a new event case `productImageUploadFailed`
- In `ProductImageActionHandler`, tracked the new event `productImageUploadFailed` on product image upload error
- Fixed typo in other event names in https://github.com/woocommerce/woocommerce-ios/commit/66b84bc53de4ef7d1e6c525cb1258cffc2c4e5a4

## Testing

- Go to the Products tab
- Add or edit a product
- Tap on the "+" cell or any image cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera, and quickly switch to offline mode --> after a bit, an error alert is shown. the console should show the Tracks event like: `🔵 Tracked product_image_upload_failed, properties: [AnyHashable("error_domain"): "NSURLErrorDomain", AnyHashable("error_code"): "-1017", ...`


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
