### PR TITLE
Order Details > Shipping Label: hide order item total & subtitle when the price is unknown

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -15,10 +15,10 @@ struct AggregateOrderItem: Equatable {
     /// for localization and string-to-number conversions.
     /// `Decimal` doesn't have all of the `NSDecimalNumber` APIs (yet).
     ///
-    let price: NSDecimalNumber
+    let price: NSDecimalNumber?
     var quantity: Decimal
     let sku: String?
-    let total: NSDecimalNumber
+    let total: NSDecimalNumber?
 
     let imageURL: URL?
 
@@ -29,10 +29,10 @@ struct AggregateOrderItem: Equatable {
     init(productID: Int64,
          variationID: Int64,
          name: String,
-         price: NSDecimalNumber,
+         price: NSDecimalNumber?,
          quantity: Decimal,
          sku: String?,
-         total: NSDecimalNumber,
+         total: NSDecimalNumber?,
          imageURL: URL? = nil,
          attributes: [OrderItemAttribute]) {
         self.productID = productID

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -479,7 +479,7 @@ private extension OrderDetailsDataSource {
             return
         }
 
-        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: orderItem, shouldHideTotalAndSubtitleIfNumbersAreZero: true, currency: order.currency)
+        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: orderItem, currency: order.currency)
         cell.configure(item: itemViewModel, imageService: imageService)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -479,7 +479,7 @@ private extension OrderDetailsDataSource {
             return
         }
 
-        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: orderItem, currency: order.currency)
+        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: orderItem, shouldHideTotalAndSubtitleIfNumbersAreZero: true, currency: order.currency)
         cell.configure(item: itemViewModel, imageService: imageService)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -108,7 +108,7 @@ private extension AggregatedShippingLabelOrderItems {
     func orderItem(from model: OrderItemModel, quantity: Int) -> AggregateOrderItem {
         switch model {
         case .productName(let name):
-            return .init(productID: 0, variationID: 0, name: name, price: 0, quantity: 0, sku: nil, total: 0, attributes: [])
+            return .init(productID: 0, variationID: 0, name: name, price: nil, quantity: 0, sku: nil, total: nil, attributes: [])
         case .product(let product, let orderItem, let name):
             let productName = orderItem?.name ?? name
             let price = orderItem?.price ??

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -11,39 +11,6 @@ struct ProductDetailsCellViewModel {
         let value: String
     }
 
-    // MARK: - Private properties
-
-    /// Yosemite.Order.currency
-    ///
-    private let currency: String
-
-    /// Currency Formatter
-    ///
-    private let currencyFormatter: CurrencyFormatter
-
-    /// Item Quantity
-    /// represented as a positive value
-    ///
-    private let positiveQuantity: Decimal
-
-    /// Item Total
-    /// represented as a positive value
-    ///
-    private let positiveTotal: NSDecimalNumber
-
-    /// Item Price
-    /// represented as a positive value
-    ///
-    private let positivePrice: NSDecimalNumber
-
-    /// Item SKU
-    ///
-    private let skuText: String?
-
-    /// Attributes of an order item.
-    ///
-    private let attributes: [OrderAttributeViewModel]
-
     // MARK: - Public properties
 
     /// The first available image for a product/variation.
@@ -56,38 +23,46 @@ struct ProductDetailsCellViewModel {
 
     /// Item Quantity as a String
     ///
-    var quantity: String {
-        return NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
-    }
+    let quantity: String
 
     /// The localized total value of this line item. This is the quantity x price.
     ///
-    var total: String {
-        currencyFormatter.formatAmount(positiveTotal, with: currency) ?? String()
-    }
+    let total: String
 
     /// Returns the localized "quantity x price" to use for the subtitle.
     ///
-    var subtitle: String {
-        let itemPrice = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
-
-        return Localization.subtitle(quantity: quantity, price: itemPrice, attributes: attributes)
-    }
+    let subtitle: String
 
     /// Item SKU
     ///
-    var sku: String? {
-        guard let sku = skuText, sku.isEmpty == false else {
-            return nil
-        }
-
-        let skuTemplate = NSLocalizedString("SKU: %@", comment: "SKU label, followed by the SKU")
-        let skuText = String.localizedStringWithFormat(skuTemplate, sku)
-
-        return skuText
-    }
+    let sku: String?
 
     // MARK: - Initializers
+
+    private init(currency: String,
+                 currencyFormatter: CurrencyFormatter,
+                 imageURL: URL?,
+                 name: String,
+                 positiveQuantity: Decimal,
+                 positiveTotal: NSDecimalNumber,
+                 positivePrice: NSDecimalNumber,
+                 skuText: String?,
+                 attributes: [OrderAttributeViewModel]) {
+        self.imageURL = imageURL
+        self.name = name
+        self.quantity = NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
+        self.total = currencyFormatter.formatAmount(positiveTotal, with: currency) ?? String()
+        self.sku = {
+            guard let sku = skuText, sku.isEmpty == false else {
+                return nil
+            }
+            return String.localizedStringWithFormat(Localization.skuFormat, sku)
+        }()
+
+        // Somehow the subtitle cannot be initialized in a closure like `sku`.
+        let itemPrice = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
+        self.subtitle = Localization.subtitle(quantity: quantity, price: itemPrice, attributes: attributes)
+    }
 
     /// Order Item initializer
     ///
@@ -95,15 +70,15 @@ struct ProductDetailsCellViewModel {
          currency: String,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          product: Product? = nil) {
-        self.currency = currency
-        self.currencyFormatter = formatter
-        self.imageURL = product?.imageURL
-        self.name = item.name
-        self.positiveQuantity = abs(item.quantity)
-        self.positiveTotal = currencyFormatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero
-        self.positivePrice = item.price.abs()
-        self.skuText = item.sku
-        self.attributes = item.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) }
+        self.init(currency: currency,
+                  currencyFormatter: formatter,
+                  imageURL: product?.imageURL,
+                  name: item.name,
+                  positiveQuantity: abs(item.quantity),
+                  positiveTotal: formatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero,
+                  positivePrice: item.price.abs(),
+                  skuText: item.sku,
+                  attributes: item.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) })
     }
 
     /// Aggregate Order Item initializer
