### PR TITLE
[Issue Refund] Improve experience on landscape orientation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
@@ -132,7 +132,7 @@ private extension ListSelectorViewController {
 
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(tableView)
+        view.pinSubviewToAllEdges(tableView)
 
         registerTableViewCells()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,24 +27,24 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Lf6-TH-48I">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="Lf6-TH-48I" secondAttribute="bottom" id="0Nd-zr-sv0"/>
                 <constraint firstItem="Lf6-TH-48I" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3l3-sh-hkW"/>
                 <constraint firstAttribute="trailing" secondItem="Lf6-TH-48I" secondAttribute="trailing" id="ICh-vm-D8Y"/>
                 <constraint firstItem="Lf6-TH-48I" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="zPp-4d-0da"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="102.89855072463769" y="29.464285714285712"/>
         </view>
         <view contentMode="scaleToFill" id="dRH-Gh-qht" userLabel="FooterView">
             <rect key="frame" x="0.0" y="0.0" width="417" height="67"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel">
                     <rect key="frame" x="16" y="0.0" width="385" height="67"/>
                     <state key="normal" title="Button"/>
                     <connections>
@@ -51,6 +52,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="aKJ-SC-KN2"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="omw-71-nel" secondAttribute="trailing" constant="16" id="Iuh-aM-xBR"/>
@@ -61,7 +63,6 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="aKJ-SC-KN2"/>
             <point key="canvasLocation" x="-699.27536231884062" y="77.34375"/>
         </view>
         <view contentMode="scaleToFill" id="KQd-59-N09" userLabel="HeaderView">
@@ -77,7 +78,7 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vQB-qj-G36">
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vQB-qj-G36">
                             <rect key="frame" x="339" y="0.0" width="46" height="51"/>
                             <state key="normal" title="Button"/>
                             <connections>
@@ -87,18 +88,23 @@
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="XWY-UK-OeP"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="Tz4-uY-TGt" firstAttribute="leading" secondItem="KQd-59-N09" secondAttribute="leading" constant="16" id="KHf-fF-Dae"/>
-                <constraint firstAttribute="trailing" secondItem="Tz4-uY-TGt" secondAttribute="trailing" constant="16" id="M9W-fJ-mIq"/>
+                <constraint firstItem="Tz4-uY-TGt" firstAttribute="leading" secondItem="XWY-UK-OeP" secondAttribute="leading" constant="16" id="KHf-fF-Dae"/>
+                <constraint firstItem="XWY-UK-OeP" firstAttribute="trailing" secondItem="Tz4-uY-TGt" secondAttribute="trailing" constant="16" id="M9W-fJ-mIq"/>
                 <constraint firstItem="Tz4-uY-TGt" firstAttribute="bottom" secondItem="KQd-59-N09" secondAttribute="bottom" constant="-10" id="P34-kc-jlD"/>
                 <constraint firstAttribute="top" secondItem="Tz4-uY-TGt" secondAttribute="top" constant="-10" id="wXt-80-mZw"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="XWY-UK-OeP"/>
             <point key="canvasLocation" x="-699.27536231884062" y="187.16517857142856"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -55,9 +55,9 @@
             <viewLayoutGuide key="safeArea" id="aKJ-SC-KN2"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="omw-71-nel" secondAttribute="trailing" constant="16" id="Iuh-aM-xBR"/>
+                <constraint firstItem="aKJ-SC-KN2" firstAttribute="trailing" secondItem="omw-71-nel" secondAttribute="trailing" constant="16" id="Iuh-aM-xBR"/>
                 <constraint firstItem="omw-71-nel" firstAttribute="top" secondItem="dRH-Gh-qht" secondAttribute="top" id="OpE-fY-xG4"/>
-                <constraint firstItem="omw-71-nel" firstAttribute="leading" secondItem="dRH-Gh-qht" secondAttribute="leading" constant="16" id="TXj-Nj-G5h"/>
+                <constraint firstItem="omw-71-nel" firstAttribute="leading" secondItem="aKJ-SC-KN2" secondAttribute="leading" constant="16" id="TXj-Nj-G5h"/>
                 <constraint firstAttribute="bottom" secondItem="omw-71-nel" secondAttribute="bottom" id="mR7-xj-5tk"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -97,7 +97,7 @@ private extension RefundConfirmationViewController {
         // Add to view
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(tableView)
+        view.pinSubviewToAllEdges(tableView)
     }
 
     func configureButtonTableFooterView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -17,7 +17,7 @@ final class RefundConfirmationViewController: UIViewController {
         return noticePresenter
     }()
 
-    /// Needed to scroll content content to a visible area when the keyboard appears.
+    /// Needed to scroll content to a visible area when the keyboard appears.
     ///
     private lazy var keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: { [weak self] frame in
         self?.handleKeyboardFrameUpdate(keyboardFrame: frame)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -17,6 +17,12 @@ final class RefundConfirmationViewController: UIViewController {
         return noticePresenter
     }()
 
+    /// Needed to scroll content content to a visible area when the keyboard appears.
+    ///
+    private lazy var keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: { [weak self] frame in
+        self?.handleKeyboardFrameUpdate(keyboardFrame: frame)
+    })
+
     /// Closure to be invoked when the refund button is pressed.
     ///
     var onRefundButtonAction: (() -> Void)?
@@ -47,6 +53,14 @@ final class RefundConfirmationViewController: UIViewController {
         configureTableView()
         configureButtonTableFooterView()
         configureKeyboardDismissal()
+        keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
+    }
+}
+
+// MARK: KeyboardScrollable
+extension RefundConfirmationViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        tableView
     }
 }
 


### PR DESCRIPTION
part of #2764 

# Why 
After doing an accessibility audit on the issue refunds feature, I noticed the experience on landscape orientation was not great, this PR fixes that.

# How
- On table view's headers and footers, make sure their leading and trailing constraints are relative to the safe area and not to the view edges.
- On table views, make sure the constraints are relative to the view edges and not to the safe area, as the table view automatically insets their cells to the safe area margins.
- On "RefundConfirmation" use a `KeyboardFrameObserver` to correctly keep display the reason text field as the keyboard appears.

# Gif
![landscape](https://user-images.githubusercontent.com/562080/101040417-1fa9b600-354a-11eb-9fdc-967a382b325e.gif)

# Testing steps
- Go to an unrefunded order
- Tap the "issue refund" button
- Rotate the device to landscape
- Complete a refund and see that everything works and looks as expected.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
