### PR TITLE
[UL&S] Login Prologue: change ordering of buttons

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -40,7 +40,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 1.28.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/513-prologue-button-order'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'develop'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.28.0'
+  # pod 'WordPressAuthenticator', '~> 1.28.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/513-prologue-button-order'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/513-prologue-button-order`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `develop`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -158,12 +158,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: issue/513-prologue-button-order
+    :branch: develop
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 033a16f4641651d23ab9b20d7c5b0c382da7748e
+    :commit: f42d815bb577d1d7aeaf51bd0ab78b21544e689b
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -207,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: dabe84b2dde80cb15f961763e2e5ef00200b0a0a
+PODFILE CHECKSUM: 5a446e26673eb924c3bbde09c5f4f9de29e90e39
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -163,7 +163,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: a673419f294428599be872f2b203c3b5cb56ee15
+    :commit: 033a16f4641651d23ab9b20d7c5b0c382da7748e
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.28.0):
+  - WordPressAuthenticator (1.29.0):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.20.0):
+  - WordPressKit (4.21.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.28.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/513-prologue-button-order`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -141,7 +141,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -156,6 +155,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: issue/513-prologue-button-order
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: a673419f294428599be872f2b203c3b5cb56ee15
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -182,8 +191,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 68f1b5b3792671888c7c1a77da02e98e3f694cd1
-  WordPressKit: 873720d78dc1db8d0a009601f5f4fe8e8aab7d38
+  WordPressAuthenticator: c8bd7279b38e1c56dd620b8f05535e350117c99e
+  WordPressKit: 98b1b095e3e312b49af0d3db5ec3c6272416eda6
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
   Wormholy: 5a186f877829e7d488963b09f204e0186b40c9a8
@@ -198,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: c3ba7bb50d92da5c01566a9bba39e0a328ea67f4
+PODFILE CHECKSUM: dabe84b2dde80cb15f961763e2e5ef00200b0a0a
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -43,7 +43,8 @@ class AuthenticationManager: Authentication {
                                                                 showLoginOptions: true,
                                                                 enableSignUp: false,
                                                                 enableSignInWithApple: isSignInWithAppleEnabled,
-                                                                enableUnifiedAuth: true)
+                                                                enableUnifiedAuth: true,
+                                                                continueWithSiteAddressFirst: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)


### PR DESCRIPTION
Closes #3128 

⚠️ Please note this PR is not against develop, but against the feature branch for UL&S 🙇

## Design:

<img width="322" alt="Screenshot 2020-11-18 at 10 30 28 AM" src="https://user-images.githubusercontent.com/2722505/99482534-1986d780-2997-11eb-9a86-b21cb183d2f0.png">

## What's changed

This PR:
* Points the Podfile to the branch in WPAuthenticator that implements the necessary changes
* Passes a flag to WPAuthenticatorConfiguration

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/99482699-813d2280-2997-11eb-8908-bd2ed297ca35.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/99482691-7da99b80-2997-11eb-9296-ae798e1e49e3.png" width="350"/> |

Animation showing buttons in action:
<img src="https://user-images.githubusercontent.com/2722505/99482756-a2057800-2997-11eb-847f-d62642d608d3.gif" width="350"/>

⚠️ Please note that the background color of the buttons container is implemented in #3165  🙇

## How to test
* Checkout the branch
* Run `bundle exec pod install`
* Log out if necessary. 
* Notice the ordering of the buttons. Tap both buttons, check that the app navigates to the right login flow (either with site address or with WP.com account)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
