### PR TITLE
[Issue Refund] Update Order once refund is submitted

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -81,12 +81,28 @@ final class RefundConfirmationViewModel {
                 self.trackCreateRefundRequestFailed(error: error)
                 return onCompletion(.failure(error))
             }
-            onCompletion(.success(()))
+
+            // We don't care if the "update order" fails. We return .success() as the refund creation already succeeded.
+            self.updateOrder { _ in
+                onCompletion(.success(()))
+            }
             self.trackCreateRefundRequestSuccess()
         }
 
         actionProcessor.dispatch(action)
         trackCreateRefundRequest()
+    }
+
+    /// Updates the order associated with the refund to reflect the latest refund status.
+    ///
+    func updateOrder(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = OrderAction.retrieveOrder(siteID: details.order.siteID, orderID: details.order.orderID) { _, error  in
+            if let error = error {
+                return onCompletion(.failure(error))
+            }
+            onCompletion(.success(()))
+        }
+        actionProcessor.dispatch(action)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -115,6 +115,11 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                 break
             }
         }
+        dispatcher.whenReceivingAction(ofType: OrderAction.self) { action in
+            if case let .retrieveOrder(_, _, onCompletion) = action {
+                onCompletion(order, nil)
+            }
+        }
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
@@ -146,12 +151,9 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let orderUpdated: Bool = try waitFor { promise in
             // Capture order updated value
             dispatcher.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case let .retrieveOrder(_, _, onCompletion):
-                    onCompletion(order.copy(status: .refunded), nil)
+                if case let .retrieveOrder(_, _, onCompletion) = action {
+                    onCompletion(order, nil)
                     promise(true)
-                default:
-                    break
                 }
             }
 
@@ -223,6 +225,11 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                 onCompletion(nil, expectedError)
             default:
                 break
+            }
+        }
+        dispatcher.whenReceivingAction(ofType: OrderAction.self) { action in
+            if case let .retrieveOrder(_, _, onCompletion) = action {
+                onCompletion(order, nil)
             }
         }
 
@@ -331,6 +338,11 @@ final class RefundConfirmationViewModelTests: XCTestCase {
                 onCompletion(refund, nil)
             default:
                 break
+            }
+        }
+        dispatcher.whenReceivingAction(ofType: OrderAction.self) { action in
+            if case let .retrieveOrder(_, _, onCompletion) = action {
+                onCompletion(order, nil)
             }
         }
 


### PR DESCRIPTION
 fixes #3257 

# Why

It was reported that after fully refunded an order, the order status is not updated instantly. This PR fixes that by updating the order from the remote source after the refund is processed successfully.

# How 

Dispatch `OrderAction.retrieveOrder` once the refund is submitted successfully.

# Gif

![Total Refund](https://user-images.githubusercontent.com/562080/100752669-dd03a480-33b6-11eb-93a2-b65258924fe1.gif)


# Testing Steps

- Go to an unrefunded order
- Tap on the select all button
- Enable the shipping switch if present.
- Submit refund
- After finishing, check that the order has the `refunded` status.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
