### PR TITLE
Order Details > Shipping Label: add CTA to section header that opens an action sheet for refund

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -45,6 +45,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var onCellAction: ((CellActionType, IndexPath?) -> Void)?
 
+    /// Closure to be executed when the shipping label more menu is tapped.
+    ///
+    var onShippingLabelMoreMenuTapped: ((_ shippingLabel: ShippingLabel, _ sourceView: UIView) -> Void)?
+
     /// Closure to be executed when the UI needs to be reloaded.
     ///
     var onUIReloadRequired: (() -> Void)?
@@ -696,6 +700,7 @@ extension OrderDetailsDataSource {
                     rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
                         + [.shippingLabelReprintButton, .shippingLabelTrackingNumber, .shippingLabelDetail]
                     let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
+                        self?.onShippingLabelMoreMenuTapped?(shippingLabel, sourceView)
                     }
                     headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
                 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -201,7 +201,12 @@ extension OrderDetailsDataSource {
 
         switch headerView {
         case let headerView as PrimarySectionHeaderView:
-            headerView.configure(title: section.title)
+            switch section.headerStyle {
+            case .actionablePrimary(let actionConfig):
+                headerView.configure(title: section.title, action: actionConfig)
+            default:
+                headerView.configure(title: section.title)
+            }
         case let headerView as TwoColumnSectionHeaderView:
             headerView.leftText = section.title
             headerView.rightText = section.rightTitle
@@ -681,15 +686,20 @@ extension OrderDetailsDataSource {
                 let title = String.localizedStringWithFormat(Title.shippingLabelPackageFormat, index + 1)
                 let isRefunded = shippingLabel.refund != nil
                 let rows: [Row]
+                let headerStyle: Section.HeaderStyle
                 if isRefunded {
                     rows = [.shippingLabelTrackingNumber, .shippingLabelDetail]
+                    headerStyle = .primary
                 } else {
                     let orderItemsCount = shippingLabel.productNames.count
                     // TODO-2167: show aggregated order items (products) for a shipping label
                     rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
                         + [.shippingLabelReprintButton, .shippingLabelTrackingNumber, .shippingLabelDetail]
+                    let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] in
+                    }
+                    headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
                 }
-                return Section(category: .shippingLabel, title: title, rows: rows, headerStyle: .primary)
+                return Section(category: .shippingLabel, title: title, rows: rows, headerStyle: headerStyle)
             }
             return sections
         }()
