### PR TITLE
[Issue Refund] Control Interactive dismiss gesture

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -92,7 +92,7 @@ private extension IssueRefundCoordinatingController {
         // Issued refund action
         refundConfirmationViewController.onRefundCompletion = { [weak self] error in
             if error == nil {
-                self?.dismissIssueRefundFlow()
+                self?.dismissIssueRefundFlow(presentSuccessNotice: true)
             } else {
                 self?.dismissProgressViewController()
             }
@@ -120,6 +120,14 @@ private extension IssueRefundCoordinatingController {
         present(actionSheet, animated: true)
     }
 
+    /// Displays a confirmation alert before dismissing the flow by a drag gesture.
+    ///
+    func presentDismissConfirmationAlert() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self) { [weak self] in
+            self?.dismissIssueRefundFlow(presentSuccessNotice: false)
+        }
+    }
+
     /// Shows a progress view while the refund is being created.
     ///
     func presentProgressViewController() {
@@ -141,11 +149,13 @@ private extension IssueRefundCoordinatingController {
         dismiss(animated: true)
     }
 
-    /// Dismisses the whole `IssueRefund` flow and presents a success notice.
+    /// Dismisses the whole `IssueRefund` flow and presents a success notice if required.
     ///
-    func dismissIssueRefundFlow() {
+    func dismissIssueRefundFlow(presentSuccessNotice: Bool) {
         presentingViewController?.dismiss(animated: true) { [weak self] in
-            self?.systemNoticePresenter.enqueue(notice: .init(title: Localization.refundSuccess))
+            if presentSuccessNotice {
+                self?.systemNoticePresenter.enqueue(notice: .init(title: Localization.refundSuccess))
+            }
         }
     }
 }
@@ -166,6 +176,12 @@ extension IssueRefundCoordinatingController: UIAdaptivePresentationControllerDel
             return true
         }
         return delegate.presentationControllerShouldDismiss(presentationController)
+    }
+
+    /// Present a dismiss flow confirmation alert when the user tried to dismiss the flow while having un-committed changes.
+    ///
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        presentDismissConfirmationAlert()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -23,6 +23,9 @@ final class IssueRefundCoordinatingController: WooNavigationController {
         self.systemNoticePresenter = systemNoticePresenter
         super.init(nibName: nil, bundle: nil)
         startRefundNavigation()
+
+        // Set presentation delegate to define custom behaviour to the user's dismiss action.
+        presentationController?.delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -144,6 +147,25 @@ private extension IssueRefundCoordinatingController {
         presentingViewController?.dismiss(animated: true) { [weak self] in
             self?.systemNoticePresenter.enqueue(notice: .init(title: Localization.refundSuccess))
         }
+    }
+}
+
+// MARK: Modal Presentation delegate
+
+/// Conform to this protocol to allow custom behaviour on when to allow an interactive dismiss gesture.
+///
+protocol IssueRefundInteractiveDismissDelegate: class {
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool
+}
+
+extension IssueRefundCoordinatingController: UIAdaptivePresentationControllerDelegate {
+    /// Asks the top view controller if it can be dismissed by an interactive gesture.
+    ///
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        guard let delegate = topViewController as? IssueRefundInteractiveDismissDelegate else {
+            return true
+        }
+        return delegate.presentationControllerShouldDismiss(presentationController)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -223,7 +223,7 @@ extension IssueRefundViewController: IssueRefundInteractiveDismissDelegate {
     /// Allow the interactive dismiss when the user has not selected any items to refund.
     ///
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        !viewModel.isNextButtonEnabled
+        !viewModel.hasUnsavedChanges
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -218,6 +218,15 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
     }
 }
 
+// MARK: Interactive Dismiss
+extension IssueRefundViewController: IssueRefundInteractiveDismissDelegate {
+    /// Allow the interactive dismiss when the user has not selected any items to refund.
+    ///
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        !viewModel.isNextButtonEnabled
+    }
+}
+
 // MARK: Constants
 private extension IssueRefundViewController {
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -41,6 +41,7 @@ final class IssueRefundViewModel {
             title = calculateTitle()
             selectedItemsTitle = createSelectedItemsCount()
             isNextButtonEnabled = calculateNextButtonEnableState()
+            hasUnsavedChanges = calculatePendingChangesState()
             onChange?()
         }
     }
