### PR TITLE
Networking layer for List/Add/Update/Delete a Product Attribute

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -101,6 +101,9 @@
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
 		451274A625276C82009911FF /* product-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = 451274A525276C82009911FF /* product-variation.json */; };
+		45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */; };
+		4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */; };
+		45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152810257A81730076B03C /* ProductAttributeMapper.swift */; };
 		4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */; };
 		453305E92459DF2100264E50 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305E82459DF2100264E50 /* PostMapper.swift */; };
 		453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EA2459E01A00264E50 /* PostMapperTests.swift */; };
@@ -492,6 +495,9 @@
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
 		451274A525276C82009911FF /* product-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation.json"; sourceTree = "<group>"; };
+		45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributesRemote.swift; sourceTree = "<group>"; };
+		4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeListMapper.swift; sourceTree = "<group>"; };
+		45152810257A81730076B03C /* ProductAttributeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapper.swift; sourceTree = "<group>"; };
 		4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-on-sale-with-empty-sale-price.json"; sourceTree = "<group>"; };
 		453305E82459DF2100264E50 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		453305EA2459E01A00264E50 /* PostMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapperTests.swift; sourceTree = "<group>"; };
@@ -1071,6 +1077,7 @@
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
 				D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */,
 				261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */,
+				45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */,
 				26615472242D596B00A31661 /* ProductCategoriesRemote.swift */,
 				D88D5A44230BC6F9007B6E01 /* ProductReviewsRemote.swift */,
 				4599FC5D24A62AA70056157A /* ProductTagsRemote.swift */,
@@ -1307,6 +1314,8 @@
 				D8FBFF1022D3B3FC006E3336 /* OrderStatsV4Mapper.swift */,
 				26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */,
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
+				45152810257A81730076B03C /* ProductAttributeMapper.swift */,
+				4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
 				45B204B72489095100FE6526 /* ProductCategoryMapper.swift */,
 				26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */,
@@ -1874,8 +1883,10 @@
 				B53EF5322180F21C003E146F /* Dictionary+Woo.swift in Sources */,
 				24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */,
 				74A1D26D21189DFF00931DFA /* SiteVisitStatsMapper.swift in Sources */,
+				45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */,
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
+				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,
@@ -1931,6 +1942,7 @@
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
+				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
 				B567AF2B20A0FA4200AB6C62 /* OrderListMapper.swift in Sources */,
 				02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		45152825257A8B740076B03C /* product-attribute-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 45152824257A8B740076B03C /* product-attribute-update.json */; };
 		4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515282A257A8C010076B03C /* product-attribute-delete.json */; };
 		45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */; };
+		45152835257A8F490076B03C /* ProductAttributeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */; };
 		4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */; };
 		453305E92459DF2100264E50 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305E82459DF2100264E50 /* PostMapper.swift */; };
 		453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EA2459E01A00264E50 /* PostMapperTests.swift */; };
@@ -510,6 +511,7 @@
 		45152824257A8B740076B03C /* product-attribute-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-update.json"; sourceTree = "<group>"; };
 		4515282A257A8C010076B03C /* product-attribute-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-delete.json"; sourceTree = "<group>"; };
 		45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapperTests.swift; sourceTree = "<group>"; };
+		45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeListMapperTests.swift; sourceTree = "<group>"; };
 		4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-on-sale-with-empty-sale-price.json"; sourceTree = "<group>"; };
 		453305E82459DF2100264E50 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		453305EA2459E01A00264E50 /* PostMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapperTests.swift; sourceTree = "<group>"; };
@@ -1434,6 +1436,7 @@
 				74CF0A8B22414D7800DB993F /* ProductMapperTests.swift */,
 				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
 				45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */,
+				45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */,
 				45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */,
 				26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */,
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
@@ -2009,6 +2012,7 @@
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,
+				45152835257A8F490076B03C /* ProductAttributeListMapperTests.swift in Sources */,
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -104,6 +104,11 @@
 		45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */; };
 		4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */; };
 		45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152810257A81730076B03C /* ProductAttributeMapper.swift */; };
