### PR TITLE
[Issue Refund] Add Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,6 +100,10 @@ extension WooAnalyticsEvent {
             case off
         }
 
+        static func quantityDialogOpened(orderID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .createOrderRefundItemQuantityDialogOpened, properties: ["order_id": "\(orderID)"])
+        }
+
         static func nextButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundNextButtonTapped, properties: ["order_id": "\(orderID)"])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,6 +100,10 @@ extension WooAnalyticsEvent {
             case off
         }
 
+        static func summaryButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .createOrderRefundSummaryRefundButtonTapped, properties: ["order_id": "\(orderID)"])
+        }
+
         static func shippingSwitchTapped(orderID: Int64, state: ShippingSwitchState) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundShippingOptionTapped, properties: ["order_id": "\(orderID)", "action": state.rawValue])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -87,3 +87,21 @@ extension WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .featureFeedbackBanner, properties: ["context": context.rawValue, "action": action.rawValue])
     }
 }
+
+
+// MARK: - Issue Refund
+//
+extension WooAnalyticsEvent {
+    // Namespace
+    enum IssueRefund {
+        /// The state of the "refund shipping" button
+        public enum ShippingSwitchState: String {
+            case on
+            case off
+        }
+
+        static func shippingSwitchTapped(orderID: Int64, state: ShippingSwitchState) {
+            WooAnalyticsEvent(statName: .createOrderRefundShippingOptionTapped, properties: ["order_id": orderID, "action": state.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -116,6 +116,13 @@ extension WooAnalyticsEvent {
             ])
         }
 
+        static func createRefundFailed(orderID: Int64, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .refundCreateFailed, properties: [
+                "order_id": "\(orderID)",
+                "error_description": error.localizedDescription,
+            ])
+        }
+
         static func selectAllButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundSelectAllItemsButtonTapped, properties: ["order_id": "\(orderID)"])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,6 +100,22 @@ extension WooAnalyticsEvent {
             case off
         }
 
+        // The method used for the refund
+        public enum RefundMethod: String {
+            case items
+            case ammount
+        }
+
+        static func createRefund(orderID: Int64, fullyRefunded: Bool, method: RefundMethod, gateway: String, ammount: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .refundCreate, properties: [
+                "order_id": "\(orderID)",
+                "is_full": "\(fullyRefunded)",
+                "method": method.rawValue,
+                "gateway": gateway,
+                "ammount": ammount
+            ])
+        }
+
         static func selectAllButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundSelectAllItemsButtonTapped, properties: ["order_id": "\(orderID)"])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -116,6 +116,10 @@ extension WooAnalyticsEvent {
             ])
         }
 
