### PR TITLE
Remove issueRefunds feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3159]
 - [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]
 - [*] the icon of the cells inside the Product Detail are now aligned at 10px from the top margin. [https://github.com/woocommerce/woocommerce-ios/pull/3199]
+- [**] Added the ability to issue refunds from the order screen. Refunds can be done towards products or towards shipping. [https://github.com/woocommerce/woocommerce-ios/pull/3204]
 
 
 5.5

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,8 +7,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease5:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .issueRefunds:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -17,8 +17,4 @@ enum FeatureFlag: Int {
     /// Product Reviews
     ///
     case reviews
-
-    /// Refunds
-    ///
-    case issueRefunds
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -636,7 +636,10 @@ extension OrderDetailsDataSource {
                 rows.append(contentsOf: refunds)
                 rows.append(.netAmount)
             }
-            rows.append(.issueRefundButton)
+
+            if !isRefundedStatus {
+                rows.append(.issueRefundButton)
+            }
 
             return Section(title: Title.payment, rows: rows)
         }()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -11,9 +11,6 @@ final class OrderDetailsDataSource: NSObject {
     /// This is only used to pass as a dependency to `OrderDetailsResultsControllers`.
     private let storageManager: StorageManagerType
 
-    /// Used while the `issueRefunds` feature is under development
-    private let isIssueRefundsEnabled: Bool
-
     private(set) var order: Order
     private let couponLines: [OrderCouponLine]?
 
@@ -145,12 +142,10 @@ final class OrderDetailsDataSource: NSObject {
     private let imageService: ImageService = ServiceLocator.imageService
 
     init(order: Order,
-         storageManager: StorageManagerType = ServiceLocator.storageManager,
-         isIssueRefundsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.issueRefunds)) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.storageManager = storageManager
         self.order = order
         self.couponLines = order.coupons
-        self.isIssueRefundsEnabled = isIssueRefundsEnabled
 
         super.init()
     }
@@ -641,10 +636,7 @@ extension OrderDetailsDataSource {
                 rows.append(contentsOf: refunds)
                 rows.append(.netAmount)
             }
-
-            if isIssueRefundsEnabled && !isRefundedStatus {
-                rows.append(.issueRefundButton)
-            }
+            rows.append(.issueRefundButton)
 
             return Section(title: Title.payment, rows: rows)
         }()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -56,24 +56,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertEqual(actualTitles, expectedTitles)
     }
 
-    func test_refund_button_is_not_visible_when_feature_is_disabled() throws {
+    func test_refund_button_is_visible() throws {
         // Given
         let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, isIssueRefundsEnabled: false)
-
-        // When
-        dataSource.reloadSections()
-
-        // Then
-        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
-        let issueRefundRow = row(row: .issueRefundButton, in: paymentSection)
-        XCTAssertNil(issueRefundRow)
-    }
-
-    func test_refund_button_is_visible_when_feature_is_enabled() throws {
-        // Given
-        let order = makeOrder()
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, isIssueRefundsEnabled: true)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
 
         // When
         dataSource.reloadSections()
@@ -84,10 +70,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNotNil(issueRefundRow)
     }
 
-    func test_refund_button_is_not_visible_when_feature_is_enabled_and_order_is_refunded() throws {
+    func test_refund_button_is_not_visible_when_the_order_is_refunded() throws {
         // Given
         let order = MockOrders().makeOrder(status: .refunded, items: [makeOrderItem()])
-        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, isIssueRefundsEnabled: true)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
 
         // When
         dataSource.reloadSections()


### PR DESCRIPTION
closes #3205

# Why 
Since all the tasks required to issue a refund are completed, now it's time to remove the feature flag that limits its availability to debug builds.

# How
Delete the `issueRefunds` feature flag from `FeatureFlag.swift`

# Testing Steps
Try to refund orders and see that everything makes sense and works as expected.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
