### PR TITLE
[Issue Refunds] Display payment gateway

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -158,9 +158,9 @@ private extension IssueRefundViewModel {
     /// Results controller that fetches the payment gateway used on this order.
     ///
     func createPaymentGatewayResultsController() -> ResultsController<StoragePaymentGateway> {
-            let predicate = NSPredicate(format: "siteID == %lld AND gatewayID == %@", state.order.siteID, state.order.paymentMethodID)
-            return ResultsController<StoragePaymentGateway>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
-        }
+        let predicate = NSPredicate(format: "siteID == %lld AND gatewayID == %@", state.order.siteID, state.order.paymentMethodID)
+        return ResultsController<StoragePaymentGateway>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -69,6 +69,14 @@ final class IssueRefundViewModel {
         return resultsController.fetchedObjects
     }()
 
+    /// Payment Gateway related to the order. Needed to build `Refund Via` section.
+    ///
+    private lazy var paymentGateway: PaymentGateway? = {
+        let resultsController = createPaymentGatewayResultsController()
+        try? resultsController.performFetch()
+        return resultsController.fetchedObjects.first
+    }()
+
     init(order: Order, refunds: [Refund], currencySettings: CurrencySettings) {
         let items = Self.filterItems(from: order, with: refunds)
         state = State(order: order, itemsToRefund: items, currencySettings: currencySettings)
@@ -84,7 +92,8 @@ final class IssueRefundViewModel {
         let details = RefundConfirmationViewModel.Details(order: state.order,
                                                           amount: "\(calculateRefundTotal())",
                                                           refundsShipping: state.shouldRefundShipping,
-                                                          items: state.refundQuantityStore.refundableItems())
+                                                          items: state.refundQuantityStore.refundableItems(),
+                                                          paymentGateway: paymentGateway)
         return RefundConfirmationViewModel(details: details, currencySettings: state.currencySettings)
     }
 }
