### PR TITLE
[Issue Refund] Fix typo in refund success notice

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -219,7 +219,7 @@ private extension RefundConfirmationViewController {
         static let refund = NSLocalizedString("Refund", comment: "The title of the button to confirm the refund.")
         static let cancel = NSLocalizedString("Cancel", comment: "The title of the button to cancel issuing a refund.")
         static let issuingRefund = NSLocalizedString("Issuing Refund...", comment: "Text of the screen that is displayed while the refund is being created.")
-        static let refundSuccess = NSLocalizedString("🎉 Products successfuly refunded",
+        static let refundSuccess = NSLocalizedString("🎉 Products successfully refunded",
                                                    comment: "Text of the notice that is displayed after the refund is created.")
         static let refundError = NSLocalizedString("There was an error issuing the refund",
                                                    comment: "Text of the notice that is displayed while the refund creation fails.")


### PR DESCRIPTION
fixes #3256 

Tiny PR to fix a typo 😇 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
