### PR TITLE
Set correct, relative path to UnitTests test plan

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1830,7 +1830,7 @@
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CCDC49EC24000533003166BA /* TestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCredentials.swift; sourceTree = "<group>"; };
-		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = "/Users/rachel/Documents/a8c/Woo/woocommerce-ios/WooCommerce/WooCommerceTests/UnitTests.xctestplan"; sourceTree = "<absolute>"; };
+		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCDC49F224006130003166BA /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UITests.xctestplan; path = WooCommerceUITests/UITests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotCredentials.swift; sourceTree = "<group>"; };
 		CCFC00BC23E9BD5500157A78 /* oauth2_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = oauth2_token.json; sourceTree = "<group>"; };


### PR DESCRIPTION
The Xcode project file accidentally had the UnitTests test plan set to an absolute file path (on my computer) instead of the test plan file in the project. This change corrects that to the file `WooCommerceTests/UnitTests.xctestplan`, with the file path relative to the project.

The scheme already [pointed to the correct test plan file](https://github.com/woocommerce/woocommerce-ios/blob/8b229f9fdb7b538f9802ac51934cc85e66ad4e21/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme#L41) so I don't think this was causing any functional issues. We should just confirm that all tests continue to run and pass after selecting and running the unit test plan, including tests in:

* WooCommerceTests
* NetworkingTests
* StorageTests
* YosemiteTests

h/t @eshurakov for noticing the absolute file path and bringing it to my attention!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