+		45152815257A83DD0076B03C /* ProductAttributesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152814257A83DD0076B03C /* ProductAttributesRemoteTests.swift */; };
+		45152819257A84A60076B03C /* product-attributes-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 45152818257A84A60076B03C /* product-attributes-all.json */; };
+		4515281F257A89B90076B03C /* product-attribute-create.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515281E257A89B90076B03C /* product-attribute-create.json */; };
+		45152825257A8B740076B03C /* product-attribute-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 45152824257A8B740076B03C /* product-attribute-update.json */; };
+		4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515282A257A8C010076B03C /* product-attribute-delete.json */; };
 		4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */; };
 		453305E92459DF2100264E50 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305E82459DF2100264E50 /* PostMapper.swift */; };
 		453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EA2459E01A00264E50 /* PostMapperTests.swift */; };
@@ -498,6 +503,11 @@
 		45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributesRemote.swift; sourceTree = "<group>"; };
 		4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeListMapper.swift; sourceTree = "<group>"; };
 		45152810257A81730076B03C /* ProductAttributeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapper.swift; sourceTree = "<group>"; };
+		45152814257A83DD0076B03C /* ProductAttributesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributesRemoteTests.swift; sourceTree = "<group>"; };
+		45152818257A84A60076B03C /* product-attributes-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attributes-all.json"; sourceTree = "<group>"; };
+		4515281E257A89B90076B03C /* product-attribute-create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-create.json"; sourceTree = "<group>"; };
+		45152824257A8B740076B03C /* product-attribute-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-update.json"; sourceTree = "<group>"; };
+		4515282A257A8C010076B03C /* product-attribute-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-delete.json"; sourceTree = "<group>"; };
 		4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-on-sale-with-empty-sale-price.json"; sourceTree = "<group>"; };
 		453305E82459DF2100264E50 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		453305EA2459E01A00264E50 /* PostMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapperTests.swift; sourceTree = "<group>"; };
@@ -963,6 +973,7 @@
 				261CF1BB255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift */,
 				74749B9422413119005C4CF2 /* ProductsRemoteTests.swift */,
 				D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */,
+				45152814257A83DD0076B03C /* ProductAttributesRemoteTests.swift */,
 				2661547A242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift */,
 				4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */,
 				7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */,
@@ -1235,6 +1246,10 @@
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
 				020220E123966CD900290165 /* product-shipping-classes-load-one.json */,
 				457FC68B2382B2FD00B41B02 /* product-update.json */,
+				45152818257A84A60076B03C /* product-attributes-all.json */,
+				4515281E257A89B90076B03C /* product-attribute-create.json */,
+				45152824257A8B740076B03C /* product-attribute-update.json */,
+				4515282A257A8C010076B03C /* product-attribute-delete.json */,
 				026CF623237D839A009563D4 /* product-variations-load-all.json */,
 				02698CF924C188E8005337C4 /* product-variations-load-all-alternative-types.json */,
 				02698CFB24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json */,
@@ -1597,6 +1612,7 @@
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
+				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
@@ -1634,9 +1650,11 @@
 				7426CA1321AF34A3004E9FFC /* site-api.json in Resources */,
 				453305ED2459E1AA00264E50 /* site-post.json in Resources */,
 				74749B99224135C4005C4CF2 /* product.json in Resources */,
+				4515281F257A89B90076B03C /* product-attribute-create.json in Resources */,
 				CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */,
 				D823D9032237450A00C90817 /* shipment_tracking_new.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,
+				4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */,
 				020C907B24C6E108001E2BEB /* product-variation-update.json in Resources */,
 				D8FBFF1822D4DDB9006E3336 /* order-stats-v4-hour.json in Resources */,
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
@@ -1660,6 +1678,7 @@
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */,
 				02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */,
+				45152819257A84A60076B03C /* product-attributes-all.json in Resources */,
 				45AB8B1324AA34CB00B5B36E /* product-tags-deleted.json in Resources */,
 				02698CFC24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
