### PR TITLE
Remove Exclusion of Future Orders

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 5.6
 -----
+- [**] Fixed order list sometimes not showing newly submitted orders. 
 - [*] now the date pickers on iOS 14 are opened as modal view. [https://github.com/woocommerce/woocommerce-ios/pull/3148]
 - [*] now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-ios/pull/3159]
 - [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -83,10 +83,6 @@ struct OrderListSyncActionUseCase {
     let siteID: Int64
     /// The current filter mode of the Order List.
     let statusFilter: OrderStatus?
-    /// If true, orders created after today's day will be included in the result.
-    ///
-    /// This will generally only be false for the All Orders tab. All other screens should show orders in the future.
-    let includesFutureOrders: Bool
 
     /// Returns the action to use when synchronizing.
     func actionFor(pageNumber: Int,
@@ -94,7 +90,6 @@ struct OrderListSyncActionUseCase {
                    reason: SyncReason?,
                    completionHandler: @escaping (Error?) -> Void) -> OrderAction {
         let statusKey = statusFilter?.slug
-        let before = includesFutureOrders ? nil : Date().nextMidnight()
 
         if pageNumber == Defaults.pageFirstIndex {
             let deleteAllBeforeSaving = reason == SyncReason.pullToRefresh
@@ -102,7 +97,7 @@ struct OrderListSyncActionUseCase {
             return OrderAction.fetchFilteredAndAllOrders(
                 siteID: siteID,
                 statusKey: statusKey,
-                before: before,
+                before: nil,
                 deleteAllBeforeSaving: deleteAllBeforeSaving,
                 pageSize: pageSize,
                 onCompletion: completionHandler
@@ -112,7 +107,7 @@ struct OrderListSyncActionUseCase {
         return OrderAction.synchronizeOrders(
             siteID: siteID,
             statusKey: statusKey,
-            before: before,
+            before: nil,
             pageNumber: pageNumber,
             pageSize: pageSize,
             onCompletion: completionHandler

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -38,14 +38,6 @@ final class OrderListViewModel {
     ///
     let statusFilter: OrderStatus?
 
-    /// If true, orders created after today's day will be included in the result.
-    ///
-    /// This will generally only be false for the All Orders tab. All other screens should show orders in the future.
-    ///
-    /// Defaults to `true`.
-    ///
-    private let includesFutureOrders: Bool
-
     private let siteID: Int64
 
     /// Used for tracking whether the app was _previously_ in the background.
@@ -63,14 +55,12 @@ final class OrderListViewModel {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
-         statusFilter: OrderStatus?,
-         includesFutureOrders: Bool = true) {
+         statusFilter: OrderStatus?) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
         self.statusFilter = statusFilter
-        self.includesFutureOrders = includesFutureOrders
     }
 
     deinit {
@@ -136,13 +126,7 @@ final class OrderListViewModel {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
             let excludeNonMatchingStatus = statusFilter.map { NSPredicate(format: "statusKey = %@", $0.slug) }
 
-            var predicates = [ excludeSearchCache, excludeNonMatchingStatus ].compactMap { $0 }
-            if !includesFutureOrders, let nextMidnight = Date().nextMidnight() {
-                // Exclude orders on and after midnight of today's date
-                let dateSubPredicate = NSPredicate(format: "dateCreated < %@", nextMidnight as NSDate)
-                predicates.append(dateSubPredicate)
-            }
-
+            let predicates = [excludeSearchCache, excludeNonMatchingStatus].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -124,8 +124,7 @@ final class OrderListViewModel {
                                reason: OrderListSyncActionUseCase.SyncReason?,
                                completionHandler: @escaping (Error?) -> Void) -> OrderAction {
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: statusFilter,
-                                                 includesFutureOrders: includesFutureOrders)
+                                                 statusFilter: statusFilter)
         return useCase.actionFor(pageNumber: pageNumber,
                                  pageSize: pageSize,
                                  reason: reason,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -197,7 +197,7 @@ extension OrdersTabbedViewController {
         let allOrdersVC = OrderListViewController(
             siteID: siteID,
             title: Localization.allOrdersTitle,
-            viewModel: OrderListViewModel(siteID: siteID, statusFilter: nil, includesFutureOrders: false),
+            viewModel: OrderListViewModel(siteID: siteID, statusFilter: nil),
             emptyStateConfig: .withLink(
                 message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                 image: .emptyOrdersImage,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -236,7 +236,7 @@ extension OrdersTabbedViewController {
         let allOrdersVC = OrdersViewController(
             siteID: siteID,
             title: Localization.allOrdersTitle,
-            viewModel: OrdersViewModel(siteID: siteID, statusFilter: nil, includesFutureOrders: false),
+            viewModel: OrdersViewModel(siteID: siteID, statusFilter: nil),
             emptyStateConfig: .withLink(
                 message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                 image: .emptyOrdersImage,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -37,14 +37,6 @@ final class OrdersViewModel {
     ///
     let statusFilter: OrderStatus?
 
-    /// If true, orders created after today's day will be included in the result.
-    ///
-    /// This will generally only be false for the All Orders tab. All other screens should show orders in the future.
-    ///
-    /// Defaults to `true`.
-    ///
-    private let includesFutureOrders: Bool
-
     /// Used for tracking whether the app was _previously_ in the background.
     ///
     private var isAppActive: Bool = true
@@ -73,14 +65,12 @@ final class OrdersViewModel {
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
          statusFilter: OrderStatus?,
-         includesFutureOrders: Bool = true,
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
         self.statusFilter = statusFilter
-        self.includesFutureOrders = includesFutureOrders
         self.stores = stores
     }
 
@@ -121,12 +111,7 @@ final class OrdersViewModel {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
             let excludeNonMatchingStatus = statusFilter.map { NSPredicate(format: "statusKey = %@", $0.slug) }
 
-            var predicates = [ excludeSearchCache, excludeNonMatchingStatus ].compactMap { $0 }
-            if !includesFutureOrders, let nextMidnight = Date().nextMidnight() {
-                // Exclude orders on and after midnight of today's date
-                let dateSubPredicate = NSPredicate(format: "dateCreated < %@", nextMidnight as NSDate)
-                predicates.append(dateSubPredicate)
-            }
+            let predicates = [ excludeSearchCache, excludeNonMatchingStatus ].compactMap { $0 }
 
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -157,8 +157,7 @@ final class OrdersViewModel {
                                reason: OrderListSyncActionUseCase.SyncReason?,
                                completionHandler: @escaping (Error?) -> Void) -> OrderAction {
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: statusFilter,
-                                                 includesFutureOrders: includesFutureOrders)
+                                                 statusFilter: statusFilter)
         return useCase.actionFor(pageNumber: pageNumber,
                                  pageSize: pageSize,
                                  reason: reason,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 		575472812452185300A94C3C /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */; };
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
+		5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */; };
 		576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576D9F2824DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift */; };
 		576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EA39125264C7400AFC0B3 /* RefundConfirmationViewController.swift */; };
 		576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EA39325264C9B00AFC0B3 /* RefundConfirmationViewModel.swift */; };
@@ -1553,6 +1554,7 @@
 		575472802452185300A94C3C /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
 		57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlus.swift"; sourceTree = "<group>"; };
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
+		5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListViewModelTests.swift; sourceTree = "<group>"; };
 		576D9F2824DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewModelTests.swift; sourceTree = "<group>"; };
 		576EA39125264C7400AFC0B3 /* RefundConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmationViewController.swift; sourceTree = "<group>"; };
 		576EA39325264C9B00AFC0B3 /* RefundConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmationViewModel.swift; sourceTree = "<group>"; };
@@ -3418,6 +3420,7 @@
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
 				57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */,
 				57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */,
+				5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -6136,6 +6139,7 @@
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */,
+				5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */,
 				26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */,
 				020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */,
 				0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -25,8 +25,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_pulling_to_refresh_on_filtered_list_it_deletes_and_performs_dual_fetch() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: orderStatus(with: .processing),
-                                                 includesFutureOrders: true)
+                                                 statusFilter: orderStatus(with: .processing))
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
@@ -51,8 +50,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_first_page_load_on_filtered_list_with_non_pull_to_refresh_reasons_will_only_perform_dual_fetch() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: orderStatus(with: .processing),
-                                                 includesFutureOrders: true)
+                                                 statusFilter: orderStatus(with: .processing))
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
@@ -78,8 +76,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_pulling_to_refresh_on_all_orders_list_deletes_and_fetches_first_page_of_all_orders_only() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: nil,
-                                                 includesFutureOrders: true)
+                                                 statusFilter: nil)
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
@@ -104,8 +101,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_first_page_load_on_all_orders_list_with_non_pull_to_refresh_reasons_will_only_perform_single_fetch() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: nil,
-                                                 includesFutureOrders: true)
+                                                 statusFilter: nil)
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
@@ -126,8 +122,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_subsequent_page_loads_on_filtered_list_will_fetch_the_given_page_on_that_list() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: orderStatus(with: .pending),
-                                                 includesFutureOrders: true)
+                                                 statusFilter: orderStatus(with: .pending))
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex + 3,
@@ -149,8 +144,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
     func test_subsequent_page_loads_on_all_orders_list_will_fetch_the_given_page_on_that_list() {
         // Arrange
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 statusFilter: nil,
-                                                 includesFutureOrders: true)
+                                                 statusFilter: nil)
 
         // Act
         let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex + 5,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -177,25 +177,25 @@ final class OrderListViewModelTests: XCTestCase {
         // Assert
         XCTAssertTrue(resynchronizeRequested)
     }
-//
-//    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
-//        // Arrange
-//        let notificationCenter = NotificationCenter()
-//        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
-//
-//        var resynchronizeRequested = false
-//        viewModel.onShouldResynchronizeIfViewIsVisible = {
-//            resynchronizeRequested = true
-//        }
-//
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Act
-//        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-//
-//        // Assert
-//        XCTAssertFalse(resynchronizeRequested)
-//    }
+
+    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activate()
+
+        // Act
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        // Assert
+        XCTAssertFalse(resynchronizeRequested)
+    }
 //
 //    // MARK: - Foreground Notifications
 //

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -45,7 +45,7 @@ final class OrderListViewModelTests: XCTestCase {
 
     // MARK: - Future Orders
 
-    func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() {
+    func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() throws {
         // Arrange
         let viewModel = OrderListViewModel(siteID: siteID,
                                            storageManager: storageManager,
@@ -54,213 +54,222 @@ final class OrderListViewModelTests: XCTestCase {
         let processingOrders = (0..<10).map { insertOrder(id: $0, status: .processing) }
         let completedOrders = (100..<105).map { insertOrder(id: $0, status: .completed) }
 
+        storage.saveIfNeeded()
+
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), processingOrders.count + completedOrders.count)
 
         // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
+        let snapshot: FetchResultSnapshot = try waitFor { promise in
+            viewModel.snapshot.dropFirst().sink { snapshot in
+                print(snapshot)
+                promise(snapshot)
+            }.store(in: &self.cancellables)
 
-        // Assert
-        XCTAssertFalse(viewModel.isEmpty)
-        XCTAssertEqual(viewModel.numberOfObjects, processingOrders.count)
-
-        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, processingOrders.orderIDs)
-    }
-
-    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
-        // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil)
-
-        let allInsertedOrders = [
-            (0..<10).map { insertOrder(id: $0, status: .processing) },
-            (100..<105).map { insertOrder(id: $0, status: .completed, dateCreated: Date().adding(days: -2)!) },
-            (200..<203).map { insertOrder(id: $0, status: .pending) },
-        ].flatMap { $0 }
-
-        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
-
-        // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Assert
-        XCTAssertFalse(viewModel.isEmpty)
-        XCTAssertEqual(viewModel.numberOfObjects, allInsertedOrders.count)
-
-        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, allInsertedOrders.orderIDs)
-    }
-
-    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
-    /// be fetched.
-    func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
-        // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID,
-                                           storageManager: storageManager,
-                                           statusFilter: orderStatus(with: .pending),
-                                           includesFutureOrders: true)
-
-        let expectedOrders = [
-            // Future orders
-            insertOrder(id: 1_000, status: .pending, dateCreated: Date().adding(days: 1)!),
-            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 2)!),
-            insertOrder(id: 1_002, status: .pending, dateCreated: Date().adding(days: 3)!),
-            // Past orders
-            insertOrder(id: 4_000, status: .pending, dateCreated: Date().adding(days: -1)!),
-            insertOrder(id: 4_001, status: .pending, dateCreated: Date().adding(days: -20)!),
-        ]
-
-        // This should be ignored because it is not the same filter
-        let ignoredFutureOrder = insertOrder(id: 2_000, status: .cancelled, dateCreated: Date().adding(days: 1)!)
-
-        // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Assert
-        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
-        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
-
-        XCTAssertFalse(viewModel.fetchedOrders.orderIDs.contains(ignoredFutureOrder.orderID))
-    }
-
-    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
-    /// midnight are included.
-    func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
-        // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false)
-
-        let ignoredOrders = [
-            // Orders in the future
-            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 1)!),
-            insertOrder(id: 1_002, status: .cancelled, dateCreated: Date().adding(days: 3)!),
-            // Exactly midnight is also ignored because it is technically "tomorrow"
-            insertOrder(id: 1_003, status: .processing, dateCreated: Date().nextMidnight()!),
-        ]
-
-        let expectedOrders = [
-            insertOrder(id: 4_001, status: .completed, dateCreated: Date()),
-            insertOrder(id: 4_002, status: .pending, dateCreated: Date().adding(days: -1)!),
-            insertOrder(id: 4_003, status: .pending, dateCreated: Date().adding(days: -20)!),
-            // 1 second before midnight is included because it is technically "today"
-            insertOrder(id: 4_004, status: .processing, dateCreated: Date().nextMidnight()!.adding(seconds: -1)!),
-        ]
-
-        // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Assert
-        XCTAssertTrue(viewModel.fetchedOrders.orderIDs.isDisjoint(with: ignoredOrders.orderIDs))
-
-        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
-        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
-    }
-
-    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
-    func test_it_groups_future_orders_in_upcoming_section() {
-        // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed))
-
-        let expectedOrders = (
-            future: [
-                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 3)!),
-                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 4)!),
-            ],
-            past: [
-                insertOrder(id: 4_000, status: .failed, dateCreated: Date().adding(days: -1)!),
-            ]
-        )
-
-        // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Assert
-        XCTAssertEqual(viewModel.numberOfSections, 2)
-
-        // The first section should be the Upcoming section
-        let upcomingSection = viewModel.sectionInfo(at: 0)
-        XCTAssertEqual(Age(rawValue: upcomingSection.name), .upcoming)
-        XCTAssertEqual(upcomingSection.numberOfObjects, expectedOrders.future.count)
-    }
-
-    // MARK: - App Activation
-
-    func test_it_requests_a_resynchronization_when_the_app_is_activated() {
-        // Arrange
-        let notificationCenter = NotificationCenter()
-        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
-
-        var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeIfViewIsVisible = {
-            resynchronizeRequested = true
+            viewModel.activate()
         }
 
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Act
-        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
-        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-
         // Assert
-        XCTAssertTrue(resynchronizeRequested)
+        XCTAssertTrue(snapshot.itemIdentifiers.isNotEmpty)
+        XCTAssertEqual(snapshot.numberOfItems, processingOrders.count)
+
+        XCTAssertEqual(viewModel.orders(from: snapshot).orderIDs, processingOrders.orderIDs)
     }
 
