### PR TITLE
[Issue Refund] Synchronize Payment Gateways

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */ = {isa = PBXBuildFile; fileRef = 261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */; };
 		261CF1B8255AE62D0090D8D3 /* PaymentGatewayRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */; };
 		261CF1BC255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1BB255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift */; };
+		261CF2CB255C50010090D8D3 /* payment-gateway-list-half.json in Resources */ = {isa = PBXBuildFile; fileRef = 261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */; };
 		262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */; };
 		265BCA02243056E3004E53EE /* categories-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA01243056E3004E53EE /* categories-all.json */; };
 		26615473242D596B00A31661 /* ProductCategoriesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615472242D596B00A31661 /* ProductCategoriesRemote.swift */; };
@@ -437,6 +438,7 @@
 		261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-list.json"; sourceTree = "<group>"; };
 		261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayRemote.swift; sourceTree = "<group>"; };
 		261CF1BB255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsGatewayRemoteTests.swift; sourceTree = "<group>"; };
+		261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-list-half.json"; sourceTree = "<group>"; };
 		262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayListMapperTests.swift; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
 		26615472242D596B00A31661 /* ProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemote.swift; sourceTree = "<group>"; };
@@ -1159,6 +1161,7 @@
 				0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */,
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
+				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
 				02698CF524C17FC1005337C4 /* product-alternative-types.json */,
@@ -1568,6 +1571,7 @@
 				D8FBFF1822D4DDB9006E3336 /* order-stats-v4-hour.json in Resources */,
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
 				022902D622E2436400059692 /* no_stats_permission_error.json in Resources */,
+				261CF2CB255C50010090D8D3 /* payment-gateway-list-half.json in Resources */,
 				45B204BC24890B1200FE6526 /* category.json in Resources */,
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -70,7 +70,7 @@ extension PaymentGateway: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let gatewayID = try container.decode(String.self, forKey: .gatewayID)
         let title = try container.decode(String.self, forKey: .title)
-        let description = try container.decode(String.self, forKey: .description)
+        let description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         let enabled = try container.decode(Bool.self, forKey: .enabled)
         let features = try container.decode([Feature].self, forKey: .features)
 

--- a/Networking/NetworkingTests/Responses/payment-gateway-list-half.json
+++ b/Networking/NetworkingTests/Responses/payment-gateway-list-half.json
@@ -1,38 +1,28 @@
 {
-  "code": 200,
-  "headers": [
+  "data": [
     {
-      "name": "Content-Type",
-      "value": "application/json"
+      "id": "bacs",
+      "title": "Direct bank transfer",
+      "description": "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.",
+      "order": "",
+      "enabled": false,
+      "method_title": "Direct bank transfer",
+      "method_description": "Take payments in person via BACS. More commonly known as direct bank/wire transfer",
+      "method_supports": [
+        "products"
+      ]
+    },
+    {
+      "id": "cheque",
+      "title": "Check payments",
+      "description": "Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.",
+      "order": "",
+      "enabled": false,
+      "method_title": "Check payments",
+      "method_description": "Take payments in person via checks. This offline gateway can also be useful to test purchases.",
+      "method_supports": [
+        "products"
+      ]
     }
-  ],
-  "body": {
-    "data": [
-      {
-        "id": "bacs",
-        "title": "Direct bank transfer",
-        "description": "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.",
-        "order": "",
-        "enabled": false,
-        "method_title": "Direct bank transfer",
-        "method_description": "Take payments in person via BACS. More commonly known as direct bank/wire transfer",
-        "method_supports": [
-          "products"
-        ]
-      },
-      {
-        "id": "cheque",
-        "title": "Check payments",
-        "description": "Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.",
-        "order": "",
-        "enabled": false,
-        "method_title": "Check payments",
-        "method_description": "Take payments in person via checks. This offline gateway can also be useful to test purchases.",
-        "method_supports": [
-          "products"
-        ]
-      }
-    ]
-  }
+  ]
 }
-

