### PR TITLE
Fix: Refund details show manual refunds as via the customer's payment method

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
@@ -66,11 +66,7 @@ final class RefundDetailsDataSource: NSObject {
     ///
     private var refundMethod: String {
         guard refund.isAutomated == true else {
-            let refundMethodTemplate = NSLocalizedString("Refunded manually via %@",
-                                                         comment: "It reads, 'Refunded manually via <payment method>'")
-            let refundMethodText = String.localizedStringWithFormat(refundMethodTemplate, order.paymentMethodTitle)
-
-            return refundMethodText
+            return NSLocalizedString("Refunded manually", comment: "Title of the refund detail cell when the refund was done manually.")
         }
 
         let refundMethodTemplate = NSLocalizedString("Refunded via %@",


### PR DESCRIPTION
fix #1860 

# Why

It was reported that on the refund details screen, a manual refund is being displayed together with the order's payment method.

<img width="818" alt="Screen Shot 2020-11-30 at 4 35 23 PM" src="https://user-images.githubusercontent.com/562080/100668539-10e4b880-332a-11eb-9920-3f5ae501e203.png">


This PR fixes that, by only showing "Refunded Manually" when the refund does not have automatic money refund support.

# Screenshots

Summary | Manually
---- | ----
<img width="386" alt="manual 1" src="https://user-images.githubusercontent.com/562080/100668114-679dc280-3329-11eb-8b8b-2c159bb1e968.png"> | <img width="392" alt="manual 2" src="https://user-images.githubusercontent.com/562080/100668118-68ceef80-3329-11eb-8ae4-9f2ec2587c56.png">

Summary | Automatted
---- | ----
<img width="398" alt="automated 2" src="https://user-images.githubusercontent.com/562080/100668122-6a001c80-3329-11eb-9162-6e4f2a4e5fa8.png"> | <img width="392" alt="automated  1" src="https://user-images.githubusercontent.com/562080/100668119-69678600-3329-11eb-9c96-6b1fe5d2551a.png"> 

# Testing Steps
- Go to a manually refunded order
- Tap on the refund 
- See that it reads "Refunded Manually" and not `Refunded Manually via {payment_method}`

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