-    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
-        // Arrange
-        let notificationCenter = NotificationCenter()
-        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
-
-        var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeIfViewIsVisible = {
-            resynchronizeRequested = true
-        }
-
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Act
-        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-
-        // Assert
-        XCTAssertFalse(resynchronizeRequested)
-    }
-
-    // MARK: - Foreground Notifications
-
-    func test_given_a_new_order_notification_it_requests_a_resynchronization() {
-        // Arrange
-        let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
-
-        var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeIfViewIsVisible = {
-            resynchronizeRequested = true
-        }
-
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Act
-        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
-        pushNotificationsManager.sendForegroundNotification(notification)
-
-        // Assert
-        XCTAssertTrue(resynchronizeRequested)
-    }
-
-    func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
-        // Arrange
-        let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
-
-        var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeIfViewIsVisible = {
-            resynchronizeRequested = true
-        }
-
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Act
-        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
-        pushNotificationsManager.sendForegroundNotification(notification)
-
-        // Assert
-        XCTAssertFalse(resynchronizeRequested)
-    }
+//    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
+//        // Arrange
+//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil)
+//
+//        let allInsertedOrders = [
+//            (0..<10).map { insertOrder(id: $0, status: .processing) },
+//            (100..<105).map { insertOrder(id: $0, status: .completed, dateCreated: Date().adding(days: -2)!) },
+//            (200..<203).map { insertOrder(id: $0, status: .pending) },
+//        ].flatMap { $0 }
+//
+//        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
+//
+//        // Act
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Assert
+//        XCTAssertFalse(viewModel.isEmpty)
+//        XCTAssertEqual(viewModel.numberOfObjects, allInsertedOrders.count)
+//
+//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, allInsertedOrders.orderIDs)
+//    }
+//
+//    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
+//    /// be fetched.
+//    func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
+//        // Arrange
+//        let viewModel = OrderListViewModel(siteID: siteID,
+//                                           storageManager: storageManager,
+//                                           statusFilter: orderStatus(with: .pending),
+//                                           includesFutureOrders: true)
+//
+//        let expectedOrders = [
+//            // Future orders
+//            insertOrder(id: 1_000, status: .pending, dateCreated: Date().adding(days: 1)!),
+//            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 2)!),
+//            insertOrder(id: 1_002, status: .pending, dateCreated: Date().adding(days: 3)!),
+//            // Past orders
+//            insertOrder(id: 4_000, status: .pending, dateCreated: Date().adding(days: -1)!),
+//            insertOrder(id: 4_001, status: .pending, dateCreated: Date().adding(days: -20)!),
+//        ]
+//
+//        // This should be ignored because it is not the same filter
+//        let ignoredFutureOrder = insertOrder(id: 2_000, status: .cancelled, dateCreated: Date().adding(days: 1)!)
+//
+//        // Act
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Assert
+//        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
+//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
+//
+//        XCTAssertFalse(viewModel.fetchedOrders.orderIDs.contains(ignoredFutureOrder.orderID))
+//    }
+//
+//    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
+//    /// midnight are included.
+//    func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
+//        // Arrange
+//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false)
+//
+//        let ignoredOrders = [
+//            // Orders in the future
+//            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 1)!),
+//            insertOrder(id: 1_002, status: .cancelled, dateCreated: Date().adding(days: 3)!),
+//            // Exactly midnight is also ignored because it is technically "tomorrow"
+//            insertOrder(id: 1_003, status: .processing, dateCreated: Date().nextMidnight()!),
+//        ]
+//
+//        let expectedOrders = [
+//            insertOrder(id: 4_001, status: .completed, dateCreated: Date()),
+//            insertOrder(id: 4_002, status: .pending, dateCreated: Date().adding(days: -1)!),
+//            insertOrder(id: 4_003, status: .pending, dateCreated: Date().adding(days: -20)!),
+//            // 1 second before midnight is included because it is technically "today"
+//            insertOrder(id: 4_004, status: .processing, dateCreated: Date().nextMidnight()!.adding(seconds: -1)!),
+//        ]
+//
+//        // Act
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Assert
+//        XCTAssertTrue(viewModel.fetchedOrders.orderIDs.isDisjoint(with: ignoredOrders.orderIDs))
+//
+//        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
+//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
+//    }
+//
+//    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
+//    func test_it_groups_future_orders_in_upcoming_section() {
+//        // Arrange
+//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed))
+//
+//        let expectedOrders = (
+//            future: [
+//                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 3)!),
+//                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 4)!),
+//            ],
+//            past: [
+//                insertOrder(id: 4_000, status: .failed, dateCreated: Date().adding(days: -1)!),
+//            ]
+//        )
+//
+//        // Act
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Assert
+//        XCTAssertEqual(viewModel.numberOfSections, 2)
+//
+//        // The first section should be the Upcoming section
+//        let upcomingSection = viewModel.sectionInfo(at: 0)
+//        XCTAssertEqual(Age(rawValue: upcomingSection.name), .upcoming)
+//        XCTAssertEqual(upcomingSection.numberOfObjects, expectedOrders.future.count)
+//    }
+//
+//    // MARK: - App Activation
+//
+//    func test_it_requests_a_resynchronization_when_the_app_is_activated() {
+//        // Arrange
+//        let notificationCenter = NotificationCenter()
+//        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
+//
+//        var resynchronizeRequested = false
+//        viewModel.onShouldResynchronizeIfViewIsVisible = {
+//            resynchronizeRequested = true
+//        }
+//
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Act
+//        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
+//        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+//
+//        // Assert
+//        XCTAssertTrue(resynchronizeRequested)
+//    }
+//
+//    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
+//        // Arrange
+//        let notificationCenter = NotificationCenter()
+//        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
+//
+//        var resynchronizeRequested = false
+//        viewModel.onShouldResynchronizeIfViewIsVisible = {
+//            resynchronizeRequested = true
+//        }
+//
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Act
+//        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+//
+//        // Assert
+//        XCTAssertFalse(resynchronizeRequested)
+//    }
+//
+//    // MARK: - Foreground Notifications
+//
+//    func test_given_a_new_order_notification_it_requests_a_resynchronization() {
+//        // Arrange
+//        let pushNotificationsManager = MockPushNotificationsManager()
+//        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+//
+//        var resynchronizeRequested = false
+//        viewModel.onShouldResynchronizeIfViewIsVisible = {
+//            resynchronizeRequested = true
+//        }
+//
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Act
+//        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
+//        pushNotificationsManager.sendForegroundNotification(notification)
+//
+//        // Assert
+//        XCTAssertTrue(resynchronizeRequested)
+//    }
+//
+//    func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
+//        // Arrange
+//        let pushNotificationsManager = MockPushNotificationsManager()
+//        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+//
+//        var resynchronizeRequested = false
+//        viewModel.onShouldResynchronizeIfViewIsVisible = {
+//            resynchronizeRequested = true
+//        }
+//
+//        viewModel.activateAndForwardUpdates(to: UITableView())
+//
+//        // Act
+//        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
+//        pushNotificationsManager.sendForegroundNotification(notification)
+//
+//        // Assert
+//        XCTAssertFalse(resynchronizeRequested)
+//    }
 }
 
 // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -48,9 +48,8 @@ final class OrderListViewModelTests: XCTestCase {
     func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() {
         // Arrange
         let viewModel = OrderListViewModel(siteID: siteID,
-                                        storageManager: storageManager,
-                                        statusFilter: orderStatus(with: .processing),
-                                        stores: stores)
+                                           storageManager: storageManager,
+                                           statusFilter: orderStatus(with: .processing))
 
         let processingOrders = (0..<10).map { insertOrder(id: $0, status: .processing) }
         let completedOrders = (100..<105).map { insertOrder(id: $0, status: .completed) }