--- a/Networking/NetworkingTests/Responses/payment-gateway-list-half.json
+++ b/Networking/NetworkingTests/Responses/payment-gateway-list-half.json
@@ -1,0 +1,38 @@
+{
+  "code": 200,
+  "headers": [
+    {
+      "name": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "body": {
+    "data": [
+      {
+        "id": "bacs",
+        "title": "Direct bank transfer",
+        "description": "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.",
+        "order": "",
+        "enabled": false,
+        "method_title": "Direct bank transfer",
+        "method_description": "Take payments in person via BACS. More commonly known as direct bank/wire transfer",
+        "method_supports": [
+          "products"
+        ]
+      },
+      {
+        "id": "cheque",
+        "title": "Check payments",
+        "description": "Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.",
+        "order": "",
+        "enabled": false,
+        "method_title": "Check payments",
+        "method_description": "Take payments in person via checks. This offline gateway can also be useful to test purchases.",
+        "method_supports": [
+          "products"
+        ]
+      }
+    ]
+  }
+}
+

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -39,6 +39,7 @@ class AuthenticatedState: StoresManagerState {
             OrderNoteStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            PaymentGatewayStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductReviewStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductCategoryStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		2618707C2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707B2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift */; };
 		261CF1C9255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */; };
 		261CF1ED255B37B40090D8D3 /* PaymentGatewayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */; };
+		261CF1F1255B389F0090D8D3 /* PaymentGatewayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */; };
 		261F94E4242EFA6D00762B58 /* ProductCategoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */; };
 		261F94E6242EFF8700762B58 /* ProductCategoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */; };
 		26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */; };
@@ -331,6 +332,7 @@
 		2618707B2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAction.swift; sourceTree = "<group>"; };
+		261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayStore.swift; sourceTree = "<group>"; };
 		261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryAction.swift; sourceTree = "<group>"; };
 		261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStore.swift; sourceTree = "<group>"; };
 		26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryUpdated.swift; sourceTree = "<group>"; };
@@ -917,6 +919,7 @@
 				74A7688B20D45EBA00F9D437 /* OrderStore.swift */,
 				7499936520EFBC7200CF01CD /* OrderNoteStore.swift */,
 				CE3B7AD62225ECA90050FE4B /* OrderStatusStore.swift */,
+				261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */,
 				749374FD2249601F007D85D1 /* ProductStore.swift */,
 				D831E2E1230E3513000037D0 /* ProductReviewStore.swift */,
 				261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */,
@@ -1392,6 +1395,7 @@
 				744A321B216D57D40051439B /* SiteVisitStats+ReadOnlyType.swift in Sources */,
 				02124DAE2431C11600980D74 /* Media+ProductImage.swift in Sources */,
 				26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */,
+				261CF1F1255B389F0090D8D3 /* PaymentGatewayStore.swift in Sources */,
 				02FF055023D983F30058E6E7 /* ExportableAsset.swift in Sources */,
 				7493750E224988DE007D85D1 /* ProductImage+ReadOnlyConvertible.swift in Sources */,
 				02FF056323DE9C490058E6E7 /* MediaAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		2614E12D24C745B2007CEE60 /* LeaderboardStatsConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614E12C24C745B2007CEE60 /* LeaderboardStatsConverterTests.swift */; };
 		2618707C2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707B2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift */; };
 		261CF1C9255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */; };
+		261CF1ED255B37B40090D8D3 /* PaymentGatewayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */; };
 		261F94E4242EFA6D00762B58 /* ProductCategoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */; };
 		261F94E6242EFF8700762B58 /* ProductCategoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */; };
 		26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */; };
@@ -329,6 +330,7 @@
 		2614E12C24C745B2007CEE60 /* LeaderboardStatsConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardStatsConverterTests.swift; sourceTree = "<group>"; };
 		2618707B2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAction.swift; sourceTree = "<group>"; };
 		261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryAction.swift; sourceTree = "<group>"; };
 		261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStore.swift; sourceTree = "<group>"; };
 		26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryUpdated.swift; sourceTree = "<group>"; };
@@ -1113,6 +1115,7 @@
 				74A7688F20D45F9300F9D437 /* OrderAction.swift */,
 				7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */,
 				CE3B7AD42225EBF10050FE4B /* OrderStatusAction.swift */,
+				261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */,
 				749374FF2249605E007D85D1 /* ProductAction.swift */,
 				D831E2E3230E3524000037D0 /* ProductReviewAction.swift */,
 				261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */,
@@ -1416,6 +1419,7 @@
 				025CA2CC238F518600B05C81 /* ProductShippingClassAction.swift in Sources */,
 				B53D89E520E6C22B00F90866 /* Model.swift in Sources */,
 				933A27352222352500C2143A /* Logging.swift in Sources */,
