### PR TITLE
Update the original Product with new linked products

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -504,6 +504,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         try container.encode(downloads, forKey: .downloads)
         try container.encode(downloadLimit, forKey: .downloadLimit)
         try container.encode(downloadExpiry, forKey: .downloadExpiry)
+
+        // Linked Products (Upsells and Cross-sell Products)
+        try container.encode(upsellIDs, forKey: .upsellIDs)
+        try container.encode(crossSellIDs, forKey: .crossSellIDs)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
@@ -187,9 +187,9 @@ private extension LinkedProductsViewController {
                                                                                             .groupedProductLinkedProductsDeleteButtonTapped)
 
         let viewController = LinkedProductsListSelectorViewController(product: product.product,
-                                                                      linkedProductIDs: viewModel.upsellIDs,
-                                                                      viewConfiguration: viewConfiguration) { [weak self] upsellIDs in
-            self?.viewModel.handleUpsellIDsChange(upsellIDs)
+                                                                      linkedProductIDs: viewModel.crossSellIDs,
+                                                                      viewConfiguration: viewConfiguration) { [weak self] crossSellIDs in
+            self?.viewModel.handleCrossSellIDsChange(crossSellIDs)
             self?.tableView.reloadData()
             self?.navigationController?.popViewController(animated: true)
         }
@@ -218,7 +218,7 @@ extension LinkedProductsViewController {
     }
 
     @objc private func completeUpdating() {
-        // TODO: to be implemented in next PRs
+        onCompletion(viewModel.upsellIDs, viewModel.crossSellIDs, viewModel.hasUnsavedChanges())
     }
 
     private func presentBackNavigationActionSheet() {


### PR DESCRIPTION
Fixes #3075 

## Description
In this PR is now possible to update remotely the Linked Products (Upsell and Cross-sell products). 

## Changes
- encode of `upsellIDs` and `crossSellIDs` in `Product` model.
- implemented the `onCompletion` callback in `LinkedProductsViewController`.

## Testing
1. Open a product detail.
2. Tap the Linked Products cell (or add Linked Products from `Add more details` bottom sheet).
3. Edit or add Upsell and Cross-sell products, then press the "Done" button.
4. If you did some changes to Linked Products, the product detail screen will show an "Update" button in the navigation bar.
4. Tap the "Update" button. -> The product should be updated remotely with the new upsell and cross-sell products.

## GIF
<img src="https://user-images.githubusercontent.com/495617/100236475-02fbf580-2f2e-11eb-9950-4240b01031ce.gif" width=400 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