@@ -69,7 +68,7 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
         // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil)
 
         let allInsertedOrders = [
             (0..<10).map { insertOrder(id: $0, status: .processing) },
@@ -94,10 +93,9 @@ final class OrderListViewModelTests: XCTestCase {
     func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
         // Arrange
         let viewModel = OrderListViewModel(siteID: siteID,
-                                        storageManager: storageManager,
-                                        statusFilter: orderStatus(with: .pending),
-                                        includesFutureOrders: true,
-                                        stores: stores)
+                                           storageManager: storageManager,
+                                           statusFilter: orderStatus(with: .pending),
+                                           includesFutureOrders: true)
 
         let expectedOrders = [
             // Future orders
@@ -126,7 +124,7 @@ final class OrderListViewModelTests: XCTestCase {
     /// midnight are included.
     func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
         // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false)
 
         let ignoredOrders = [
             // Orders in the future
@@ -157,7 +155,7 @@ final class OrderListViewModelTests: XCTestCase {
     /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
     func test_it_groups_future_orders_in_upcoming_section() {
         // Arrange
-        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed), stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed))
 
         let expectedOrders = (
             future: [
@@ -186,7 +184,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {
         // Arrange
         let notificationCenter = NotificationCenter()
-        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -206,7 +204,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
         // Arrange
         let notificationCenter = NotificationCenter()
-        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -227,7 +225,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_given_a_new_order_notification_it_requests_a_resynchronization() {
         // Arrange
         let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -247,7 +245,7 @@ final class OrderListViewModelTests: XCTestCase {
     func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
         // Arrange
         let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -89,38 +89,38 @@ final class OrderListViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.orderIDs(from: snapshot), allInsertedOrders.orderIDs)
     }
-//
-//    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
-//    /// be fetched.
-//    func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
-//        // Arrange
-//        let viewModel = OrderListViewModel(siteID: siteID,
-//                                           storageManager: storageManager,
-//                                           statusFilter: orderStatus(with: .pending),
-//                                           includesFutureOrders: true)
-//
-//        let expectedOrders = [
-//            // Future orders
-//            insertOrder(id: 1_000, status: .pending, dateCreated: Date().adding(days: 1)!),
-//            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 2)!),
-//            insertOrder(id: 1_002, status: .pending, dateCreated: Date().adding(days: 3)!),
-//            // Past orders
-//            insertOrder(id: 4_000, status: .pending, dateCreated: Date().adding(days: -1)!),
-//            insertOrder(id: 4_001, status: .pending, dateCreated: Date().adding(days: -20)!),
-//        ]
-//
-//        // This should be ignored because it is not the same filter
-//        let ignoredFutureOrder = insertOrder(id: 2_000, status: .cancelled, dateCreated: Date().adding(days: 1)!)
-//
-//        // Act
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Assert
-//        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
-//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
-//
-//        XCTAssertFalse(viewModel.fetchedOrders.orderIDs.contains(ignoredFutureOrder.orderID))
-//    }
+
+    /// Test that all orders including orders dated in the future (dateCreated) will be fetched.
+    func test_it_also_loads_future_orders_from_the_DB() throws {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           storageManager: storageManager,
+                                           statusFilter: orderStatus(with: .pending),
+                                           includesFutureOrders: true)
+
+        let expectedOrders = [
+            // Future orders
+            insertOrder(id: 1_000, status: .pending, dateCreated: Date().adding(days: 1)!),
+            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 2)!),
+            insertOrder(id: 1_002, status: .pending, dateCreated: Date().adding(days: 3)!),
+            // Past orders
+            insertOrder(id: 4_000, status: .pending, dateCreated: Date().adding(days: -1)!),
+            insertOrder(id: 4_001, status: .pending, dateCreated: Date().adding(days: -20)!),
+        ]
+
+        // This should be ignored because it is not the same filter
+        let ignoredFutureOrder = insertOrder(id: 2_000, status: .cancelled, dateCreated: Date().adding(days: 1)!)
+
+        // Act
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Assert
+        XCTAssertEqual(snapshot.numberOfItems, expectedOrders.count)
+
+        let orderIDs = viewModel.orderIDs(from: snapshot)
+        XCTAssertEqual(orderIDs, expectedOrders.orderIDs)
+        XCTAssertFalse(orderIDs.contains(ignoredFutureOrder.orderID))
+    }
 //
 //    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
 //    /// midnight are included.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -121,33 +121,40 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(orderIDs, expectedOrders.orderIDs)
         XCTAssertFalse(orderIDs.contains(ignoredFutureOrder.orderID))
     }
-//
-//    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
-//    func test_it_groups_future_orders_in_upcoming_section() {
-//        // Arrange
-//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed))
-//
-//        let expectedOrders = (
-//            future: [
-//                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 3)!),
-//                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 4)!),
-//            ],
-//            past: [
-//                insertOrder(id: 4_000, status: .failed, dateCreated: Date().adding(days: -1)!),
-//            ]
-//        )
-//
-//        // Act
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Assert
-//        XCTAssertEqual(viewModel.numberOfSections, 2)
-//
-//        // The first section should be the Upcoming section
-//        let upcomingSection = viewModel.sectionInfo(at: 0)
-//        XCTAssertEqual(Age(rawValue: upcomingSection.name), .upcoming)
-//        XCTAssertEqual(upcomingSection.numberOfObjects, expectedOrders.future.count)
-//    }
+
+    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
+    func test_it_groups_future_orders_in_upcoming_section() throws {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           storageManager: storageManager,
+                                           statusFilter: orderStatus(with: .failed))
+
+        let expectedOrders = (
+            future: [
+                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 3)!),
+                insertOrder(id: 1_001, status: .failed, dateCreated: Date().adding(days: 4)!),
+                insertOrder(id: 1_002, status: .failed, dateCreated: Date().adding(days: 5)!),
+            ],
+            past: [
+                insertOrder(id: 4_000, status: .failed, dateCreated: Date().adding(days: -1)!),
+            ]
+        )
+
+        // Act
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Assert
+        XCTAssertEqual(snapshot.numberOfSections, 2)
+
+        // The first section should be the Upcoming section
+        let sectionID = try XCTUnwrap(snapshot.sectionIdentifiers.first)
+        XCTAssertEqual(Age(rawValue: sectionID), .upcoming)
+
+        let sectionTitle = try XCTUnwrap(viewModel.sectionTitleFor(sectionIdentifier: sectionID))
+        XCTAssertEqual(sectionTitle, Age(rawValue: sectionID)?.description)
+
+        XCTAssertEqual(snapshot.numberOfItems(inSection: sectionID), expectedOrders.future.count)
+    }
 //
 //    // MARK: - App Activation
 //

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -65,7 +65,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertTrue(snapshot.itemIdentifiers.isNotEmpty)
         XCTAssertEqual(snapshot.numberOfItems, processingOrders.count)
 
