### PR TITLE
Add orderCreation feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,6 +7,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease5:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .orderCreation:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -14,6 +14,10 @@ enum FeatureFlag: Int {
     ///
     case editProductsRelease5
 
+    /// Order Creation
+    ///
+    case orderCreation
+
     /// Product Reviews
     ///
     case reviews


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3235.

Adds `orderCreation` feature flag.
