### PR TITLE
Add extra space when displaying multiple dimensions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -514,9 +514,9 @@ private extension DefaultProductFormTableViewModel {
                                                     comment: "Format of the weight on the Shipping Settings row - weight[unit]")
         static let oneDimensionFormat = NSLocalizedString("Dimensions: %1$@%2$@",
                                                           comment: "Format of one dimension on the Shipping Settings row - dimension[unit]")
-        static let twoDimensionsFormat = NSLocalizedString("Dimensions: %1$@ x %2$@%3$@",
+        static let twoDimensionsFormat = NSLocalizedString("Dimensions: %1$@ x %2$@ %3$@",
                                                            comment: "Format of 2 dimensions on the Shipping Settings row - dimension x dimension[unit]")
-        static let fullDimensionsFormat = NSLocalizedString("Dimensions: %1$@ x %2$@ x %3$@%4$@",
+        static let fullDimensionsFormat = NSLocalizedString("Dimensions: %1$@ x %2$@ x %3$@ %4$@",
                                                             comment: "Format of all 3 dimensions on the Shipping Settings row - L x W x H[unit]")
 
         // Short description


### PR DESCRIPTION
## Details

This PR adds a space between dimensions and a unit in case there are 2 or 3 dimensions. Adding a space brings iOS in line with Android (https://github.com/woocommerce/woocommerce-android/pull/3180/files)

Closes #3189 

## Tests
1. Open a details for a physical product
2. Add shipping details

- [ ] When there is only one dimension specified, there is no space between dimension and unit
- [ ] When there are two or more dimensions specified, there is a space between dimension and unit

| Before  | After  |
|---|---|
| ![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 45 06](https://user-images.githubusercontent.com/54751/100622230-e8a48c00-3320-11eb-9abd-40baf89b0995.png) | ![Simulator Screen Shot - iPhone 11 - 2020-11-30 at 13 49 09](https://user-images.githubusercontent.com/54751/100622254-efcb9a00-3320-11eb-8e0e-33378f07aa79.png) |

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