@@ -979,6 +989,8 @@ extension OrderDetailsDataSource {
         enum HeaderStyle {
             /// Uses the PrimarySectionHeaderView
             case primary
+            /// Uses the PrimarySectionHeaderView with action configuration
+            case actionablePrimary(actionConfig: PrimarySectionHeaderView.ActionConfiguration)
             /// Uses the TwoColumnSectionHeaderView
             case twoColumn
 
@@ -986,7 +998,7 @@ extension OrderDetailsDataSource {
             ///
             var viewType: UITableViewHeaderFooterView.Type {
                 switch self {
-                case .primary:
+                case .primary, .actionablePrimary:
                     return PrimarySectionHeaderView.self
                 case .twoColumn:
                     return TwoColumnSectionHeaderView.self

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -695,7 +695,7 @@ extension OrderDetailsDataSource {
                     // TODO-2167: show aggregated order items (products) for a shipping label
                     rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
                         + [.shippingLabelReprintButton, .shippingLabelTrackingNumber, .shippingLabelDetail]
-                    let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] in
+                    let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
                     }
                     headerStyle = .actionablePrimary(actionConfig: headerActionConfig)
                 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -116,6 +116,14 @@ final class OrderDetailsViewModel {
         }
     }
 
+    /// Closure to be executed when the shipping label more menu is tapped.
+    ///
+    var onShippingLabelMoreMenuTapped: ((_ shippingLabel: ShippingLabel, _ sourceView: UIView) -> Void)? {
+        didSet {
+            dataSource.onShippingLabelMoreMenuTapped = onShippingLabelMoreMenuTapped
+        }
+    }
+
     /// Helpers
     ///
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -139,6 +139,10 @@ private extension OrderDetailsViewController {
         viewModel.onCellAction = { [weak self] (actionType, indexPath) in
             self?.handleCellAction(actionType, at: indexPath)
         }
+
+        viewModel.onShippingLabelMoreMenuTapped = { [weak self] shippingLabel, sourceView in
+            self?.shippingLabelMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)
+        }
     }
 
     /// Reloads the tableView's data, assuming the view has been loaded.
@@ -352,6 +356,22 @@ private extension OrderDetailsViewController {
         let safariViewController = SFSafariViewController(url: url)
         present(safariViewController, animated: true, completion: nil)
     }
+
+    func shippingLabelMoreMenuTapped(shippingLabel: ShippingLabel, sourceView: UIView) {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addCancelActionWithTitle(Localization.ShippingLabelMoreMenu.cancelAction)
+
+        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { _ in
+            // TODO-2168: refund a shipping label
+        }
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.sourceView = sourceView
+
+        present(actionSheet, animated: true)
+    }
 }
 
 // MARK: - UITableViewDelegate Conformance
@@ -496,6 +516,14 @@ private extension OrderDetailsViewController {
         static let copyTrackingNumber = NSLocalizedString("Copy Tracking Number", comment: "Copy tracking number button title")
         static let trackShipment = NSLocalizedString("Track Shipment", comment: "Track shipment button title")
         static let deleteTracking = NSLocalizedString("Delete Tracking", comment: "Delete tracking button title")
+    }
+
+    enum Localization {
+        enum ShippingLabelMoreMenu {
+            static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel the shipping label more menu action sheet")
+            static let requestRefundAction = NSLocalizedString("Request a Refund",
+                                                               comment: "Request a refund on a shipping label from the shipping label more menu action sheet")
+        }
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
@@ -7,15 +7,27 @@ import UIKit
 /// This is originally used for the Order Details' Product section header.
 ///
 final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
+    /// Custom configurations for the CTA.
+    struct ActionConfiguration {
+        let image: UIImage
+        let actionHandler: () -> Void
+    }
 
     @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private weak var actionButton: UIButton!
     @IBOutlet private var containerView: UIView!
+
+    private var actionHandler: (() -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
 
         titleLabel.text = ""
         titleLabel.applyHeadlineStyle()
+
+        actionButton.isHidden = true
+        actionButton.setTitle(nil, for: .normal)
+        actionButton.setContentHuggingPriority(.required, for: .horizontal)
 
         containerView.backgroundColor = Colors.containerViewBackgroundColor
 
@@ -24,8 +36,15 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
 
     /// Change the configurable properties of this header.
     ///
-    func configure(title: String?) {
+    func configure(title: String?, action: ActionConfiguration? = nil) {
         titleLabel.text = title
+        actionButton.isHidden = action == nil
+
+        if let action = action {
+            actionButton.applyIconButtonStyle(icon: action.image)
+            actionHandler = action.actionHandler
+            actionButton.addTarget(self, action: #selector(onAction), for: .touchUpInside)
+        }
     }
 
     /// Creates a dummy border which will cover the grouped section separator that is normally
@@ -42,6 +61,12 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
             containerView.trailingAnchor.constraint(equalTo: separator.trailingAnchor),
             containerView.bottomAnchor.constraint(equalTo: separator.topAnchor)
         ])
+    }
+}
+
+private extension PrimarySectionHeaderView {
+    @objc func onAction() {
+        actionHandler?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
@@ -10,14 +10,14 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
     /// Custom configurations for the CTA.
     struct ActionConfiguration {
         let image: UIImage
-        let actionHandler: () -> Void
+        let actionHandler: (_ sourceView: UIView) -> Void
     }
 
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private weak var actionButton: UIButton!
     @IBOutlet private var containerView: UIView!
 
-    private var actionHandler: (() -> Void)?
+    private var actionHandler: ((_ sourceView: UIView) -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -43,7 +43,7 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
         if let action = action {
             actionButton.applyIconButtonStyle(icon: action.image)
             actionHandler = action.actionHandler
-            actionButton.addTarget(self, action: #selector(onAction), for: .touchUpInside)
+            actionButton.addTarget(self, action: #selector(onAction(_:)), for: .touchUpInside)
         }
     }
 
@@ -65,8 +65,8 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
 }
 
 private extension PrimarySectionHeaderView {
-    @objc func onAction() {
-        actionHandler?()
+    @objc func onAction(_ sourceView: UIView) {
+        actionHandler?(sourceView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,18 +16,27 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="95D-6l-YMn">
                     <rect key="frame" x="0.0" y="14" width="433" height="104"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Iste Nihil Occaecati" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LhT-W3-uWF">
-                            <rect key="frame" x="16" y="16" width="401" height="88"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VUa-Je-20h">
+                            <rect key="frame" x="16" y="16" width="397" height="88"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Iste Nihil Occaecati" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LhT-W3-uWF">
+                                    <rect key="frame" x="0.0" y="0.0" width="198.5" height="88"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="efT-hG-fgb">
+                                    <rect key="frame" x="198.5" y="0.0" width="198.5" height="88"/>
+                                    <state key="normal" title="Button"/>
+                                </button>
+                            </subviews>
+                        </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="LhT-W3-uWF" secondAttribute="trailing" constant="16" id="L9N-Cc-ugv"/>
-                        <constraint firstItem="LhT-W3-uWF" firstAttribute="top" secondItem="95D-6l-YMn" secondAttribute="top" constant="16" id="a7P-6Q-hnP"/>
-                        <constraint firstItem="LhT-W3-uWF" firstAttribute="leading" secondItem="95D-6l-YMn" secondAttribute="leading" constant="16" id="yWp-Om-JcY"/>
-                        <constraint firstAttribute="bottom" secondItem="LhT-W3-uWF" secondAttribute="bottom" id="zaM-cs-of8"/>
+                        <constraint firstAttribute="bottom" secondItem="VUa-Je-20h" secondAttribute="bottom" id="9BP-cM-RlX"/>
+                        <constraint firstItem="VUa-Je-20h" firstAttribute="leading" secondItem="95D-6l-YMn" secondAttribute="leading" constant="16" id="Nll-24-zjn"/>
+                        <constraint firstItem="VUa-Je-20h" firstAttribute="top" secondItem="95D-6l-YMn" secondAttribute="top" constant="16" id="Vvk-xM-Fvj"/>
+                        <constraint firstAttribute="trailing" secondItem="VUa-Je-20h" secondAttribute="trailing" constant="20" id="fiO-iP-ak6"/>
                     </constraints>
                 </view>
             </subviews>
@@ -40,6 +50,7 @@
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="actionButton" destination="efT-hG-fgb" id="zop-7k-aa5"/>
                 <outlet property="containerView" destination="95D-6l-YMn" id="VNy-Mm-tf1"/>
                 <outlet property="titleLabel" destination="LhT-W3-uWF" id="WpX-KO-aCd"/>
             </connections>


### PR DESCRIPTION
Part of #2167 

## Changes

- Updated `PrimarySectionHeaderView`'s xib from one label to a `UIStackView` with a label and button. In `PrimarySectionHeaderView`, added a struct `ActionConfiguration` that is optional in the view's configuration.
- In `OrderDetailsDataSource`, added a new case `Section.HeaderStyle.actionablePrimary` with a `PrimarySectionHeaderView.ActionConfiguration` associated value for configuring the action. In each shipping label section setup, set the header style to `actionablePrimary` if the shipping label hasn't been refunded. The action handler is propagated from `OrderDetailsViewController` to `OrderDetailsViewModel` following the existing pattern. I first tried reusing `onCellAction` but it does not provide a source view and the action is not from a cell either.

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label and an order with at least one refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, a shipping label package card should be shown "Package #" with an ellipsis CTA at the right side of the header
- Tap on the ellipsis CTA --> an action sheet should be opened with one action to request a refund (to be implemented in #2168)

## Example screenshots

Note for reviewers: please focus on the non-refunded label's section header where an ellipsis more menu is added with "Request a Refund" action

\ | order details | refund request action sheet
-- | -- | --
dark | ![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 12 03 01](https://user-images.githubusercontent.com/1945542/100182823-7dba1600-2f18-11eb-9ba9-51fbdd5fefe8.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 12 03 03](https://user-images.githubusercontent.com/1945542/100182832-81e63380-2f18-11eb-9ee2-528962b02d73.png)
light | ![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 12 15 02](https://user-images.githubusercontent.com/1945542/100182835-83176080-2f18-11eb-8d6f-456fdd6f12f2.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 12 15 05](https://user-images.githubusercontent.com/1945542/100182841-84488d80-2f18-11eb-807b-9c2203fa596c.png)
iPad | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-11-25 at 12 18 49](https://user-images.githubusercontent.com/1945542/100182952-bd80fd80-2f18-11eb-9f0a-49dadc0610a0.png) | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-11-25 at 12 00 24](https://user-images.githubusercontent.com/1945542/100182941-b8bc4980-2f18-11eb-9b2c-cd1c627f0da7.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
