### PR TITLE
Fix disabled state for buttons

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -8,7 +8,6 @@ extension UIButton {
     /// Applies the Primary Button Style: Solid BG!
     ///
     func applyPrimaryButtonStyle() {
-        backgroundColor = .primaryButtonBackground
         contentEdgeInsets = Style.defaultEdgeInsets
         layer.borderColor = UIColor.primaryButtonBorder.cgColor
         layer.borderWidth = Style.defaultBorderWidth
@@ -21,6 +20,11 @@ extension UIButton {
         setTitleColor(.primaryButtonTitle, for: .highlighted)
         setTitleColor(.buttonDisabledTitle, for: .disabled)
 
+        let normalBackgroundImage = UIImage.renderBackgroundImage(fill: .primaryButtonBackground,
+                                                                  border: .primaryButtonBorder)
+            .applyTintColorToiOS13(.primaryButtonBackground)
+        setBackgroundImage(normalBackgroundImage, for: .normal)
+
         let highlightedBackgroundImage = UIImage.renderBackgroundImage(fill: .primaryButtonDownBackground,
                                                                        border: .primaryButtonDownBorder)
             .applyTintColorToiOS13(.primaryButtonDownBackground)
@@ -28,7 +32,7 @@ extension UIButton {
 
         let disabledBackgroundImage = UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
                                                                     border: .buttonDisabledBorder)
-            .applyTintColorToiOS13(.buttonDisabledBackground)
+            .applyTintColorToiOS13(.buttonDisabledBorder) // Use border as tint color since the background is clear
         setBackgroundImage(disabledBackgroundImage, for: .disabled)
     }
 


### PR DESCRIPTION
fixes #3081 

# Why 

While working on the issue refunds project I noticed that the disabled states for our app buttons were wrong.
<img width="300" alt="previous" src="https://user-images.githubusercontent.com/562080/100126065-8264c880-2e4b-11eb-989e-4766788e01f0.png">

This happens because the background-image for the disabled state was a clear color hence showing the default view' background color(pink)

# How

The issue is fixed by not assigning a general background color anymore, but only assigning default images to the different button states (normal, disabled, highlighted)

# Screenshots

Light Disabled | Light Enabled
---- | ----
<img width="397" alt="disabled-light" src="https://user-images.githubusercontent.com/562080/100126716-5269f500-2e4c-11eb-94ea-9dd37c754354.png"> | <img width="388" alt="enabled-light" src="https://user-images.githubusercontent.com/562080/100126725-539b2200-2e4c-11eb-985c-1d259d478c8c.png">


Dark Disabled | Dark Enabled
---- | ----
<img width="402" alt="disabled-dark" src="https://user-images.githubusercontent.com/562080/100126748-5a299980-2e4c-11eb-9936-a3b3e87dd1bd.png"> | <img width="393" alt="enabled-dark" src="https://user-images.githubusercontent.com/562080/100126752-5ac23000-2e4c-11eb-9c32-7b42ef197611.png">

# Testing Steps
- Go to an un-refunded order
- Tap on "Issue Refund" button
- See the "next" button with the correct disabled state
- Select some items
- See the "next" button with the correct enabled state

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
