### PR TITLE
Add CoreDataManager Unit Tests

### DIFF
--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -119,7 +119,8 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.success)
-        XCTAssertTrue(result.debugMessages.isEmpty)
+        XCTAssertEqual(result.debugMessages.count, 1)
+        assertThat(try XCTUnwrap(result.debugMessages.first), contains: "Skipping migration.")
         XCTAssertEqual(fileManager.fileExistsInvocationCount, 1)
         XCTAssertEqual(fileManager.allMethodsInvocationCount, 1)
     }

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -119,6 +119,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.success)
+        XCTAssertTrue(result.debugMessages.isEmpty)
         XCTAssertEqual(fileManager.fileExistsInvocationCount, 1)
         XCTAssertEqual(fileManager.allMethodsInvocationCount, 1)
     }

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -119,8 +119,6 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.success)
-        XCTAssertEqual(result.debugMessages.count, 1)
-        assertThat(try XCTUnwrap(result.debugMessages.first), contains: "Skipping migration.")
         XCTAssertEqual(fileManager.fileExistsInvocationCount, 1)
         XCTAssertEqual(fileManager.allMethodsInvocationCount, 1)
     }

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -119,15 +119,16 @@ final class CoreDataManagerTests: XCTestCase {
                                                    in: manager.viewStorage as! NSManagedObjectContext))
 
         // When
-        // Use a models inventory with an old model. this will cause a loading error and make the
-        // `CoreDataManager` recover and recreate the database.
-        let olderModelsInventory = ManagedObjectModelsInventory(
+        // Use a models inventory with an old and only one model. This will cause a loading error
+        // because it is not compatible. This will then make `CoreDataManager` recover and
+        // recreate the database.
+        let invalidModelsInventory = ManagedObjectModelsInventory(
             packageURL: modelsInventory.packageURL,
             currentModel: try XCTUnwrap(modelsInventory.model(for: .init(name: "Model 2"))),
             versions: [.init(name: "Model 2")]
         )
 
-        manager = try makeManager(using: olderModelsInventory, deletingExistingStoreFiles: false)
+        manager = try makeManager(using: invalidModelsInventory, deletingExistingStoreFiles: false)
 
         // Then
         // The rows should have been deleted during the recovery.

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -212,6 +212,7 @@ final class CoreDataManagerTests: XCTestCase {
         _ = manager.persistentContainer
 
         // Then
+        // The store should still be compatible with the model we used the first time.
         try assertThat(manager, isCompatibleWith: modelsInventory.currentModel)
 
         // The rows should have been kept.

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -21,8 +21,7 @@ final class CoreDataManagerTests: XCTestCase {
     ///
     func test_persistentContainer_loads_expected_data_model_and_sqlite_database() throws {
         // Given
-        let modelsInventory = try ManagedObjectModelsInventory.from(packageName: storageIdentifier,
-                                                                    bundle: Bundle(for: CoreDataManager.self))
+        let modelsInventory = try makeModelsInventory()
 
         let manager = CoreDataManager(name: storageIdentifier, crashLogger: MockCrashLogger())
 
@@ -123,8 +122,7 @@ final class CoreDataManagerTests: XCTestCase {
         // Use a models inventory with an old model. this will cause a loading error and make the
         // `CoreDataManager` recover and recreate the database.
         let olderModelsInventory: ManagedObjectModelsInventory = try {
-            let inventory =
-                try ManagedObjectModelsInventory.from(packageName: storageIdentifier, bundle: .init(for: CoreDataManager.self))
+            let inventory = try makeModelsInventory()
 
             return ManagedObjectModelsInventory(
                 packageURL: inventory.packageURL,
@@ -160,6 +158,10 @@ private extension CoreDataManagerTests {
         account.userID = 0
         account.username = ""
         return account
+    }
+
+    func makeModelsInventory() throws -> ManagedObjectModelsInventory {
+        try ManagedObjectModelsInventory.from(packageName: storageIdentifier, bundle: .init(for: CoreDataManager.self))
     }
 
     func deleteStoreFiles(at storeURL: URL) throws {

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -269,7 +269,12 @@ private extension CoreDataManagerTests {
                     isCompatibleWith model: NSManagedObjectModel,
                     file: StaticString = #file,
                     line: UInt = #line) throws {
-        let store = try XCTUnwrap(manager.persistentContainer.persistentStoreCoordinator.persistentStores.first)
+        let coordinator = manager.persistentContainer.persistentStoreCoordinator
+
+        // We assume that there is only 1 store loaded.
+        XCTAssertEqual(coordinator.persistentStores.count, 1)
+
+        let store = try XCTUnwrap(coordinator.persistentStores.first)
         let isCompatible = model.isConfiguration(withName: nil,
                                                  compatibleWithStoreMetadata: store.metadata)
         XCTAssertTrue(isCompatible,

--- a/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -146,6 +146,7 @@ final class CoreDataManagerTests: XCTestCase {
     func test_accessing_persistentContainer_will_automatically_migrate_the_database() throws {
         // Given
         let modelsInventory = try makeModelsInventory()
+        // Create an inventory with up to Model 33 only. This is what we'll load first.
         let olderModelsInventory: ManagedObjectModelsInventory = try {
             let model33Index = try XCTUnwrap(modelsInventory.versions.firstIndex(of: .init(name: "Model 33")))
             let versions = Array(modelsInventory.versions.prefix(through: model33Index))


### PR DESCRIPTION
Part of #2667. 

I have a [WIP branch](https://github.com/woocommerce/woocommerce-ios/compare/issue/2667-reduce-file-operations-in-core-data) which reduces the `FileManager` operations in our Core Data stack. As we've seen observed with the effect of https://github.com/woocommerce/woocommerce-ios/pull/3069, removing the `FileManager` is effective in reducing the crashes. This is the from the [Sentry event](https://sentry.io/share/issue/d1497b3ad58e4cba8249599fd9efc0eb/):

<img src="https://user-images.githubusercontent.com/198826/100031853-e20f9500-2db3-11eb-91e1-abaa55895076.png" width="300">

But for now, I'm only submitting additional unit tests. AKA “Cover My Ass”. 😄 

## Changes

I added unit tests that prove that `CoreDataManager` will (or will not) automatically migrate the database. These are simple tests as more migration-specific tests will be added to [`CoreDataIterativeMigratotTests`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2667-add-core-data-unit-tests/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift) later. 

## Testing

Please review the code and make sure the build is green. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

 