### PR TITLE
Hide WordPress.com TOS 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.31.0-beta.3'
+  # pod 'WordPressAuthenticator', '~> 1.31.0-beta.3'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/535-terms-of-service'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.31.0-beta.3):
+  - WordPressAuthenticator (1.31.0-beta.4):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.31.0-beta.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/535-terms-of-service`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -141,7 +141,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -156,6 +155,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: issue/535-terms-of-service
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 571f7fec731ade233bc4166463c6acaf84251af8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -182,7 +191,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b43cd7f1ec8eb0bd2efd5b7b93d16d72be402046
+  WordPressAuthenticator: 3bc0d09d1617e540c6475cceac62ed6c3755cf22
   WordPressKit: 3cba388ffed57891c3821e1efc08a2b71382b214
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
   WordPressUI: 07ad23f17631bdce0171383e533eb7c4c29280aa
@@ -198,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 51c9d4a826f7bd87e3109e5c801c602a6b62c762
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
 
-PODFILE CHECKSUM: 25565253d6035bcea3995dcf6c1d42ac1e060c27
+PODFILE CHECKSUM: d5b6591348227663d9a0f1b3f50bcb3bf5618f90
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -154,10 +154,16 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         return false
     }
 
-    /// Indicates whether if the Support Action should be enabled, or not.
+    /// Indicates whether the Support Action should be enabled, or not.
     ///
     var supportActionEnabled: Bool {
         return true
+    }
+
+    /// Indicates whether a link to WP.com TOS should be available, or not.
+    ///
+    var wpcomTermsOfServiceEnabled: Bool {
+        return false
     }
 
     /// Indicates if Support is Enabled.


### PR DESCRIPTION
Closes #3145 
Ref: wordpress-mobile/WordPressAuthenticator-iOS#536

## Changes

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101435919-23717a00-3948-11eb-8199-32951ac94596.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101435911-1fddf300-3948-11eb-8339-948b6f4365ac.png" width="350"/> |

* Point the podfile to the branch in WPAuthenticator that actually implements the solution
* Update AuthenticationManager to implement the new delegate method that allows removing the link to the TOS

## Testing
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary
* Attempt to log in with a WordPress.com account. Notice if the link to the Terms Of Service worth above the "Continue" button is visible.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
