### PR TITLE
Remove duplicated line in TopBannerView

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -187,7 +187,6 @@ private extension TopBannerView {
         buttonsStackView.pinSubviewToAllEdges(separatorBackground)
 
         // Style buttons
-        buttonsStackView.addArrangedSubviews(actionButtons)
         actionButtons.forEach { button in
             button.applyLinkButtonStyle()
             button.backgroundColor = backgroundColor(for: viewModel.type)


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/issues/1549.

## Description

No functional changes, just duplicate line removed. This line was adding array of buttons to stack view before iterating and adding same buttons one by one.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
