### PR TITLE
Pass boolean flag to enable unified login and signup

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -42,7 +42,8 @@ class AuthenticationManager: Authentication {
                                                                 userAgent: UserAgent.defaultUserAgent,
                                                                 showLoginOptions: true,
                                                                 enableSignUp: false,
-                                                                enableSignInWithApple: isSignInWithAppleEnabled)
+                                                                enableSignInWithApple: isSignInWithAppleEnabled,
+                                                                enableUnifiedAuth: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)


### PR DESCRIPTION
Closes #3124 

⚠️  Notice how the PR is not against develop, but against the long-lived feature branch were we will implement Unified Login and signup.

This PR does not fully implement the new Unified Login flow, it only activates the configuration flag necessary to start working on customising the flow and the UI. The actual implementation, the customisation of the UI and the navigation flows begins after this PR.

# Changes
* Pass a boolean flag to WPAuthenticator (via WordPressAuthenticatorConfiguration), so that the authentication library starts displaying the unified login flow.

# Testing
* Check the branch, build and run. 
* It should be possible to log in with wordpress.com and with a site address. 
* Please avoid using SIWA for now. 

# Example screenshots
| | Before | After |
| ---- | ---- | ---- |
| Prologue | <img src="https://user-images.githubusercontent.com/2722505/98780929-8f87bd80-2430-11eb-828a-940bff3f93a6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/98780944-957d9e80-2430-11eb-8dca-ef5f9537f070.png" width="350"/> |
| Login with WP.com | <img src="https://user-images.githubusercontent.com/2722505/98781114-d1186880-2430-11eb-921d-0bff24042090.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/98781128-d4abef80-2430-11eb-8808-09bda6e4e12c.png" width="350"/> |
| Login with Site Address | <img src="https://user-images.githubusercontent.com/2722505/98781332-1ccb1200-2431-11eb-85e8-42d733306349.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/98781339-1e94d580-2431-11eb-837f-517802cf86d4.png" width="350"/> |

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
