### PR TITLE
Add keyboard dismiss in Order -> Add Tracking screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]
 - [*] the icon of the cells inside the Product Detail are now aligned at 10px from the top margin. [https://github.com/woocommerce/woocommerce-ios/pull/3199]
 - [**] Added the ability to issue refunds from the order screen. Refunds can be done towards products or towards shipping. [https://github.com/woocommerce/woocommerce-ios/pull/3204]
+- [*] Add keyboard dismiss in Add Tracking screen [https://github.com/woocommerce/woocommerce-ios/pull/3220]
 
 
 5.5

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -353,6 +353,10 @@ private extension ManualTrackingViewController {
     func executeAction(for indexPath: IndexPath) {
         let row = rowAtIndexPath(indexPath)
 
+        if row == .shippingProvider || row == .dateShipped {
+            view.endEditing(true)
+        }
+
         if row == .dateShipped && viewModel.isAdding {
             displayDatePicker(at: indexPath)
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -258,7 +258,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
         let cellViewModel = TitleAndEditableValueTableViewCellViewModel(
             title: NSLocalizedString("Tracking number", comment: "Add / Edit shipping carrier. Title of cell presenting tracking number"),
             placeholder: NSLocalizedString("Enter tracking number", comment: "Add custom shipping carrier. Placeholder of cell presenting tracking number"),
-            initialValue: viewModel.trackingNumber
+            initialValue: viewModel.trackingNumber,
+            hidesKeyboardOnReturn: true
         )
         cell.update(viewModel: cellViewModel)
         cell.accessoryType = .none

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
@@ -32,6 +32,10 @@ final class TitleAndEditableValueTableViewCell: UITableViewCell {
         value.text = viewModel?.currentValue
         value.isEnabled = viewModel?.allowsEditing ?? false
 
+        if viewModel?.hidesKeyboardOnReturn == true {
+            value.addTarget(value, action: #selector(resignFirstResponder), for: UIControl.Event.editingDidEndOnExit)
+        }
+
         self.viewModel = viewModel
 
         applyStyle(style)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellViewModel.swift
@@ -12,6 +12,8 @@ final class TitleAndEditableValueTableViewCellViewModel {
     let placeholder: String?
     /// If `false`, the text field will be disabled. Defaults to `true`.
     let allowsEditing: Bool
+    /// If `true`, the keyboard will be dismissed on tapping return. Defaults to `false`.
+    let hidesKeyboardOnReturn: Bool
 
     private let valueSubject: BehaviorSubject<String?>
 
@@ -27,10 +29,11 @@ final class TitleAndEditableValueTableViewCellViewModel {
         valueSubject.value
     }
 
-    init(title: String?, placeholder: String? = nil, initialValue: String? = nil, allowsEditing: Bool = true) {
+    init(title: String?, placeholder: String? = nil, initialValue: String? = nil, allowsEditing: Bool = true, hidesKeyboardOnReturn: Bool = false) {
         self.title = title
         self.placeholder = placeholder
         self.allowsEditing = allowsEditing
+        self.hidesKeyboardOnReturn = hidesKeyboardOnReturn
 
         valueSubject = BehaviorSubject(initialValue)
     }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/3102.

##  Description

This PR adds keyboard dismiss in Order -> Add Tracking screen:
1. on "return" when tracking number field is active
2. when carrier field tapped
3. when calendar field tapped

### Known limitations

Can be seen in the end of "after" video.
Keyboard won't dismiss if you tap inside date picker expanded cell - this is managed by date picker and I didn't want to increase complexity and affect all usage cases of this date picker. Also with regular flow user will first tap on "date" cell to expand datepicker - and keyboard will be dismissed already for next step.

## Testing

1. Open order screen
2. Tap "Add tracking" option
3. Tap "Tracking number" field to activate keyboard
4. Try tapping "return" on keyboard
5. Try tapping other fields (carrier and date) and observe keyboard dismiss

## Videos

 Before | After 
--------|------
![Screen Recording 2020-11-26 at 18 36 26](https://user-images.githubusercontent.com/3132438/100432301-79256700-30aa-11eb-8724-cfdcaa95da31.gif)|![Screen Recording 2020-11-27 at 12 24 21](https://user-images.githubusercontent.com/3132438/100433195-c48c4500-30ab-11eb-8c20-3691dfc65574.gif)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
