### PR TITLE
The Date Picker is presented in a modal view on iOS 14

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,12 @@
+*** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+
+5.6
+-----
+- [*] now the date pickers on iOS 14 are opened as modal view.
+
+
 5.5
 -----
- 
-*** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 - [**] Products M4 features are now available to all. Products M4 features: add a simple/grouped/external product with actions to publish or save as draft. [https://github.com/woocommerce/woocommerce-ios/pull/3133]
 - [*] enhancement: Order details screen now shows variation attributes for WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3109]
 - [*] fix: Product detail screen now includes the number of ratings for that product. [https://github.com/woocommerce/woocommerce-ios/pull/3089]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 5.6
 -----
-- [*] now the date pickers on iOS 14 are opened as modal view.
+- [*] now the date pickers on iOS 14 are opened as modal view. [https://github.com/woocommerce/woocommerce-ios/pull/3148]
 
 
 5.5

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
@@ -28,7 +28,7 @@ extension DatePickerTableViewCell {
 
     static func getDefaultCellHeight() -> CGFloat {
         if #available(iOS 14, *) {
-            return CGFloat(380)
+            return CGFloat(50)
         }
 
         return CGFloat(216)
@@ -42,7 +42,7 @@ private extension DatePickerTableViewCell {
 
     func configureDatePicker() {
         if #available(iOS 14, *) {
-            picker.preferredDatePickerStyle = .inline
+            picker.preferredDatePickerStyle = .compact
         }
     }
 }


### PR DESCRIPTION
Fixes #3138 
Fixes #3137 

As discussed here p5T066-1Bt#comment-6220 and [here](https://a8c.slack.com/archives/C6H8C3G23/p1605102505396700) and as proposed by @Garance91540, now we show the date picker on iOS 14 as a modal view and not inline like the previous behavior.

## Testing
1. Run the app on iOS 14.
2. Open a product, try to schedule a sale price. -> On iOS 14 the date picker should be presented modally if you try to edit the date.
3. Try from an order detail, to add tracking. -> On iOS 14 the date picker should be presented modally if you try to edit the date.

## Screenshots
| Schedule sale price | Modal picker selector | Add Tracking |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-11-12 at 14 09 43](https://user-images.githubusercontent.com/495617/98947494-94fb0b80-24f5-11eb-8f4e-67e5d33b7232.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-11-12 at 14 09 46](https://user-images.githubusercontent.com/495617/98947503-97f5fc00-24f5-11eb-9bc6-e1ed34f3d4b1.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-11-12 at 14 10 08](https://user-images.githubusercontent.com/495617/98947509-9b898300-24f5-11eb-848b-de4f701f7177.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