+        static func createRefundSuccess(orderID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .refundCreateSuccess, properties: ["order_id": "\(orderID)"])
+        }
+
         static func createRefundFailed(orderID: Int64, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .refundCreateFailed, properties: [
                 "order_id": "\(orderID)",

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,8 +100,8 @@ extension WooAnalyticsEvent {
             case off
         }
 
-        static func shippingSwitchTapped(orderID: Int64, state: ShippingSwitchState) {
-            WooAnalyticsEvent(statName: .createOrderRefundShippingOptionTapped, properties: ["order_id": orderID, "action": state.rawValue])
+        static func shippingSwitchTapped(orderID: Int64, state: ShippingSwitchState) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .createOrderRefundShippingOptionTapped, properties: ["order_id": "\(orderID)", "action": state.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -102,8 +102,8 @@ extension WooAnalyticsEvent {
 
         // The method used for the refund
         public enum RefundMethod: String {
-            case items
-            case ammount
+            case items = "ITEMS"
+            case amount = "AMOUNT"
         }
 
         static func createRefund(orderID: Int64, fullyRefunded: Bool, method: RefundMethod, gateway: String, ammount: String) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,6 +100,10 @@ extension WooAnalyticsEvent {
             case off
         }
 
+        static func selectAllButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .createOrderRefundSelectAllItemsButtonTapped, properties: ["order_id": "\(orderID)"])
+        }
+
         static func quantityDialogOpened(orderID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundItemQuantityDialogOpened, properties: ["order_id": "\(orderID)"])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -100,6 +100,10 @@ extension WooAnalyticsEvent {
             case off
         }
 
+        static func nextButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .createOrderRefundNextButtonTapped, properties: ["order_id": "\(orderID)"])
+        }
+
         static func summaryButtonTapped(orderID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .createOrderRefundSummaryRefundButtonTapped, properties: ["order_id": "\(orderID)"])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -95,24 +95,24 @@ extension WooAnalyticsEvent {
     // Namespace
     enum IssueRefund {
         /// The state of the "refund shipping" button
-        public enum ShippingSwitchState: String {
+        enum ShippingSwitchState: String {
             case on
             case off
         }
 
         // The method used for the refund
-        public enum RefundMethod: String {
+        enum RefundMethod: String {
             case items = "ITEMS"
             case amount = "AMOUNT"
         }
 
-        static func createRefund(orderID: Int64, fullyRefunded: Bool, method: RefundMethod, gateway: String, ammount: String) -> WooAnalyticsEvent {
+        static func createRefund(orderID: Int64, fullyRefunded: Bool, method: RefundMethod, gateway: String, amount: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .refundCreate, properties: [
                 "order_id": "\(orderID)",
                 "is_full": "\(fullyRefunded)",
                 "method": method.rawValue,
                 "gateway": gateway,
-                "ammount": ammount
+                "amount": amount
             ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -402,6 +402,17 @@ public enum WooAnalyticsStat: String {
     case appFeedbackPrompt = "app_feedback_prompt"
     case surveyScreen = "survey_screen"
     case featureFeedbackBanner = "feature_feedback_banner"
+
+    // MARK: Issue Refund events
+    //
+    case refundCreate = "refund_create"
+    case refundCreateFailed = "refund_create_failed"
+    case refundCreateSuccess = "refund_create_success"
+    case createOrderRefundSelectAllItemsButtonTapped = "create_order_refund_select_all_items_button_tapped"
+    case createOrderRefundItemQuantityDialogOpened = "create_order_refund_item_quantity_dialog_opened"
+    case createOrderRefundNextButtonTapped = "create_order_refund_next_button_tapped"
+    case createOrderRefundSummaryRefundButtonTapped = "create_order_refund_summary_refund_button_tapped"
+    case createOrderRefundShippingOptionTapped = "create_order_refund_shipping_option_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -92,7 +92,6 @@ private extension IssueRefundViewController {
             }
             self?.viewModel.updateRefundQuantity(quantity: selectedQuantity, forItemAtIndex: indexPath.row)
         }
-        
         show(selectorViewController, sender: nil)
         viewModel.trackQuantityButtonTapped()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -92,7 +92,9 @@ private extension IssueRefundViewController {
             }
             self?.viewModel.updateRefundQuantity(quantity: selectedQuantity, forItemAtIndex: indexPath.row)
         }
+        
         show(selectorViewController, sender: nil)
+        viewModel.trackQuantityButtonTapped()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -66,6 +66,8 @@ private extension IssueRefundViewController {
     @IBAction func nextButtonWasPressed(_ sender: Any) {
         let confirmationViewModel = viewModel.createRefundConfirmationViewModel()
         show(RefundConfirmationViewController(viewModel: confirmationViewModel), sender: self)
+
+        viewModel.trackNextButtonTapped()
     }
 
     @IBAction func selectAllButtonWasPressed(_ sender: Any) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -152,7 +152,7 @@ extension IssueRefundViewModel {
 
 // MARK: Analytics
 extension IssueRefundViewModel {
-    /// Tracks when the shipping swtich state changes
+    /// Tracks when the shipping switch state changes
     ///
     private func trackShippingSwitchChanged() {
         let action: WooAnalyticsEvent.IssueRefund.ShippingSwitchState = state.shouldRefundShipping ? .on : .off
@@ -165,10 +165,10 @@ extension IssueRefundViewModel {
         analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
     }
 
-    /// Tracks when the user taps the "next" button
+    /// Tracks when the user taps the "quantity" button
     ///
     func trackQuantityButtonTapped() {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.quantityDialogOpened(orderID: state.order.orderID))
     }
 
     /// Tracks when the user taps the "select all" button

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -77,7 +77,10 @@ final class IssueRefundViewModel {
         return resultsController.fetchedObjects.first
     }()
 
-    init(order: Order, refunds: [Refund], currencySettings: CurrencySettings) {
+    private let analytics: Analytics
+
+    init(order: Order, refunds: [Refund], currencySettings: CurrencySettings, analytics: Analytics = ServiceLocator.analytics) {
+        self.analytics = analytics
         let items = Self.filterItems(from: order, with: refunds)
         state = State(order: order, itemsToRefund: items, currencySettings: currencySettings)
         sections = createSections()
@@ -104,6 +107,10 @@ extension IssueRefundViewModel {
     ///
     func toggleRefundShipping() {
         state.shouldRefundShipping.toggle()
+
+        // Analytics
+        let action: WooAnalyticsEvent.IssueRefund.ShippingSwitchState = state.shouldRefundShipping ? .on : .off
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.shippingSwitchTapped(orderID: state.order.orderID, state: action))
     }
 
     /// Returns the number of items available for refund for the provided item index.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -99,12 +99,6 @@ final class IssueRefundViewModel {
                                                           paymentGateway: paymentGateway)
         return RefundConfirmationViewModel(details: details, currencySettings: state.currencySettings)
     }
-
-    /// Tracks when the user taps the "next" button
-    ///
-    func trackNextButtonTapped() {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
-    }
 }
 
 // MARK: User Actions
@@ -156,6 +150,22 @@ extension IssueRefundViewModel {
         }
     }
 }
+
+// MARK: Analytics
+extension IssueRefundViewModel {
+    /// Tracks when the user taps the "next" button
+    ///
+    func trackNextButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
+    }
+
+    /// Tracks when the user taps the "next" button
+    ///
+    func trackQuantityButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
+    }
+}
+
 
 // MARK: Results Controller
 private extension IssueRefundViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -148,6 +148,8 @@ extension IssueRefundViewModel {
         state.itemsToRefund.forEach { refundable in
             state.refundQuantityStore.update(quantity: refundable.quantity, for: refundable.item)
         }
+
+        trackSelectAllButtonTapped()
     }
 }
 
@@ -163,6 +165,12 @@ extension IssueRefundViewModel {
     ///
     func trackQuantityButtonTapped() {
         analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
+    }
+
+    /// Tracks when the user taps the "select all" button
+    ///
+    func trackSelectAllButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.selectAllButtonTapped(orderID: state.order.orderID))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -107,10 +107,7 @@ extension IssueRefundViewModel {
     ///
     func toggleRefundShipping() {
         state.shouldRefundShipping.toggle()
-
-        // Analytics
-        let action: WooAnalyticsEvent.IssueRefund.ShippingSwitchState = state.shouldRefundShipping ? .on : .off
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.shippingSwitchTapped(orderID: state.order.orderID, state: action))
+        trackShippingSwitchChanged()
     }
 
     /// Returns the number of items available for refund for the provided item index.
@@ -155,6 +152,13 @@ extension IssueRefundViewModel {
 
 // MARK: Analytics
 extension IssueRefundViewModel {
+    /// Tracks when the shipping swtich state changes
+    ///
+    private func trackShippingSwitchChanged() {
+        let action: WooAnalyticsEvent.IssueRefund.ShippingSwitchState = state.shouldRefundShipping ? .on : .off
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.shippingSwitchTapped(orderID: state.order.orderID, state: action))
+    }
+
     /// Tracks when the user taps the "next" button
     ///
     func trackNextButtonTapped() {
@@ -169,7 +173,7 @@ extension IssueRefundViewModel {
 
     /// Tracks when the user taps the "select all" button
     ///
-    func trackSelectAllButtonTapped() {
+    private func trackSelectAllButtonTapped() {
         analytics.track(event: WooAnalyticsEvent.IssueRefund.selectAllButtonTapped(orderID: state.order.orderID))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -99,6 +99,12 @@ final class IssueRefundViewModel {
                                                           paymentGateway: paymentGateway)
         return RefundConfirmationViewModel(details: details, currencySettings: state.currencySettings)
     }
+
+    /// Tracks when the user taps the "next" button
+    ///
+    func trackNextButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.nextButtonTapped(orderID: state.order.orderID))
+    }
 }
 
 // MARK: User Actions

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -75,6 +75,7 @@ private extension RefundConfirmationViewController {
     func configureButtonTableFooterView() {
         tableView.tableFooterView = ButtonTableFooterView(frame: .zero, title: Localization.refund) { [weak self] in
             guard let self = self else { return }
+            self.viewModel.trackSummaryButtonTapped()
             self.displayConfirmationAlert { didConfirm in
                 if didConfirm {
                     self.submitRefund()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -165,7 +165,7 @@ extension RefundConfirmationViewModel {
                                                                           fullyRefunded: details.amount == details.order.total,
                                                                           method: .items,
                                                                           gateway: details.order.paymentMethodID,
-                                                                          ammount: details.amount))
+                                                                          amount: details.amount))
     }
 
     /// Tracks when the create refund request succeeds.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -82,6 +82,7 @@ final class RefundConfirmationViewModel {
                 return onCompletion(.failure(error))
             }
             onCompletion(.success(()))
+            self.trackCreateRefundRequestSuccess()
         }
 
         actionProcessor.dispatch(action)
@@ -165,6 +166,12 @@ extension RefundConfirmationViewModel {
                                                                           method: .items,
                                                                           gateway: details.order.paymentMethodID,
                                                                           ammount: details.amount))
+    }
+
+    /// Tracks when the create refund request succeeds.
+    ///
+    private func trackCreateRefundRequestSuccess() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefundSuccess(orderID: details.order.orderID))
     }
 
     /// Tracks when the create refund request fails.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -81,13 +81,9 @@ final class RefundConfirmationViewModel {
             }
             onCompletion(.success(()))
         }
