### PR TITLE
Order Details: update Products, Tracking, and Add Tracking sections based on shipping labels

### DIFF
--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -1,0 +1,41 @@
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import Networking
+
+
+extension AggregateOrderItem {
+    func copy(
+        productID: CopiableProp<Int64> = .copy,
+        variationID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        price: NullableCopiableProp<NSDecimalNumber> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        total: NullableCopiableProp<NSDecimalNumber> = .copy,
+        imageURL: NullableCopiableProp<URL> = .copy,
+        attributes: CopiableProp<[OrderItemAttribute]> = .copy
+    ) -> AggregateOrderItem {
+        let productID = productID ?? self.productID
+        let variationID = variationID ?? self.variationID
+        let name = name ?? self.name
+        let price = price ?? self.price
+        let quantity = quantity ?? self.quantity
+        let sku = sku ?? self.sku
+        let total = total ?? self.total
+        let imageURL = imageURL ?? self.imageURL
+        let attributes = attributes ?? self.attributes
+
+        return AggregateOrderItem(
+            productID: productID,
+            variationID: variationID,
+            name: name,
+            price: price,
+            quantity: quantity,
+            sku: sku,
+            total: total,
+            imageURL: imageURL,
+            attributes: attributes
+        )
+    }
+}

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -129,4 +129,44 @@ final class AggregateDataHelper {
 
         return sorted
     }
