### PR TITLE
Order Details > Shipping Label: add printing instructions info row

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -261,6 +261,12 @@ extension UIImage {
         return UIImage.gridicon(.infoOutline)
     }
 
+    /// Info Outline Icon (footnote)
+    ///
+    static var infoOutlineFootnoteImage: UIImage {
+        .gridicon(.infoOutline, size: CGSize(width: 20, height: 20))
+    }
+
     /// Files Download Icon
     ///
     static var cloudImage: UIImage {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -245,6 +245,8 @@ private extension OrderDetailsDataSource {
             configureShippingLabelDetail(cell: cell)
         case let cell as TopLeftImageTableViewCell where row == .shippingNotice:
             configureShippingNotice(cell: cell)
+        case let cell as TopLeftImageTableViewCell where row == .shippingLabelPrintingInfo:
+            configureShippingLabelPrintingInfo(cell: cell)
         case let cell as LeftImageTableViewCell where row == .addOrderNote:
             configureNewNote(cell: cell)
         case let cell as OrderNoteHeaderTableViewCell:
@@ -446,6 +448,22 @@ private extension OrderDetailsDataSource {
             "Show the shipment details for this shipping label.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to view shipping label shipment details."
         )
+    }
+
+    private func configureShippingLabelPrintingInfo(cell: TopLeftImageTableViewCell) {
+        cell.imageView?.image = .infoOutlineFootnoteImage
+        cell.imageView?.tintColor = .systemColor(.secondaryLabel)
+        cell.textLabel?.text = Title.shippingLabelPrintingInfoAction
+        cell.textLabel?.textColor = .systemColor(.secondaryLabel)
+        cell.textLabel?.applyFootnoteStyle()
+        cell.selectionStyle = .none
+
+        cell.accessibilityTraits = .button
+        cell.accessibilityLabel = Title.shippingLabelPrintingInfoAction
+        cell.accessibilityHint =
+            NSLocalizedString("Tap to show instructions on how to print a shipping label on the mobile device",
+                              comment:
+                                "VoiceOver accessibility hint for the row that shows instructions on how to print a shipping label on the mobile device")
     }
 
     private func configureShippingLabelProduct(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
@@ -717,7 +735,7 @@ extension OrderDetailsDataSource {
                     // TODO-2167: show printing instructions
                     let orderItemsCount = shippingLabelOrderItemsAggregator.orderItems(of: shippingLabel).count
                     rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
-                        + [.shippingLabelReprintButton, .shippingLabelTrackingNumber, .shippingLabelDetail]
+                        + [.shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]
                     let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
                         self?.onShippingLabelMoreMenuTapped?(shippingLabel, sourceView)
                     }
@@ -985,6 +1003,10 @@ extension OrderDetailsDataSource {
         static let shippingLabelPackageFormat =
             NSLocalizedString("Package %d",
                               comment: "Order shipping label package section title format. The number indicates the index of the shipping label package.")
+        static let shippingLabelPrintingInfoAction =
+            NSLocalizedString("Don’t know how to print from your phone?",
+                              comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
+                                "a shipping label on the mobile device.")
     }
 
     enum Footer {
@@ -1094,6 +1116,7 @@ extension OrderDetailsDataSource {
         case tracking
         case trackingAdd
         case shippingLabelDetail
+        case shippingLabelPrintingInfo
         case shippingLabelProduct
         case shippingLabelReprintButton
         case shippingLabelTrackingNumber
@@ -1140,6 +1163,8 @@ extension OrderDetailsDataSource {
                 return LeftImageTableViewCell.reuseIdentifier
             case .shippingLabelDetail:
                 return WooBasicTableViewCell.reuseIdentifier
+            case .shippingLabelPrintingInfo:
+                return TopLeftImageTableViewCell.reuseIdentifier
             case .shippingLabelProduct:
                 return ProductDetailsTableViewCell.reuseIdentifier
             case .shippingLabelTrackingNumber:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -456,7 +456,7 @@ private extension OrderDetailsDataSource {
         cell.textLabel?.text = Title.shippingLabelPrintingInfoAction
         cell.textLabel?.textColor = .systemColor(.secondaryLabel)
         cell.textLabel?.applyFootnoteStyle()
-        cell.selectionStyle = .none
+        cell.selectionStyle = .default
 
         cell.accessibilityTraits = .button
         cell.accessibilityLabel = Title.shippingLabelPrintingInfoAction

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -238,6 +238,9 @@ extension OrderDetailsViewModel {
                                                                    forceReadOnly: true)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
+        case .shippingLabelPrintingInfo:
+            // TODO-2174: present instructions on how to print shipping labels
+            break
         case .shippingLabelProduct:
             guard let item = dataSource.shippingLabelOrderItem(at: indexPath), item.productOrVariationID > 0 else {
                 return

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -144,6 +144,16 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.infoOutlineImage)
     }
 
+    func testInfoOutlineFootnoteImageIsNotNil() {
+        XCTAssertNotNil(UIImage.infoOutlineFootnoteImage)
+    }
+
+    func testInfoOutlineFootnoteImageMatchesExpectedSize() {
+        let size = CGSize(width: 20, height: 20)
+        let image = UIImage.infoOutlineFootnoteImage
+        XCTAssertEqual(size, image.size)
+    }
+
     func testInvisibleImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.invisibleImage)
     }


### PR DESCRIPTION
Part of #2167 

## Changes

- Added `UIImage.infoOutlineFootnoteImage` for an `infoOutline` Gridicon with size 20x20 with two test cases
- In `OrderDetailsDataSource`, added `Row.shippingLabelPrintingInfo` case which is configured to use `TopLeftImageTableViewCell` with `infoOutlineFootnoteImage` and instructions title
- In `OrderDetailsViewModel`, added placeholder for handling the tap action

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, a shipping label package card is shown with a row below the Reprint Shipping Label CTA with "Don’t know how to print from your phone?" text and info outline icon

## Example screenshots

Notes for reviewers:
- The Reprint Shipping Label CTA background color is fixed separately in https://github.com/woocommerce/woocommerce-ios/pull/3227
- There are known design items that I'll implement separately because it affects more than just the printing info row:
  - Hide separators of "Reprint Shipping Label" CTA and the printing info row (I found some solutions like by setting the cell's `separatorInset` but it could have side effects on reused cells, would like to do more testing on this one)
  - Remove top spacing in the printing info row (it requires refactoring of `TopLeftImageTableViewCell` to use Auto Layout)

light | dark
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 16 38 59](https://user-images.githubusercontent.com/1945542/100587914-2529b500-332c-11eb-8540-cb17e2f94959.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 16 39 15](https://user-images.githubusercontent.com/1945542/100587925-28bd3c00-332c-11eb-9216-637a901b0eea.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
