### PR TITLE
The icon of the cells inside the Product Detail are now aligned at 10px from the top margin

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] now the date pickers on iOS 14 are opened as modal view. [https://github.com/woocommerce/woocommerce-ios/pull/3148]
 - [*] now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3159]
 - [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]
+- [*] the icon of the cells inside the Product Detail are now aligned at 10px from the top margin. [https://github.com/woocommerce/woocommerce-ios/pull/3199]
 
 
 5.5

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -51,6 +51,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     }
 
     @IBOutlet private weak var contentStackView: UIStackView!
+    @IBOutlet private weak var contentImageStackView: UIStackView!
     @IBOutlet private weak var contentImageView: UIImageView!
     @IBOutlet private weak var titleAndTextStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
@@ -78,7 +79,7 @@ extension ImageAndTitleAndTextTableViewCell {
         descriptionLabel.isHidden = viewModel.text == nil || viewModel.text?.isEmpty == true
         descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
-        contentImageView.isHidden = viewModel.image == nil
+        contentImageStackView.isHidden = viewModel.image == nil
         accessoryType = viewModel.isActionable ? .disclosureIndicator: .none
         selectionStyle = viewModel.isActionable ? .default: .none
         accessoryView = nil

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,12 +20,22 @@
                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="I1O-4G-30m">
                         <rect key="frame" x="16" y="10" width="288" height="24"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="htD-vN-CNs">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="G6b-yZ-9yw">
                                 <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="htD-vN-CNs" secondAttribute="height" multiplier="1:1" id="4FY-Di-29I"/>
-                                </constraints>
-                            </imageView>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="htD-vN-CNs">
+                                        <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="htD-vN-CNs" secondAttribute="height" multiplier="1:1" id="jEC-Tg-tzT"/>
+                                        </constraints>
+                                    </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w47-ua-lii">
+                                        <rect key="frame" x="0.0" y="24" width="24" height="0.0"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HHf-VV-Yya">
                                 <rect key="frame" x="24" y="0.0" width="264" height="24"/>
                                 <subviews>
@@ -44,6 +54,10 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="G6b-yZ-9yw" secondAttribute="bottom" id="g1I-8c-ECx"/>
+                            <constraint firstItem="G6b-yZ-9yw" firstAttribute="top" secondItem="I1O-4G-30m" secondAttribute="top" id="uNh-au-xH6"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
@@ -55,6 +69,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="contentImageStackView" destination="G6b-yZ-9yw" id="7de-oG-7MU"/>
                 <outlet property="contentImageView" destination="htD-vN-CNs" id="HtO-a8-POz"/>
                 <outlet property="contentStackView" destination="I1O-4G-30m" id="ehz-kd-Cf7"/>
                 <outlet property="descriptionLabel" destination="afj-1k-DXC" id="elJ-NR-F1b"/>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CZ3-4H-uDU">
-                        <rect key="frame" x="16" y="18" width="24" height="24"/>
+                        <rect key="frame" x="16" y="9" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="EE1-07-gk9"/>
                             <constraint firstAttribute="height" constant="24" id="kTO-5Q-iBN"/>
@@ -38,7 +39,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="12b-yC-TgZ" customClass="RatingView" customModule="WooCommerce" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="100" height="21.5"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="mHV-65-IxC"/>
                                 </constraints>
@@ -59,10 +60,10 @@
                     </stackView>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="CZ3-4H-uDU" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="9" id="1HO-Om-ygx"/>
                     <constraint firstAttribute="bottom" secondItem="yP0-v9-44i" secondAttribute="bottom" constant="7" id="36U-Vo-Lcl"/>
                     <constraint firstItem="yP0-v9-44i" firstAttribute="leading" secondItem="CZ3-4H-uDU" secondAttribute="trailing" constant="16" id="ANM-Xd-eIv"/>
                     <constraint firstItem="jNf-Yw-A2U" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="9" id="Bou-YM-FUc"/>
-                    <constraint firstItem="CZ3-4H-uDU" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Eeu-xl-AMO"/>
                     <constraint firstItem="CZ3-4H-uDU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="UvX-03-lZv"/>
                     <constraint firstAttribute="trailing" secondItem="jNf-Yw-A2U" secondAttribute="trailing" constant="16" id="YbM-Jr-kAK"/>
                     <constraint firstItem="yP0-v9-44i" firstAttribute="top" secondItem="jNf-Yw-A2U" secondAttribute="bottom" constant="2" id="ZYv-Lk-8GL"/>
@@ -80,4 +81,9 @@
             <point key="canvasLocation" x="137.68115942028987" y="109.82142857142857"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
Fixes #3198 

## Description
I noticed that in the cells inside the product detail, we never followed the convention used on Figma for the icons. Previously, the icons were vertically aligned with the cell, but in reality, we expected to see the icon at 10px from the top margin of the cell.

## Changes
- I modified the xib of the cell `ImageAndTitleAndTextTableViewCell` introducing a vertical stack view that contains the icon and an empty view.
- I also modified the xib of the cell `ProductReviewsTableViewCell`, which is used inside the Product Detail, moving the icon in the new position.

## Testing
- Open a product detail, and make sure the icons are now shown in the right position.
- Tap on the bottom button "Add more details", and make sure that the appearance of the cells inside the bottom sheet is like before.

## Screenshots
| Before             |  After |  Bottom Action Sheet (no changes because the icons are hidden) |
:-------------------------:|:-------------------------:|:-------------------------:
![100082283-57c54080-2e48-11eb-9142-1a4043393c44](https://user-images.githubusercontent.com/495617/100094137-d88c3880-2e58-11eb-8155-cd4b97dcebd1.png) |  ![Simulator Screen Shot - iPhone 11 Pro - 2020-11-24 at 13 18 51](https://user-images.githubusercontent.com/495617/100094220-f6599d80-2e58-11eb-8237-87f30407fd1a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-11-24 at 13 18 47](https://user-images.githubusercontent.com/495617/100094231-fa85bb00-2e58-11eb-93dd-747b1e63e6b2.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
