### PR TITLE
Edit Products: show the Linked products cell in Product Detail settings and inside the bottom action sheet

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -231,6 +231,12 @@ extension UIImage {
         return UIImage.gridicon(.listCheckmark, size: CGSize(width: 24, height: 24))
     }
 
+    /// Linked Products Icon
+    ///
+    static var linkedProductsImage: UIImage {
+        return UIImage.gridicon(.reblog, size: CGSize(width: 24, height: 24))
+    }
+
     /// Jetpack Logo Image
     ///
     static var jetpackLogoImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
@@ -9,6 +9,7 @@ enum ProductFormBottomSheetAction {
     case editTags
     case editShortDescription
     case editSKU
+    case editLinkedProducts
 
     init?(productFormAction: ProductFormEditAction) {
         switch productFormAction {
@@ -24,6 +25,8 @@ enum ProductFormBottomSheetAction {
             self = .editShortDescription
         case .sku:
             self = .editSKU
+        case .linkedProducts:
+            self = .editLinkedProducts
         default:
             return nil
         }
@@ -51,6 +54,9 @@ extension ProductFormBottomSheetAction {
         case .editSKU:
             return NSLocalizedString("SKU",
                                      comment: "Title of the product form bottom sheet action for editing short description.")
+        case .editLinkedProducts:
+            return NSLocalizedString("Linked products",
+                                     comment: "Title of the product form bottom sheet action for editing linked products.")
         }
     }
 
@@ -74,7 +80,9 @@ extension ProductFormBottomSheetAction {
         case .editSKU:
             return NSLocalizedString("Easily identify your products with unique codes",
                                      comment: "Subtitle of the product form bottom sheet action for editing SKU.")
-
+        case .editLinkedProducts:
+            return NSLocalizedString("Increase sales with upsells and cross-sells",
+                                     comment: "Subtitle of the product form bottom sheet action for linked products.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -578,7 +578,7 @@ private extension DefaultProductFormTableViewModel {
                                                            comment: "Format of the number of Downloadable Files row in the plural form. Reads, `5 files`")
 
         // Linked Products
-        static let linkedProductsTitle = NSLocalizedString("Linked Products",
+        static let linkedProductsTitle = NSLocalizedString("Linked products",
                                                            comment: "Title of the Linked Products row on Product main screen")
         static let singularUpsellProductFormat =
             NSLocalizedString("%ld upsell product",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -432,12 +432,10 @@ private extension DefaultProductFormTableViewModel {
         let icon = UIImage.linkedProductsImage
         let title = Localization.linkedProductsTitle
 
-        var linkedProductsDetails = [String]()
-
-        linkedProductsDetails.append(Localization.upsellProducts(count: product.upsellIDs.count))
-        linkedProductsDetails.append(Localization.crossSellProducts(count: product.crossSellIDs.count))
-
-        let details = linkedProductsDetails.isEmpty ? nil : linkedProductsDetails.joined(separator: "\n")
+        let details = [
+            Localization.upsellProducts(count: product.upsellIDs.count),
+            Localization.crossSellProducts(count: product.crossSellIDs.count),
+        ].joined(separator: "\n")
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -434,19 +434,9 @@ private extension DefaultProductFormTableViewModel {
 
         var linkedProductsDetails = [String]()
 
-        if product.upsellIDs.count <= 1 {
-            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.singularUpsellProductFormat, product.upsellIDs.count))
-        }
-        else {
-            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.pluralUpsellProductsFormat, product.upsellIDs.count))
-        }
+        linkedProductsDetails.append(Localization.upsellProducts(count: product.upsellIDs.count))
+        linkedProductsDetails.append(Localization.crossSellProducts(count: product.crossSellIDs.count))
 
-        if product.crossSellIDs.count <= 1 {
-            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.singularCrossSellProductFormat, product.crossSellIDs.count))
-        }
-        else {
-            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.pluralCrossSellProductsFormat, product.crossSellIDs.count))
-        }
         let details = linkedProductsDetails.isEmpty ? nil : linkedProductsDetails.joined(separator: "\n")
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
@@ -580,17 +570,31 @@ private extension DefaultProductFormTableViewModel {
         // Linked Products
         static let linkedProductsTitle = NSLocalizedString("Linked products",
                                                            comment: "Title of the Linked Products row on Product main screen")
-        static let singularUpsellProductFormat =
-            NSLocalizedString("%ld upsell product",
-                              comment: "Format of upsell linked products row in the singular form. Reads, `1 upsell product`")
-        static let pluralUpsellProductsFormat =
-            NSLocalizedString("%ld upsell products",
-                              comment: "Format of upsell linked products row in the plural form. Reads, `5 upsell products`")
-        static let singularCrossSellProductFormat =
-            NSLocalizedString("%ld cross-sell product",
-                              comment: "Format of cross-sell linked products row in the singular form. Reads, `1 cross-sell product`")
-        static let pluralCrossSellProductsFormat =
-            NSLocalizedString("%ld cross-sell products",
-                              comment: "Format of cross-sell linked products row in the plural form. Reads, `5 cross-sell products`")
+        static func upsellProducts(count: Int) -> String {
+            let format: String = {
+                if count <= 1 {
+                    return NSLocalizedString("%ld upsell product",
+                                             comment: "Format of upsell linked products row in the singular form. Reads, `1 upsell product`")
+                } else {
+                    return NSLocalizedString("%ld upsell products",
+                                             comment: "Format of upsell linked products row in the plural form. Reads, `5 upsell products`")
+                }
+            }()
+
+            return String.localizedStringWithFormat(format, count)
+        }
+        static func crossSellProducts(count: Int) -> String {
+            let format: String = {
+                if count <= 1 {
+                    return NSLocalizedString("%ld cross-sell product",
+                                             comment: "Format of cross-sell linked products row in the singular form. Reads, `1 cross-sell product`")
+                } else {
+                    return NSLocalizedString("%ld cross-sell products",
+                                             comment: "Format of cross-sell linked products row in the plural form. Reads, `5 cross-sell products`")
+                }
+            }()
+
+            return String.localizedStringWithFormat(format, count)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -86,6 +86,8 @@ private extension DefaultProductFormTableViewModel {
                 return .variations(viewModel: variationsRow(product: product.product))
             case .downloadableFiles:
                 return .downloadableFiles(viewModel: downloadsRow(product: product))
+            case .linkedProducts(let editable):
+                return .linkedProducts(viewModel: linkedProductsRow(product: product, isEditable: editable), isEditable: editable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -423,6 +425,35 @@ private extension DefaultProductFormTableViewModel {
                                                         title: title,
                                                         details: details)
     }
+
+    // MARK: Linked products only
+
+    func linkedProductsRow(product: ProductFormDataModel, isEditable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.linkedProductsImage
+        let title = Localization.linkedProductsTitle
+
+        var linkedProductsDetails = [String]()
+
+        if product.upsellIDs.count <= 1 {
+            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.singularUpsellProductFormat, product.upsellIDs.count))
+        }
+        else {
+            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.pluralUpsellProductsFormat, product.upsellIDs.count))
+        }
+
+        if product.crossSellIDs.count <= 1 {
+            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.singularCrossSellProductFormat, product.crossSellIDs.count))
+        }
+        else {
+            linkedProductsDetails.append(String.localizedStringWithFormat(Localization.pluralCrossSellProductsFormat, product.crossSellIDs.count))
+        }
+        let details = linkedProductsDetails.isEmpty ? nil : linkedProductsDetails.joined(separator: "\n")
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details,
+                                                        isActionable: isEditable)
+    }
 }
 
 private extension DefaultProductFormTableViewModel {
@@ -545,5 +576,21 @@ private extension DefaultProductFormTableViewModel {
                                                                comment: "Format of the number of Downloadable Files row in the singular form. Reads, `1 file`")
         static let pluralDownloadsFormat = NSLocalizedString("%ld files",
                                                            comment: "Format of the number of Downloadable Files row in the plural form. Reads, `5 files`")
+
+        // Linked Products
+        static let linkedProductsTitle = NSLocalizedString("Linked Products",
+                                                           comment: "Title of the Linked Products row on Product main screen")
+        static let singularUpsellProductFormat =
+            NSLocalizedString("%ld upsell product",
+                              comment: "Format of upsell linked products row in the singular form. Reads, `1 upsell product`")
+        static let pluralUpsellProductsFormat =
+            NSLocalizedString("%ld upsell products",
+                              comment: "Format of upsell linked products row in the plural form. Reads, `5 upsell products`")
+        static let singularCrossSellProductFormat =
+            NSLocalizedString("%ld cross-sell product",
+                              comment: "Format of cross-sell linked products row in the singular form. Reads, `1 cross-sell product`")
+        static let pluralCrossSellProductsFormat =
+            NSLocalizedString("%ld cross-sell products",
+                              comment: "Format of cross-sell linked products row in the plural form. Reads, `5 cross-sell products`")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -143,6 +143,14 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.downloadExpiry
     }
 
