### PR TITLE
Removed the Product Title in product screen navigation bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] now the date pickers on iOS 14 are opened as modal view. [https://github.com/woocommerce/woocommerce-ios/pull/3148]
 - [*] now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3159]
+- [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]
 
 
 5.5

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -724,15 +724,6 @@ private extension ProductFormViewController {
 // MARK: Navigation Bar Items
 //
 private extension ProductFormViewController {
-    func updateNavigationBarTitle(productName: String) {
-        navigationItem.title = productName
-        switch presentationStyle {
-        case .contained(let containerViewController):
-            containerViewController.navigationItem.title = productName
-        default:
-            break
-        }
-    }
 
     func updateNavigationBar(isUpdateEnabled: Bool) {
         var rightBarButtonItems = [UIBarButtonItem]()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -107,7 +107,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         handleSwipeBackGesture()
 
         observeProduct()
-        observeProductName()
         observeUpdateCTAVisibility()
 
         productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
@@ -383,7 +382,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar(isUpdateEnabled: false)
-        updateNavigationBarTitle(productName: product.name)
         removeNavigationBackBarButtonText()
     }
 
@@ -460,12 +458,6 @@ private extension ProductFormViewController {
     func observeProduct() {
         cancellableProduct = viewModel.observableProduct.subscribe { [weak self] product in
             self?.onProductUpdated(product: product)
-        }
-    }
-
-    func observeProductName() {
-        cancellableProductName = viewModel.productName?.subscribe { [weak self] name in
-            self?.updateNavigationBarTitle(productName: name)
         }
     }
 


### PR DESCRIPTION
Fixes #3178 

## Description
Since it's currently a bit hard to see the "Update" and "Publish" CTAs right now on the Product Screen, as suggested by @Garance91540 I removed the product title from the navigation bar.

## Testing
#### Case 1
1. Try to create a new product.
2. The title of the screen should be empty, and it should be shown only the "Publish" CTA.

#### Case 2
1. Try to edit an existing product.
2. Try to edit the title of the product. The title of the screen should be empty, showing only the "Update" CTA.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
<img width="439" alt="Screen Shot 2020-11-19 at 10 33 24" src="https://user-images.githubusercontent.com/495617/99951514-87a81180-2d7e-11eb-894a-fb4065dc93e0.png"> | ![update product name](https://user-images.githubusercontent.com/495617/99951517-8971d500-2d7e-11eb-9ca3-9944db3abb97.gif)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