-        actionProcessor.dispatch(action)
-    }
 
-    /// Tracks when the user taps the "summary" button
-    ///
-    func trackSummaryButtonTapped() {
-        analytics.track(event: WooAnalyticsEvent.IssueRefund.summaryButtonTapped(orderID: details.order.orderID))
+        actionProcessor.dispatch(action)
+        trackCreateRefundRequest()
     }
 }
 
@@ -148,6 +144,25 @@ private extension RefundConfirmationViewModel {
             return false
         }
         return paymentGateway.features.contains(.refunds)
+    }
+}
+
+// MARK: Analytics
+extension RefundConfirmationViewModel {
+    /// Tracks when the user taps the "summary" button
+    ///
+    func trackSummaryButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.summaryButtonTapped(orderID: details.order.orderID))
+    }
+
+    /// Tracks when the create refund request is made.
+    ///
+    func trackCreateRefundRequest() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.createRefund(orderID: details.order.orderID,
+                                                                          fullyRefunded: details.amount == details.order.total,
+                                                                          method: .items,
+                                                                          gateway: details.order.paymentMethodID,
+                                                                          ammount: details.amount))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -48,10 +48,16 @@ final class RefundConfirmationViewModel {
         )
     ]
 
-    init(details: Details, actionProcessor: StoresManager = ServiceLocator.stores, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+    private let analytics: Analytics
+
+    init(details: Details,
+         actionProcessor: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.details = details
         self.actionProcessor = actionProcessor
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.analytics = analytics
     }
 
     /// Submit the refund.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -83,6 +83,12 @@ final class RefundConfirmationViewModel {
         }
         actionProcessor.dispatch(action)
     }
