### PR TITLE
Add order creation button on orders screen navbar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -89,7 +89,7 @@ private extension OrdersRootViewController {
         navigationItem.leftBarButtonItem = ordersViewController.createSearchBarButtonItem()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
-            navigationItem.rightBarButtonItem = ordersViewController.createOrderCreationBarButtonItem()
+            navigationItem.rightBarButtonItem = ordersViewController.createNewOrderBarButtonItem()
         }
 
         removeNavigationBackBarButtonText()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -88,6 +88,10 @@ private extension OrdersRootViewController {
     func configureNavigationButtons() {
         navigationItem.leftBarButtonItem = ordersViewController.createSearchBarButtonItem()
 
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderCreation) {
+            navigationItem.rightBarButtonItem = ordersViewController.createOrderCreationBarButtonItem()
+        }
+
         removeNavigationBackBarButtonText()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -71,6 +71,12 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         present(navigationController, animated: true, completion: nil)
     }
 
+    /// Shows Order Creation flow.
+    ///
+    @objc private func createOrder() {
+        // TODO-3237: show order creation screen
+    }
+
     // MARK: - ButtonBarPagerTabStripViewController Conformance
 
     /// Return the ViewControllers for "Processing" and "All Orders".
@@ -163,6 +169,18 @@ extension OrdersTabbedViewController {
         return button
     }
 
+    /// Create a `UIBarButtonItem` to be used as order creation trigger on the top-right.
+    ///
+    func createOrderCreationBarButtonItem() -> UIBarButtonItem {
+        let button = UIBarButtonItem(image: .plusImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(createOrder))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = Localization.orderCreationBarButtonAccessibilityLabel
+        return button
+    }
+
     /// Creates the view controllers to be shown in tabs.
     func makeViewControllers() -> [UIViewController] {
         // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
@@ -220,5 +238,7 @@ private extension OrdersTabbedViewController {
             NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
                               comment: "The detailed message shown in the Orders → All Orders tab if the list is empty.")
         static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
+        static let orderCreationBarButtonAccessibilityLabel = NSLocalizedString("Create order",
+                                                                                comment: "Accessibility label for 'Create order' button")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -171,7 +171,7 @@ extension OrdersTabbedViewController {
 
     /// Create a `UIBarButtonItem` to be used as order creation trigger on the top-right.
     ///
-    func createOrderCreationBarButtonItem() -> UIBarButtonItem {
+    func createNewOrderBarButtonItem() -> UIBarButtonItem {
         let button = UIBarButtonItem(image: .plusImage,
                                      style: .plain,
                                      target: self,


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3236.

### Description

Adds plus button in orders screen navbar, hidden behind feature flag. Action is useless for now, navigation will be added in https://github.com/woocommerce/woocommerce-ios/issues/3237.

I've decided to implement it on `OrdersTabbedViewController` level, since search action also handled there. Quick test with new view controller to be pushed there works fine - navigation bar works, whole screen area is used.

### Screenshot

<img src="https://user-images.githubusercontent.com/3132438/101192818-ad7dc200-366c-11eb-8535-ec6f9a7cf75d.png" width="300">

Update release notes:
- This is potentially (after enabling feature flag) user-facing change, but I decided to skip release-notes for now until whole branch is ready.