@@ -60,6 +61,10 @@ final class IssueRefundViewModel {
     /// Boolean indicating if the next button is enabled
     ///
     private(set) var isNextButtonEnabled: Bool = false
+
+    /// Boolean indicating if there are refunds pending to commit
+    ///
+    private(set) var hasUnsavedChanges: Bool = false
 
     /// The sections and rows to display in the `UITableView`.
     ///
@@ -91,6 +96,7 @@ final class IssueRefundViewModel {
         title = calculateTitle()
         isNextButtonEnabled = calculateNextButtonEnableState()
         selectedItemsTitle = createSelectedItemsCount()
+        hasUnsavedChanges = calculatePendingChangesState()
     }
 
     /// Creates the `ViewModel` to be used when navigating to the page where the user can
@@ -316,7 +322,13 @@ extension IssueRefundViewModel {
     /// Calculates wether the next button should be enabled or not
     ///
     private func calculateNextButtonEnableState() -> Bool {
-        return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping
+        calculatePendingChangesState()
+    }
+
+    /// Calculates wether the are pending changes to commit
+    ///
+    private func calculatePendingChangesState() -> Bool {
+        state.refundQuantityStore.count() > 0 || state.shouldRefundShipping
     }
 
     /// Returns `true` if a shipping refund is found.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -325,7 +325,7 @@ extension IssueRefundViewModel {
         calculatePendingChangesState()
     }
 
-    /// Calculates wether the are pending changes to commit
+    /// Calculates wether there are pending changes to commit
     ///
     private func calculatePendingChangesState() -> Bool {
         state.refundQuantityStore.count() > 0 || state.shouldRefundShipping

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -193,6 +193,15 @@ private extension RefundConfirmationViewController {
     }
 }
 
+// MARK: Interactive Dismiss
+extension RefundConfirmationViewController: IssueRefundInteractiveDismissDelegate {
+    /// Don't allow interactive dismiss gesture.
+    ///
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        false
+    }
+}
+
 // MARK: - Localization
 
 private extension RefundConfirmationViewController {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -442,7 +442,7 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
-    func test_viewModel_starts_with_no_saved_changes() {
+    func test_viewModel_starts_with_no_unsaved_changes() {
         // Given
         let currencySettings = CurrencySettings()
         let items = [

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -442,6 +442,37 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isNextButtonEnabled)
     }
 
+    func test_viewModel_starts_with_no_saved_changes() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertFalse(viewModel.hasUnsavedChanges)
+    }
+
+    func test_viewModel_unsaved_changes_states_becomes_true_after_selecting_items() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // When
+        viewModel.selectAllOrderItems()
+
+        // Then
+        XCTAssertTrue(viewModel.hasUnsavedChanges)
+    }
+
     // MARK: Analytics
     //
     func test_viewModel_tracks_shipping_switch_action_correcly() {


### PR DESCRIPTION
fix #3264

# Why
It was reported that the new(IOS 13+) interactive dismiss behavior for the issue refund flow was too easy to activate causing changes to the flow to be lost.

This PR fixes that by showing a confirmation action sheet when the user tries to dismiss the issue refund flow with a drag gesture but it has some unsaved changes.

# How

**On `IssueRefundCordinatingController`**
- Created a new protocol `IssueRefundInteractiveDismissDelegate` to allow its view controllers to decide if they should be dismissed by drag gesture or not.
- Set itself to be the presentation delegate and forward the `presentationControllerShouldDismiss` message.
- Present a confirmation action sheet when the user tries to dismiss the flow by a drag gesture while having unsaved changes.
- Update the `dismissIssueRefundFlow` method to be able to dismiss the flow without presenting the success notice.

**On `IssueRefundViewModel`**
- Added a new property `hasUnsavedChanges` that is computed on every state change

**On `IssueRefundViewController`**
- Conform to `IssueRefundInteractiveDismissDelegate` to allow dismissal when the view model does not have any pending changes.

**on `RefundConfirmationViewController`**
- Always return false for the `presentationControllerShouldDismiss` method as in that screen there are always changes pending to save.

# Demo
![interactive-dismiss](https://user-images.githubusercontent.com/562080/101369144-f3f23d00-3875-11eb-9c58-4fb30316f65f.gif)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
