### PR TITLE
[UL&S] Present error when Jetpack is either not connected or not activated

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -199,8 +199,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
 
         guard let site = siteInfo, site.hasValidJetpack == true else {
-            let siteURL = siteInfo?.url ?? "your site"
-            let viewModel = JetpackErrorViewModel(siteURL: siteURL)
+            let viewModel = JetpackErrorViewModel(siteURL: siteInfo?.url)
             let installJetpackUI = ULErrorViewController(viewModel: viewModel)
 
             let authenticationResult: WordPressAuthenticatorResult = .injectViewController(value: installJetpackUI)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -198,7 +198,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
 
-        guard let site = siteInfo, site.hasJetpack == true else {
+        guard let site = siteInfo, site.hasValidJetpack == true else {
             let siteURL = siteInfo?.url ?? "your site"
             let viewModel = JetpackErrorViewModel(siteURL: siteURL)
             let installJetpackUI = ULErrorViewController(viewModel: viewModel)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -9,8 +9,8 @@ import WordPressUI
 struct JetpackErrorViewModel: ULErrorViewModel {
     private let siteURL: String
 
-    init(siteURL: String) {
-        self.siteURL = siteURL
+    init(siteURL: String?) {
+        self.siteURL = siteURL ?? Localization.yourSite
     }
 
     // MARK: - Data and configuration
@@ -80,6 +80,11 @@ private extension JetpackErrorViewModel {
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
                                                             comment: "Action button that will restart the login flow."
                                                             + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let yourSite = NSLocalizedString("your site",
+                                                comment: "Placeholder for site url, if the url is unknown."
+                                                    + "Presented when logging in with a site address that does not have a valid Jetpack installation."
+                                                + "The error would read: to use this app for your site you'll need...")
 
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -49,8 +49,8 @@ struct JetpackErrorViewModel: ULErrorViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        //let refreshCommand = NavigateToRoot()
-        //refreshCommand.execute(from: viewController)
+        let refreshCommand = NavigateToRoot()
+        refreshCommand.execute(from: viewController)
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressComSiteInfo+Woo.swift
@@ -1,0 +1,12 @@
+import WordPressAuthenticator
+
+extension WordPressComSiteInfo {
+
+    /// Encapsulates the rules that declare a WordPress site as having a valid
+    /// Jetpack installation
+    var hasValidJetpack: Bool {
+        return hasJetpack &&
+            isJetpackConnected &&
+            isJetpackActive
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -962,6 +962,7 @@
 		D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */; };
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
 		D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */; };
+		D88100D3257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88100D2257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift */; };
 		D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A319256B5CC500FE5605 /* ULErrorViewController.swift */; };
 		D881A31C256B5CC500FE5605 /* ULErrorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */; };
 		D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88CA755237CE515005D2F44 /* UITabBar+Appearance.swift */; };
@@ -2036,6 +2037,7 @@
 		D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComSiteInfo+Woo.swift"; sourceTree = "<group>"; };
+		D88100D2257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressComSiteInfoWooTests.swift; sourceTree = "<group>"; };
 		D881A319256B5CC500FE5605 /* ULErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULErrorViewController.swift; sourceTree = "<group>"; };
 		D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ULErrorViewController.xib; sourceTree = "<group>"; };
 		D88CA755237CE515005D2F44 /* UITabBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Appearance.swift"; sourceTree = "<group>"; };
@@ -4025,6 +4027,7 @@
 				0273707D24C0047800167204 /* SequenceHelpersTests.swift */,
 				02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */,
 				025C00CB2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift */,
+				D88100D2257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6058,6 +6061,7 @@
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
 				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
 				0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */,
+				D88100D3257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -49,11 +49,11 @@
 		020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
+		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
+		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */; };
 		0211254225778BDF0075AD2A /* ShippingLabelDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0211254025778BDF0075AD2A /* ShippingLabelDetailsViewController.xib */; };
 		021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021125472577CC650075AD2A /* ShippingLabelDetailsViewModel.swift */; };
-		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
-		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */; };
 		0212275E2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */; };
 		0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */; };
@@ -961,6 +961,7 @@
 		D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5222EF4F5900A14A29 /* NotificationsBadgeController.swift */; };
 		D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */; };
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
+		D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */; };
 		D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A319256B5CC500FE5605 /* ULErrorViewController.swift */; };
 		D881A31C256B5CC500FE5605 /* ULErrorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */; };
 		D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88CA755237CE515005D2F44 /* UITabBar+Appearance.swift */; };
@@ -1104,11 +1105,11 @@
 		020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
