### PR TITLE
[Issue Refunds] Handle accessibility fonts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -75,6 +75,9 @@ private extension RefundItemTableViewCell {
         itemQuantityButton.applySecondaryButtonStyle()
         itemQuantityButton.titleLabel?.applyBodyStyle()
         itemQuantityButton.contentEdgeInsets = Constants.quantityButtonInsets
+
+        itemQuantityButton.accessibilityLabel = Localization.quantity
+        itemQuantityButton.accessibilityHint = Localization.quantityHint
     }
 }
 
@@ -136,6 +139,12 @@ private extension RefundItemTableViewCell {
         static let itemImageViewHeight: CGFloat = 39.0
         static let itemImageViewBorderWidth: CGFloat = 0.5
         static let quantityButtonInsets = UIEdgeInsets(top: 8, left: 22, bottom: 8, right: 22)
+    }
+
+    enum Localization {
+        static let quantity = NSLocalizedString("Quantity", comment: "The accessibility label for the quantity button when selecting an item to refund")
+        static let quantityHint = NSLocalizedString("Tap to modify the item refund quantity",
+                                                    comment: "The accessibility hint for the quantity button when selecting an item to refund")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -14,7 +14,6 @@ final class IssueRefundViewController: UIViewController {
     @IBOutlet private var nextButton: UIButton!
     @IBOutlet private var selectAllButton: UIButton!
 
-
     private let imageService: ImageService
 
     private let viewModel: IssueRefundViewModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -154,6 +154,7 @@ private extension IssueRefundViewController {
     func configureHeaderStackView() {
         headerStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
         headerStackView.alignment = headerStackView.axis == .vertical ? .center : .fill
+        headerStackView.spacing = 8
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -9,9 +9,11 @@ final class IssueRefundViewController: UIViewController {
     @IBOutlet private var tableFooterView: UIView!
     @IBOutlet private var tableHeaderView: UIView!
 
+    @IBOutlet private var headerStackView: UIStackView!
     @IBOutlet private var itemsSelectedLabel: UILabel!
     @IBOutlet private var nextButton: UIButton!
     @IBOutlet private var selectAllButton: UIButton!
+
 
     private let imageService: ImageService
 
@@ -140,11 +142,29 @@ private extension IssueRefundViewController {
         selectAllButton.setTitle(Localization.selectAllTitle, for: .normal)
 
         itemsSelectedLabel.applySecondaryBodyStyle()
+        configureHeaderStackView()
     }
 
     func configureFooterView() {
         nextButton.applyPrimaryButtonStyle()
         nextButton.setTitle(Localization.nextTitle, for: .normal)
+    }
+
+    /// Changes the axis and alignment of the stack views that need special treatment on larger size categories.
+    ///
+    func configureHeaderStackView() {
+        headerStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
+        headerStackView.alignment = headerStackView.axis == .vertical ? .center : .fill
+    }
+}
+
+// MARK: Accessibility handling
+//
+extension IssueRefundViewController {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        configureHeaderStackView()
+        tableView.updateHeaderHeight()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController">
             <connections>
+                <outlet property="headerStackView" destination="Tz4-uY-TGt" id="6fc-2R-6b0"/>
                 <outlet property="itemsSelectedLabel" destination="Xkm-ge-1e1" id="1mf-3u-V0q"/>
                 <outlet property="nextButton" destination="omw-71-nel" id="Sgb-5r-DTF"/>
                 <outlet property="selectAllButton" destination="vQB-qj-G36" id="Rhx-j4-fi3"/>
@@ -68,11 +69,11 @@
             <rect key="frame" x="0.0" y="0.0" width="417" height="71"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tz4-uY-TGt">
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tz4-uY-TGt">
                     <rect key="frame" x="16" y="10" width="385" height="51"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xkm-ge-1e1">
-                            <rect key="frame" x="0.0" y="0.0" width="339" height="51"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Xkm-ge-1e1">
+                            <rect key="frame" x="0.0" y="0.0" width="331" height="51"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SettingTitleAndValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SettingTitleAndValueTableViewCell.swift
@@ -21,7 +21,7 @@ final class SettingTitleAndValueTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         applyDefaultBackgroundStyle()
-
+        enableMultipleLines()
         apply(style: .default)
     }
 }
@@ -57,5 +57,12 @@ extension SettingTitleAndValueTableViewCell {
             titleLabel.applyHeadlineStyle()
             valueLabel.applyHeadlineStyle()
         }
+    }
+
+    /// Needed specially when dealing with big accessibility traits
+    ///
+    func enableMultipleLines() {
+        titleLabel.numberOfLines = 0
+        valueLabel.numberOfLines = 0
     }
 }


### PR DESCRIPTION
fix #2764 

# Why

After doing an accessibility audit on the issue refunds feature, I noticed the experience with big accessibility traits was not great, this PR fixes that.

# How
- On `IssueRefundViewConntroller` I added an `IBOutlet` to the table header stack view to be able to change its axis and alignment depending on the current accessibility traits.
- On  `SettingTitleAndValueTableViewCell` modify the title and value label to spawn over multiple lines if required.

# Demo
![big-font](https://user-images.githubusercontent.com/562080/101083587-bee6a180-357a-11eb-9562-7413cb93730f.gif)

# Testing steps 
- Modify your device to use a large(accessibility) font
- Navigate to an unrefunded order
- Experiment the flow with that bigger font and corroborate that all elements are visible

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