+
+    /// Tracks when the user taps the "summary" button
+    ///
+    func trackSummaryButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.IssueRefund.summaryButtonTapped(orderID: details.order.orderID))
+    }
 }
 
 // MARK: Refund Details

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -423,7 +423,21 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["action"] as? String, "on")
     }
 
-    func test_viewModel_correctly_logs_when_the_next_button_is_tapped() {
+    func test_viewModel_correctly_tracks_when_the_next_button_is_tapped() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder()
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, analytics: analytics)
+
+        // When
+        viewModel.trackNextButtonTapped()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundNextButtonTapped.rawValue)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
+    }
+
+    func test_viewModel_correctly_tracks_when_the_quantity_button_is_tapped() {
         // Given
         let currencySettings = CurrencySettings()
         let order = MockOrders().makeOrder()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -444,10 +444,10 @@ final class IssueRefundViewModelTests: XCTestCase {
         let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, analytics: analytics)
 
         // When
-        viewModel.trackNextButtonTapped()
+        viewModel.trackQuantityButtonTapped()
 
         // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundNextButtonTapped.rawValue)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundItemQuantityDialogOpened.rawValue)
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -422,4 +422,18 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["action"] as? String, "on")
     }
+
+    func test_viewModel_correctly_logs_when_the_next_button_is_tapped() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder()
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, analytics: analytics)
+
+        // When
+        viewModel.trackNextButtonTapped()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundNextButtonTapped.rawValue)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -450,4 +450,18 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundNextButtonTapped.rawValue)
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
     }