+		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
+		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDetailsViewController.swift; sourceTree = "<group>"; };
 		0211254025778BDF0075AD2A /* ShippingLabelDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelDetailsViewController.xib; sourceTree = "<group>"; };
 		021125472577CC650075AD2A /* ShippingLabelDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDetailsViewModel.swift; sourceTree = "<group>"; };
-		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
-		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorSectionHeaderView.swift; sourceTree = "<group>"; };
 		0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorSectionHeaderView.xib; sourceTree = "<group>"; };
 		0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -2034,6 +2035,7 @@
 		D8736B5222EF4F5900A14A29 /* NotificationsBadgeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsBadgeController.swift; sourceTree = "<group>"; };
 		D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
+		D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComSiteInfo+Woo.swift"; sourceTree = "<group>"; };
 		D881A319256B5CC500FE5605 /* ULErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULErrorViewController.swift; sourceTree = "<group>"; };
 		D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ULErrorViewController.xib; sourceTree = "<group>"; };
 		D88CA755237CE515005D2F44 /* UITabBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Appearance.swift"; sourceTree = "<group>"; };
@@ -4474,6 +4476,7 @@
 				02BA12842461674B008D8325 /* Optional+String.swift */,
 				02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */,
 				571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */,
+				D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */,
 				025C00B925514A7100FAC222 /* BarcodeScannerFrameScaler.swift */,
 			);
 			path = Extensions;
@@ -5739,6 +5742,7 @@
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
+				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/WordPressComSiteInfoWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/WordPressComSiteInfoWooTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import WooCommerce
+@testable import WordPressAuthenticator
+
+final class WordPressComSiteInfoWooTests: XCTestCase {
+    func test_is_valid_when_jetpack_is_active_and_connected() {
+        let infoSite = WordPressComSiteInfo(remote: hasJetpack())
+
+        XCTAssertTrue(infoSite.hasValidJetpack)
+    }
+
+    func test_is_not_valid_when_site_does_not_have_jetpack() {
+        let infoSite = WordPressComSiteInfo(remote: doesNotHaveJetpack())
+
+        XCTAssertFalse(infoSite.hasValidJetpack)
+    }
+
+    func test_is_not_valid_when_site_has_jetpack_installed_but_not_active() {
+        let infoSite = WordPressComSiteInfo(remote: hasJetpackInactive())
+
+        XCTAssertFalse(infoSite.hasValidJetpack)
+    }
+
+    func test_is_not_valid_when_site_has_jetpack_installed_but_not_connected() {
+        let infoSite = WordPressComSiteInfo(remote: hasJetpackNotConnected())
+
+        XCTAssertFalse(infoSite.hasValidJetpack)
+    }
+}
+
+
+private extension WordPressComSiteInfoWooTests {
+    func hasJetpack() -> [AnyHashable: Any] {
+        return [
+            "isJetpackActive": true,
+            "jetpackVersion": false,
+            "isWordPressDotCom": false,
+            "urlAfterRedirects": "https://somewhere.com",
+            "hasJetpack": true,
+            "isWordPress": true,
+            "isJetpackConnected": true
+        ] as [AnyHashable: Any]
+    }
+
+    func doesNotHaveJetpack() -> [AnyHashable: Any] {
+        return [
+            "isJetpackActive": true,
+            "jetpackVersion": false,
+            "isWordPressDotCom": false,
+            "urlAfterRedirects": "https://somewhere.com",
+            "hasJetpack": false,
+            "isWordPress": true,
+            "isJetpackConnected": true
+        ] as [AnyHashable: Any]
+    }
+
+    func hasJetpackInactive() -> [AnyHashable: Any] {
+        return [
+            "isJetpackActive": false,
+            "jetpackVersion": false,
+            "isWordPressDotCom": false,
+            "urlAfterRedirects": "https://somewhere.com",
+            "hasJetpack": true,
+            "isWordPress": true,
+            "isJetpackConnected": true
+        ] as [AnyHashable: Any]
+    }
+
+    func hasJetpackNotConnected() -> [AnyHashable: Any] {
+        return [
+            "isJetpackActive": true,
+            "jetpackVersion": false,
+            "isWordPressDotCom": false,
+            "urlAfterRedirects": "https://somewhere.com",
+            "hasJetpack": true,
+            "isWordPress": true,
+            "isJetpackConnected": false
+        ] as [AnyHashable: Any]
+    }
+}


### PR DESCRIPTION
Closes #3252 

It turns out that, when implementing the first iteration of the Jetpack error, I missed the case when Jetpack might be installed but not activated.

## Changes
* Add an extension to WordPressComSiteInfo (a struct originally declared in WPAuthenticator) to add a var that encapsulates the logic that decides if a site is accepted or not according to the state of its Jetpack installation.
* Add a couple of tests to cover that logic
* A minor change to the way the view model that backs the error deals with the case of an unknown url.
* Also, I uncommented two lines in the view model that should have been uncommented already and that support navigating back to the root of the UL&S stack.

This is the end result, for a site that has jetpack installed, but not active and not connected:

<img src="https://user-images.githubusercontent.com/2722505/101305552-e50f8880-387d-11eb-87fb-4fa85ec99cbd.gif" width="350"/>

## How to test
* Check out the branch, run `bundle exec pod install`
* Attempt to log in with a site address. edgetest.mystagingwebsite.com is a Pressable site with Jetpack installed but not active and not connected, but feel free to use another site.
* Notice that we do not navigate to the "login with username and password" screen anymore, but display the error in the gif above.

cc @jaclync  who reported the original bug 🙇 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