@@ -1999,6 +2018,7 @@
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,
 				7412A8EE21B6E335005D182A /* ReportOrderMapperTests.swift in Sources */,
 				74CF0A8C22414D7800DB993F /* ProductMapperTests.swift in Sources */,
+				45152815257A83DD0076B03C /* ProductAttributesRemoteTests.swift in Sources */,
 				B505F6D720BEE58800BB1B69 /* AccountRemoteTests.swift in Sources */,
 				453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */,
 				CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		4515281F257A89B90076B03C /* product-attribute-create.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515281E257A89B90076B03C /* product-attribute-create.json */; };
 		45152825257A8B740076B03C /* product-attribute-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 45152824257A8B740076B03C /* product-attribute-update.json */; };
 		4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515282A257A8C010076B03C /* product-attribute-delete.json */; };
+		45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */; };
 		4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */; };
 		453305E92459DF2100264E50 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305E82459DF2100264E50 /* PostMapper.swift */; };
 		453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EA2459E01A00264E50 /* PostMapperTests.swift */; };
@@ -508,6 +509,7 @@
 		4515281E257A89B90076B03C /* product-attribute-create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-create.json"; sourceTree = "<group>"; };
 		45152824257A8B740076B03C /* product-attribute-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-update.json"; sourceTree = "<group>"; };
 		4515282A257A8C010076B03C /* product-attribute-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-delete.json"; sourceTree = "<group>"; };
+		45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapperTests.swift; sourceTree = "<group>"; };
 		4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-on-sale-with-empty-sale-price.json"; sourceTree = "<group>"; };
 		453305E82459DF2100264E50 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		453305EA2459E01A00264E50 /* PostMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapperTests.swift; sourceTree = "<group>"; };
@@ -1431,6 +1433,7 @@
 				CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */,
 				74CF0A8B22414D7800DB993F /* ProductMapperTests.swift */,
 				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
+				45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */,
 				45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */,
 				26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */,
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
@@ -2040,6 +2043,7 @@
 				9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,
 				D8FBFF0F22D3B25E006E3336 /* WooAPIVersionTests.swift in Sources */,
