### PR TITLE
UL&S: Update copy for login with WordPress - Enter email

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -11,6 +11,12 @@ struct AuthenticationConstants {
         comment: "Sign in instructions on the 'log in using email' screen."
     )
 
+    /// Get started instructions (Continue with WordPress.com)
+    ///
+    static let getStartedInstructions = NSLocalizedString(
+        "Log in with your WordPress.com account email address to manage your WooCommerce stores.",
+        comment: "Sign in instructions on the 'log in using WordPress.com account' screen."
+    )
     /// Login with Jetpack instructions.
     ///
     static let jetpackInstructions = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -76,6 +76,7 @@ class AuthenticationManager: Authentication {
                                                 statusBarStyle: .default)
 
         let displayStrings = WordPressAuthenticatorDisplayStrings(emailLoginInstructions: AuthenticationConstants.emailInstructions,
+                                                                  getStartedInstructions: AuthenticationConstants.getStartedInstructions,
                                                                   jetpackLoginInstructions: AuthenticationConstants.jetpackInstructions,
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions)


### PR DESCRIPTION
Closes #3118 

⚠️ Please note this PR is not against develop, but against the feature branch for UL&S 🙇

# Changes
* Added a specific new string to the set of strings provided to WPAuthenticator

Also, note that removing the link to the terms of service is deferred to #3145

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/98904753-2ddd5700-24f5-11eb-854b-3f7c641dc447.png" width="350"/> |  <img src="https://user-images.githubusercontent.com/2722505/98904797-4188bd80-24f5-11eb-83b7-7378243deb01.png" width="350"/> |

# Testing
* Checkout the branch, build and run.
* Log off if necessary.
* Start the login flow, select "Continue with WordPress.com"
* Check the copy in the "Enter email" screen.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
