### PR TITLE
Prevent banner dismiss when tapping "give feedback" on products screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] removed the Product Title in product screen navigation bar. [https://github.com/woocommerce/woocommerce-ios/pull/3187]
 - [*] the icon of the cells inside the Product Detail are now aligned at 10px from the top margin. [https://github.com/woocommerce/woocommerce-ios/pull/3199]
 - [**] Added the ability to issue refunds from the order screen. Refunds can be done towards products or towards shipping. [https://github.com/woocommerce/woocommerce-ios/pull/3204]
+- [*] Prevent banner dismiss when tapping "give feedback" on products screen. [https://github.com/woocommerce/woocommerce-ios/pull/3221]
 
 
 5.5

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -550,22 +550,12 @@ private extension ProductsViewController {
         present(filterProductListViewController, animated: true, completion: nil)
     }
 
-    /// Presents products survey and mark feedback as given to update banner visibility
+    /// Presents products survey
     ///
     func presentProductsFeedback() {
         // Present survey
         let navigationController = SurveyCoordinatingController(survey: .productsM4Feedback)
-        present(navigationController, animated: true) { [weak self] in
-
-            // Mark survey as given and update top banner view
-            let action = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .given(Date())) { result in
-                if let error = result.failure {
-                    CrashLogging.logError(error)
-                }
-                self?.hideTopBannerView()
-            }
-            ServiceLocator.stores.dispatch(action)
-        }
+        present(navigationController, animated: true, completion: nil)
     }
 
     /// Mark feedback request as dismissed and update banner visibility


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/2945.

##  Description

This PR adds removes banner dismiss logic when tapping "give feedback" on products screen.

## Testing

1. Open products screen
2. Tap "Give feedback"
3. Dismiss feedback screen
4. Banner should be still available

## Screenshot

![](https://user-images.githubusercontent.com/3132438/100437241-8bef6a00-30b1-11eb-966f-9a0713938aba.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
