### PR TITLE
Variable Products: Add variations row if Milestone 5 is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -389,10 +389,12 @@ private extension DefaultProductFormTableViewModel {
             }
         }
 
+        let isActionable = product.variations.isNotEmpty || (product.variations.isEmpty && isEditProductsRelease5Enabled)
+
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
                                                         details: details,
-                                                        isActionable: product.variations.isNotEmpty)
+                                                        isActionable: isActionable)
     }
 
     // MARK: Product variation only

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -370,8 +370,6 @@ private extension DefaultProductFormTableViewModel {
 
     func variationsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.variationsImage
-        print("IS enabled?", isEditProductsRelease5Enabled)
-        print("Is empty?", product.attributes.isEmpty)
         let title = (product.variations.isEmpty && isEditProductsRelease5Enabled) ? Localization.addVariationsTitle : Localization.variationsTitle
 
         let details: String

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -12,12 +12,16 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     //
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
+    private let isEditProductsRelease5Enabled: Bool
+
     init(product: ProductFormDataModel,
          actionsFactory: ProductFormActionsFactoryProtocol,
          currency: String,
-         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.currency = currency
         self.currencyFormatter = currencyFormatter
+            self.isEditProductsRelease5Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
         configureSections(product: product, actionsFactory: actionsFactory)
     }
 }
@@ -366,18 +370,25 @@ private extension DefaultProductFormTableViewModel {
 
     func variationsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.variationsImage
-        let title = Localization.variationsTitle
+        print("IS enabled?", isEditProductsRelease5Enabled)
+        print("Is empty?", product.attributes.isEmpty)
+        let title = (product.variations.isEmpty && isEditProductsRelease5Enabled) ? Localization.addVariationsTitle : Localization.variationsTitle
 
-        let attributes = product.attributes
-
-        let format = NSLocalizedString("%1$@ (%2$ld options)", comment: "Format for each Product attribute")
         let details: String
-        if product.variations.isEmpty {
-            details = Localization.variationsPlaceholder
-        } else {
-            details = attributes
+        let format = NSLocalizedString("%1$@ (%2$ld options)", comment: "Format for each Product attribute")
+
+        switch product.variations.count {
+        case 1...:
+            details = product.attributes
                 .map({ String.localizedStringWithFormat(format, $0.name, $0.options.count) })
                 .joined(separator: "\n")
+        default:
+            if isEditProductsRelease5Enabled {
+                details = ""
+            }
+            else {
+                details = Localization.variationsPlaceholder
+            }
         }
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
@@ -537,6 +548,8 @@ private extension DefaultProductFormTableViewModel {
                                                                    comment: "Format of the number of grouped products in plural form")
 
         // Variations
+        static let addVariationsTitle = NSLocalizedString("Add variations",
+                                                          comment: "Title for adding variations row on Product main screen for a variable product")
         static let variationsTitle =
             NSLocalizedString("Variations",
                               comment: "Title of the Product Variations row on Product main screen for a variable product")


### PR DESCRIPTION
Fixes #3180 

## Description
When opening a variable product with no existing variations, now we show an “Add variations” row if milestone 5 is enabled, otherwise we should show the previous behavior. The row will lead to attributes + variations generation flow, starting from #3181, which will be added later.

## Testing
#### Case 1
1. Make sure the feature flag `editProductsRelease5` is enabled.
2. Open a variable product without variations.
3. You should see the new cell "Add variations"

#### Case 2
1. Make sure the feature flag `editProductsRelease5` is disabled.
2. Open a variable product without variations.
3. You should see the previous cell "No variations yet"

#### Case 3
1. Open a variable product with variations.
2. You should see the existing product attributes/variations inside the cell.

## Screenshots
| No Variations (Milestone 5 enabled)             |  No Variations (Milestone 5 disabled) |  With Variations |
:-------------------------:|:-------------------------:|:-------------------------:
![No Variations Milestone 5 enabled](https://user-images.githubusercontent.com/495617/100630780-41792200-332b-11eb-8750-4bdbf09b4fc5.png) | ![No Variations Milestone 5 Disabled](https://user-images.githubusercontent.com/495617/100630841-5655b580-332b-11eb-8b96-9d34b9ee4938.png) | ![With Variations](https://user-images.githubusercontent.com/495617/100630852-59e93c80-332b-11eb-8096-e9726ce8a8fa.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