-        XCTAssertEqual(viewModel.orders(from: snapshot).orderIDs, processingOrders.orderIDs)
+        XCTAssertEqual(viewModel.orderIDs(from: snapshot), processingOrders.orderIDs)
     }
 
 //    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
@@ -269,12 +269,12 @@ final class OrderListViewModelTests: XCTestCase {
 
 @available(iOS 13.0, *)
 private extension OrderListViewModel {
-    /// Returns the Order instances for all the given object IDs.
+    /// Returns the corresponding order IDs instances for all the given FetchResultSnapshot IDs.
     ///
-    func orders(from snapshot: FetchResultSnapshot) -> [Yosemite.Order] {
-        snapshot.itemIdentifiers.compactMap { objectID in
-            detailsViewModel(withID: objectID)?.order
-        }
+    func orderIDs(from snapshot: FetchResultSnapshot) -> Set<Int64> {
+        Set(snapshot.itemIdentifiers.compactMap { objectID in
+            detailsViewModel(withID: objectID)?.order.orderID
+        })
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -59,14 +59,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), processingOrders.count + completedOrders.count)
 
         // Act
-        let snapshot: FetchResultSnapshot = try waitFor { promise in
-            viewModel.snapshot.dropFirst().sink { snapshot in
-                print(snapshot)
-                promise(snapshot)
-            }.store(in: &self.cancellables)
-
-            viewModel.activate()
-        }
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
 
         // Assert
         XCTAssertTrue(snapshot.itemIdentifiers.isNotEmpty)
@@ -297,6 +290,20 @@ private extension Array where Element == Yosemite.Order {
 
 @available(iOS 13.0, *)
 private extension OrderListViewModelTests {
+
+    /// Activate the viewModel to start fetching and then return the first
+    /// valid `FetchResultSnapshot` triggered.
+    func activateAndRetrieveSnapshot(of viewModel: OrderListViewModel) throws -> FetchResultSnapshot {
+        return try waitFor { promise in
+            // The first snapshot is dropped because it's just the default empty one.
+            viewModel.snapshot.dropFirst().sink { snapshot in
+                promise(snapshot)
+            }.store(in: &self.cancellables)
+
+            viewModel.activate()
+        }
+    }
+
     func orderStatus(with status: OrderStatusEnum) -> Yosemite.OrderStatus {
         OrderStatus(name: nil, siteID: siteID, slug: status.rawValue, total: 0)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -1,0 +1,328 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+import Storage
+
+private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
+private typealias Defaults = OrdersViewModel.Defaults
+
+/// Tests for `OrderListViewModel`.
+///
+@available(iOS 13.0, *)
+final class OrderListViewModelTests: XCTestCase {
+    /// The `siteID` value doesn't matter.
+    private let siteID: Int64 = 1_000_000
+    private let pageSize = 50
+
+    private let unimportantCompletionHandler: ((Error?) -> Void) = { _ in
+        // noop
+    }
+
+    private var storageManager: StorageManagerType!
+    private var stores: StoresManager!
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockupStorageManager()
+        stores = MockupStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.sessionManager.setStoreId(siteID)
+    }
+
+    override func tearDown() {
+        // If not resetting store ID back to `nil`, it could cause other test failures since `setStoreId` changes UserDefaults.
+        stores.sessionManager.setStoreId(nil)
+        stores = nil
+        storageManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Future Orders
+
+    func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                        storageManager: storageManager,
+                                        statusFilter: orderStatus(with: .processing),
+                                        stores: stores)
+
+        let processingOrders = (0..<10).map { insertOrder(id: $0, status: .processing) }
+        let completedOrders = (100..<105).map { insertOrder(id: $0, status: .completed) }
+
+        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), processingOrders.count + completedOrders.count)
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertFalse(viewModel.isEmpty)
+        XCTAssertEqual(viewModel.numberOfObjects, processingOrders.count)
+
+        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, processingOrders.orderIDs)
+    }
+
+    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, stores: stores)
+
+        let allInsertedOrders = [
+            (0..<10).map { insertOrder(id: $0, status: .processing) },
+            (100..<105).map { insertOrder(id: $0, status: .completed, dateCreated: Date().adding(days: -2)!) },
+            (200..<203).map { insertOrder(id: $0, status: .pending) },
+        ].flatMap { $0 }
+
+        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertFalse(viewModel.isEmpty)
+        XCTAssertEqual(viewModel.numberOfObjects, allInsertedOrders.count)
+
+        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, allInsertedOrders.orderIDs)
+    }
+
+    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
+    /// be fetched.
+    func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                        storageManager: storageManager,
+                                        statusFilter: orderStatus(with: .pending),
+                                        includesFutureOrders: true,
+                                        stores: stores)
+
+        let expectedOrders = [
+            // Future orders
+            insertOrder(id: 1_000, status: .pending, dateCreated: Date().adding(days: 1)!),
+            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 2)!),
+            insertOrder(id: 1_002, status: .pending, dateCreated: Date().adding(days: 3)!),
+            // Past orders
+            insertOrder(id: 4_000, status: .pending, dateCreated: Date().adding(days: -1)!),
+            insertOrder(id: 4_001, status: .pending, dateCreated: Date().adding(days: -20)!),
+        ]
+
+        // This should be ignored because it is not the same filter
+        let ignoredFutureOrder = insertOrder(id: 2_000, status: .cancelled, dateCreated: Date().adding(days: 1)!)
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
+        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
+
+        XCTAssertFalse(viewModel.fetchedOrders.orderIDs.contains(ignoredFutureOrder.orderID))
+    }
+
+    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
+    /// midnight are included.
+    func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false, stores: stores)
+
+        let ignoredOrders = [
+            // Orders in the future
+            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 1)!),
+            insertOrder(id: 1_002, status: .cancelled, dateCreated: Date().adding(days: 3)!),
+            // Exactly midnight is also ignored because it is technically "tomorrow"
+            insertOrder(id: 1_003, status: .processing, dateCreated: Date().nextMidnight()!),
+        ]
+
+        let expectedOrders = [
+            insertOrder(id: 4_001, status: .completed, dateCreated: Date()),
+            insertOrder(id: 4_002, status: .pending, dateCreated: Date().adding(days: -1)!),
+            insertOrder(id: 4_003, status: .pending, dateCreated: Date().adding(days: -20)!),
+            // 1 second before midnight is included because it is technically "today"
+            insertOrder(id: 4_004, status: .processing, dateCreated: Date().nextMidnight()!.adding(seconds: -1)!),
+        ]
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertTrue(viewModel.fetchedOrders.orderIDs.isDisjoint(with: ignoredOrders.orderIDs))
+
+        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
+        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
+    }
+
+    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
+    func test_it_groups_future_orders_in_upcoming_section() {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed), stores: stores)
+
+        let expectedOrders = (
+            future: [
+                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 3)!),
+                insertOrder(id: 1_000, status: .failed, dateCreated: Date().adding(days: 4)!),
+            ],
+            past: [
+                insertOrder(id: 4_000, status: .failed, dateCreated: Date().adding(days: -1)!),
+            ]
+        )
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertEqual(viewModel.numberOfSections, 2)
+
+        // The first section should be the Upcoming section
+        let upcomingSection = viewModel.sectionInfo(at: 0)
+        XCTAssertEqual(Age(rawValue: upcomingSection.name), .upcoming)
+        XCTAssertEqual(upcomingSection.numberOfObjects, expectedOrders.future.count)
+    }
+
+    // MARK: - App Activation
+
+    func test_it_requests_a_resynchronization_when_the_app_is_activated() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        // Assert
+        XCTAssertTrue(resynchronizeRequested)
+    }
+
+    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        // Assert
+        XCTAssertFalse(resynchronizeRequested)
+    }
+
+    // MARK: - Foreground Notifications
+
+    func test_given_a_new_order_notification_it_requests_a_resynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertTrue(resynchronizeRequested)
+    }
+
+    func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertFalse(resynchronizeRequested)
+    }
+}
+
+// MARK: - Helpers
+
+private extension OrderListViewModel {
+    /// Returns the Order instances for all the rows
+    ///
+    var fetchedOrders: [Yosemite.Order] {
+        (0..<numberOfSections).flatMap { section in
+            (0..<numberOfRows(in: section)).compactMap { row in
+                detailsViewModel(at: IndexPath(row: row, section: section))?.order
+            }
+        }
+    }
+}
+
+private extension Array where Element == Yosemite.Order {
+    /// Returns all the IDs
+    ///
+    var orderIDs: Set<Int64> {
+        Set(map(\.orderID))
+    }
+}
+
+// MARK: - Builders
+
+private extension OrderListViewModelTests {
+    func orderStatus(with status: OrderStatusEnum) -> Yosemite.OrderStatus {
+        OrderStatus(name: nil, siteID: siteID, slug: status.rawValue, total: 0)
+    }
+
+    func insertOrder(id orderID: Int64,
+                     status: OrderStatusEnum,
+                     dateCreated: Date = Date()) -> Yosemite.Order {
+        let readonlyOrder = Order(siteID: siteID,
+                                  orderID: orderID,
+                                  parentID: 0,
+                                  customerID: 11,
+                                  number: "963",
+                                  status: status,
+                                  currency: "USD",
+                                  customerNote: "",
+                                  dateCreated: dateCreated,
+                                  dateModified: Date(),
+                                  datePaid: nil,
+                                  discountTotal: "30.00",
+                                  discountTax: "1.20",
+                                  shippingTotal: "0.00",
+                                  shippingTax: "0.00",
+                                  total: "31.20",
+                                  totalTax: "1.20",
+                                  paymentMethodID: "stripe",
+                                  paymentMethodTitle: "Credit Card (Stripe)",
+                                  items: [],
+                                  billingAddress: nil,
+                                  shippingAddress: nil,
+                                  shippingLines: [],
+                                  coupons: [],
+                                  refunds: [])
+
+        let storageOrder = storage.insertNewObject(ofType: StorageOrder.self)
+        storageOrder.update(with: readonlyOrder)
+
+        return readonlyOrder
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -20,7 +20,6 @@ final class OrderListViewModelTests: XCTestCase {
     }
 
     private var storageManager: StorageManagerType!
-    private var stores: StoresManager!
 
     private var storage: StorageType {
         storageManager.viewStorage
@@ -31,14 +30,9 @@ final class OrderListViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storageManager = MockupStorageManager()
-        stores = MockupStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.sessionManager.setStoreId(siteID)
     }
 
     override func tearDown() {
-        // If not resetting store ID back to `nil`, it could cause other test failures since `setStoreId` changes UserDefaults.
-        stores.sessionManager.setStoreId(nil)
-        stores = nil
         storageManager = nil
 
         cancellables.forEach {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -122,38 +122,6 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(orderIDs.contains(ignoredFutureOrder.orderID))
     }
 //
-//    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
-//    /// midnight are included.
-//    func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
-//        // Arrange
-//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false)
-//
-//        let ignoredOrders = [
-//            // Orders in the future
-//            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 1)!),
-//            insertOrder(id: 1_002, status: .cancelled, dateCreated: Date().adding(days: 3)!),
-//            // Exactly midnight is also ignored because it is technically "tomorrow"
-//            insertOrder(id: 1_003, status: .processing, dateCreated: Date().nextMidnight()!),
-//        ]
-//
-//        let expectedOrders = [
-//            insertOrder(id: 4_001, status: .completed, dateCreated: Date()),
-//            insertOrder(id: 4_002, status: .pending, dateCreated: Date().adding(days: -1)!),
-//            insertOrder(id: 4_003, status: .pending, dateCreated: Date().adding(days: -20)!),
-//            // 1 second before midnight is included because it is technically "today"
-//            insertOrder(id: 4_004, status: .processing, dateCreated: Date().nextMidnight()!.adding(seconds: -1)!),
-//        ]
-//
-//        // Act
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Assert
-//        XCTAssertTrue(viewModel.fetchedOrders.orderIDs.isDisjoint(with: ignoredOrders.orderIDs))
-//
-//        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
-//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
-//    }
-//
 //    /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
 //    func test_it_groups_future_orders_in_upcoming_section() {
 //        // Arrange

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -46,8 +46,6 @@ final class OrderListViewModelTests: XCTestCase {
         let processingOrders = (0..<10).map { insertOrder(id: $0, status: .processing) }
         let completedOrders = (100..<105).map { insertOrder(id: $0, status: .completed) }
 
-        storage.saveIfNeeded()
-
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), processingOrders.count + completedOrders.count)
 
         // Act

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -265,14 +265,13 @@ final class OrderListViewModelTests: XCTestCase {
 
 // MARK: - Helpers
 
+@available(iOS 13.0, *)
 private extension OrderListViewModel {
-    /// Returns the Order instances for all the rows
+    /// Returns the Order instances for all the given object IDs.
     ///
-    var fetchedOrders: [Yosemite.Order] {
-        (0..<numberOfSections).flatMap { section in
-            (0..<numberOfRows(in: section)).compactMap { row in
-                detailsViewModel(at: IndexPath(row: row, section: section))?.order
-            }
+    func orders(from snapshot: FetchResultSnapshot) -> [Yosemite.Order] {
+        snapshot.itemIdentifiers.compactMap { objectID in
+            detailsViewModel(withID: objectID)?.order
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -85,8 +85,7 @@ final class OrderListViewModelTests: XCTestCase {
         // Arrange
         let viewModel = OrderListViewModel(siteID: siteID,
                                            storageManager: storageManager,
-                                           statusFilter: orderStatus(with: .pending),
-                                           includesFutureOrders: true)
+                                           statusFilter: orderStatus(with: .pending))
 
         let expectedOrders = [
             // Future orders

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -62,33 +62,33 @@ final class OrderListViewModelTests: XCTestCase {
         let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
 
         // Assert
-        XCTAssertTrue(snapshot.itemIdentifiers.isNotEmpty)
+        XCTAssertTrue(snapshot.numberOfItems > 0)
         XCTAssertEqual(snapshot.numberOfItems, processingOrders.count)
 
         XCTAssertEqual(viewModel.orderIDs(from: snapshot), processingOrders.orderIDs)
     }
 
-//    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
-//        // Arrange
-//        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil)
-//
-//        let allInsertedOrders = [
-//            (0..<10).map { insertOrder(id: $0, status: .processing) },
-//            (100..<105).map { insertOrder(id: $0, status: .completed, dateCreated: Date().adding(days: -2)!) },
-//            (200..<203).map { insertOrder(id: $0, status: .pending) },
-//        ].flatMap { $0 }
-//
-//        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
-//
-//        // Act
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Assert
-//        XCTAssertFalse(viewModel.isEmpty)
-//        XCTAssertEqual(viewModel.numberOfObjects, allInsertedOrders.count)
-//
-//        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, allInsertedOrders.orderIDs)
-//    }
+    func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() throws {
+        // Arrange
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil)
+
+        let allInsertedOrders = [
+            (0..<10).map { insertOrder(id: $0, status: .processing) },
+            (100..<105).map { insertOrder(id: $0, status: .completed, dateCreated: Date().adding(days: -2)!) },
+            (200..<203).map { insertOrder(id: $0, status: .pending) },
+        ].flatMap { $0 }
+
+        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
+
+        // Act
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Assert
+        XCTAssertTrue(snapshot.numberOfItems > 0)
+        XCTAssertEqual(snapshot.numberOfItems, allInsertedOrders.count)
+
+        XCTAssertEqual(viewModel.orderIDs(from: snapshot), allInsertedOrders.orderIDs)
+    }
 //
 //    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
 //    /// be fetched.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import Storage
+import Combine
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 private typealias Defaults = OrdersViewModel.Defaults
@@ -25,6 +26,8 @@ final class OrderListViewModelTests: XCTestCase {
         storageManager.viewStorage
     }
 
+    private var cancellables = Set<AnyCancellable>()
+
     override func setUp() {
         super.setUp()
         storageManager = MockupStorageManager()
@@ -37,6 +40,12 @@ final class OrderListViewModelTests: XCTestCase {
         stores.sessionManager.setStoreId(nil)
         stores = nil
         storageManager = nil
+
+        cancellables.forEach {
+            $0.cancel()
+        }
+        cancellables.removeAll()
+
         super.tearDown()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -4,9 +4,6 @@ import Yosemite
 import Storage
 import Combine
 
-private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
-private typealias Defaults = OrdersViewModel.Defaults
-
 /// Tests for `OrderListViewModel`.
 ///
 @available(iOS 13.0, *)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -193,48 +193,48 @@ final class OrderListViewModelTests: XCTestCase {
         // Assert
         XCTAssertFalse(resynchronizeRequested)
     }
-//
-//    // MARK: - Foreground Notifications
-//
-//    func test_given_a_new_order_notification_it_requests_a_resynchronization() {
-//        // Arrange
-//        let pushNotificationsManager = MockPushNotificationsManager()
-//        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
-//
-//        var resynchronizeRequested = false
-//        viewModel.onShouldResynchronizeIfViewIsVisible = {
-//            resynchronizeRequested = true
-//        }
-//
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Act
-//        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
-//        pushNotificationsManager.sendForegroundNotification(notification)
-//
-//        // Assert
-//        XCTAssertTrue(resynchronizeRequested)
-//    }
-//
-//    func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
-//        // Arrange
-//        let pushNotificationsManager = MockPushNotificationsManager()
-//        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
-//
-//        var resynchronizeRequested = false
-//        viewModel.onShouldResynchronizeIfViewIsVisible = {
-//            resynchronizeRequested = true
-//        }
-//
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Act
-//        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
-//        pushNotificationsManager.sendForegroundNotification(notification)
-//
-//        // Assert
-//        XCTAssertFalse(resynchronizeRequested)
-//    }
+
+    // MARK: - Foreground Notifications
+
+    func test_given_a_new_order_notification_it_requests_a_resynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activate()
+
+        // Act
+        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertTrue(resynchronizeRequested)
+    }
+
+    func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrderListViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activate()
+
+        // Act
+        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertFalse(resynchronizeRequested)
+    }
 }
 
 // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -287,6 +287,7 @@ private extension Array where Element == Yosemite.Order {
 
 // MARK: - Builders
 
+@available(iOS 13.0, *)
 private extension OrderListViewModelTests {
     func orderStatus(with status: OrderStatusEnum) -> Yosemite.OrderStatus {
         OrderStatus(name: nil, siteID: siteID, slug: status.rawValue, total: 0)
@@ -295,32 +296,10 @@ private extension OrderListViewModelTests {
     func insertOrder(id orderID: Int64,
                      status: OrderStatusEnum,
                      dateCreated: Date = Date()) -> Yosemite.Order {
-        let readonlyOrder = Order(siteID: siteID,
-                                  orderID: orderID,
-                                  parentID: 0,
-                                  customerID: 11,
-                                  number: "963",
-                                  status: status,
-                                  currency: "USD",
-                                  customerNote: "",
-                                  dateCreated: dateCreated,
-                                  dateModified: Date(),
-                                  datePaid: nil,
-                                  discountTotal: "30.00",
-                                  discountTax: "1.20",
-                                  shippingTotal: "0.00",
-                                  shippingTax: "0.00",
-                                  total: "31.20",
-                                  totalTax: "1.20",
-                                  paymentMethodID: "stripe",
-                                  paymentMethodTitle: "Credit Card (Stripe)",
-                                  items: [],
-                                  billingAddress: nil,
-                                  shippingAddress: nil,
-                                  shippingLines: [],
-                                  coupons: [],
-                                  refunds: [])
-
+        let readonlyOrder = MockOrders().empty().copy(siteID: siteID,
+                                                      orderID: orderID,
+                                                      status: status,
+                                                      dateCreated: dateCreated)
         let storageOrder = storage.insertNewObject(ofType: StorageOrder.self)
         storageOrder.update(with: readonlyOrder)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -155,28 +155,28 @@ final class OrderListViewModelTests: XCTestCase {
 
         XCTAssertEqual(snapshot.numberOfItems(inSection: sectionID), expectedOrders.future.count)
     }
-//
-//    // MARK: - App Activation
-//
-//    func test_it_requests_a_resynchronization_when_the_app_is_activated() {
-//        // Arrange
-//        let notificationCenter = NotificationCenter()
-//        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
-//
-//        var resynchronizeRequested = false
-//        viewModel.onShouldResynchronizeIfViewIsVisible = {
-//            resynchronizeRequested = true
-//        }
-//
-//        viewModel.activateAndForwardUpdates(to: UITableView())
-//
-//        // Act
-//        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
-//        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-//
-//        // Assert
-//        XCTAssertTrue(resynchronizeRequested)
-//    }
+
+    // MARK: - App Activation
+
+    func test_it_requests_a_resynchronization_when_the_app_is_activated() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let viewModel = OrderListViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activate()
+
+        // Act
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        // Assert
+        XCTAssertTrue(resynchronizeRequested)
+    }
 //
 //    func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
 //        // Arrange

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -35,7 +35,7 @@ final class OrderListViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Future Orders
+    // MARK: - Orders Loading
 
     func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() throws {
         // Arrange

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -10,11 +10,6 @@ import Combine
 final class OrderListViewModelTests: XCTestCase {
     /// The `siteID` value doesn't matter.
     private let siteID: Int64 = 1_000_000
-    private let pageSize = 50
-
-    private let unimportantCompletionHandler: ((Error?) -> Void) = { _ in
-        // noop
-    }
 
     private var storageManager: StorageManagerType!
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -13,11 +13,6 @@ private typealias Defaults = OrdersViewModel.Defaults
 final class OrdersViewModelTests: XCTestCase {
     /// The `siteID` value doesn't matter.
     private let siteID: Int64 = 1_000_000
-    private let pageSize = 50
-
-    private let unimportantCompletionHandler: ((Error?) -> Void) = { _ in
-        // noop
-    }
 
     private var storageManager: StorageManagerType!
     private var stores: StoresManager!

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -36,7 +36,7 @@ final class OrdersViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Future Orders
+    // MARK: - Orders Loading
 
     func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() {
         // Arrange
@@ -82,8 +82,7 @@ final class OrdersViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fetchedOrders.orderIDs, allInsertedOrders.orderIDs)
     }
 
-    /// If `includeFutureOrders` is `true`, all orders including orders dated in the future (dateCreated) will
-    /// be fetched.
+    /// Test that all orders including orders dated in the future (dateCreated) will be fetched.
     func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
         // Arrange
         let viewModel = OrdersViewModel(siteID: siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -94,7 +94,6 @@ final class OrdersViewModelTests: XCTestCase {
         let viewModel = OrdersViewModel(siteID: siteID,
                                         storageManager: storageManager,
                                         statusFilter: orderStatus(with: .pending),
-                                        includesFutureOrders: true,
                                         stores: stores)
 
         let expectedOrders = [
@@ -118,38 +117,6 @@ final class OrdersViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
 
         XCTAssertFalse(viewModel.fetchedOrders.orderIDs.contains(ignoredFutureOrder.orderID))
-    }
-
-    /// If `includesFutureOrders` is `false`, only orders created up to the current day are returned. Orders before
-    /// midnight are included.
-    func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
-        // Arrange
-        let viewModel = OrdersViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false, stores: stores)
-
-        let ignoredOrders = [
-            // Orders in the future
-            insertOrder(id: 1_001, status: .pending, dateCreated: Date().adding(days: 1)!),
-            insertOrder(id: 1_002, status: .cancelled, dateCreated: Date().adding(days: 3)!),
-            // Exactly midnight is also ignored because it is technically "tomorrow"
-            insertOrder(id: 1_003, status: .processing, dateCreated: Date().nextMidnight()!),
-        ]
-
-        let expectedOrders = [
-            insertOrder(id: 4_001, status: .completed, dateCreated: Date()),
-            insertOrder(id: 4_002, status: .pending, dateCreated: Date().adding(days: -1)!),
-            insertOrder(id: 4_003, status: .pending, dateCreated: Date().adding(days: -20)!),
-            // 1 second before midnight is included because it is technically "today"
-            insertOrder(id: 4_004, status: .processing, dateCreated: Date().nextMidnight()!.adding(seconds: -1)!),
-        ]
-
-        // Act
-        viewModel.activateAndForwardUpdates(to: UITableView())
-
-        // Assert
-        XCTAssertTrue(viewModel.fetchedOrders.orderIDs.isDisjoint(with: ignoredOrders.orderIDs))
-
-        XCTAssertEqual(viewModel.numberOfObjects, expectedOrders.count)
-        XCTAssertEqual(viewModel.fetchedOrders.orderIDs, expectedOrders.orderIDs)
     }
 
     /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.


### PR DESCRIPTION
Closes #3203.  
Fixes #2202. 
Closes #2805. 

Before | After 
--------|-------
  <img src="https://user-images.githubusercontent.com/198826/100154322-a089f300-2e62-11eb-9e92-be68d9f7368b.png" width="300">   |       <img src="https://user-images.githubusercontent.com/198826/100154095-4f79ff00-2e62-11eb-81c8-1937cda01379.png" width="300">

## Findings

We currently don't show orders that are dated in the future in the All Orders. A few months ago, we decided to show all the orders, regardless of what their `dateCreated` value is. This was done on Android (https://github.com/woocommerce/woocommerce-android/pull/2413) but I totally forgot to do the same on iOS. This fixes my mistake. 

Removing the exclusion of future orders also fixes #2202. This actually makes me wonder whether the `predicates` with the date constraint is why we're getting reports from users saying that their orders are not loading. 

https://github.com/woocommerce/woocommerce-ios/blob/1c94af3a701bd16bcbadd142f08acd50cd421666/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift#L140-L145

We never update the date argument in this constraint so if the app is never terminated, it's possible that the constraint will stay on the same date. For example:

Scenario | Date | Predicate | Result
--------|-------|---|---
User installs and opens the app.        |    2020-11-20  | `dateCreated < 2020-11-21` | All good and all orders (except future orders) should be loaded
User comes back to the app 2 days later. The app was never terminated by iOS. | 2020-11-22 | `dateCreated < 2020-11-21` | Orders submitted on Nov 21 and 22nd are not shown. 

🤦 

## Changes

This removes the exclusion of future orders, which also fixes the bug I mentioned above. 

In addition to that, I copied the [`OrdersViewModelTests`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2202-fix-orders-predicate/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift) to its newer iOS-13 only version, [`OrderListViewModelTests`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2202-fix-orders-predicate/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift). This should allow us to safely remove the deprecated `OrdersViewModel` when we drop iOS 12.0 support. 

## Testing

1. Submit a new order on the web.
2. Set the device's date back one month.
3. Run the app on the device.
4. Navigate to All Orders. 
5. Confirm that you still see the order you just submitted. It should be under the “Upcoming” section.
6. Set the device date back to today.
7. Pull-to-refresh to All Orders. 
8. Confirm that all the orders are still shown. But the order you submitted should be in the “Today” section. 
9. Navigate away from the All Orders tab. Maybe go to Processing.
10. Submit another order on the web. 
11. Navigate back to the All Orders tab. 
12. Don't do a pull-to-refresh. Wait a while and then confirm that the last order you submitted is shown. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

 