### PR TITLE
[Issue Refunds] Confirmation → Dismiss Keyboard when Scrolling

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -37,6 +37,7 @@ final class RefundConfirmationViewController: UIViewController {
         configureMainView()
         configureTableView()
         configureButtonTableFooterView()
+        configureKeyboardDismissal()
     }
 }
 
@@ -56,6 +57,9 @@ private extension RefundConfirmationViewController {
             HeadlineLabelTableViewCell.self,
             WooBasicTableViewCell.self
         ].forEach(tableView.registerNib)
+
+        // Keyboard handling
+        tableView.keyboardDismissMode = .onDrag
 
         // Delegation
         tableView.dataSource = self
@@ -83,6 +87,14 @@ private extension RefundConfirmationViewController {
             }
         }
         tableView.updateFooterHeight()
+    }
+
+    /// Hides the keyboard by asking the view's first responder to resign on each main view tap.
+    ///
+    func configureKeyboardDismissal() {
+        let tap = UITapGestureRecognizer(target: view, action: #selector(UIView.endEditing))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
     }
 }
 


### PR DESCRIPTION
fixes #2980 

# Why

This PR adds two ways for a user to dismiss the keyboard in the `IssueConfirmationViewController` once they have added a refund reason.

1. By dragging the table view
2. By tapping outside the reason text field.

# How
- Set the table view's `keyboardDismissMode` property to `.onDrag`
- Add a tap gesture recognizer on the view controller's view and force any text field to resign their first responder status.

# GIF
![keyboard-dismiss](https://user-images.githubusercontent.com/562080/100660939-ba26b100-3320-11eb-8cdc-ebdb378c53f2.gif)

# Testing Steps
- Go to an unrefunded order
- Tap the "Issue Refund" button
- Select an item to refund
- Tap the next button
- Tap  the "reason" text field
- Drag the table view or tap outside the text field and see the keyboard dismiss.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