+
+    func test_viewModel_correctly_tracks_when_the_sellectAll_button_is_tapped() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder()
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings, analytics: analytics)
+
+        // When
+        viewModel.selectAllOrderItems()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundSelectAllItemsButtonTapped.rawValue)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -203,7 +203,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(error, expectedError)
     }
 
-    func test_viewModel_correctly_logs_when_the_summary_button_is_tapped() {
+    func test_viewModel_correctly_tracks_when_the_summary_button_is_tapped() {
         // Given
         let order = MockOrders().makeOrder()
         let details = RefundConfirmationViewModel.Details(order: order, amount: "0.0", refundsShipping: false, items: [], paymentGateway: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -233,7 +233,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["is_full"] as? String, "true")
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["method"] as? String, WooAnalyticsEvent.IssueRefund.RefundMethod.items.rawValue)
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["gateway"] as? String, order.paymentMethodID)
-        XCTAssertEqual(analyticsProvider.receivedProperties.first?["ammount"] as? String, details.amount)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["amount"] as? String, details.amount)
     }
 
     func test_viewModel_correctly_tracks_full_partial_refund_request_when_submit_method_is_called() {
@@ -252,7 +252,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["is_full"] as? String, "false")
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["method"] as? String, WooAnalyticsEvent.IssueRefund.RefundMethod.items.rawValue)
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["gateway"] as? String, order.paymentMethodID)
-        XCTAssertEqual(analyticsProvider.receivedProperties.first?["ammount"] as? String, details.amount)
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["amount"] as? String, details.amount)
     }
 
     func test_view_model_tracks_when_refund_creation_fails() throws {


### PR DESCRIPTION
closes #2793

# Why 

To complete the "Issue Refund" feature we need to match the tracking that is already implemented in Android.
Specifically, the following events are added:

- refund_create
- refund_create_failed
- refund_create_success
- create_order_refund_select_all_items_button_tapped
- create_order_refund_shipping_option_tapped
- create_order_refund_item_quantity_dialog_opened
- create_order_refund_summary_refund_button_tapped
- create_order_refund_next_button_tapped
- create_order_refund_shipping_option_tapped 

# How
- Added track identifiers enum cases to `WooAnalyticsStat`
- Added track events methods to `WooAnalyticsEvents`
- Fire methods from `IssueRefundViewModel` and `RefundConfirmationViewModel`
- Add test cases

# Testing Steps
- Confirm the analytics are being tracked correctly and printed in the console while issuing a refund

**or**

- Trust the unit tests 😅 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
