### PR TITLE
[UL&S] Update capitalization of button titles in Login Prologue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -40,7 +40,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 1.28.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/518-prologue-button-titles'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'develop'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile
+++ b/Podfile
@@ -40,7 +40,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 1.28.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'develop'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/518-prologue-button-titles'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `develop`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/518-prologue-button-titles`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -158,12 +158,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: develop
+    :branch: issue/518-prologue-button-titles
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: f42d815bb577d1d7aeaf51bd0ab78b21544e689b
+    :commit: af4a57fb692c29c28d837ea97301bf9e2bdc516b
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -207,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 5a446e26673eb924c3bbde09c5f4f9de29e90e39
+PODFILE CHECKSUM: b2760dc8e1378218d30516638371c648332ca8ce
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/518-prologue-button-titles`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `develop`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -158,12 +158,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: issue/518-prologue-button-titles
+    :branch: develop
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: af4a57fb692c29c28d837ea97301bf9e2bdc516b
+    :commit: f4f47e20e8d812e828a9c5dc8d24c4b599c8e606
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -207,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: b2760dc8e1378218d30516638371c648332ca8ce
+PODFILE CHECKSUM: 5a446e26673eb924c3bbde09c5f4f9de29e90e39
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -38,7 +38,7 @@ struct AuthenticationConstants {
 
     /// Title of "Continue With WordPress.com" button in Login Prologue
     //
-    static let continueWithWPButtontitle = NSLocalizedString(
+    static let continueWithWPButtonTitle = NSLocalizedString(
         "Continue With WordPress.com",
         comment: "Button title. Takes the user to the login by email flow."
     )

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -40,7 +40,7 @@ struct AuthenticationConstants {
     //
     static let continueWithWPButtonTitle = NSLocalizedString(
         "Continue With WordPress.com",
-        comment: "Button title. Takes the user to the login by email flow."
+        comment: "Button title. Takes the user to the login with WordPress.com flow."
     )
 
     /// Title of "Enter your store address" button in Login Prologue

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -35,14 +35,14 @@ struct AuthenticationConstants {
         "Log in with your WordPress.com account to manage your WooCommerce stores.",
         comment: "Sign in instructions for logging in with a username and password."
     )
-    
+
     /// Title of "Continue With WordPress.com" button in Login Prologue
     //
     static let continueWithWPButtontitle = NSLocalizedString(
         "Continue With WordPress.com",
         comment: "Button title. Takes the user to the login by email flow."
     )
-    
+
     /// Title of "Enter your store address" button in Login Prologue
     //
     static let enterYourSiteAddressButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -36,9 +36,17 @@ struct AuthenticationConstants {
         comment: "Sign in instructions for logging in with a username and password."
     )
     
+    /// Title of "Continue With WordPress.com" button in Login Prologue
+    //
+    static let continueWithWPButtontitle = NSLocalizedString(
+        "Continue With WordPress.com",
+        comment: "Button title. Takes the user to the login by email flow."
+    )
+    
     /// Title of "Enter your store address" button in Login Prologue
     //
-    static let enterYourSiteAddressButtonTitle = NSLocalizedString("Enter Your Store Address",
-                                                                   comment: "Button title. Takes the user to the login by store address flow."
+    static let enterYourSiteAddressButtonTitle = NSLocalizedString(
+        "Enter Your Store Address",
+        comment: "Button title. Takes the user to the login by store address flow."
     )
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -35,4 +35,10 @@ struct AuthenticationConstants {
         "Log in with your WordPress.com account to manage your WooCommerce stores.",
         comment: "Sign in instructions for logging in with a username and password."
     )
+    
+    /// Title of "Enter your store address" button in Login Prologue
+    //
+    static let enterYourSiteAddressButtonTitle = NSLocalizedString("Enter Your Store Address",
+                                                                   comment: "Button title. Takes the user to the login by store address flow."
+    )
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -81,7 +81,7 @@ class AuthenticationManager: Authentication {
                                                                   jetpackLoginInstructions: AuthenticationConstants.jetpackInstructions,
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
-                                                                  continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtontitle,
+                                                                  continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtonTitle,
                                                                   enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -80,7 +80,8 @@ class AuthenticationManager: Authentication {
                                                                   getStartedInstructions: AuthenticationConstants.getStartedInstructions,
                                                                   jetpackLoginInstructions: AuthenticationConstants.jetpackInstructions,
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
-                                                                  usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions)
+                                                                  usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
+                                                                  enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -81,6 +81,7 @@ class AuthenticationManager: Authentication {
                                                                   jetpackLoginInstructions: AuthenticationConstants.jetpackInstructions,
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
+                                                                  continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtontitle,
                                                                   enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,


### PR DESCRIPTION
Closes #3175 

⚠️ Please note this PR is not against develop, but against the feature branch for UL&S 🙇

## Design:

<img width="322" alt="99482534-1986d780-2997-11eb-9a86-b21cb183d2f0" src="https://user-images.githubusercontent.com/2722505/99616309-f5d79600-2a57-11eb-87d5-30bef2f9360d.png">

## What's changed:
This PR:
* Points the Podfile to the branch in WPAuthenticator that implements the necessary changes
* Passes custom strings to WPAuthenticator to be used as titles in the Login Prologue

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/99616435-3c2cf500-2a58-11eb-82b3-2d165343a58a.png" witdh="350"/> | <img src="https://user-images.githubusercontent.com/2722505/99616432-39ca9b00-2a58-11eb-9f8f-a6c3a136fedb.png" witdh="350"/> |

## How to test
* Checkout the branch
* run `bundle exec pod install` to point the dependency with WPAuthenticator to the correct branch
* Build and run. Log out if necessary
* 👀  on the button titles in Login Prologue. Check that words are capitalized as expected in the design

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