+				261CF1ED255B37B40090D8D3 /* PaymentGatewayAction.swift in Sources */,
 				74685D5020F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift in Sources */,
 				74A7689020D45F9300F9D437 /* OrderAction.swift in Sources */,
 				D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		261CF1C9255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */; };
 		261CF1ED255B37B40090D8D3 /* PaymentGatewayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */; };
 		261CF1F1255B389F0090D8D3 /* PaymentGatewayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */; };
+		261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */; };
 		261F94E4242EFA6D00762B58 /* ProductCategoryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */; };
 		261F94E6242EFF8700762B58 /* ProductCategoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */; };
 		26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */; };
@@ -333,6 +334,7 @@
 		261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAction.swift; sourceTree = "<group>"; };
 		261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayStore.swift; sourceTree = "<group>"; };
+		261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayStoreTests.swift; sourceTree = "<group>"; };
 		261F94E3242EFA6D00762B58 /* ProductCategoryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryAction.swift; sourceTree = "<group>"; };
 		261F94E5242EFF8700762B58 /* ProductCategoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStore.swift; sourceTree = "<group>"; };
 		26577516243D5E42003168A5 /* ProductCategoryUpdated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryUpdated.swift; sourceTree = "<group>"; };
@@ -953,6 +955,7 @@
 				573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */,
 				7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */,
 				7455262F22305F88003F8932 /* OrderStatusStoreTests.swift */,
+				261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */,
 				744914F6224AD2AF00546DE4 /* ProductStoreTests.swift */,
 				D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */,
 				265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */,
