### PR TITLE
[Issue Refund] Correctly parse HTML characters on the shipping title

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -17,7 +17,7 @@ extension RefundShippingDetailsViewModel {
     ///
     init(shippingLine: ShippingLine, currency: String, currencySettings: CurrencySettings) {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        self.carrierRate = shippingLine.methodTitle
+        self.carrierRate = shippingLine.methodTitle.strippedHTML
         self.carrierCost = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? ""
         self.shippingTax = currencyFormatter.formatAmount(shippingLine.totalTax, with: currency) ?? ""
         self.shippingSubtotal = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? ""

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingDetailsViewModelTests.swift
@@ -21,4 +21,16 @@ final class RefundShippingDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingSubtotal, "$10.20")
         XCTAssertEqual(viewModel.shippingTotal, "$11.50")
     }
+
+    func test_viewModel_is_correctly_parses_html_in_the_shipping_method_title() {
+        // Given
+        let shippingLine = ShippingLine(shippingID: 0, methodTitle: "USPS Flat Rate &#8364;", methodID: "USPS", total: "", totalTax: "", taxes: [])
+        let currencySettings = CurrencySettings()
+
+        // When
+        let viewModel = RefundShippingDetailsViewModel(shippingLine: shippingLine, currency: "usd", currencySettings: currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.carrierRate, "USPS Flat Rate €")
+    }
 }


### PR DESCRIPTION
fix #3092 

# Why
It was reported that on the "IssueRefund" screen, shipping titles with HTML characters are not correctly rendered.

# How
This PR fixes that by calling the `.strippedHTML` method on the shipping title when creating the `RefundShippingDetailsViewModel`

# Screenshots
Before | After
---- | ----
<img width="385" alt="Screen Shot 2020-12-02 at 11 42 51 AM" src="https://user-images.githubusercontent.com/562080/100904013-8cfb0f80-3494-11eb-8385-cc68544d233e.png"> | <img width="397" alt="Screen Shot 2020-12-02 at 11 42 00 AM" src="https://user-images.githubusercontent.com/562080/100904022-8e2c3c80-3494-11eb-9cb6-b4858b9060fc.png">

# Testing steps
- Make sure you have a shipping method with HTML characters
- Issue an order with that shipping method
- Go to the app and try to issue a refund on the shipping costs
- See the shipping title/rate correctly formatted.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
