### PR TITLE
Add missing unit tests for error view models

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 1.31.0-beta.3'
+  pod 'WordPressAuthenticator', '~> 1.31.0-beta.4'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/535-terms-of-service'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/535-terms-of-service'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.23.0-beta.4):
+  - WordPressKit (4.23.0-beta.6):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/535-terms-of-service`)
+  - WordPressAuthenticator (~> 1.31.0-beta.4)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -141,6 +141,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -155,16 +156,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: issue/535-terms-of-service
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 571f7fec731ade233bc4166463c6acaf84251af8
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -192,7 +183,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 3bc0d09d1617e540c6475cceac62ed6c3755cf22
-  WordPressKit: 3cba388ffed57891c3821e1efc08a2b71382b214
+  WordPressKit: a511b4d038254afefca7c818723307029fb1a6d1
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
   WordPressUI: 07ad23f17631bdce0171383e533eb7c4c29280aa
   Wormholy: bfc1c8679eefd0edd92638758e21c3961b1b3b50
@@ -207,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 51c9d4a826f7bd87e3109e5c801c602a6b62c762
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
 
-PODFILE CHECKSUM: d5b6591348227663d9a0f1b3f50bcb3bf5618f90
+PODFILE CHECKSUM: fa36bd99e23ff94d6dc2741c3aa3da6e7cbaaf8e
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
@@ -10,9 +10,7 @@ struct NotWPErrorViewModel: ULErrorViewModel {
     // MARK: - Data and configuration
     let image: UIImage = .loginNoWordPressError
 
-    var text: NSAttributedString {
-        NSMutableAttributedString(string: Localization.errorMessage)
-    }
+    let text: NSAttributedString = .init(string: Localization.errorMessage)
 
     let isAuxiliaryButtonHidden = true
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -952,6 +952,7 @@
 		D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833C2230DC9D002168F3 /* StringWooTests.swift */; };
 		D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */; };
 		D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */; };
+		D85DD1E1257F376200861AA8 /* NotWPAccountViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85DD1E0257F376200861AA8 /* NotWPAccountViewModelTests.swift */; };
 		D8610BCC256F284700A5DF27 /* ULErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */; };
 		D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BD1256F291000A5DF27 /* JetpackErrorViewModel.swift */; };
 		D8610BDD256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */; };
@@ -2029,6 +2030,7 @@
 		D85B833C2230DC9D002168F3 /* StringWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringWooTests.swift; path = WooCommerceTests/Extensions/StringWooTests.swift; sourceTree = SOURCE_ROOT; };
 		D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SummaryTableViewCellTests.swift; path = "WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellTests.swift"; sourceTree = SOURCE_ROOT; };
 		D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotWPErrorViewModelTests.swift; sourceTree = "<group>"; };
+		D85DD1E0257F376200861AA8 /* NotWPAccountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotWPAccountViewModelTests.swift; sourceTree = "<group>"; };
 		D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULErrorViewModel.swift; sourceTree = "<group>"; };
 		D8610BD1256F291000A5DF27 /* JetpackErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackErrorViewModel.swift; sourceTree = "<group>"; };
 		D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackErrorViewModelTests.swift; sourceTree = "<group>"; };
@@ -3417,6 +3419,7 @@
 				57C2F6E424C27B1E00131012 /* Epilogue */,
 				D8610BF6256F5F0900A5DF27 /* ULErrorViewControllerTests.swift */,
 				D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */,
+				D85DD1E0257F376200861AA8 /* NotWPAccountViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -6174,6 +6177,7 @@
 				57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
+				D85DD1E1257F376200861AA8 /* NotWPAccountViewModelTests.swift in Sources */,
 				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -951,6 +951,7 @@
 		D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */; };
 		D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833C2230DC9D002168F3 /* StringWooTests.swift */; };
 		D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */; };
+		D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */; };
 		D8610BCC256F284700A5DF27 /* ULErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */; };
 		D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BD1256F291000A5DF27 /* JetpackErrorViewModel.swift */; };
 		D8610BDD256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */; };
@@ -2027,6 +2028,7 @@
 		D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StatusListTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/StatusListTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D85B833C2230DC9D002168F3 /* StringWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringWooTests.swift; path = WooCommerceTests/Extensions/StringWooTests.swift; sourceTree = SOURCE_ROOT; };
 		D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SummaryTableViewCellTests.swift; path = "WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellTests.swift"; sourceTree = SOURCE_ROOT; };
+		D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotWPErrorViewModelTests.swift; sourceTree = "<group>"; };
 		D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULErrorViewModel.swift; sourceTree = "<group>"; };
 		D8610BD1256F291000A5DF27 /* JetpackErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackErrorViewModel.swift; sourceTree = "<group>"; };
 		D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackErrorViewModelTests.swift; sourceTree = "<group>"; };
@@ -3414,6 +3416,7 @@
 				D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */,
 				57C2F6E424C27B1E00131012 /* Epilogue */,
 				D8610BF6256F5F0900A5DF27 /* ULErrorViewControllerTests.swift */,
+				D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -6217,6 +6220,7 @@
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
+				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,
 				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
 				57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 @testable import WooCommerce
 
-final class NotWPErrorViewModelTests: XCTestCase {
+final class NotWPAccountViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_image() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
 
         // When
         let image = viewModel.image
@@ -16,7 +16,7 @@ final class NotWPErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_error_message() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
         let expectation = NSAttributedString(string: Expectations.errorMessage)
 
         // When
@@ -28,29 +28,29 @@ final class NotWPErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_visibility_for_auxiliary_button() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
 
         // When
         let isHidden = viewModel.isAuxiliaryButtonHidden
 
         // Then
-        XCTAssertTrue(isHidden)
+        XCTAssertFalse(isHidden)
     }
 
     func test_viewmodel_provides_expected_title_for_auxiliary_button() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
 
         // When
         let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
 
         // Then
-        XCTAssertEqual(auxiliaryButtonTitle, "")
+        XCTAssertEqual(auxiliaryButtonTitle, Expectations.needHelpFindingEmail)
     }
 
     func test_viewmodel_provides_expected_title_for_primary_button() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
 
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
@@ -61,7 +61,7 @@ final class NotWPErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_secondary_button() {
         // Given
-        let viewModel = NotWPErrorViewModel()
+        let viewModel = NotWPAccountViewModel()
 
         // When
         let secondaryButtonTitle = viewModel.secondaryButtonTitle
@@ -72,19 +72,23 @@ final class NotWPErrorViewModelTests: XCTestCase {
 }
 
 
-private extension NotWPErrorViewModelTests {
+private extension NotWPAccountViewModelTests {
     private enum Expectations {
         static let image = UIImage.loginNoWordPressError
-        static let errorMessage = NSLocalizedString("The website is not a WordPress site. For us to connect to it, the site must have WordPress installed.",
-                                                    comment: "Message explaining that a site is not a WordPress site. "
-                                                        + "Reads like 'The website awebsite.com you'll is not a WordPress site...")
+        static let errorMessage = NSLocalizedString("It looks like this email isn't associated with a WordPress.com account.",
+                                                    comment: "Message explaining that an email is not associated with a WordPress.com account. "
+                                                        + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let primaryButtonTitle = NSLocalizedString("Enter Another Store",
+        static let needHelpFindingEmail = NSLocalizedString("Need help finding the connected email?",
+                                                     comment: "Button linking to webview that explains what Jetpack is"
+                                                        + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let primaryButtonTitle = NSLocalizedString("Enter Your Store Address",
                                                           comment: "Action button linking to instructions for enter another store."
-                                                          + "Presented when logging in with a site address that is not a WordPress site")
+                                                          + "Presented when logging in with an email address that is not a WordPress.com account")
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
                                                             comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                            + "Presented when logging in with an email address that does not match a WordPress.com account")
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPErrorViewModelTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import WooCommerce
+
+final class NotWPErrorViewModelTests: XCTestCase {
+
+    func test_viewmodel_provides_expected_image() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+
+        // When
+        let image = viewModel.image
+
+        // Then
+        XCTAssertEqual(image, Expectations.image)
+    }
+
+    func test_viewmodel_provides_expected_error_message() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+        let expectation = NSAttributedString(string: Expectations.errorMessage)
+
+        // When
+        let errorMessage = viewModel.text
+
+        // Then
+        XCTAssertEqual(errorMessage, expectation)
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_auxiliary_button() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+
+        // When
+        let isVisible = viewModel.isAuxiliaryButtonHidden
+
+        // Then
+        XCTAssertTrue(isVisible)
+    }
+
+    func test_viewmodel_provides_expected_title_for_auxiliary_button() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+
+        // When
+        let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonTitle, "")
+    }
+
+    func test_viewmodel_provides_expected_title_for_primary_button() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
+    }
+
+    func test_viewmodel_provides_expected_title_for_secondary_button() {
+        // Given
+        let viewModel = NotWPErrorViewModel()
+
+        // When
+        let secondaryButtonTitle = viewModel.secondaryButtonTitle
+
+        // Then
+        XCTAssertEqual(secondaryButtonTitle, Expectations.secondaryButtonTitle)
+    }
+}
+
+
+private extension NotWPErrorViewModelTests {
+    private enum Expectations {
+        static let image = UIImage.loginNoWordPressError
+        static let errorMessage = NSLocalizedString("The website is not a WordPress site. For us to connect to it, the site must have WordPress installed.",
+                                                    comment: "Message explaining that a site is not a WordPress site. "
+                                                        + "Reads like 'The website awebsite.com you'll is not a WordPress site...")
+
+        static let primaryButtonTitle = NSLocalizedString("Enter Another Store",
+                                                          comment: "Action button linking to instructions for enter another store."
+                                                          + "Presented when logging in with a site address that is not a WordPress site")
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+    }
+}
+


### PR DESCRIPTION
Closes #3292 

## Changes
* Added unit tests for two view models that were missing tests.

## How to test
* We should be fine if CI passes ✅ 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