@@ -145,6 +154,13 @@ private extension IssueRefundViewModel {
         let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", state.order.siteID, itemsIDs)
         return ResultsController<StorageProduct>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
+
+    /// Results controller that fetches the payment gateway used on this order.
+    ///
+    func createPaymentGatewayResultsController() -> ResultsController<StoragePaymentGateway> {
+            let predicate = NSPredicate(format: "siteID == %lld AND gatewayID == %@", state.order.siteID, state.order.paymentMethodID)
+            return ResultsController<StoragePaymentGateway>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
+        }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -44,7 +44,8 @@ private extension RefundConfirmationViewController {
         [
             SettingTitleAndValueTableViewCell.self,
             TitleAndEditableValueTableViewCell.self,
-            HeadlineLabelTableViewCell.self
+            HeadlineLabelTableViewCell.self,
+            WooBasicTableViewCell.self
         ].forEach(tableView.registerNib)
 
         // Delegation
@@ -105,6 +106,11 @@ extension RefundConfirmationViewController: UITableViewDataSource {
             let cell = tableView.dequeueReusableCell(HeadlineLabelTableViewCell.self, for: indexPath)
             cell.update(style: .regular, headline: row.title, body: row.body)
             cell.selectionStyle = .none
+            return cell
+        case let row as RefundConfirmationViewModel.SimpleTextRow:
+            let cell = tableView.dequeueReusableCell(WooBasicTableViewCell.self, for: indexPath)
+            cell.applyPlainTextStyle()
+            cell.bodyLabel.text = row.text
             return cell
         default:
             assertionFailure("Unsupported row.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -47,8 +47,7 @@ final class RefundConfirmationViewModel {
         Section(
             title: Localization.refundVia,
             rows: [
-                TitleAndBodyRow(title: Localization.manualRefund(via: "Stripe"),
-                                body: Localization.refundWillNotBeIssued(paymentMethod: "Stripe"))
+                makeRefundViaRow()
             ]
         )
     ]
@@ -97,6 +96,17 @@ private extension RefundConfirmationViewModel {
         let totalRefunded = useCase.totalRefunded().abs()
         let totalRefundedFormatted = currencyFormatter.formatAmount(totalRefunded) ?? ""
         return TwoColumnRow(title: Localization.previouslyRefunded, value: totalRefundedFormatted, isHeadline: false)
+    }
+
+    /// Returns a row with special formatting if the payment gateway does not supports automatic money refunds.
+    ///
+    func makeRefundViaRow() -> RefundConfirmationViewModelRow {
+        if gatewaySupportsAutomaticRefunds() {
+            return TitleAndBodyRow(title: details.order.paymentMethodTitle, body: nil)
+        } else {
+            return TitleAndBodyRow(title: Localization.manualRefund(via: details.order.paymentMethodTitle),
+                                   body: Localization.refundWillNotBeIssued(paymentMethod: details.order.paymentMethodTitle))
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -94,7 +94,7 @@ private extension RefundConfirmationViewModel {
         return TwoColumnRow(title: Localization.previouslyRefunded, value: totalRefundedFormatted, isHeadline: false)
     }
 
-    /// Returns a row with special formatting if the payment gateway does not supports automatic money refunds.
+    /// Returns a row with special formatting if the payment gateway does not support automatic money refunds.
     ///
     func makeRefundViaRow() -> RefundConfirmationViewModelRow {
         if gatewaySupportsAutomaticRefunds() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -15,14 +15,6 @@ final class RefundConfirmationViewModel {
     ///
     private let details: Details
 
-    /// Payment Gateway related to the order. Needed to build `Refund Via` section.
-    ///
-    private lazy var paymentGateway: PaymentGateway? = {
-        let resultsController = createPaymentGatewayResultsController()
-        try? resultsController.performFetch()
-        return resultsController.fetchedObjects.first
-    }()
-
     /// Amount currency formatter
     ///
     private let currencyFormatter: CurrencyFormatter
@@ -85,6 +77,10 @@ extension RefundConfirmationViewModel {
         /// Order items and quantities to refund
         ///
         let items: [RefundableOrderItem]
+
+        /// Payment gateway used with the order
+        ///
+        let paymentGateway: PaymentGateway?
     }
 }
 
@@ -116,20 +112,10 @@ private extension RefundConfirmationViewModel {
     /// If no payment gateway is found, `false` will be returned.
     ///
     func gatewaySupportsAutomaticRefunds() -> Bool {
-        guard let paymentGateway = paymentGateway else {
+        guard let paymentGateway = details.paymentGateway else {
             return false
         }
         return paymentGateway.features.contains(.refunds)
-    }
-}
-
-// MARK: Results Controller
-private extension RefundConfirmationViewModel {
-    /// Results controller that fetches the payment gateway related to this order
-    ///
-    func createPaymentGatewayResultsController() -> ResultsController<StoragePaymentGateway> {
-        let predicate = NSPredicate(format: "siteID == %lld AND gatewayID == %@", details.order.siteID, details.order.paymentMethodID)
-        return ResultsController<StoragePaymentGateway>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -98,7 +98,7 @@ private extension RefundConfirmationViewModel {
     ///
     func makeRefundViaRow() -> RefundConfirmationViewModelRow {
         if gatewaySupportsAutomaticRefunds() {
-            return TitleAndBodyRow(title: details.order.paymentMethodTitle, body: nil)
+            return SimpleTextRow(text: details.order.paymentMethodTitle)
         } else {
             return TitleAndBodyRow(title: Localization.manualRefund(via: details.order.paymentMethodTitle),
                                    body: Localization.refundWillNotBeIssued(paymentMethod: details.order.paymentMethodTitle))
@@ -149,6 +149,11 @@ extension RefundConfirmationViewModel {
     struct TitleAndBodyRow: RefundConfirmationViewModelRow {
         let title: String
         let body: String?
+    }
+
+    /// A row that shows a simple text on it.
+    struct SimpleTextRow: RefundConfirmationViewModelRow {
+        let text: String
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -22,7 +22,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         ]
         let order = MockOrders().empty().copy(refunds: refundItems)
 
-        let details = RefundConfirmationViewModel.Details(order: order, amount: "0.0", refundsShipping: false, items: [])
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "0.0", refundsShipping: false, items: [], paymentGateway: nil)
 
         let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
 
@@ -43,12 +43,48 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                                                 numberOfDecimals: 2)
 
         let order = MockOrders().empty()
-        let details = RefundConfirmationViewModel.Details(order: order, amount: "130.3473", refundsShipping: false, items: [])
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "130.3473", refundsShipping: false, items: [], paymentGateway: nil)
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, currencySettings: currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.refundAmount, "$130.35")
+    }
+
+    func test_viewModel_has_automatic_refundVia_values_when_using_a_gateway_that_support_refunds() throws {
+        // Given
+        let order = MockOrders().empty().copy(paymentMethodID: "stipe", paymentMethodTitle: "Stripe")
+        let gateway = PaymentGateway(siteID: 123, gatewayID: "stripe", title: "Stripe", description: "", enabled: true, features: [.refunds])
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "", refundsShipping: false, items: [], paymentGateway: gateway)
+
+        // When
+        let viewModel = RefundConfirmationViewModel(details: details)
+
+        // We expect the Refund Via row to be the last item in the last row.
+        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
+
+        // Then
+        XCTAssertEqual(row.title, gateway.title)
+        XCTAssertNil(row.body)
+    }
+
+    func test_viewModel_has_manual_refundVia_values_when_using_a_gateway_that_does_not_support_refunds() throws {
+        // Given
+        let order = MockOrders().empty().copy(paymentMethodID: "stipe", paymentMethodTitle: "Stripe")
+        let gateway = PaymentGateway(siteID: 123, gatewayID: "stripe", title: "Stripe", description: "", enabled: true, features: [])
+        let details = RefundConfirmationViewModel.Details(order: order, amount: "", refundsShipping: false, items: [], paymentGateway: gateway)
+
+        // When
+        let viewModel = RefundConfirmationViewModel(details: details)
+
+        // We expect the Refund Via row to be the last item in the last row.
+        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
+
+        // Then
+        let title = NSLocalizedString("Manual Refund via Stripe", comment: "")
+        let body = NSLocalizedString("A refund will not be issued to the customer. You will need to manually issue the refund through Stripe.", comment: "")
+        XCTAssertEqual(row.title, title)
+        XCTAssertEqual(row.body, body)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -65,7 +65,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
 
         // Then
-        XCTAssertEqual(row.title, gateway.title)
+        XCTAssertEqual(row.title, order.paymentMethodTitle)
         XCTAssertNil(row.body)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -62,11 +62,10 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let viewModel = RefundConfirmationViewModel(details: details)
 
         // We expect the Refund Via row to be the last item in the last row.
-        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.TitleAndBodyRow)
+        let row = try XCTUnwrap(viewModel.sections.last?.rows.last as? RefundConfirmationViewModel.SimpleTextRow)
 
         // Then
-        XCTAssertEqual(row.title, order.paymentMethodTitle)
-        XCTAssertNil(row.body)
+        XCTAssertEqual(row.text, order.paymentMethodTitle)
     }
 
     func test_viewModel_has_manual_refundVia_values_when_using_a_gateway_that_does_not_support_refunds() throws {


### PR DESCRIPTION
closes #2892

# Why
After [syncing all payment gateways](https://github.com/woocommerce/woocommerce-ios/issues/3110) we can query the order's payment gateway to display information on how the refund will be made.

# How
- Fetch the payment gateway using the order's `paymentGatewayID` on `IssueRefundViewModel`
- On `RefundConfirmationViewModel` decide which "refund via" string to show depending on the payment gateway automatic refund support.


# Screenshots
Automatic | Manual
---- | ----
<img width="386" alt="automatic" src="https://user-images.githubusercontent.com/562080/99124486-466e6f80-25d0-11eb-8edc-2d9232fe577f.png"> | <img width="390" alt="manual" src="https://user-images.githubusercontent.com/562080/99124483-44a4ac00-25d0-11eb-9bb9-3f1bdc81d28b.png">

# Testing Steps

1.
- Go to an order that was made with stripe(or a gateway that does not support automatic refunds)
- Tap the Issue Refund button
- Select some items to refund and tap next
- See that the refund via information shows the correct payment gateway

2.
- Go to an order that was made with bank transfer(or a gateway that does support automatic refunds)
- Tap the Issue Refund button
- Select some items to refund and tap next
- See that the refund via information shows the payment gateway with the manual refund disclaimer


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
