### PR TITLE
UL&S: Remove mention to Jetpack and link to Jetpack's configuration instructions

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -76,8 +76,8 @@ private extension LoginPrologueViewController {
     func setupUpperLabel() {
         upperLabel.text = NSLocalizedString("Manage orders, track sales and monitor store activity with real-time alerts.", comment: "Login Prologue Legend")
         upperLabel.adjustsFontForContentSizeCategory = true
-        upperLabel.font = StyleManager.subheadlineBoldFont
-        upperLabel.textColor = .text
+        upperLabel.font = StyleManager.headlineSemiBold
+        upperLabel.textColor = .primary
     }
 
     func setupSlantedRectangle() {

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -46,13 +46,7 @@ final class LoginPrologueViewController: UIViewController {
         setupBackgroundView()
         setupContainerView()
         setupSlantedRectangle()
-        setupJetpackImage()
 
-        setupLabels()
-    }
-
-    private func setupLabels() {
-        setupDisclaimerLabel()
         setupUpperLabel()
     }
 
@@ -90,21 +84,6 @@ private extension LoginPrologueViewController {
         slantedRectangle.image = UIImage.slantedRectangle.withRenderingMode(.alwaysTemplate)
         slantedRectangle.tintColor = .authPrologueBottomBackgroundColor
     }
-
-    func setupJetpackImage() {
-        jetpackImageView.image = UIImage.jetpackLogoImage.imageWithTintColor(.white)
-    }
-
-    func setupDisclaimerLabel() {
-        disclaimerTextView.attributedText = disclaimerAttributedText
-        disclaimerTextView.adjustsFontForContentSizeCategory = true
-        disclaimerTextView.textContainerInset = .zero
-        disclaimerTextView.linkTextAttributes = [
-            .foregroundColor: UIColor.white,
-            .underlineColor: UIColor.white,
-            .underlineStyle: NSUnderlineStyle.single.rawValue
-        ]
-    }
 }
 
 
@@ -131,49 +110,5 @@ extension LoginPrologueViewController {
 
         safariViewController.modalPresentationStyle = .pageSheet
         present(safariViewController, animated: true, completion: nil)
-    }
-}
-
-
-// MARK: - Handling updated trait collections
-//
-extension LoginPrologueViewController {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            setupLabels()
-        }
-    }
-}
-
-
-// MARK: - Private Methods
-//
-private extension LoginPrologueViewController {
-
-    /// Returns the Disclaimer Attributed Text (which contains a link to the Jetpack Setup URL).
-    ///
-    var disclaimerAttributedText: NSAttributedString {
-        let disclaimerText = NSLocalizedString(
-            "This app requires Jetpack to connect to your Store. <br /> Read the <a " +
-                "href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
-            comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. " +
-            "Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. " +
-            "Place the second sentence after the `<br />` tag. " +
-            "Place the noun, \'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. " +
-            "If a literal translation of 'Read the configuration instructions' does not make sense in your language, " +
-            "please use a contextually appropriate substitution. " +
-            "For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
-        )
-        let disclaimerAttributes: [NSAttributedString.Key: Any] = [
-            .font: StyleManager.thinCaptionFont,
-            .foregroundColor: UIColor.white
-        ]
-
-        let disclaimerAttrText = NSMutableAttributedString()
-        disclaimerAttrText.append(disclaimerText.htmlToAttributedString)
-        disclaimerAttrText.addAttributes(disclaimerAttributes, range: NSRange(location: 0, length: disclaimerAttrText.length))
-
-        return disclaimerAttrText
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,8 +12,6 @@
             <connections>
                 <outlet property="backgroundView" destination="3vu-Xh-Yk9" id="SU5-64-Opq"/>
                 <outlet property="containerView" destination="o29-Vv-KDs" id="U7h-cw-w9k"/>
-                <outlet property="disclaimerTextView" destination="vue-fy-kfo" id="Pph-D3-yFK"/>
-                <outlet property="jetpackImageView" destination="ua7-QM-6C0" id="EZJ-r0-klP"/>
                 <outlet property="slantedRectangle" destination="Rhn-8s-tRs" id="dC6-d7-uzp"/>
                 <outlet property="upperLabel" destination="n36-ix-D75" id="crr-RQ-Us6"/>
                 <outlet property="view" destination="V2X-Xj-JeZ" id="Vob-Ki-8K1"/>
@@ -26,44 +24,14 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3vu-Xh-Yk9" userLabel="Bottom View">
                     <rect key="frame" x="0.0" y="862" width="414" height="34"/>
-                    <color key="backgroundColor" red="0.55453354120254517" green="0.35826593637466431" blue="0.52943503856658936" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <viewLayoutGuide key="safeArea" id="tzS-rk-lug"/>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o29-Vv-KDs" userLabel="Container View">
-                    <rect key="frame" x="0.0" y="755.5" width="414" height="106.5"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-jetpack-gray" translatesAutoresizingMaskIntoConstraints="NO" id="ua7-QM-6C0">
-                            <rect key="frame" x="20" y="20" width="20" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="20" id="1sl-aL-ruy"/>
-                                <constraint firstAttribute="width" constant="20" id="nqC-Mn-V1d"/>
-                            </constraints>
-                        </imageView>
-                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="scrollableAxes" bouncesZoom="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="vue-fy-kfo">
-                            <rect key="frame" x="50" y="20" width="344" height="66.5"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <string key="text">L1
-L2
-L3</string>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            <dataDetectorType key="dataDetectorTypes" link="YES"/>
-                            <connections>
-                                <outlet property="delegate" destination="-1" id="9tD-Ce-KS4"/>
-                            </connections>
-                        </textView>
-                    </subviews>
                     <color key="backgroundColor" red="0.55453354120254517" green="0.35826593637466431" blue="0.52943503856658936" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                    <constraints>
-                        <constraint firstItem="vue-fy-kfo" firstAttribute="leading" secondItem="ua7-QM-6C0" secondAttribute="trailing" constant="10" id="2Yg-40-duj"/>
-                        <constraint firstAttribute="bottom" secondItem="vue-fy-kfo" secondAttribute="bottom" constant="20" id="5zQ-nw-m4f"/>
-                        <constraint firstAttribute="trailing" secondItem="vue-fy-kfo" secondAttribute="trailing" constant="20" id="R7H-B6-HbM"/>
-                        <constraint firstItem="ua7-QM-6C0" firstAttribute="top" secondItem="o29-Vv-KDs" secondAttribute="top" constant="20" id="VZk-aL-Jh7"/>
-                        <constraint firstItem="vue-fy-kfo" firstAttribute="top" secondItem="ua7-QM-6C0" secondAttribute="top" id="hro-Pt-llj"/>
-                        <constraint firstItem="ua7-QM-6C0" firstAttribute="leading" secondItem="o29-Vv-KDs" secondAttribute="leading" constant="20" id="wt3-Fc-eK8"/>
-                    </constraints>
                 </view>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1" image="prologue-slanted-rectangle" translatesAutoresizingMaskIntoConstraints="NO" id="Rhn-8s-tRs" userLabel="Slanted ImageView">
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o29-Vv-KDs" userLabel="Container View">
+                    <rect key="frame" x="0.0" y="755.5" width="414" height="106.5"/>
+                    <color key="backgroundColor" red="0.55453354120254517" green="0.35826593637466431" blue="0.52943503856658936" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                </view>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1" ambiguous="YES" image="prologue-slanted-rectangle" translatesAutoresizingMaskIntoConstraints="NO" id="Rhn-8s-tRs" userLabel="Slanted ImageView">
                     <rect key="frame" x="0.0" y="595.5" width="414" height="160"/>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="200" image="prologue-bubbles" translatesAutoresizingMaskIntoConstraints="NO" id="pzF-Fz-byr" userLabel="Bubbles View">
@@ -86,6 +54,7 @@ L3</string>
                     </constraints>
                 </imageView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="3oc-0l-uZX"/>
             <constraints>
                 <constraint firstItem="pzF-Fz-byr" firstAttribute="centerY" secondItem="V2X-Xj-JeZ" secondAttribute="centerY" priority="750" id="6Eb-jV-s6M"/>
                 <constraint firstAttribute="bottom" secondItem="3vu-Xh-Yk9" secondAttribute="bottom" id="DQs-9H-0q1"/>
@@ -109,7 +78,6 @@ L3</string>
                 <constraint firstItem="o29-Vv-KDs" firstAttribute="bottom" secondItem="3oc-0l-uZX" secondAttribute="bottom" id="yj6-tl-g4o"/>
                 <constraint firstItem="3vu-Xh-Yk9" firstAttribute="trailing" secondItem="V2X-Xj-JeZ" secondAttribute="trailing" id="zQC-U3-vhG"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="3oc-0l-uZX"/>
             <variation key="default">
                 <mask key="constraints">
                     <exclude reference="cTv-I1-UNU"/>
@@ -119,7 +87,6 @@ L3</string>
         </view>
     </objects>
     <resources>
-        <image name="icon-jetpack-gray" width="72" height="72"/>
         <image name="prologue-bubbles" width="108" height="175"/>
         <image name="prologue-logo" width="263" height="54"/>
         <image name="prologue-slanted-rectangle" width="375" height="160"/>


### PR DESCRIPTION
Closes #3128 

⚠️ Please notice this PR is not against `develop`, but against the feature branch for UL&S 🙇 

# Changes

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/98886118-59008000-24ce-11eb-89d6-39fe0dcc5061.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/98886121-5bfb7080-24ce-11eb-8320-bd443efcb166.png" width="350"/> |

* The area where Jetpack was mentioned is removed. 
* Some code that dealt with dynamic type, and that is not necessary anymore, is also removed.

The design (notice the link to Jetpack is missing):
<img src="https://user-images.githubusercontent.com/2722505/98886167-77667b80-24ce-11eb-99b5-85d10af20a57.png" width="350"/>

The order of the buttons at the bottom is a separate ticket: #3128 

# Testing
* Checkout the branch, build and run.
* Log out if necessary.
* Attempt to log in again. Notice if the reference to Jetpack is gone from the login prologue
* Change font sizes. The label "Manage orders..." should change its font size.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