+
+    /// Combines aggregate order items with order items from non-refunded shipping labels.
+    ///
+    /// - Parameters:
+    ///   - orderItems: an array of aggregate order items, like after combining with refunded products by calling `combineOrderItems`.
+    ///   - orderItemsInNonRefundedShippingLabels: an array of aggregate order items from shipping labels that could have duplicate products/variations.
+    /// - Returns: an array of aggregate order items based on the given `orderItems` whose elements are removed if fully covered in shipping labels, and the
+    ///           quantity is subtracted by the total quantity from the given order items in shipping labels.
+    static func combineAggregatedOrderItems(_ orderItems: [AggregateOrderItem],
+                                            with orderItemsInNonRefundedShippingLabels: [AggregateOrderItem]) -> [AggregateOrderItem] {
+        // Generates a dictionary that maps a unique order item (keyed by `productID` and `variationID`) to the sum of quantity from order items in shipping
+        // labels.
+        let orderItemsByProductAndVariationID = Dictionary(grouping: orderItemsInNonRefundedShippingLabels) { $0.hashValue }
+        let orderItemCountsByProductAndVariationID = orderItemsByProductAndVariationID.mapValues {
+            $0.reduce(into: 0) { result, orderItem in
+                result += orderItem.quantity
+            }
+        }
+        return orderItems.compactMap { orderItem in
+            // If the order item is not in any shipping labels, the original order item is returned.
+            guard let orderItemCountInNonRefundedShippingLabels = orderItemCountsByProductAndVariationID[orderItem.hashValue] else {
+                return orderItem
+            }
+            // If the order item quantity is <= the sum in the shipping labels, the order item is skipped.
+            guard orderItemCountInNonRefundedShippingLabels < orderItem.quantity else {
+                return nil
+            }
+            // If the order item quantity is larger than the sum in the shipping labels, the order item's quantity is deducted by the sum in the shipping
+            // labels.
+            return .init(productID: orderItem.productID,
+                         variationID: orderItem.variationID,
+                         name: orderItem.name,
+                         price: orderItem.price,
+                         quantity: orderItem.quantity - orderItemCountInNonRefundedShippingLabels,
+                         sku: orderItem.sku,
+                         total: orderItem.total,
+                         imageURL: orderItem.imageURL,
+                         attributes: orderItem.attributes)
+        }
+    }
 }

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -136,7 +136,7 @@ final class AggregateDataHelper {
     ///   - orderItems: an array of aggregate order items, like after combining with refunded products by calling `combineOrderItems`.
     ///   - orderItemsInNonRefundedShippingLabels: an array of aggregate order items from shipping labels that could have duplicate products/variations.
     /// - Returns: an array of aggregate order items based on the given `orderItems` whose elements are removed if fully covered in shipping labels, and the
-    ///           quantity is subtracted by the total quantity from the given order items in shipping labels.
+    ///            quantity is subtracted by the total quantity from the given order items in shipping labels.
     static func combineAggregatedOrderItems(_ orderItems: [AggregateOrderItem],
                                             with orderItemsInNonRefundedShippingLabels: [AggregateOrderItem]) -> [AggregateOrderItem] {
         // Generates a dictionary that maps a unique order item (keyed by `productID` and `variationID`) to the sum of quantity from order items in shipping
@@ -152,7 +152,7 @@ final class AggregateDataHelper {
             guard let orderItemCountInNonRefundedShippingLabels = orderItemCountsByProductAndVariationID[orderItem.hashValue] else {
                 return orderItem
             }
-            // If the order item quantity is <= the sum in the shipping labels, the order item is skipped.
+            // If the order item quantity is <= the sum in the shipping labels, the order item is skipped since it's shown in the shipping label sections.
             guard orderItemCountInNonRefundedShippingLabels < orderItem.quantity else {
                 return nil
             }

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -158,15 +158,7 @@ final class AggregateDataHelper {
             }
             // If the order item quantity is larger than the sum in the shipping labels, the order item's quantity is deducted by the sum in the shipping
             // labels.
-            return .init(productID: orderItem.productID,
-                         variationID: orderItem.variationID,
-                         name: orderItem.name,
-                         price: orderItem.price,
-                         quantity: orderItem.quantity - orderItemCountInNonRefundedShippingLabels,
-                         sku: orderItem.sku,
-                         total: orderItem.total,
-                         imageURL: orderItem.imageURL,
-                         attributes: orderItem.attributes)
+            return orderItem.copy(quantity: orderItem.quantity - orderItemCountInNonRefundedShippingLabels)
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -1,10 +1,11 @@
 import Foundation
+import Networking
 import Yosemite
 
 /// This model represents a computed summary of order items.
 /// (order items - refunded order items) = aggregate order item data.
 ///
-struct AggregateOrderItem: Equatable {
+struct AggregateOrderItem: Equatable, GeneratedCopiable {
     let productID: Int64
     let variationID: Int64
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -111,7 +111,11 @@ final class OrderDetailsDataSource: NSObject {
     /// Calculate the new order item quantities and totals after refunded products have altered the fields
     ///
     var aggregateOrderItems: [AggregateOrderItem] {
-        return AggregateDataHelper.combineOrderItems(items, with: refunds)
+        let orderItemsAfterCombiningWithRefunds = AggregateDataHelper.combineOrderItems(items, with: refunds)
+        let orderItemsAfterCombiningWithRefundsAndShippingLabels = AggregateDataHelper
+            .combineAggregatedOrderItems(orderItemsAfterCombiningWithRefunds,
+                                         with: shippingLabelOrderItemsAggregator.orderItemsOfNonRefundedShippingLabels(shippingLabels))
+        return orderItemsAfterCombiningWithRefundsAndShippingLabels
     }
 
     /// All the condensed refunds in an order
@@ -719,13 +723,12 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            var rows = [Row]()
-
-            if refundedProductsCount > 0 {
-                rows = Array(repeating: .aggregateOrderItem, count: aggregateOrderItems.count)
-            } else {
-                rows = Array(repeating: .orderItem, count: items.count)
+            let aggregateOrderItemCount = aggregateOrderItems.count
+            guard aggregateOrderItemCount > 0 else {
+                return nil
             }
+
+            var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
             if isProcessingPayment {
                 rows.append(.fulfillButton)
@@ -821,6 +824,11 @@ extension OrderDetailsDataSource {
         }()
 
         let tracking: Section? = {
+            // Tracking section is hidden if there are non-empty non-refunded shipping labels.
+            guard shippingLabels.nonRefunded.isEmpty else {
+                return nil
+            }
+
             guard orderTracking.count > 0 else {
                 return nil
             }
@@ -830,6 +838,11 @@ extension OrderDetailsDataSource {
         }()
 
         let addTracking: Section? = {
+            // Add tracking section is hidden if there are non-empty non-refunded shipping labels.
+            guard shippingLabels.nonRefunded.isEmpty else {
+                return nil
+            }
+
             // Hide the section if the shipment
             // tracking plugin is not installed
             guard trackingIsReachable else {

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -38,7 +38,12 @@ struct AggregatedShippingLabelOrderItems {
 
     /// Returns an order item for a shipping label given an index, if available. Otherwise, nil is returned.
     func orderItem(of shippingLabel: ShippingLabel, at index: Int) -> AggregateOrderItem? {
-        return orderItems(of: shippingLabel)[safe: index]
+        orderItems(of: shippingLabel)[safe: index]
+    }
+
+    /// Returns an array of order items from all of the given non-refunded shipping labels.
+    func orderItemsOfNonRefundedShippingLabels(_ shippingLabels: [ShippingLabel]) -> [AggregateOrderItem] {
+        shippingLabels.nonRefunded.flatMap { orderItems(of: $0) }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/Collection+ShippingLabel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/Collection+ShippingLabel.swift
@@ -3,6 +3,6 @@ import Yosemite
 extension Collection where Iterator.Element == ShippingLabel {
     /// Returns a collection of non-refunded shipping labels.
     var nonRefunded: [Element] {
-        self.filter { $0.refund == nil }
+        filter { $0.refund == nil }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/Collection+ShippingLabel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/Collection+ShippingLabel.swift
@@ -1,0 +1,8 @@
+import Yosemite
+
+extension Collection where Iterator.Element == ShippingLabel {
+    /// Returns a collection of non-refunded shipping labels.
+    var nonRefunded: [Element] {
+        self.filter { $0.refund == nil }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
+		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */; };
 		0212275E2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */; };
 		0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */; };
@@ -1095,6 +1096,7 @@
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
+		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorSectionHeaderView.swift; sourceTree = "<group>"; };
 		0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorSectionHeaderView.xib; sourceTree = "<group>"; };
 		0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -3711,6 +3713,7 @@
 				CE50345621B1F26C007573C6 /* ZendeskManagerTests.swift */,
 				0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */,
 				0277AEAA256CAA5300F45C4A /* MockShippingLabelAddress.swift */,
+				0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -6007,6 +6010,7 @@
 				02404EE42315151400FF1170 /* MockupStatsVersionStoresManager.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
 				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
+				0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
+		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
 		0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */; };
 		0212275E2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */; };
 		0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */; };
@@ -1093,6 +1094,7 @@
 		020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
+		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
 		0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorSectionHeaderView.swift; sourceTree = "<group>"; };
 		0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorSectionHeaderView.xib; sourceTree = "<group>"; };
 		0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -2197,6 +2199,14 @@
 				025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */,
 			);
 			path = "View Models";
+			sourceTree = "<group>";
+		};
+		0211252225773EB40075AD2A /* Copiable */ = {
+			isa = PBXGroup;
+			children = (
+				0211252725773F220075AD2A /* Models+Copiable.generated.swift */,
+			);
+			path = Copiable;
 			sourceTree = "<group>";
 		};
 		0212275F244989D20042161F /* BottomSheetListSelector */ = {
@@ -3888,6 +3898,7 @@
 				D8D15F81230A178100D48B3F /* ServiceLocator */,
 				747AA0872107CE270047A89B /* Analytics */,
 				B55D4C0420B6026700D7A50F /* Authentication */,
+				0211252225773EB40075AD2A /* Copiable */,
 				CE1CCB4C20572444000EE3AC /* Extensions */,
 				B57B67882107545B00AF8905 /* Model */,
 				B5BBD6DC21B1701F00E3207E /* Notifications */,
@@ -5783,6 +5794,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
+				0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */,
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02564A89246CDF6100D6DB2A /* ProductsTopBannerFactory.swift */; };
 		02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02564A8B246CE38E00D6DB2A /* SwappableSubviewContainerView.swift */; };
 		025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */; };
+		025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C025773236009D7E6C /* Collection+ShippingLabel.swift */; };
+		025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0258B66B2518754D00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66A2518754C00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift */; };
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
@@ -1188,6 +1190,8 @@
 		02564A89246CDF6100D6DB2A /* ProductsTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTopBannerFactory.swift; sourceTree = "<group>"; };
 		02564A8B246CE38E00D6DB2A /* SwappableSubviewContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwappableSubviewContainerView.swift; sourceTree = "<group>"; };
 		025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModelTests.swift; sourceTree = "<group>"; };
+		025678C025773236009D7E6C /* Collection+ShippingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabel.swift"; sourceTree = "<group>"; };
+		025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabelTests.swift"; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0258B66A2518754C00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+AddProductTests.swift"; sourceTree = "<group>"; };
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -2473,6 +2477,7 @@
 			isa = PBXGroup;
 			children = (
 				02619857256B53DD00E321E9 /* AggregatedShippingLabelOrderItems.swift */,
+				025678C025773236009D7E6C /* Collection+ShippingLabel.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -2546,6 +2551,7 @@
 			isa = PBXGroup;
 			children = (
 				0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */,
+				025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -5489,6 +5495,7 @@
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
+				025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
@@ -6137,6 +6144,7 @@
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
+				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
 				57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -91,6 +91,55 @@ final class AggregateDataHelperTests: XCTestCase {
         XCTAssertEqual(aggregatedOrderItems.count, 1)
         XCTAssertEqual(aggregatedOrderItems[0].attributes, orderItemAttributes)
     }
+
+    func test_combining_AggregateOrderItem_with_shipping_labels_with_partial_products() {
+        // Given
+        let orderItemNotInShippingLabels = AggregateOrderItem(productID: 1, variationID: 32, name: "Beach", price: nil, quantity: 2, sku: nil, total: nil, attributes: [])
+        let orderItemPartiallyInShippingLabels = AggregateOrderItem(productID: 1, variationID: 26, name: "Beach", price: nil, quantity: 2.5, sku: nil, total: nil, attributes: [])
+        let orderItemInShippingLabels = AggregateOrderItem(productID: 1, variationID: 0, name: "Wario", price: nil, quantity: 3.5, sku: nil, total: nil, attributes: [])
+        let orderItemsInNonRefundedShippingLabels: [AggregateOrderItem] = [
+            .init(productID: orderItemInShippingLabels.productID,
+                  variationID: orderItemInShippingLabels.variationID,
+                  name: "",
+                  price: nil,
+                  quantity: 2.5,
+                  sku: nil,
+                  total: nil,
+                  attributes: []),
+            .init(productID: orderItemPartiallyInShippingLabels.productID,
+                  variationID: orderItemPartiallyInShippingLabels.variationID,
+                  name: "",
+                  price: nil,
+                  quantity: 1,
+                  sku: nil,
+                  total: nil,
+                  attributes: []),
+            .init(productID: orderItemInShippingLabels.productID,
+                  variationID: orderItemInShippingLabels.variationID,
+                  name: "",
+                  price: nil,
+                  quantity: 1,
+                  sku: nil,
+                  total: nil,
+                  attributes: [])
+        ]
+
+        // When
+        let combinedOrderItems = AggregateDataHelper
+            .combineAggregatedOrderItems([orderItemInShippingLabels, orderItemPartiallyInShippingLabels, orderItemNotInShippingLabels],
+                                         with: orderItemsInNonRefundedShippingLabels)
+
+        // Then
+        let orderItemPartiallyInShippingLabelsWithUpdatedQuantity = AggregateOrderItem(productID: orderItemPartiallyInShippingLabels.productID,
+                                                                          variationID: orderItemPartiallyInShippingLabels.variationID,
+                                                                          name: orderItemPartiallyInShippingLabels.name,
+                                                                          price: orderItemPartiallyInShippingLabels.price,
+                                                                          quantity: 1.5,
+                                                                          sku: orderItemPartiallyInShippingLabels.sku,
+                                                                          total: orderItemPartiallyInShippingLabels.total,
+                                                                          attributes: orderItemPartiallyInShippingLabels.attributes)
+        XCTAssertEqual(combinedOrderItems, [orderItemPartiallyInShippingLabelsWithUpdatedQuantity, orderItemNotInShippingLabels])
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -94,9 +94,34 @@ final class AggregateDataHelperTests: XCTestCase {
 
     func test_combining_AggregateOrderItem_with_shipping_labels_with_partial_products() {
         // Given
-        let orderItemNotInShippingLabels = AggregateOrderItem(productID: 1, variationID: 32, name: "Beach", price: nil, quantity: 2, sku: nil, total: nil, attributes: [])
-        let orderItemPartiallyInShippingLabels = AggregateOrderItem(productID: 1, variationID: 26, name: "Beach", price: nil, quantity: 2.5, sku: nil, total: nil, attributes: [])
-        let orderItemInShippingLabels = AggregateOrderItem(productID: 1, variationID: 0, name: "Wario", price: nil, quantity: 3.5, sku: nil, total: nil, attributes: [])
+        // Order items (e.g. after combining with refunded products using `AggregateDataHelper.combineOrderItems`).
+        let orderItemNotInShippingLabels = AggregateOrderItem(productID: 1,
+                                                              variationID: 32,
+                                                              name: "Beach",
+                                                              price: nil,
+                                                              quantity: 2,
+                                                              sku: nil,
+                                                              total: nil,
+                                                              attributes: [])
+        let orderItemPartiallyInShippingLabels = AggregateOrderItem(productID: 1,
+                                                                    variationID: 26,
+                                                                    name: "Beach",
+                                                                    price: nil,
+                                                                    quantity: 2.5,
+                                                                    sku: nil,
+                                                                    total: nil,
+                                                                    attributes: [])
+        let orderItemInShippingLabels = AggregateOrderItem(productID: 1,
+                                                           variationID: 0,
+                                                           name: "Wario",
+                                                           price: nil,
+                                                           quantity: 3.5,
+                                                           sku: nil,
+                                                           total: nil,
+                                                           attributes: [])
+        let orderItems = [orderItemInShippingLabels, orderItemPartiallyInShippingLabels, orderItemNotInShippingLabels]
+
+        // Order items from non-refunded shipping labels.
         let orderItemsInNonRefundedShippingLabels: [AggregateOrderItem] = [
             .init(productID: orderItemInShippingLabels.productID,
                   variationID: orderItemInShippingLabels.variationID,
@@ -126,18 +151,10 @@ final class AggregateDataHelperTests: XCTestCase {
 
         // When
         let combinedOrderItems = AggregateDataHelper
-            .combineAggregatedOrderItems([orderItemInShippingLabels, orderItemPartiallyInShippingLabels, orderItemNotInShippingLabels],
-                                         with: orderItemsInNonRefundedShippingLabels)
+            .combineAggregatedOrderItems(orderItems, with: orderItemsInNonRefundedShippingLabels)
 
         // Then
-        let orderItemPartiallyInShippingLabelsWithUpdatedQuantity = AggregateOrderItem(productID: orderItemPartiallyInShippingLabels.productID,
-                                                                          variationID: orderItemPartiallyInShippingLabels.variationID,
-                                                                          name: orderItemPartiallyInShippingLabels.name,
-                                                                          price: orderItemPartiallyInShippingLabels.price,
-                                                                          quantity: 1.5,
-                                                                          sku: orderItemPartiallyInShippingLabels.sku,
-                                                                          total: orderItemPartiallyInShippingLabels.total,
-                                                                          attributes: orderItemPartiallyInShippingLabels.attributes)
+        let orderItemPartiallyInShippingLabelsWithUpdatedQuantity = orderItemPartiallyInShippingLabels.copy(quantity: 1.5)
         XCTAssertEqual(combinedOrderItems, [orderItemPartiallyInShippingLabelsWithUpdatedQuantity, orderItemNotInShippingLabels])
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -92,7 +92,7 @@ final class AggregateDataHelperTests: XCTestCase {
         XCTAssertEqual(aggregatedOrderItems[0].attributes, orderItemAttributes)
     }
 
-    func test_combining_AggregateOrderItem_with_shipping_labels_with_partial_products() {
+    func test_combining_AggregateOrderItem_with_shipping_labels() {
         // Given
         // Order items (e.g. after combining with refunded products using `AggregateDataHelper.combineOrderItems`).
         let orderItemNotInShippingLabels = MockAggregateOrderItem.emptyItem()

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -95,58 +95,28 @@ final class AggregateDataHelperTests: XCTestCase {
     func test_combining_AggregateOrderItem_with_shipping_labels_with_partial_products() {
         // Given
         // Order items (e.g. after combining with refunded products using `AggregateDataHelper.combineOrderItems`).
-        let orderItemNotInShippingLabels = AggregateOrderItem(productID: 1,
-                                                              variationID: 32,
-                                                              name: "Beach",
-                                                              price: nil,
-                                                              quantity: 2,
-                                                              sku: nil,
-                                                              total: nil,
-                                                              attributes: [])
-        let orderItemPartiallyInShippingLabels = AggregateOrderItem(productID: 1,
-                                                                    variationID: 26,
-                                                                    name: "Beach",
-                                                                    price: nil,
-                                                                    quantity: 2.5,
-                                                                    sku: nil,
-                                                                    total: nil,
-                                                                    attributes: [])
-        let orderItemInShippingLabels = AggregateOrderItem(productID: 1,
-                                                           variationID: 0,
-                                                           name: "Wario",
-                                                           price: nil,
-                                                           quantity: 3.5,
-                                                           sku: nil,
-                                                           total: nil,
-                                                           attributes: [])
+        let orderItemNotInShippingLabels = MockAggregateOrderItem.emptyItem()
+            .copy(productID: 1, variationID: 32, quantity: 2)
+        let orderItemPartiallyInShippingLabels = MockAggregateOrderItem.emptyItem()
+            .copy(productID: 1, variationID: 26, quantity: 2.5)
+        let orderItemInShippingLabels = MockAggregateOrderItem.emptyItem()
+            .copy(productID: 1, variationID: 0, quantity: 3.5)
         let orderItems = [orderItemInShippingLabels, orderItemPartiallyInShippingLabels, orderItemNotInShippingLabels]
 
         // Order items from non-refunded shipping labels.
         let orderItemsInNonRefundedShippingLabels: [AggregateOrderItem] = [
-            .init(productID: orderItemInShippingLabels.productID,
-                  variationID: orderItemInShippingLabels.variationID,
-                  name: "",
-                  price: nil,
-                  quantity: 2.5,
-                  sku: nil,
-                  total: nil,
-                  attributes: []),
-            .init(productID: orderItemPartiallyInShippingLabels.productID,
-                  variationID: orderItemPartiallyInShippingLabels.variationID,
-                  name: "",
-                  price: nil,
-                  quantity: 1,
-                  sku: nil,
-                  total: nil,
-                  attributes: []),
-            .init(productID: orderItemInShippingLabels.productID,
-                  variationID: orderItemInShippingLabels.variationID,
-                  name: "",
-                  price: nil,
-                  quantity: 1,
-                  sku: nil,
-                  total: nil,
-                  attributes: [])
+            MockAggregateOrderItem.emptyItem()
+                .copy(productID: orderItemInShippingLabels.productID,
+                      variationID: orderItemInShippingLabels.variationID,
+                      quantity: 2.5),
+            MockAggregateOrderItem.emptyItem()
+                .copy(productID: orderItemPartiallyInShippingLabels.productID,
+                      variationID: orderItemPartiallyInShippingLabels.variationID,
+                      quantity: 1),
+            MockAggregateOrderItem.emptyItem()
+                .copy(productID: orderItemInShippingLabels.productID,
+                      variationID: orderItemInShippingLabels.variationID,
+                      quantity: 1)
         ]
 
         // When

--- a/WooCommerce/WooCommerceTests/Tools/MockAggregateOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockAggregateOrderItem.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import WooCommerce
+
+/// Generates mock `AggregateOrderItem`
+///
+public struct MockAggregateOrderItem {
+    /// Consider setting a subset of properties using `.copy`.
+    public static func emptyItem() -> AggregateOrderItem {
+        .init(productID: 0,
+              variationID: 0,
+              name: "",
+              price: nil,
+              quantity: 0,
+              sku: nil,
+              total: nil,
+              attributes: [])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/Collection+ShippingLabelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/Collection+ShippingLabelTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class Collection_ShippingLabelTests: XCTestCase {
+    func test_nonRefunded_returns_empty_array_when_all_shipping_labels_are_refunded() {
+        // Given
+        let shippingLabels: [ShippingLabel] = [
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending)),
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending)),
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending))
+        ]
+
+        // When
+        let nonRefunded = shippingLabels.nonRefunded
+
+        // Then
+        XCTAssertEqual(nonRefunded, [])
+    }
+
+    func test_nonRefunded_returns_non_refunded_shipping_labels() {
+        // Given
+        let nonRefundedShippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let refundedShippingLabels: [ShippingLabel] = [
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending)),
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending)),
+            MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending))
+        ]
+        let shippingLabels = refundedShippingLabels + [nonRefundedShippingLabel]
+
+        // When
+        let nonRefunded = shippingLabels.nonRefunded
+
+        // Then
+        XCTAssertEqual(nonRefunded, [nonRefundedShippingLabel])
+    }
+}


### PR DESCRIPTION
Part of #2167 

## Why

Now that the shipping label sections also show order items (products/variations) in an order, we only want to show the order items & quantity that are not yet included in a non-refunded shipping label so that the store owner can still create a shipping label for the remaining items in M2. Before this PR, the Products section shows the order items combined with refunded products. This PR updates the Products section to show the **order items combined with refunded products and non-refunded shipping labels**. It also hides the tracking sections if there are non-empty non-refunded shipping labels.

## Changes

- Added a helper function to `AggregateDataHelper` to combine aggregate order items with those from non-refunded shipping labels with a test case
- Added a helper function to `AggregatedShippingLabelOrderItems` that returns an array of order items from all of the given non-refunded shipping labels
- Added an extension helper to a collection of `ShippingLabel` to return non-refunded shipping labels
- In `OrderDetailsDataSource`:
  - Updates the Products section to show the combined aggregate order items from refunded products **plus non-refunded shipping labels**
  - Hides the tracking sections if there are non-empty non-refunded shipping labels
- Implemented `GeneratedCopiable` for `AggregateOrderItem` and ran `rake generate` after removing `TestKit` to generate `Models+Copiable.generated.swift` in WooCommerce target. This is used in `AggregateDataHelper` and the test case

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

There are many edge cases like with refunded products and refunded shipping labels in multi-package scenario. Feel free to test what makes sense to you!

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, the Products section should only show the products that aren't covered by the non-refunded shipping labels (the section is hidden if there are no products to show). Also, the Tracking and Add Tracking sections should be hidden

## Example screenshots

\ | before | after
-- | -- | --
there are remaining order items | ![Simulator Screen Shot - iPhone 11 - 2020-12-02 at 11 56 53](https://user-images.githubusercontent.com/1945542/100827225-38a55f00-3497-11eb-87fc-06ddb7c51954.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-02 at 11 54 12](https://user-images.githubusercontent.com/1945542/100827451-b4071080-3497-11eb-882a-f2c332e91b86.png)
no remaining order items | ![Simulator Screen Shot - iPhone 11 - 2020-12-02 at 11 57 04](https://user-images.githubusercontent.com/1945542/100827228-3cd17c80-3497-11eb-9bb8-cd47348e8712.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-02 at 11 54 36](https://user-images.githubusercontent.com/1945542/100827463-b8cbc480-3497-11eb-9650-a62a2f3b694f.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
