### PR TITLE
[Issue Refund] Confirm and submit refund

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -65,7 +65,7 @@ private extension RefundConfirmationViewController {
 
     func configureButtonTableFooterView() {
         tableView.tableFooterView = ButtonTableFooterView(frame: .zero, title: Localization.refund) { [weak self] in
-            self?.viewModel.submit()
+            self?.viewModel.submit(onCompletion: { _ in })
         }
         tableView.updateFooterHeight()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -218,7 +218,7 @@ private extension RefundConfirmationViewController {
         static let refund = NSLocalizedString("Refund", comment: "The title of the button to confirm the refund.")
         static let cancel = NSLocalizedString("Cancel", comment: "The title of the button to cancel issuing a refund.")
         static let issuingRefund = NSLocalizedString("Issuing Refund...", comment: "Text of the screen that is displayed while the refund is being created.")
-        static let refundSuccess = NSLocalizedString("🎉 Products sucessfuly refunded",
+        static let refundSuccess = NSLocalizedString("🎉 Products successfuly refunded",
                                                    comment: "Text of the notice that is displayed after the refund is created.")
         static let refundError = NSLocalizedString("There was an error issuing the refund",
                                                    comment: "Text of the notice that is displayed while the refund creation fails.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -144,11 +144,12 @@ private extension RefundConfirmationViewController {
         let actionSheet = UIAlertController(title: Localization.confirmationTitle(amount: viewModel.refundAmount),
                                             message: Localization.confirmationBody,
                                             preferredStyle: .alert)
+        actionSheet.view.tintColor = .text
         actionSheet.addCancelActionWithTitle(Localization.cancel) { _ in
             onCompletion(false)
         }
 
-        actionSheet.addActionWithTitle(Localization.refund, style: .default) { _ in
+        actionSheet.addDefaultActionWithTitle(Localization.refund) { _ in
             onCompletion(true)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -11,6 +11,12 @@ final class RefundConfirmationViewController: UIViewController {
 
     private let viewModel: RefundConfirmationViewModel
 
+    private lazy var noticePresenter: NoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     init(viewModel: RefundConfirmationViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -152,13 +158,48 @@ private extension RefundConfirmationViewController {
     /// Submits the refund and dismisses the flow upon successful completion.
     ///
     func submitRefund() {
+        presentProgressViewController()
         self.viewModel.submit { [weak self] result in
             switch result {
             case .success:
-                self?.dismiss(animated: true, completion: nil)
+                self?.dismissPresentationFlow()
             case .failure(let error):
-                DDLogError("Error issuing refund: \(error)")
+                self?.dismissProgressViewController(with: error)
             }
+        }
+    }
+
+    /// Shows a progress view while the refund is being created.
+    ///
+    func presentProgressViewController() {
+        let viewProperties = InProgressViewProperties(title: Localization.issuingRefund, message: "")
+        let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
+
+        // Before iOS 13, a modal with transparent background requires certain
+        // `modalPresentationStyle` to prevent the view from turning dark after being presented.
+        if #available(iOS 13.0, *) {} else {
+            inProgressViewController.modalPresentationStyle = .overCurrentContext
+        }
+
+        present(inProgressViewController, animated: true)
+    }
+
+    /// Dismisses the whole `IssueRefund` flow.
+    ///
+    func dismissPresentationFlow() {
+        // Dismiss the progress view controller
+        dismiss(animated: true) { [weak self] in
+            // Dismiss the issue refund flow
+            self?.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    /// Dismisses the progress view and displays a refund error notice.
+    ///
+    func dismissProgressViewController(with error: Error) {
+        dismiss(animated: true) { [weak self] in
+            self?.noticePresenter.enqueue(notice: .init(title: Localization.refundError))
+            DDLogError("Error issuing refund: \(error)")
         }
     }
 }
@@ -169,6 +210,9 @@ private extension RefundConfirmationViewController {
     enum Localization {
         static let refund = NSLocalizedString("Refund", comment: "The title of the button to confirm the refund.")
         static let cancel = NSLocalizedString("Cancel", comment: "The title of the button to cancel issuing a refund.")
+        static let issuingRefund = NSLocalizedString("Issuing Refund...", comment: "Text of the screen that is displayed while the refund is being created.")
+        static let refundError = NSLocalizedString("There was an error issuing the refund.",
+                                                   comment: "Text of the notice that is displayed while the refund creation fails.")
         static let confirmationBody = NSLocalizedString("Are you sure you want to issue a refund? This can't be undone.",
                                                         comment: "The text on the confirmation alert before issuing a refund.")
         static func confirmationTitle(amount: String) -> String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -11,14 +11,17 @@ final class RefundConfirmationViewController: UIViewController {
 
     private let viewModel: RefundConfirmationViewModel
 
-    private lazy var noticePresenter: NoticePresenter = {
+    private lazy var contextNoticePresenter: NoticePresenter = {
         let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         return noticePresenter
     }()
 
-    init(viewModel: RefundConfirmationViewModel) {
+    private let systemNoticePresenter: NoticePresenter
+
+    init(viewModel: RefundConfirmationViewModel, systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.viewModel = viewModel
+        self.systemNoticePresenter = systemNoticePresenter
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -191,7 +194,10 @@ private extension RefundConfirmationViewController {
         // Dismiss the progress view controller
         dismiss(animated: true) { [weak self] in
             // Dismiss the issue refund flow
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true, completion: {
+                // Show a success notice
+                self?.systemNoticePresenter.enqueue(notice: .init(title: Localization.refundSuccess))
+            })
         }
     }
 
@@ -199,7 +205,7 @@ private extension RefundConfirmationViewController {
     ///
     func dismissProgressViewController(with error: Error) {
         dismiss(animated: true) { [weak self] in
-            self?.noticePresenter.enqueue(notice: .init(title: Localization.refundError))
+            self?.contextNoticePresenter.enqueue(notice: .init(title: Localization.refundError))
             DDLogError("Error issuing refund: \(error)")
         }
     }
@@ -212,7 +218,9 @@ private extension RefundConfirmationViewController {
         static let refund = NSLocalizedString("Refund", comment: "The title of the button to confirm the refund.")
         static let cancel = NSLocalizedString("Cancel", comment: "The title of the button to cancel issuing a refund.")
         static let issuingRefund = NSLocalizedString("Issuing Refund...", comment: "Text of the screen that is displayed while the refund is being created.")
-        static let refundError = NSLocalizedString("There was an error issuing the refund.",
+        static let refundSuccess = NSLocalizedString("🎉 Products sucessfuly refunded",
+                                                   comment: "Text of the notice that is displayed after the refund is created.")
+        static let refundError = NSLocalizedString("There was an error issuing the refund",
                                                    comment: "Text of the notice that is displayed while the refund creation fails.")
         static let confirmationBody = NSLocalizedString("Are you sure you want to issue a refund? This can't be undone.",
                                                         comment: "The text on the confirmation alert before issuing a refund.")

--- a/Yosemite/YosemiteTests/Mockups/MockupStorage+Sample.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupStorage+Sample.swift
@@ -69,4 +69,14 @@ extension MockupStorageManager {
 
         return newProductTag
     }
+
+    /// Inserts a new (Sample) Order into the specified context.
+    ///
+    @discardableResult
+    func insertSampleOrder(readOnlyOrder: Order) -> StorageOrder {
+        let newOrder = viewStorage.insertNewObject(ofType: StorageOrder.self)
+        newOrder.update(with: readOnlyOrder)
+
+        return newOrder
+    }
 }


### PR DESCRIPTION
closes #3033 
closes #2769 

# Why

This PR connects the wires and gives the ability to a user to issue a refund! 🎉 

_PS: Handling of previous shipping refunds is not yet supported._

# How
The above is accomplished by:
**Show a confirmation alert before issuing the refund**
Done by showing a simple `AlertViewController` in `RefundConfirmationViewController `

**Submit the refund to the API when the user confirms it.**
Updates `RefundConfirmationViewModel` to dispatch the `RefundStore.createRefund` action.

**Show a progress view while the refund is being created.**
Present an overlay controller from `RefundConfirmationViewController` powered by `InProgressViewController`

**Navigate back to the order details if the refund creation is successful.**
Dismiss the overlay and the modal refund flow after in `RefundConfirmationViewController` after the refund creation finishes

**Show an error notice if the refund creation fails**
If there is an error, show a generic notice and `DDLogError` the actual error.

**Update the order details screen to shows the new refund information.**
Update `RefundsStore` to update the refund's order - condensed refunds array to include the newly created refund.

# Gif
Success | Error
---- | ----
![Refund flow!](https://user-images.githubusercontent.com/562080/99484349-30451400-292e-11eb-8fc4-9b99e1c44ee0.gif) | ![error](https://user-images.githubusercontent.com/562080/99484810-2f60b200-292f-11eb-835f-8f84c0d1ace2.gif)


# Testing Steps
**Success**
- Navigate to a non-refunded order
- Tap on the "Issue Refund" button
- Select some items to refund and tap next
- Tap on the "Refund" button
- See the order detail updated with the new refund information.

**Error**
- Navigate to a non-refunded order
- Tap on the "Issue Refund" button
- Select some items to refund and tap next
- Turn off any internet connection
- Tap on the "Refund" button
- See the error notice.

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