@@ -112,15 +87,15 @@ struct ProductDetailsCellViewModel {
          currency: String,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          product: Product? = nil) {
-        self.currency = currency
-        self.currencyFormatter = formatter
-        self.imageURL = aggregateItem.imageURL ?? product?.imageURL
-        self.name = aggregateItem.name
-        self.positiveQuantity = abs(aggregateItem.quantity)
-        self.positiveTotal = aggregateItem.total.abs()
-        self.positivePrice = aggregateItem.price.abs()
-        self.skuText = aggregateItem.sku
-        self.attributes = aggregateItem.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) }
+        self.init(currency: currency,
+                  currencyFormatter: formatter,
+                  imageURL: aggregateItem.imageURL ?? product?.imageURL,
+                  name: aggregateItem.name,
+                  positiveQuantity: abs(aggregateItem.quantity),
+                  positiveTotal: aggregateItem.total.abs(),
+                  positivePrice: aggregateItem.price.abs(),
+                  skuText: aggregateItem.sku,
+                  attributes: aggregateItem.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) })
     }
 
     /// Refunded Order Item initializer
@@ -129,16 +104,15 @@ struct ProductDetailsCellViewModel {
          currency: String,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          product: Product? = nil) {
-        self.currency = currency
-        self.currencyFormatter = formatter
-        self.imageURL = product?.imageURL
-        self.name = refundedItem.name
-        self.positiveQuantity = abs(refundedItem.quantity)
-        self.positiveTotal = currencyFormatter.convertToDecimal(from: refundedItem.total)?.abs() ?? NSDecimalNumber.zero
-        self.positivePrice = refundedItem.price.abs()
-        self.skuText = refundedItem.sku
-        // Attributes are not supported for a refund item yet.
-        self.attributes = []
+        self.init(currency: currency,
+                  currencyFormatter: formatter,
+                  imageURL: product?.imageURL,
+                  name: refundedItem.name,
+                  positiveQuantity: abs(refundedItem.quantity),
+                  positiveTotal: formatter.convertToDecimal(from: refundedItem.total)?.abs() ?? NSDecimalNumber.zero,
+                  positivePrice: refundedItem.price.abs(),
+                  skuText: refundedItem.sku,
+                  attributes: []) // Attributes are not supported for a refund item yet.
     }
 }
 