+    var upsellIDs: [Int64] {
+        product.upsellIDs
+    }
+
+    var crossSellIDs: [Int64] {
+        product.crossSellIDs
+    }
+
     func isStockStatusEnabled() -> Bool {
         // Only a variable product's stock status is not editable.
         productType != .variable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -171,6 +171,14 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.downloadExpiry
     }
 
+    var upsellIDs: [Int64] {
+        []
+    }
+
+    var crossSellIDs: [Int64] {
+        []
+    }
+
     // Visibility logic
 
     func allowsMultipleImages() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -105,8 +105,8 @@ private extension ProductFormActionsFactory {
             .tags(editable: editable),
             shouldShowDownloadableProduct ? .downloadableFiles: nil,
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil,
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -126,8 +126,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil,
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -145,8 +145,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil,
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -164,8 +164,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil,
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -182,8 +182,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            .productType(editable: false),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .productType(editable: false)
         ]
         return actions.compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -13,6 +13,7 @@ enum ProductFormEditAction: Equatable {
     case categories(editable: Bool)
     case tags(editable: Bool)
     case shortDescription(editable: Bool)
+    case linkedProducts(editable: Bool)
     // Affiliate products only
     case sku(editable: Bool)
     case externalURL(editable: Bool)
@@ -92,7 +93,8 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowProductTypeRow = formType != .add
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
-        let showDownloadableProduct = isEditProductsRelease5Enabled && product.downloadable
+        let shouldShowDownloadableProduct = isEditProductsRelease5Enabled && product.downloadable
+        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
@@ -101,9 +103,10 @@ private extension ProductFormActionsFactory {
             .inventorySettings(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
-            showDownloadableProduct ? .downloadableFiles: nil,
+            shouldShowDownloadableProduct ? .downloadableFiles: nil,
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil
+            shouldShowProductTypeRow ? .productType(editable: editable): nil,
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -113,6 +116,7 @@ private extension ProductFormActionsFactory {
         let shouldShowExternalURLRow = editable || product.product.externalURL?.isNotEmpty == true
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let shouldShowProductTypeRow = formType != .add
+        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
@@ -122,7 +126,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil
+            shouldShowProductTypeRow ? .productType(editable: editable): nil,
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -131,6 +136,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let shouldShowProductTypeRow = formType != .add
+        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts(editable: editable),
@@ -139,7 +145,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil
+            shouldShowProductTypeRow ? .productType(editable: editable): nil,
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -147,6 +154,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowProductTypeRow = formType != .add
+        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .variations,
@@ -156,7 +164,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowProductTypeRow ? .productType(editable: editable): nil
+            shouldShowProductTypeRow ? .productType(editable: editable): nil,
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -164,6 +173,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: false): nil,
@@ -172,7 +182,8 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            .productType(editable: false)
+            .productType(editable: false),
+            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil
         ]
         return actions.compactMap { $0 }
     }
@@ -208,6 +219,8 @@ private extension ProductFormActionsFactory {
             return product.product.categories.isNotEmpty
         case .tags:
             return product.product.tags.isNotEmpty
+        case .linkedProducts:
+            return isEditProductsRelease5Enabled && (product.upsellIDs.count > 0 || product.crossSellIDs.count > 0)
         // Downloadable files. Only core product types for downloadable files are able to handle downloadable files.
         case .downloadableFiles:
             return isEditProductsRelease5Enabled && product.downloadable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -60,6 +60,10 @@ protocol ProductFormDataModel {
     var downloadableFiles: [ProductDownload] { get }
     var downloadLimit: Int64 { get }
     var downloadExpiry: Int64 { get }
+
+    // Linked Products
+    var upsellIDs: [Int64] { get }
+    var crossSellIDs: [Int64] { get }
 }
 
 // MARK: Helpers that can be derived from `ProductFormDataModel`

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -68,6 +68,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .groupedProducts,
              .variations,
              .downloadableFiles,
+             .linkedProducts,
              .status,
              .noPriceWarning:
             return [ImageAndTitleAndTextTableViewCell.self]
@@ -94,6 +95,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .groupedProducts,
              .variations,
              .downloadableFiles,
+             .linkedProducts,
              .status,
              .noPriceWarning:
             return ImageAndTitleAndTextTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -217,6 +217,7 @@ private extension ProductFormTableViewDataSource {
              .sku(let viewModel, _),
              .groupedProducts(let viewModel, _),
              .downloadableFiles(let viewModel),
+             .linkedProducts(let viewModel, _),
              .variations(let viewModel):
             configureSettings(cell: cell, viewModel: viewModel)
         case .reviews(let viewModel, let ratingCount, let averageRating):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -37,6 +37,7 @@ enum ProductFormSection: Equatable {
         case downloadableFiles(viewModel: ViewModel)
         case noPriceWarning(viewModel: WarningViewModel)
         case status(viewModel: SwitchableViewModel, isEditable: Bool)
+        case linkedProducts(viewModel: ViewModel, isEditable: Bool)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -274,8 +274,14 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
             case .downloadableFiles:
-                //TODO: Add analytics
+                //TODO: Add Analytics M5
                 showDownloadableFiles()
+            case .linkedProducts(_, let isEditable):
+                guard isEditable else {
+                    return
+                }
+                // TODO: Add Analytics M5 https://github.com/woocommerce/woocommerce-ios/issues/3151
+                editLinkedProducts()
             case .productType(_, let isEditable):
                 guard isEditable else {
                     return
@@ -535,6 +541,9 @@ private extension ProductFormViewController {
                                                                         case .editSKU:
                                                                             ServiceLocator.analytics.track(.productDetailViewSKUTapped)
                                                                             self?.editSKU()
+                                                                        case .editLinkedProducts:
+                                                                            // TODO: Analytics M5 https://github.com/woocommerce/woocommerce-ios/issues/3151
+                                                                            self?.editLinkedProducts()
                                                                         }
                                                                     }
         }
@@ -1134,6 +1143,18 @@ private extension ProductFormViewController {
             return
         }
         viewModel.updateSKU(sku)
+    }
+}
+
+// MARK: Action - Edit Linked Products
+//
+private extension ProductFormViewController {
+    func editLinkedProducts() {
+        // TODO: to be implemented https://github.com/woocommerce/woocommerce-ios/issues/3072
+    }
+
+    func onEditLinkedProductsCompletion() {
+        // TODO: to be implemented https://github.com/woocommerce/woocommerce-ios/issues/3072
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -148,6 +148,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.inventoryImage)
     }
 
+    func test_linkedProducts_image_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.linkedProductsImage)
+    }
+
     func testLinkImageIsNotNil() {
         XCTAssertNotNil(UIImage.linkImage)
     }

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -42,7 +42,9 @@ final class MockProduct {
                  menuOrder: Int = 0,
                  categories: [ProductCategory] = [],
                  tags: [ProductTag] = [],
-                 images: [ProductImage] = []) -> Product {
+                 images: [ProductImage] = [],
+                 upsellIDs: [Int64] = [99, 1234566],
+                 crossSellIDs: [Int64] = [1234, 234234, 3]) -> Product {
 
     return Product(siteID: testSiteID,
                    productID: testProductID,
@@ -94,8 +96,8 @@ final class MockProduct {
                    averageRating: "4.30",
                    ratingCount: 23,
                    relatedIDs: [31, 22, 369, 414, 56],
-                   upsellIDs: [99, 1234566],
-                   crossSellIDs: [1234, 234234, 3],
+                   upsellIDs: upsellIDs,
+                   crossSellIDs: crossSellIDs,
                    parentID: 0,
                    purchaseNote: "Thank you!",
                    categories: categories,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -87,7 +87,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_viewModel_for_physical_simple_product_without_linked_products() {
+    func test_viewModel_for_product_without_linked_products_shows_editLinkedProducts_in_bottom_sheet() {
         // Arrange
         let product = Fixtures.physicalSimpleProductWithoutLinkedProducts
         let model = EditableProductModel(product: product)
@@ -114,7 +114,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_viewModel_for_physical_simple_product_with_linked_products() {
+    func test_viewModel_for_product_with_linked_products_shows_linkedProducts_action_in_settings_section() {
         // Arrange
         let product = Fixtures.physicalSimpleProductWithImages
         let model = EditableProductModel(product: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -87,6 +87,62 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
+    func test_viewModel_for_physical_simple_product_without_linked_products() {
+        // Arrange
+        let product = Fixtures.physicalSimpleProductWithoutLinkedProducts
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit,
+                                                isEditProductsRelease5Enabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: true),
+                                                                       .categories(editable: true),
+                                                                       .tags(editable: true),
+                                                                       .shortDescription(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editLinkedProducts]
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func test_viewModel_for_physical_simple_product_with_linked_products() {
+        // Arrange
+        let product = Fixtures.physicalSimpleProductWithImages
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit,
+                                                isEditProductsRelease5Enabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .reviews,
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: true),
+                                                                       .categories(editable: true),
+                                                                       .tags(editable: true),
+                                                                       .shortDescription(editable: true),
+                                                                       .productType(editable: true),
+                                                                       .linkedProducts(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
     func testViewModelForDownloadableSimpleProduct() {
         // Arrange
         let product = Fixtures.downloadableSimpleProduct
@@ -108,7 +164,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .tags(editable: true),
                                                                        .downloadableFiles,
                                                                        .shortDescription(editable: true),
-                                                                       .productType(editable: true)]
+                                                                       .productType(editable: true),
+                                                                       .linkedProducts(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -326,6 +383,19 @@ private extension ProductFormActionsFactoryTests {
                                                                                     categories: [category],
                                                                                     tags: [tag],
                                                                                     images: [image])
+        // downloadable: false, virtual: true, reviews: false, with inventory/shipping/categories/tags/short description
+        static let physicalSimpleProductWithoutLinkedProducts = MockProduct().product(downloadable: false,
+                                                                                    shortDescription: "desc", productType: .simple,
+                                                                                    manageStock: true, sku: "uks", stockQuantity: nil,
+                                                                                    dimensions: ProductDimensions(length: "", width: "", height: ""),
+                                                                                    weight: "2",
+                                                                                    virtual: false,
+                                                                                    reviewsAllowed: false,
+                                                                                    categories: [category],
+                                                                                    tags: [tag],
+                                                                                    images: [image],
+                                                                                    upsellIDs: [],
+                                                                                    crossSellIDs: [])
         // downloadable: false, virtual: true, with inventory/shipping/categories/tags/short description
         static let virtualSimpleProduct = MockProduct().product(downloadable: false, shortDescription: "desc", productType: .simple,
                                                                 manageStock: true, sku: "uks", stockQuantity: nil,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -135,8 +135,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
-                                                                       .productType(editable: true),
-                                                                       .linkedProducts(editable: true)]
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -164,8 +164,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .tags(editable: true),
                                                                        .downloadableFiles,
                                                                        .shortDescription(editable: true),
-                                                                       .productType(editable: true),
-                                                                       .linkedProducts(editable: true)]
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -57,8 +57,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
                                                                        .reviews,
                                                                        .downloadableFiles,
-                                                                       .productType(editable: true),
-                                                                       .linkedProducts(editable: true)]
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editShortDescription]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -57,7 +57,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
                                                                        .reviews,
                                                                        .downloadableFiles,
-                                                                       .productType(editable: true)]
+                                                                       .productType(editable: true),
+                                                                       .linkedProducts(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editShortDescription]


### PR DESCRIPTION
Fixes #3071 

## Description
As part of Milestone 5, in this PR I introduced the logic for showing/hiding the Linked Products cell inside the Product Detail screen or in the action sheet under the button "Add more details".

## Changes
- Added a new icon + test for Linked Products.
- Added `editLinkedProducts` case in `ProductFormBottomSheetAction` for managing title and description of the cell inside the bottom sheet.
- Added the new linked products row in `DefaultProductFormTableViewModel`.
- Added the properties `upsellIDs` and `crossSellIDs` used for Linked Products inside `EditableProductModel`, `EditableProductVariationModel` and `ProductFormDataModel`.
- Managed the appearance of the Linked Products cell in `ProductFormActionsFactory`.
- Added linked products empty (for the moment) actions in `ProductFormViewController`.
- Updated the old tests, and added two new test cases about the Linked Products appearance in `ProductFormActionsFactoryTests`.

## Testing

#### Case 1
1. Open any type of product (simple, variable, grouped, etc...) with some Linked Products. You can some linked products from wp-admin.
2. If everything is in place, you will see the new `Linked Products` cell at the end of the list, showing upsell and cross-sell products info. The action will be implemented in the next PR.
3. If for that product the "Add more details" button is enabled, tapping it you shouldn't see the Linked Products cell in the bottom action sheet.

#### Case 2
1. Open any type of product (simple, variable, grouped, etc...) without Linked Products.
2. Tap the "Add more details" button.
3. You should see the `Linked Products` cell in the bottom action sheet. The action will be implemented in the next PR.


## Screenshots
| Product with Linked products   |  If the Product has no Linked products, you will see the cell inside the bottom action sheet |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-11-17 at 20 01 24](https://user-images.githubusercontent.com/495617/99435727-d124d680-2910-11eb-9fa8-4897283a2faf.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-11-17 at 20 01 17](https://user-images.githubusercontent.com/495617/99435774-e4d03d00-2910-11eb-840d-12e272a93407.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
