### PR TITLE
[Issue Refund] Hide "select all" CTA when there are no products left to refund

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -75,6 +75,7 @@ private extension IssueRefundViewController {
         title = viewModel.title
         itemsSelectedLabel.text = viewModel.selectedItemsTitle
         nextButton.isEnabled = viewModel.isNextButtonEnabled
+        selectAllButton.isHidden = !viewModel.isSelectAllButtonVisible
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -61,6 +61,10 @@ final class IssueRefundViewModel {
     ///
     private(set) var isNextButtonEnabled: Bool = false
 
+    /// Boolean indicating if the "select all" button is visible
+    ///
+    private(set) var isSelectAllButtonVisible: Bool = true
+
     /// The sections and rows to display in the `UITableView`.
     ///
     private(set) var sections: [Section] = []
@@ -90,6 +94,7 @@ final class IssueRefundViewModel {
         sections = createSections()
         title = calculateTitle()
         isNextButtonEnabled = calculateNextButtonEnableState()
+        isSelectAllButtonVisible = calculateSelectAllButtonVisibility()
         selectedItemsTitle = createSelectedItemsCount()
     }
 
@@ -317,6 +322,12 @@ extension IssueRefundViewModel {
     ///
     private func calculateNextButtonEnableState() -> Bool {
         return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping
+    }
+
+    /// Calculates wether the "select all" button should be visible or not.
+    ///
+    private func calculateSelectAllButtonVisibility() -> Bool {
+        return state.itemsToRefund.isNotEmpty
     }
 
     /// Returns `true` if a shipping refund is found.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -500,4 +500,37 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, WooAnalyticsStat.createOrderRefundSelectAllItemsButtonTapped.rawValue)
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["order_id"] as? String, "\(order.orderID)")
     }
+
+    func test_viewModel_shows_selectAllButton_if_there_are_items_to_refund() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50, totalTax: "2.97"),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertTrue(viewModel.isSelectAllButtonVisible)
+    }
+
+    func test_viewModel_hides_selectAllButton_if_there_are_no_items_to_refund() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, productID: 1, quantity: 3, price: 11.50, totalTax: "2.97"),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+        let refund = MockRefunds.sampleRefund(items: [
+            MockRefunds.sampleRefundItem(itemID: 1, productID: 1, quantity: -3),
+        ])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [refund], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertFalse(viewModel.isSelectAllButtonVisible)
+    }
 }


### PR DESCRIPTION
fix #3283 

# Why

It was reported that after refunding all products(but not shipping) and then going back to the "issue refund" screen the "Select All" button was still visible but it did nothing since there are no products left to refund.

This PR fixes that situation by hiding that button when there are no more products to refund.

# How

- Added a new property `isSelectAllButtonVisible` in `IssueRefundViewModel` that is calculated at init.
- Update `IssueRefundViewController` to set the button visibility based on the viewmodel.  

# Screenshot
<img width="385" alt="SelectAllButton-demo" src="https://user-images.githubusercontent.com/562080/101363951-fd78a680-386f-11eb-9df1-60b3de2225b2.png">


# Testing Steps
- Go to the Orders tab.
- Select an order with products + a shipping cost.
- Scroll down to the payments section and select "Issue Refund."
- Refund all of the products (but not the shipping).
- On the order detail, select "Issue Refund" again.
- Notice the "Select All" CTA don't appear anymore.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
