### PR TITLE
Fix secondary button background color

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -52,6 +52,11 @@ extension UIButton {
         setTitleColor(.secondaryButtonTitle, for: .highlighted)
         setTitleColor(.buttonDisabledTitle, for: .disabled)
 
+        let normalBackgroundImage = UIImage.renderBackgroundImage(fill: .secondaryButtonBackground,
+                                                                  border: .secondaryButtonBorder)
+            .applyTintColorToiOS13(.secondaryButtonBackground)
+        setBackgroundImage(normalBackgroundImage, for: .normal)
+
         let highlightedBackgroundImage = UIImage.renderBackgroundImage(fill: .secondaryButtonDownBackground,
                                                                        border: .secondaryButtonDownBorder)
             .applyTintColorToiOS13(.secondaryButtonDownBackground)


### PR DESCRIPTION
Part of #2167 

## Changes

After the change to set a normal background image for primary buttons, the secondary button in a cell still keeps the background image when it's reused from a cell with primary button. This PR set the normal background image for secondary buttons similar to primary buttons in https://github.com/woocommerce/woocommerce-ios/commit/74c81971cf357ec190a70f8712969663112fd4d3#diff-cfbdf6fc7e3bd4bf03be587e71fd7e9dc505fad690ad8529962015081d2009fc so that it has the correct background color

## Testing

Sometimes I can reproduce with "Issue Refund" CTA in order details, but not all the time. I can always reproduce in order details with at least one shipping label.

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, a shipping label package card should be shown with a "Reprint Shipping Label" CTA that has the expected background color (see screenshots below)

## Example screenshots

(Please notice the background color of the "Reprint Shipping Label" CTA)

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 44 29](https://user-images.githubusercontent.com/1945542/100573820-a58fec00-3313-11eb-8726-4664ecf057ef.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 48 21](https://user-images.githubusercontent.com/1945542/100573835-ab85cd00-3313-11eb-8daf-4320a9cee072.png)
![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 45 49](https://user-images.githubusercontent.com/1945542/100573833-a9bc0980-3313-11eb-8262-4400905b0ee6.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 48 07](https://user-images.githubusercontent.com/1945542/100573834-aa54a000-3313-11eb-960d-037aea5b8d9c.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
