### PR TITLE
Order Details: display shipping label cards with partial UI

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -79,6 +79,8 @@ final class OrderDetailsDataSource: NSObject {
         return resultsControllers.refunds
     }
 
+    private var shippingLabels: [ShippingLabel] = []
+
     /// Shipping Lines from an Order
     ///
     private var shippingLines: [ShippingLine] {
@@ -227,6 +229,8 @@ private extension OrderDetailsDataSource {
             configureShippingMethod(cell: cell)
         case let cell as WooBasicTableViewCell where row == .billingDetail:
             configureBillingDetail(cell: cell)
+        case let cell as WooBasicTableViewCell where row == .shippingLabelDetail:
+            configureShippingLabelDetail(cell: cell)
         case let cell as TopLeftImageTableViewCell where row == .shippingNotice:
             configureShippingNotice(cell: cell)
         case let cell as LeftImageTableViewCell where row == .addOrderNote:
@@ -245,12 +249,18 @@ private extension OrderDetailsDataSource {
             configureNetAmount(cell: cell)
         case let cell as ProductDetailsTableViewCell where row == .orderItem:
             configureOrderItem(cell: cell, at: indexPath)
+        case let cell as ProductDetailsTableViewCell where row == .shippingLabelProduct:
+            configureShippingLabelProduct(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
             configureAggregateOrderItem(cell: cell, at: indexPath)
-        case let cell as ButtonTableViewCell:
+        case let cell as ButtonTableViewCell where row == .fulfillButton:
             configureFulfillmentButton(cell: cell)
-        case let cell as OrderTrackingTableViewCell:
+        case let cell as ButtonTableViewCell where row == .shippingLabelReprintButton:
+            configureReprintShippingLabelButton(cell: cell)
+        case let cell as OrderTrackingTableViewCell where row == .tracking:
             configureTracking(cell: cell, at: indexPath)
+        case let cell as OrderTrackingTableViewCell where row == .shippingLabelTrackingNumber:
+            configureShippingLabelTrackingNumber(cell: cell, at: indexPath)
         case let cell as LeftImageTableViewCell where row == .trackingAdd:
             configureNewTracking(cell: cell)
         case let cell as SummaryTableViewCell:
@@ -408,6 +418,54 @@ private extension OrderDetailsDataSource {
         cell.configure(item: itemViewModel, imageService: imageService)
     }
 
+    private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
+        cell.bodyLabel?.text = Footer.showShippingLabelDetails
+        cell.applyPlainTextStyle()
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+
+        cell.accessibilityTraits = .button
+        cell.accessibilityLabel = NSLocalizedString(
+            "View Shipment Details",
+            comment: "Accessibility label for the 'View Shipment Details' button"
+        )
+
+        cell.accessibilityHint = NSLocalizedString(
+            "Show the shipment details for this shipping label.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view shipping label shipment details."
+        )
+    }
+
+    private func configureShippingLabelProduct(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
+        cell.selectionStyle = .default
+
+        // TODO-2167: show aggregated order item (product) for a shipping label
+    }
+
+    private func configureShippingLabelTrackingNumber(cell: OrderTrackingTableViewCell, at indexPath: IndexPath) {
+        guard let shippingLabel = shippingLabel(at: indexPath) else {
+            return
+        }
+
+        cell.topText = shippingLabel.serviceName
+
+        // TODO-2167: update design for shipping label tracking number
+    }
+
+    private func configureReprintShippingLabelButton(cell: ButtonTableViewCell) {
+        cell.configure(style: .secondary, title: Titles.reprintShippingLabel) {
+            // TODO-2174: reprint shipping label UX
+        }
+    }
+
+    private func shippingLabel(at indexPath: IndexPath) -> ShippingLabel? {
+        guard let firstShippingLabelSectionIndex = sections.firstIndex(where: { $0.category == .shippingLabel }) else {
+            return nil
+        }
+        let shippingLabelIndex = indexPath.section - firstShippingLabelSectionIndex
+        return shippingLabels[shippingLabelIndex]
+    }
+
     private func configureAggregateOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
         cell.selectionStyle = .default
 
@@ -563,7 +621,7 @@ extension OrderDetailsDataSource {
     /// When: Shipping == nil               >>> Display: Shipping = "No address specified"
     ///
     func reloadSections() {
-        let summary = Section(row: .summary)
+        let summary = Section(category: .summary, row: .summary)
 
         let shippingNotice: Section? = {
             // Hide the shipping method warning if order contains only virtual products
@@ -572,7 +630,7 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            return Section(title: nil, rightTitle: nil, footer: nil, rows: [.shippingNotice])
+            return Section(category: .shippingNotice, title: nil, rightTitle: nil, footer: nil, rows: [.shippingNotice])
         }()
 
         let products: Section? = {
@@ -598,7 +656,7 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            return Section(title: Localization.pluralizedProducts(count: items.count), rightTitle: nil, rows: rows, headerStyle: .primary)
+            return Section(category: .products, title: Localization.pluralizedProducts(count: items.count), rightTitle: nil, rows: rows, headerStyle: .primary)
         }()
 
         let refundedProducts: Section? = {
@@ -609,7 +667,31 @@ extension OrderDetailsDataSource {
 
             let row: Row = .refundedProducts
 
-            return Section(title: Title.refundedProducts, row: row)
+            return Section(category: .refundedProducts, title: Title.refundedProducts, row: row)
+        }()
+
+        let shippingLabels: [Section] = {
+            let shippingLabels = resultsControllers.shippingLabels
+            guard shippingLabels.isNotEmpty else {
+                return []
+            }
+
+            self.shippingLabels = shippingLabels
+            let sections = shippingLabels.enumerated().map { index, shippingLabel -> Section in
+                let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
+                let isRefunded = shippingLabel.refund != nil
+                let rows: [Row]
+                if isRefunded {
+                    rows = [.shippingLabelTrackingNumber, .shippingLabelDetail]
+                } else {
+                    let orderItemsCount = shippingLabel.productNames.count
+                    // TODO-2167: show aggregated order items (products) for a shipping label
+                    rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
+                        + [.shippingLabelReprintButton, .shippingLabelTrackingNumber, .shippingLabelDetail]
+                }
+                return Section(category: .shippingLabel, title: title, rows: rows, headerStyle: .primary)
+            }
+            return sections
         }()
 
         let customerInformation: Section = {
@@ -631,7 +713,7 @@ extension OrderDetailsDataSource {
             }
             rows.append(.billingDetail)
 
-            return Section(title: Title.information, rows: rows)
+            return Section(category: .customerInformation, title: Title.information, rows: rows)
         }()
 
         let payment: Section = {
@@ -646,7 +728,7 @@ extension OrderDetailsDataSource {
                 rows.append(.issueRefundButton)
             }
 
-            return Section(title: Title.payment, rows: rows)
+            return Section(category: .payment, title: Title.payment, rows: rows)
         }()
 
         let tracking: Section? = {
@@ -655,7 +737,7 @@ extension OrderDetailsDataSource {
             }
 
             let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
-            return Section(title: Title.tracking, rows: rows)
+            return Section(category: .tracking, title: Title.tracking, rows: rows)
         }()
 
         let addTracking: Section? = {
@@ -668,23 +750,24 @@ extension OrderDetailsDataSource {
             let title = orderTracking.count == 0 ? NSLocalizedString("Optional Tracking Information", comment: "") : nil
             let row = Row.trackingAdd
 
-            return Section(title: title, rightTitle: nil, rows: [row])
+            return Section(category: .addTracking, title: title, rightTitle: nil, rows: [row])
         }()
 
         let notes: Section = {
             let rows = [.addOrderNote] + orderNotesSections.map {$0.row}
-            return Section(title: Title.notes, rows: rows)
+            return Section(category: .notes, title: Title.notes, rows: rows)
         }()
 
-        sections = [summary,
+        sections = ([summary,
                     shippingNotice,
-                    products,
-                    refundedProducts,
+                    products] +
+                    shippingLabels +
+                    [refundedProducts,
                     payment,
                     customerInformation,
                     tracking,
                     addTracking,
-                    notes].compactMap { $0 }
+                    notes]).compactMap { $0 }
 
         updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
     }
@@ -848,6 +931,7 @@ extension OrderDetailsDataSource {
         static let refunded = NSLocalizedString("Refunded",
                                                 comment: "The title for the refunded amount cell")
         static let netAmount = NSLocalizedString("Net", comment: "The title for the net amount paid cell")
+        static let reprintShippingLabel = NSLocalizedString("Reprint Shipping Label", comment: "Text on the button that reprints a shipping label")
     }
 
     enum Icons {
@@ -864,14 +948,32 @@ extension OrderDetailsDataSource {
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
+        static let shippingLabelPackageFormat =
+            NSLocalizedString("Package %d",
+                              comment: "Order shipping label package section title format. The number indicates the index of the shipping label package.")
     }
 
     enum Footer {
         static let showBilling = NSLocalizedString("View Billing Information",
                                                    comment: "Button on bottom of Customer's information to show the billing details")
+        static let showShippingLabelDetails = NSLocalizedString("View Shipment Details",
+                                                                comment: "Button on bottom of shipping label package card to show shipping details")
     }
 
     struct Section {
+        enum Category {
+            case summary
+            case shippingNotice
+            case products
+            case shippingLabel
+            case refundedProducts
+            case payment
+            case customerInformation
+            case tracking
+            case addTracking
+            case notes
+        }
+
         /// The table header style of a `Section`.
         ///
         enum HeaderStyle {
@@ -892,17 +994,20 @@ extension OrderDetailsDataSource {
             }
         }
 
+        let category: Category
         let title: String?
         let rightTitle: String?
         let footer: String?
         let rows: [Row]
         let headerStyle: HeaderStyle
 
-        init(title: String? = nil,
+        init(category: Category,
+             title: String? = nil,
              rightTitle: String? = nil,
              footer: String? = nil,
              rows: [Row],
              headerStyle: HeaderStyle = .twoColumn) {
+            self.category = category
             self.title = title
             self.rightTitle = rightTitle
             self.footer = footer
@@ -910,12 +1015,13 @@ extension OrderDetailsDataSource {
             self.headerStyle = headerStyle
         }
 
-        init(title: String? = nil,
+        init(category: Category,
+             title: String? = nil,
              rightTitle: String? = nil,
              footer: String? = nil,
              row: Row,
              headerStyle: HeaderStyle = .twoColumn) {
-            self.init(title: title, rightTitle: rightTitle, footer: footer, rows: [row], headerStyle: headerStyle)
+            self.init(category: category, title: title, rightTitle: rightTitle, footer: footer, rows: [row], headerStyle: headerStyle)
         }
     }
 
@@ -951,6 +1057,10 @@ extension OrderDetailsDataSource {
         case netAmount
         case tracking
         case trackingAdd
+        case shippingLabelDetail
+        case shippingLabelProduct
+        case shippingLabelReprintButton
+        case shippingLabelTrackingNumber
         case shippingNotice
         case addOrderNote
         case orderNoteHeader
@@ -992,6 +1102,14 @@ extension OrderDetailsDataSource {
                 return OrderTrackingTableViewCell.reuseIdentifier
             case .trackingAdd:
                 return LeftImageTableViewCell.reuseIdentifier
+            case .shippingLabelDetail:
+                return WooBasicTableViewCell.reuseIdentifier
+            case .shippingLabelProduct:
+                return ProductDetailsTableViewCell.reuseIdentifier
+            case .shippingLabelTrackingNumber:
+                return OrderTrackingTableViewCell.reuseIdentifier
+            case .shippingLabelReprintButton:
+                return ButtonTableViewCell.reuseIdentifier
             case .shippingNotice:
                 return TopLeftImageTableViewCell.reuseIdentifier
             case .addOrderNote:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -670,13 +670,13 @@ extension OrderDetailsDataSource {
             return Section(category: .refundedProducts, title: Title.refundedProducts, row: row)
         }()
 
-        let shippingLabels: [Section] = {
-            let shippingLabels = resultsControllers.shippingLabels
+        let shippingLabels = resultsControllers.shippingLabels
+        self.shippingLabels = shippingLabels
+
+        let shippingLabelSections: [Section] = {
             guard shippingLabels.isNotEmpty else {
                 return []
             }
-
-            self.shippingLabels = shippingLabels
             let sections = shippingLabels.enumerated().map { index, shippingLabel -> Section in
                 let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
                 let isRefunded = shippingLabel.refund != nil
@@ -761,7 +761,7 @@ extension OrderDetailsDataSource {
         sections = ([summary,
                     shippingNotice,
                     products] +
-                    shippingLabels +
+                    shippingLabelSections +
                     [refundedProducts,
                     payment,
                     customerInformation,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -349,11 +349,11 @@ extension OrderDetailsViewModel {
     func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
         let action = ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in
             switch result {
+            case .success:
+                onCompletion?(nil)
             case .failure(let error):
                 DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
                 onCompletion?(error)
-            case .success:
-                onCompletion?(nil)
             }
         }
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -346,6 +346,19 @@ extension OrderDetailsViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
+    func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
+        let action = ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in
+            switch result {
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
+                onCompletion?(error)
+            case .success:
+                onCompletion?(nil)
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
     func deleteTracking(_ tracking: ShipmentTracking, onCompletion: @escaping (Error?) -> Void) {
         let siteID = order.siteID
         let orderID = order.orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -65,6 +65,7 @@ final class OrderDetailsViewController: UIViewController {
         syncNotes()
         syncProducts()
         syncRefunds()
+        syncShippingLabels()
         syncTrackingsHidingAddButtonIfNecessary()
     }
 
@@ -224,6 +225,11 @@ extension OrderDetailsViewController {
         }
 
         group.enter()
+        syncShippingLabels() { _ in
+            group.leave()
+        }
+
+        group.enter()
         syncNotes { _ in
             group.leave()
         }
@@ -271,6 +277,10 @@ private extension OrderDetailsViewController {
 
     func syncRefunds(onCompletion: ((Error?) -> ())? = nil) {
         viewModel.syncRefunds(onCompletion: onCompletion)
+    }
+
+    func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
+        viewModel.syncShippingLabels(onCompletion: onCompletion)
     }
 
     func deleteTracking(_ tracking: ShipmentTracking) {


### PR DESCRIPTION
Part of #2167 

## Changes

- In `OrderDetailsResultsControllers`, added a FRC of `StorageShippingLabel` for an order's shipping labels
- In `OrderDetailsViewController` and `OrderDetailsViewModel`, triggered syncing for shipping labels
- In `OrderDetailsDataSource`, added new sections for all shipping labels when reloading sections:
  - Added an enum `Section.Category` so that we can look up the first shipping label section for `IndexPath` mapping to a specific `ShippingLabel` because the number of shipping label sections is variable
  - If a shipping label is refunded, only the tracking number row and details row are shown
  - Otherwise, these rows are shown:
    - `shippingLabel.productNames.count` product rows (without any setup so you might see some reused cells),
    - "Reprint Shipping Label" button row
    - Tracking number row
    - Details row

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label and an order with at least one refunded shipping label

**Notes**: the product rows and tracking number row are to be implemented separately, you might see reused cells during your testing. All the UI subtasks in #2167.

### Refunded shipping label card

- Go to the orders tab
- Tap on an order with at least one refunded shipping label --> after syncing, a shipping label package card should be shown "Package #" with the refunded rows in the "Changes" section above (tracking number row and details row)

### Non-refunded shipping label card

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, a shipping label package card should be shown "Package #" with the non-refunded rows in the "Changes" section above (`shippingLabel.productNames.count` product rows, "Reprint Shipping Label" button row, tracking number row, details row)

## Example screenshots

**Notes**: the **product rows** and **tracking number row** are to be implemented separately, please ignore these rows

Refunded shipping label card | Non-refunded shipping label card
-- | --
![Simulator Screen Shot - iPhone 12 - 2020-11-23 at 18 29 43](https://user-images.githubusercontent.com/1945542/99952065-0a9a8d80-2dba-11eb-9719-4763033bf726.png) | ![Simulator Screen Shot - iPhone 12 - 2020-11-23 at 18 15 13](https://user-images.githubusercontent.com/1945542/99952048-02dae900-2dba-11eb-9dbf-9032fe33de45.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