+				45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */,
 				26B2F74924C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift in Sources */,
 				74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */,
 				0212683524C046CB00F8A892 /* MockNetwork+Path.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductAttributeListMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeListMapper.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Mapper: ProductAttribute List
+///
+struct ProductAttributeListMapper: Mapper {
+    /// Site Identifier associated to the `ProductAttribute`s that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the ProductAttribute Endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into [ProductAttribute].
+    ///
+    func map(response: Data) throws -> [ProductAttribute] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductAttributeListEnvelope.self, from: response).productAttributes
+    }
+}
+
+
+/// ProductAttributeListEnvelope Disposable Entity:
+/// `Load All Products Attributes` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductAttributeListEnvelope: Decodable {
+    let productAttributes: [ProductAttribute]
+
+    private enum CodingKeys: String, CodingKey {
+        case productAttributes = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductAttributeMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeMapper.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+
+/// Mapper: ProductAttribute
+///
+struct ProductAttributeMapper: Mapper {
+
+    /// Site Identifier associated to the `productAttribute`s that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the ProductAttribute Endpoints.
+    ///
+    let siteID: Int64
+
+
+    /// (Attempts) to convert a dictionary into ProductAttribute.
+    ///
+    func map(response: Data) throws -> ProductAttribute {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductAttributeEnvelope.self, from: response).productAttribute
+    }
+}
+
+
+/// ProductAttributeEnvelope Disposable Entity:
+/// `Load Product Attribute` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductAttributeEnvelope: Decodable {
+    let productAttribute: ProductAttribute
+
+    private enum CodingKeys: String, CodingKey {
+        case productAttribute = "data"
+    }
+}

--- a/Networking/Networking/Remote/ProductAttributesRemote.swift
+++ b/Networking/Networking/Remote/ProductAttributesRemote.swift
@@ -13,7 +13,7 @@ public final class ProductAttributesRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllProductAttributes(for siteID: Int64,
-                                         completion: @escaping ([ProductAttribute]?, Error?) -> Void) {
+                                         completion: @escaping (Result<[ProductAttribute], Error>) -> Void) {
 
         let path = Path.attributes
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path)

--- a/Networking/Networking/Remote/ProductAttributesRemote.swift
+++ b/Networking/Networking/Remote/ProductAttributesRemote.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Product Attributes: Remote Endpoints for fetching global product attributes.
+///
+public final class ProductAttributesRemote: Remote {
+
+    // MARK: - Product Attributes
+
+    /// Retrieves all of the global`ProductAttribute` available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote products attributes.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadAllProductAttributes(for siteID: Int64,
+                                         completion: @escaping ([ProductAttribute]?, Error?) -> Void) {
+
+        let path = Path.attributes
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path)
+
+        let mapper = ProductAttributeListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Create a new `ProductAttribute`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll add a new product attribute.
+    ///     - name: Attribute name.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createProductAttribute(for siteID: Int64,
+                                       name: String,
+                                       completion: @escaping (Result<ProductAttribute, Error>) -> Void) {
+        let parameters = [
+            ParameterKey.name: name,
+            ParameterKey.slug: name,
+            ParameterKey.type: Default.type,
+            ParameterKey.orderBy: Default.orderBy,
+            ParameterKey.hasArchives: Default.hasArchives
+        ]
+
+        let path = Path.attributes
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductAttributeMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Update a `ProductAttribute`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll update the product attribute.
+    ///     - productAttributeID: ID of the Product Attribute that will be updated.
+    ///     - name: Attribute name.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductAttribute(for siteID: Int64,
+                                       productAttributeID: Int64,
+                                       name: String,
+                                       completion: @escaping (Result<ProductAttribute, Error>) -> Void) {
+        let parameters = [
+            ParameterKey.attributeID: String(productAttributeID),
+            ParameterKey.name: name,
+            ParameterKey.slug: name,
+            ParameterKey.type: Default.type,
+            ParameterKey.orderBy: Default.orderBy,
+            ParameterKey.hasArchives: Default.hasArchives
+        ]
+
+        let path = Path.attributes
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductAttributeMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Delete a `ProductAttribute`.  This also will delete all terms from the selected attribute.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll delete the product attribute.
+    ///     - productAttributeID: ID of the Product Attribute that will be deleted.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func deleteProductAttribute(for siteID: Int64,
+                                       productAttributeID: Int64,
+                                       completion: @escaping (Result<ProductAttribute, Error>) -> Void) {
+
+        let path = Path.attributes + "/\(productAttributeID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path)
+        let mapper = ProductAttributeMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants
+//
+public extension ProductAttributesRemote {
+
+    enum Default {
+        public static let type: String = "select"
+        public static let orderBy: String = "menu_order"
+        public static let hasArchives: String = "false"
+    }
+
+    private enum Path {
+        static let attributes = "products/attributes"
+    }
+
+    private enum ParameterKey {
+        static let attributeID: String = "id"
+        static let name: String = "name"
+        static let slug: String = "slug"
+        static let type: String = "type"
+        static let orderBy: String = "order_by"
+        static let hasArchives: String = "has_archives"
+    }
+}

--- a/Networking/Networking/Remote/ProductAttributesRemote.swift
+++ b/Networking/Networking/Remote/ProductAttributesRemote.swift
@@ -69,7 +69,7 @@ public final class ProductAttributesRemote: Remote {
             ParameterKey.hasArchives: Default.hasArchives
         ]
 
-        let path = Path.attributes
+        let path = Path.attributes + "/\(productAttributeID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductAttributeMapper(siteID: siteID)
 

--- a/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductAttributeListMapper Unit Tests
+///
+final class ProductAttributeListMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductAttribute Fields are parsed correctly.
+    ///
+    func test_ProductAttribute_fields_are_properly_parsed() throws {
+        let productAttributes = try XCTUnwrap(mapProductAttributesResponse())
+        XCTAssertEqual(productAttributes.count, 2)
+
+        let firstProductAttribute = productAttributes[1]
+
+        XCTAssertEqual(firstProductAttribute.attributeID, 1)
+        XCTAssertEqual(firstProductAttribute.name, "Color")
+        XCTAssertEqual(firstProductAttribute.position, 0)
+        XCTAssertEqual(firstProductAttribute.visible, true)
+        XCTAssertEqual(firstProductAttribute.variation, true)
+        XCTAssertEqual(firstProductAttribute.options, [])
+    }
+
+}
+
+
+/// Private Methods.
+///
+private extension ProductAttributeListMapperTests {
+
+    /// Returns the ProductAttributeMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductAttribute(from filename: String) throws -> [ProductAttribute]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try ProductAttributeListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductAttributeListMapper output upon receiving `product-attribute-all`
+    ///
+    func mapProductAttributesResponse() throws -> [ProductAttribute]? {
+        return try mapProductAttribute(from: "product-attribute-all")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeListMapperTests.swift
@@ -13,17 +13,17 @@ final class ProductAttributeListMapperTests: XCTestCase {
     /// Verifies that all of the ProductAttribute Fields are parsed correctly.
     ///
     func test_ProductAttribute_fields_are_properly_parsed() throws {
-        let productAttributes = try XCTUnwrap(mapProductAttributesResponse())
+        let productAttributes = try mapProductAttributesResponse()
         XCTAssertEqual(productAttributes.count, 2)
 
-        let firstProductAttribute = productAttributes[1]
+        let secondProductAttribute = productAttributes[1]
 
-        XCTAssertEqual(firstProductAttribute.attributeID, 1)
-        XCTAssertEqual(firstProductAttribute.name, "Color")
-        XCTAssertEqual(firstProductAttribute.position, 0)
-        XCTAssertEqual(firstProductAttribute.visible, true)
-        XCTAssertEqual(firstProductAttribute.variation, true)
-        XCTAssertEqual(firstProductAttribute.options, [])
+        XCTAssertEqual(secondProductAttribute.attributeID, 2)
+        XCTAssertEqual(secondProductAttribute.name, "Size")
+        XCTAssertEqual(secondProductAttribute.position, 0)
+        XCTAssertEqual(secondProductAttribute.visible, true)
+        XCTAssertEqual(secondProductAttribute.variation, true)
+        XCTAssertEqual(secondProductAttribute.options, [])
     }
 
 }
@@ -35,9 +35,9 @@ private extension ProductAttributeListMapperTests {
 
     /// Returns the ProductAttributeMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapProductAttribute(from filename: String) throws -> [ProductAttribute]? {
+    func mapProductAttribute(from filename: String) throws -> [ProductAttribute] {
         guard let response = Loader.contentsOf(filename) else {
-            return nil
+            return []
         }
 
         return try ProductAttributeListMapper(siteID: dummySiteID).map(response: response)
@@ -45,7 +45,7 @@ private extension ProductAttributeListMapperTests {
 
     /// Returns the ProductAttributeListMapper output upon receiving `product-attribute-all`
     ///
-    func mapProductAttributesResponse() throws -> [ProductAttribute]? {
-        return try mapProductAttribute(from: "product-attribute-all")
+    func mapProductAttributesResponse() throws -> [ProductAttribute] {
+        return try mapProductAttribute(from: "product-attributes-all")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductAttributeMapper Unit Tests
+///
+final class ProductAttributeMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductAttribute Fields are parsed correctly.
+    ///
+    func test_ProductAttribute_fields_are_properly_parsed() throws {
+        let productAttribute = try XCTUnwrap(mapProductCategoryResponse())
+
+        XCTAssertEqual(productAttribute.attributeID, 1)
+        XCTAssertEqual(productAttribute.name, "Color")
+        XCTAssertEqual(productAttribute.position, 0)
+        XCTAssertEqual(productAttribute.visible, true)
+        XCTAssertEqual(productAttribute.variation, true)
+        XCTAssertEqual(productAttribute.options, [])
+    }
+
+}
+
+
+/// Private Methods.
+///
+private extension ProductAttributeMapperTests {
+
+    /// Returns the ProductAttributeMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductAttribute(from filename: String) throws -> ProductAttribute? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try ProductAttributeMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductAttributeMapper output upon receiving `product-attribute-create`
+    ///
+    func mapProductCategoryResponse() throws -> ProductAttribute? {
+        return try mapProductAttribute(from: "product-attribute-create")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeMapperTests.swift
@@ -13,7 +13,7 @@ final class ProductAttributeMapperTests: XCTestCase {
     /// Verifies that all of the ProductAttribute Fields are parsed correctly.
     ///
     func test_ProductAttribute_fields_are_properly_parsed() throws {
-        let productAttribute = try XCTUnwrap(mapProductCategoryResponse())
+        let productAttribute = try XCTUnwrap(mapProductAttributeResponse())
 
         XCTAssertEqual(productAttribute.attributeID, 1)
         XCTAssertEqual(productAttribute.name, "Color")
@@ -42,7 +42,7 @@ private extension ProductAttributeMapperTests {
 
     /// Returns the ProductAttributeMapper output upon receiving `product-attribute-create`
     ///
-    func mapProductCategoryResponse() throws -> ProductAttribute? {
+    func mapProductAttributeResponse() throws -> ProductAttribute? {
         return try mapProductAttribute(from: "product-attribute-create")
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductAttributesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductAttributesRemoteTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+import TestKit
+@testable import Networking
+
+/// ProductAttributesRemoteTests
+///
+final class ProductAttributesRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all product attributes tests
+
+    /// Verifies that loadAllProductAttributes properly parses the `product-attributes-all` sample response.
+    ///
+    func test_loadAllProductAttributes_properly_returns_parsed_productAttributes() throws {
+        // Given
+        let remote = ProductAttributesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attributes-all")
+
+        // When
+        let result = try waitFor { promise in
+            remote.loadAllProductAttributes(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let expectedResult = [ProductAttribute(attributeID: 1, name: "Color", position: 0, visible: true, variation: true, options: []),
+                              ProductAttribute(attributeID: 2, name: "Size", position: 0, visible: true, variation: true, options: [])]
+
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response, expectedResult)
+        XCTAssertEqual(response.count, 2)
+    }
+
+    /// Verifies that loadAllProductAttributes properly relays Networking Layer errors.
+    ///
+    func test_loadAllProductAttributes_properly_relays_netwoking_errors() throws {
+        // Given
+        let remote = ProductAttributesRemote(network: network)
+
+        // When
+        let result = try waitFor { promise in
+            remote.loadAllProductAttributes(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNil(try? result.get())
+        XCTAssertNotNil(result.failure)
+    }
+
+    // MARK: - Create a product attribute tests
+
+    /// Verifies that createProductAttribute properly parses the `product-attribute-create` sample response.
+    ///
+    func test_createProductAttribute_properly_returns_parsed_productAttribute() throws {
+        // Given
+        let remote = ProductAttributesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attribute-create")
+
+        // When
+        let result = try waitFor { promise in
+            remote.createProductAttribute(for: self.sampleSiteID, name: "Color") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response.name, "Color")
+        XCTAssertNil(result.failure)
+    }
+
+    /// Verifies that createProductAttribute properly relays Networking Layer errors.
+    ///
+    func test_createProductAttribute_properly_relays_netwoking_errors() throws {
+        // Given
+        let remote = ProductAttributesRemote(network: network)
+
+        // When
+        let result = try waitFor { promise in
+            remote.createProductAttribute(for: self.sampleSiteID, name: "Color") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNil(try? result.get())
+        XCTAssertNotNil(result.failure)
+    }
+
+    // MARK: - Update a product attribute tests
+
+    /// Verifies that updateProductAttribute properly parses the `product-attribute-update` sample response.
+    ///
+    func test_updateProductAttribute_properly_returns_parsed_productAttribute() throws {
+        // Given
+        let defaultProductAttributeID: Int64 = 1
+        let remote = ProductAttributesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/attributes/\(defaultProductAttributeID)", filename: "product-attribute-update")
+
+        // When
+        let result = try waitFor { promise in
+            remote.updateProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID, name: "Color") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response.name, "Color")
+        XCTAssertNil(result.failure)
+    }
+
+    /// Verifies that updateProductAttribute properly relays Networking Layer errors.
+    ///
+    func test_updateProductAttribute_properly_relays_netwoking_errors() throws {
+        // Given
+        let defaultProductAttributeID: Int64 = 1
+        let remote = ProductAttributesRemote(network: network)
+
+        // When
+        let result = try waitFor { promise in
+            remote.updateProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID, name: "Color") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNil(try? result.get())
+        XCTAssertNotNil(result.failure)
+    }
+
+    // MARK: - Delete a product attribute tests
+
+    /// Verifies that deleteProductAttribute properly parses the `product-attribute-delete` sample response.
+    ///
+    func test_deleteProductAttribute_properly_returns_parsed_productAttribute() throws {
+        // Given
+        let defaultProductAttributeID: Int64 = 1
+        let remote = ProductAttributesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/attributes/\(defaultProductAttributeID)", filename: "product-attribute-delete")
+
+        // When
+        let result = try waitFor { promise in
+            remote.deleteProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response.name, "Size")
+        XCTAssertNil(result.failure)
+    }
+
+    /// Verifies that deleteProductAttribute properly relays Networking Layer errors.
+    ///
+    func test_deleteProductAttribute_properly_relays_netwoking_errors() throws {
+        // Given
+        let defaultProductAttributeID: Int64 = 1
+        let remote = ProductAttributesRemote(network: network)
+
+        // When
+        let result = try waitFor { promise in
+            remote.deleteProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNil(try? result.get())
+        XCTAssertNotNil(result.failure)
+    }
+
+}

--- a/Networking/NetworkingTests/Responses/product-attribute-create.json
+++ b/Networking/NetworkingTests/Responses/product-attribute-create.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": 1,
+    "name": "Color",
+    "slug": "pa_color",
+    "type": "select",
+    "order_by": "menu_order",
+    "has_archives": true,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/6"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes"
+        }
+      ]
+    }
+  }
+}

--- a/Networking/NetworkingTests/Responses/product-attribute-delete.json
+++ b/Networking/NetworkingTests/Responses/product-attribute-delete.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": 1,
+    "name": "Size",
+    "slug": "pa_size",
+    "type": "select",
+    "order_by": "name",
+    "has_archives": true,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/6"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes"
+        }
+      ]
+    }
+  }
+}

--- a/Networking/NetworkingTests/Responses/product-attribute-update.json
+++ b/Networking/NetworkingTests/Responses/product-attribute-update.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": 1,
+    "name": "Color",
+    "slug": "pa_color",
+    "type": "select",
+    "order_by": "name",
+    "has_archives": true,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/6"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes"
+        }
+      ]
+    }
+  }
+}

--- a/Networking/NetworkingTests/Responses/product-attributes-all.json
+++ b/Networking/NetworkingTests/Responses/product-attributes-all.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "Color",
+      "slug": "pa_color",
+      "type": "select",
+      "order_by": "menu_order",
+      "has_archives": true,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/attributes/6"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/attributes"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "name": "Size",
+      "slug": "pa_size",
+      "type": "select",
+      "order_by": "menu_order",
+      "has_archives": false,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/attributes/2"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/attributes"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of #3181 

It seems that the **Add Variable Products** functionality needs a lot of API requests that should be implemented on our side.
In this PR, I implemented the first four API requests inside the networking layer for Listing, Adding, Updating and Deleting the global [Product Attributes](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-attributes) using the endpoint `/wp-json/wc/v3/products/attributes`. The listing of the Product Attributes will be shown inside the screen that will be implemented for #3181.

The Yosemite and Storage layers changes will be submitted in another PR.

## Changes
- Implemented `ProductAttributeMapper` + tests for mapping a single `ProductAttribute` entity.
- Implemented `ProductAttributeListMapper` + tests for mapping a list of `ProductAttribute` entities.
- Implemented `ProductAttributesRemote` + tests for the networking requests.
- Added some JSON files for mock purposes.

Note: this PR surpassed the 500 LOC because of the JSON files that I added.

## Testing
- just CI, since we don't use them inside the code at the moment.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