@@ -1540,6 +1543,7 @@
 				0248B36B2459127200A271A4 /* MockupNetwork+Path.swift in Sources */,
 				B5C9DE252087FF20006B910A /* MockupProcessor.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
+				261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */,
 				02124DB02431C18700980D74 /* Media+ProductImageTests.swift in Sources */,
 				0248B3672459020500A271A4 /* ResultsController+FilterProductTests.swift in Sources */,
 				B54EAF2121188C470029C35E /* EntityListenerTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Networking
+
+/// Defines all of the `actions` supported by the `PaymentGatewayStore`.
+///
+public enum PaymentGatewayAction: Action {
+    /// Retrieves and stores all payment gateways for the provided `siteID`
+    ///
+    case synchronizePaymentGateways(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Networking
 
 /// Defines all of the `actions` supported by the `PaymentGatewayStore`.
 ///

--- a/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Networking
+import Storage
+
+/// Implements `PaymentGatewayAction` actions
+///
+public final class PaymentGatewayStore: Store {
+
+    private let remote: PaymentGatewayRemote
+
+    /// Shared private StorageType for use during then entire Orders sync process
+    ///
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.newDerivedStorage()
+    }()
+
+    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.remote = PaymentGatewayRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: PaymentGatewayAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? PaymentGatewayAction else {
+            assertionFailure("PaymentGatewayStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case let .synchronizePaymentGateways(siteID, onCompletion):
+            synchronizePaymentGateways(siteID: siteID, onCompletion: onCompletion)
+        }
+    }
+}
+
+// MARK: Storage Methods
+private extension PaymentGatewayStore {
+
+    /// Loads and stores all payment gateways for the provided `siteID`
+    func synchronizePaymentGateways(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        remote.loadAllPaymentGateways(siteID: siteID) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let paymentGateways):
+                self.upsertPaymentGatewaysInBackground(siteID: siteID, paymentGateways: paymentGateways) {
+                    onCompletion(.success(()))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly Payment Gateways Entities
+    /// *in a background thread*. `onCompletion` will be called on the main thread!
+    ///
+    func upsertPaymentGatewaysInBackground(siteID: Int64, paymentGateways: [PaymentGateway], onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform { [weak self] in
+            self?.upsertPaymentGateways(siteID: siteID, paymentGateways: paymentGateways)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly Payment Gateways Entities in the current thread
+    ///
+    func upsertPaymentGateways(siteID: Int64, paymentGateways: [PaymentGateway]) {
+        let derivedStorage = sharedDerivedStorage
+        for gateway in paymentGateways {
+            let storageGateway = derivedStorage.loadPaymentGateway(siteID: gateway.siteID, gatewayID: gateway.gatewayID) ??
+                derivedStorage.insertNewObject(ofType: Storage.PaymentGateway.self)
+            storageGateway.update(with: gateway)
+        }
+
+        // Now, remove any objects that exist in storage but not in paymentGateways
+        let storedGateways = derivedStorage.loadAllPaymentGateways(siteID: siteID)
+        storedGateways.forEach{ storedGateway in
+            if paymentGateways.contains(where: { $0.gatewayID == storedGateway.gatewayID }) {
+                derivedStorage.deleteObject(storedGateway)
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
@@ -86,7 +86,7 @@ private extension PaymentGatewayStore {
         // Now, remove any objects that exist in storage but not in paymentGateways
         let storedGateways = derivedStorage.loadAllPaymentGateways(siteID: siteID)
         storedGateways.forEach{ storedGateway in
-            if paymentGateways.contains(where: { $0.gatewayID == storedGateway.gatewayID }) {
+            if !paymentGateways.contains(where: { $0.gatewayID == storedGateway.gatewayID }) {
                 derivedStorage.deleteObject(storedGateway)
             }
         }

--- a/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayStore.swift
@@ -85,7 +85,7 @@ private extension PaymentGatewayStore {
 
         // Now, remove any objects that exist in storage but not in paymentGateways
         let storedGateways = derivedStorage.loadAllPaymentGateways(siteID: siteID)
-        storedGateways.forEach{ storedGateway in
+        storedGateways.forEach { storedGateway in
             if !paymentGateways.contains(where: { $0.gatewayID == storedGateway.gatewayID }) {
                 derivedStorage.deleteObject(storedGateway)
             }

--- a/Yosemite/YosemiteTests/Stores/PaymentGatewayStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/PaymentGatewayStoreTests.swift
@@ -7,7 +7,7 @@ import TestKit
 
 /// PaymentGatewayStore Unit Tests
 ///
-final class PaymentGatewayStoreTest: XCTestCase {
+final class PaymentGatewayStoreTests: XCTestCase {
 
     /// Mockup Dispatcher!
     ///
@@ -38,7 +38,7 @@ final class PaymentGatewayStoreTest: XCTestCase {
         network = MockupNetwork(useResponseQueue: true)
     }
 
-    func test_synchronize_gateways_correcly_persists_payment_gateways() throws {
+    func test_synchronize_gateways_correctly_persists_payment_gateways() throws {
         // Given
         let store = PaymentGatewayStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "payment_gateways", filename: "payment-gateway-list")
@@ -59,13 +59,13 @@ final class PaymentGatewayStoreTest: XCTestCase {
         XCTAssertNotNil(viewStorage.loadPaymentGateway(siteID: sampleSiteID, gatewayID: "cod"))
     }
 
-    func test_synchrone_gateways_correctly_deletes_stale_payment_gateways() throws {
+    func test_synchronize_gateways_correctly_deletes_stale_payment_gateways() throws {
         // Given
         let store = PaymentGatewayStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "payment_gateways", filename: "payment-gateway-list")
         network.simulateResponse(requestUrlSuffix: "payment_gateways", filename: "payment-gateway-list-half")
 
-        let firstSync = PaymentGatewayAction.synchronizePaymentGateways(siteID: self.sampleSiteID) { _ in }
+        let firstSync = PaymentGatewayAction.synchronizePaymentGateways(siteID: sampleSiteID) { _ in }
         store.onAction(firstSync)
 
         // When


### PR DESCRIPTION
fix #3110 

# Why

For the **Issue Refund** project, we need to know if a specific payment gateway supports to automatically refund money to the customer.

In order to do that, this PR synchronizes all payment gateways for site ID at launch.

# How

- Created `PaymentGatewayAction` and `PaymentGatewayStore` that adds synchronize payment gateway methods.
- Update `DefaultsStoreManager` to sync payment gateways on the `synchronizeEntities` method, which is called in the `AppDelegate` at launch.

# Testing Steps

**You can:**
- Launch the app
- See the payment gateways on any core data editor/visualizer

**Or**
- Replace the line `368` on `AppDelegate` with
```swift
        ServiceLocator.stores.synchronizeEntities(onCompletion: {
            let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
            let gateways = ServiceLocator.storageManager.viewStorage.loadAllPaymentGateways(siteID: siteID)
            print("-----------------------PAYMENT GATEWAYS----------------------")
            gateways.forEach {
                print($0.title)
            }
            print("-----------------------END PAYMENT GATEWAYS----------------------")
        })
```
- Launch the app
- See all payment gateways printed on the console

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