@@ -146,6 +120,7 @@ struct ProductDetailsCellViewModel {
 
 private extension ProductDetailsCellViewModel {
     enum Localization {
+        static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
         static let subtitleFormat =
             NSLocalizedString("%1$@ x %2$@", comment: "In Order Details,"
                                 + " the pattern used to show the quantity multiplied by the price. For example, “23 x $400.00”."

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -61,14 +61,14 @@ struct ProductDetailsCellViewModel {
 
         self.total = {
             guard let positiveTotal = positiveTotal else {
-                return ""
+                return String()
             }
             return currencyFormatter.formatAmount(positiveTotal, with: currency) ?? String()
         }()
 
         self.subtitle = {
             guard let positivePrice = positivePrice else {
-                return ""
+                return String()
             }
             let itemPrice = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
             return Localization.subtitle(quantity: quantity, price: itemPrice, attributes: attributes)

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -44,10 +44,9 @@ struct ProductDetailsCellViewModel {
                  imageURL: URL?,
                  name: String,
                  positiveQuantity: Decimal,
-                 positiveTotal: NSDecimalNumber,
-                 positivePrice: NSDecimalNumber,
+                 positiveTotal: NSDecimalNumber?,
+                 positivePrice: NSDecimalNumber?,
                  skuText: String?,
-                 shouldHideTotalAndSubtitleIfNumbersAreZero: Bool = false,
                  attributes: [OrderAttributeViewModel]) {
         self.imageURL = imageURL
         self.name = name
@@ -61,16 +60,14 @@ struct ProductDetailsCellViewModel {
         }()
 
         self.total = {
-            let shouldHideTotalLabel = shouldHideTotalAndSubtitleIfNumbersAreZero && positiveTotal == 0
-            guard shouldHideTotalLabel == false else {
+            guard let positiveTotal = positiveTotal else {
                 return ""
             }
             return currencyFormatter.formatAmount(positiveTotal, with: currency) ?? String()
         }()
 
         self.subtitle = {
-            let shouldHideSubtitleLabel = shouldHideTotalAndSubtitleIfNumbersAreZero && positivePrice == 0
-            guard shouldHideSubtitleLabel == false else {
+            guard let positivePrice = positivePrice else {
                 return ""
             }
             let itemPrice = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
@@ -98,7 +95,6 @@ struct ProductDetailsCellViewModel {
     /// Aggregate Order Item initializer
     ///
     init(aggregateItem: AggregateOrderItem,
-         shouldHideTotalAndSubtitleIfNumbersAreZero: Bool = false,
          currency: String,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          product: Product? = nil) {
@@ -107,10 +103,9 @@ struct ProductDetailsCellViewModel {
                   imageURL: aggregateItem.imageURL ?? product?.imageURL,
                   name: aggregateItem.name,
                   positiveQuantity: abs(aggregateItem.quantity),
-                  positiveTotal: aggregateItem.total.abs(),
-                  positivePrice: aggregateItem.price.abs(),
+                  positiveTotal: aggregateItem.total?.abs(),
+                  positivePrice: aggregateItem.price?.abs(),
                   skuText: aggregateItem.sku,
-                  shouldHideTotalAndSubtitleIfNumbersAreZero: shouldHideTotalAndSubtitleIfNumbersAreZero,
                   attributes: aggregateItem.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,26 +18,26 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p6h-Fq-FjW">
-                        <rect key="frame" x="15" y="19" width="44" height="44"/>
+                        <rect key="frame" x="16" y="19" width="44" height="44"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="44" id="9vH-gW-wOd"/>
                             <constraint firstAttribute="height" constant="44" id="hcJ-qM-Kx2"/>
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="En5-gn-p39">
-                        <rect key="frame" x="75" y="19" width="230" height="85"/>
+                        <rect key="frame" x="76" y="19" width="228" height="85"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HX7-V5-bhX">
-                                <rect key="frame" x="0.0" y="0.0" width="230" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="228" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Title Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14R-zK-tgC">
-                                        <rect key="frame" x="0.0" y="0.0" width="190.5" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="188.5" height="50"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="893" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pPE-SE-pY7">
-                                        <rect key="frame" x="198.5" y="0.0" width="31.5" height="50"/>
+                                        <rect key="frame" x="196.5" y="0.0" width="31.5" height="50"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -55,7 +55,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total price (item price x qty)" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBM-H2-zE2">
-                                <rect key="frame" x="0.0" y="69" width="230" height="16"/>
+                                <rect key="frame" x="0.0" y="69" width="228" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -70,6 +70,7 @@
                     <constraint firstItem="En5-gn-p39" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="VsH-Qa-5gp"/>
                     <constraint firstItem="p6h-Fq-FjW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="WkU-sH-Aqw"/>
                     <constraint firstItem="En5-gn-p39" firstAttribute="leading" secondItem="p6h-Fq-FjW" secondAttribute="trailing" constant="16" id="Yht-tO-bpS"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="p6h-Fq-FjW" secondAttribute="bottom" constant="8" id="n9m-uT-vqx"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02564A87246C047C00D6DB2A /* Optional+StringTests.swift */; };
 		02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02564A89246CDF6100D6DB2A /* ProductsTopBannerFactory.swift */; };
 		02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02564A8B246CE38E00D6DB2A /* SwappableSubviewContainerView.swift */; };
+		025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0258B66B2518754D00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66A2518754C00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift */; };
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
@@ -1191,6 +1192,7 @@
 		02564A87246C047C00D6DB2A /* Optional+StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+StringTests.swift"; sourceTree = "<group>"; };
 		02564A89246CDF6100D6DB2A /* ProductsTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTopBannerFactory.swift; sourceTree = "<group>"; };
 		02564A8B246CE38E00D6DB2A /* SwappableSubviewContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwappableSubviewContainerView.swift; sourceTree = "<group>"; };
+		025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModelTests.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0258B66A2518754C00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+AddProductTests.swift"; sourceTree = "<group>"; };
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -3408,6 +3410,7 @@
 			children = (
 				57F2C6CA246DEBBF0074063B /* Order Summary Section */,
 				0277AE99256CA86D00F45C4A /* Shipping Labels */,
+				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 			);
 			path = "Order Details";
 			sourceTree = "<group>";
@@ -6004,6 +6007,7 @@
 				B57C5C9F21B80E8300FF82B2 /* SampleError.swift in Sources */,
 				02404EE42315151400FF1170 /* MockupStatsVersionStoresManager.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
+				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class ProductDetailsCellViewModelTests: XCTestCase {
+    private let currencyFormatter = CurrencyFormatter(currencySettings: .init())
+
+    // MARK: `OrderItem`
+
+    func test_initializing_with_OrderItem() {
+        // Given
+        let sku = "sku"
+        let item = makeOrderItem(quantity: 2.5,
+                                 price: 3.5,
+                                 total: "8.5",
+                                 sku: "sku",
+                                 attributes: [])
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(item: item,
+                                                    currency: "$",
+                                                    formatter: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(viewModel.imageURL, nil)
+        XCTAssertEqual(viewModel.name, item.name)
+        let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
+        XCTAssertEqual(viewModel.quantity, quantity)
+        XCTAssertEqual(viewModel.total, "$8.50")
+        let subtitle = String.localizedStringWithFormat(Localization.subtitleFormat, quantity, "$3.50")
+        XCTAssertEqual(viewModel.subtitle, subtitle)
+        XCTAssertEqual(viewModel.sku, String.localizedStringWithFormat(Localization.skuFormat, sku))
+    }
+
+    // MARK: `AggregateOrderItem`
+
+    func test_initializing_with_AggregateOrderItem() {
+        // Given
+        let sku = "sku"
+        let item = makeAggregateOrderItem(quantity: 2,
+                                          price: 3.5,
+                                          total: 7,
+                                          sku: sku,
+                                          imageURL: URL(string: "woo.com/woo.jpeg"),
+                                          attributes: [
+                                            .init(metaID: 2, name: "Woo", value: "Wao"),
+                                            .init(metaID: 25, name: "Wooo", value: "Waoo")
+                                          ])
+
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
+                                                    currency: "$",
+                                                    formatter: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(viewModel.imageURL, item.imageURL)
+        XCTAssertEqual(viewModel.name, item.name)
+        let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
+        XCTAssertEqual(viewModel.quantity, quantity)
+        XCTAssertEqual(viewModel.total, "$7.00")
+        let subtitle = String.localizedStringWithFormat(Localization.subtitleWithAttributesFormat, "Wao, Waoo", quantity, "$3.50")
+        XCTAssertEqual(viewModel.subtitle, subtitle)
+        XCTAssertEqual(viewModel.sku, String.localizedStringWithFormat(Localization.skuFormat, sku))
+    }
+
+    func test_total_and_subtitle_are_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_on_with_zero_values() {
+        // Given
+        let item = makeAggregateOrderItem(quantity: 2.5, price: 0.0, total: 0.0)
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
+                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: true,
+                                                    currency: "$")
+        let total = viewModel.total
+        let subtitle = viewModel.subtitle
+
+        // Then
+        XCTAssertEqual(total, "")
+        XCTAssertEqual(subtitle, "")
+    }
+
+    func test_total_and_subtitle_are_not_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_on_with_nonzero_values() {
+        // Given
+        let item = makeAggregateOrderItem(quantity: 2.5, price: 1.0, total: 2.5)
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
+                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: true,
+                                                    currency: "$")
+        let total = viewModel.total
+        let subtitle = viewModel.subtitle
+
+        // Then
+        XCTAssertNotEqual(total, "")
+        XCTAssertNotEqual(subtitle, "")
+    }
+
+    func test_total_and_subtitle_are_not_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_off_with_zero_values() {
+        // Given
+        let item = makeAggregateOrderItem(quantity: 2.5, price: 0.0, total: 0.0)
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
+                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: false,
+                                                    currency: "$")
+        let total = viewModel.total
+        let subtitle = viewModel.subtitle
+
+        // Then
+        XCTAssertNotEqual(total, "")
+        XCTAssertNotEqual(subtitle, "")
+    }
+
+    // MARK: `OrderItemRefund`
+
+    func test_initializing_with_OrderItemRefund_with_empty_sku() {
+        // Given
+        let item = makeOrderItemRefund(quantity: 2.5,
+                                       price: -18,
+                                       total: "-18",
+                                       sku: "")
+
+        // When
+        let viewModel = ProductDetailsCellViewModel(refundedItem: item,
+                                                    currency: "$",
+                                                    formatter: currencyFormatter)
+
+        // Then
+        XCTAssertEqual(viewModel.imageURL, nil)
+        XCTAssertEqual(viewModel.name, item.name)
+        let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
+        XCTAssertEqual(viewModel.quantity, quantity)
+        XCTAssertEqual(viewModel.total, "$18.00")
+        let subtitle = String.localizedStringWithFormat(Localization.subtitleFormat, quantity, "$18.00")
+        XCTAssertEqual(viewModel.subtitle, subtitle)
+        XCTAssertEqual(viewModel.sku, nil)
+    }
+}
+
+private extension ProductDetailsCellViewModelTests {
+    func makeOrderItem(quantity: Decimal,
+                       price: NSDecimalNumber,
+                       total: String,
+                       sku: String = "",
+                       attributes: [OrderItemAttribute] = []) -> OrderItem {
+        OrderItem(itemID: 0,
+                  name: "fun order",
+                  productID: 1,
+                  variationID: 2,
+                  quantity: quantity,
+                  price: price,
+                  sku: sku,
+                  subtotal: "0",
+                  subtotalTax: "1.0",
+                  taxClass: "",
+                  taxes: [],
+                  total: total,
+                  totalTax: "",
+                  attributes: attributes)
+    }
+
+    func makeAggregateOrderItem(quantity: Decimal,
+                                price: NSDecimalNumber,
+                                total: NSDecimalNumber,
+                                sku: String = "",
+                                imageURL: URL? = nil,
+                                attributes: [OrderItemAttribute] = []) -> AggregateOrderItem {
+        AggregateOrderItem(productID: 1,
+                           variationID: 6,
+                           name: "order",
+                           price: price,
+                           quantity: quantity,
+                           sku: sku,
+                           total: total,
+                           imageURL: imageURL,
+                           attributes: attributes)
+    }
+
+    func makeOrderItemRefund(quantity: Decimal,
+                             price: NSDecimalNumber,
+                             total: String,
+                             sku: String = "") -> OrderItemRefund {
+        OrderItemRefund(itemID: 73,
+                        name: "Ninja Silhouette",
+                        productID: 1,
+                        variationID: 6,
+                        quantity: quantity,
+                        price: price,
+                        sku: sku,
+                        subtotal: "-18.00",
+                        subtotalTax: "0.00",
+                        taxClass: "",
+                        taxes: [],
+                        total: total,
+                        totalTax: "0.00")
+    }
+}
+
+private extension ProductDetailsCellViewModelTests {
+    enum Localization {
+        static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "SKU label in order details > product row. The variable shows the SKU of the product.")
+        static let subtitleFormat =
+            NSLocalizedString("%1$@ x %2$@", comment: "In Order Details,"
+                                + " the pattern used to show the quantity multiplied by the price. For example, “23 x $400.00”."
+                                + " The %1$@ is the quantity. The %2$@ is the formatted price with currency (e.g. $400.00).")
+        static let subtitleWithAttributesFormat =
+            NSLocalizedString("%1$@・%2$@ x %3$@", comment: "In Order Details > product details: if the product has attributes,"
+                                + " the pattern used to show the attributes and quantity multiplied by the price. For example, “purple, has logo・23 x $400.00”."
+                                + " The %1$@ is the list of attributes (e.g. from variation)."
+                                + " The %2$@ is the quantity. The %3$@ is the formatted price with currency (e.g. $400.00).")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -64,14 +64,12 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sku, String.localizedStringWithFormat(Localization.skuFormat, sku))
     }
 
-    func test_total_and_subtitle_are_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_on_with_zero_values() {
+    func test_total_and_subtitle_are_empty_if_price_and_total_are_nil() {
         // Given
-        let item = makeAggregateOrderItem(quantity: 2.5, price: 0.0, total: 0.0)
+        let item = makeAggregateOrderItem(quantity: 2.5, price: nil, total: nil)
 
         // When
-        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
-                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: true,
-                                                    currency: "$")
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item, currency: "$")
         let total = viewModel.total
         let subtitle = viewModel.subtitle
 
@@ -80,30 +78,12 @@ final class ProductDetailsCellViewModelTests: XCTestCase {
         XCTAssertEqual(subtitle, "")
     }
 
-    func test_total_and_subtitle_are_not_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_on_with_nonzero_values() {
-        // Given
-        let item = makeAggregateOrderItem(quantity: 2.5, price: 1.0, total: 2.5)
-
-        // When
-        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
-                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: true,
-                                                    currency: "$")
-        let total = viewModel.total
-        let subtitle = viewModel.subtitle
-
-        // Then
-        XCTAssertNotEqual(total, "")
-        XCTAssertNotEqual(subtitle, "")
-    }
-
-    func test_total_and_subtitle_are_not_empty_if_shouldHideTotalAndSubtitleIfNumbersAreZero_is_off_with_zero_values() {
+    func test_total_and_subtitle_are_not_empty_if_price_and_total_are_not_nil() {
         // Given
         let item = makeAggregateOrderItem(quantity: 2.5, price: 0.0, total: 0.0)
 
         // When
-        let viewModel = ProductDetailsCellViewModel(aggregateItem: item,
-                                                    shouldHideTotalAndSubtitleIfNumbersAreZero: false,
-                                                    currency: "$")
+        let viewModel = ProductDetailsCellViewModel(aggregateItem: item, currency: "$")
         let total = viewModel.total
         let subtitle = viewModel.subtitle
 
@@ -161,8 +141,8 @@ private extension ProductDetailsCellViewModelTests {
     }
 
     func makeAggregateOrderItem(quantity: Decimal,
-                                price: NSDecimalNumber,
-                                total: NSDecimalNumber,
+                                price: NSDecimalNumber?,
+                                total: NSDecimalNumber?,
                                 sku: String = "",
                                 imageURL: URL? = nil,
                                 attributes: [OrderItemAttribute] = []) -> AggregateOrderItem {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AggregatedShippingLabelOrderItemsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AggregatedShippingLabelOrderItemsTests.swift
@@ -17,7 +17,7 @@ final class AggregatedShippingLabelOrderItemsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(shippingLabelOrderItems, [
-            .init(productID: 0, variationID: 0, name: "Password protected!", price: 0, quantity: 0, sku: nil, total: 0, attributes: [])
+            .init(productID: 0, variationID: 0, name: "Password protected!", price: nil, quantity: 0, sku: nil, total: nil, attributes: [])
         ])
         XCTAssertEqual(shippingLabelOrderItems[0], aggregatedOrderItems.orderItem(of: shippingLabel, at: 0))
     }


### PR DESCRIPTION
Part of #2167

## Why

In a shipping label's API response, we only know the product/variation IDs or names depending on the WCS plugin version. Before the products/variations are fetched given the IDs, we do not know the price/total of the product/variation for an order item in a shipping label. For example, right now we don't fetch the missing variations for an Order in order details (it's a subtask in #2167), so that the order items with missing variations don't have a valid price/total. We currently set the missing price/total values for such order items to zero as in the before/after screenshots below, and this PR updates `AggregateOrderItem` to allow its price and total values to be `nil` so that we can hide the total & subtitle labels in this scenario.

## Changes

I took the chance to refactor `ProductDetailsCellViewModel` a bit so that it's easier to customize the logic when the price/total value is `nil`.

- Updated `AggregateOrderItem`'s `price` and `total` to be nullable
- In `AggregatedShippingLabelOrderItems`, updated to set `AggregateOrderItem`'s `price` and `total` to be `nil` if only the name is known
- In `ProductDetailsCellViewModel`, refactored to remove the private properties that were only used for public calculated properties and consolidate the logic that sets the public properties in a private initializer
  - The only behavior change is so that we set the `total` and `subtitle` strings to be empty if an item's `price`/`total` is `nil`
  - Added unit tests for the existing `ProductDetailsCellViewModel` usage for `OrderItem`/`AggregateOrderItem`/`OrderItemRefund`
- Added an Auto Layout constraint to `ProductDetailsTableViewCell`'s image view: `superview.bottom >= imageView.bottom + 8px` so that the image has some margin at the bottom when the subtitle isn't shown

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/).

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- In core, create an order with a variation. Then create a shipping label for this order
- Launch the app, log out and in to the store without going to the Products tab
- Go to the orders tab
- Tap on the order with a variation & shipping label --> after syncing, the variation order item should not show any total or subtitle like in the example screenshot below

## Example screenshots

before | after
-- | --
<img src="https://user-images.githubusercontent.com/1945542/100717302-d431c380-33f4-11eb-8a78-f1838c2d02c6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/100717784-7e115000-33f5-11eb-854e-b8b50730afd1.png" width="300" />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
