### PR TITLE
Fix product subtitle wrapping in order details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [**] Products M4 features are now available to all. Products M4 features: add a simple/grouped/external product with actions to publish or save as draft. [https://github.com/woocommerce/woocommerce-ios/pull/3133]
 - [*] enhancement: Order details screen now shows variation attributes for WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3109]
 - [*] fix: Product detail screen now includes the number of ratings for that product. [https://github.com/woocommerce/woocommerce-ios/pull/3089]
+- [*] fix: Product subtitle now wraps correctly in order details. [https://github.com/woocommerce/woocommerce-ios/pull/3201]
 
 
 5.4

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -71,6 +71,7 @@ private extension ProductDetailsTableViewCell {
 
     func configureSubtitleLabel() {
         subtitleLabel.applySecondaryFootnoteStyle()
+        subtitleLabel?.numberOfLines = 0
         subtitleLabel?.text = ""
     }
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/3170

##  Description

This PR fixes product subtitle line wrapping in order details. This line can be long if product variation attributes take a lot of space (e.g. many attributes, or long attribute names).

Targeting `release/5.5` as requested in https://a8c.slack.com/archives/C6H8C3G23/p1606147049148000?thread_ts=1605882376.113500&cid=C6H8C3G23

## Testing

1. Create a variable product with many attributes with long name.
2. Create a new order for that variable product + attributes.
3. Open the order details for that order in the app.

## Screenshots

 Before | After 
--------|-------
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/100121234-f2923f00-2e89-11eb-97ed-e65a74413bbc.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/100121456-0342b500-2e8a-11eb-922f-c316f1f248e0.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
