### PR TITLE
Remove deprecation warning in MediaAssetExporter

### DIFF
--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -76,7 +76,7 @@ final class MediaAssetExporter: MediaExporter {
         }
 
         // Request the image.
-        imageManager.requestImageData(for: asset,
+        imageManager.requestImageDataAndOrientation(for: asset,
                                       options: options,
                                       resultHandler: { [weak self] (data, uti, orientation, info) in
                                         guard let self = self else {


### PR DESCRIPTION
Closes #3303 

## Changes
* Update call to PHImageManager's requestImageData to requestImageDataAndOrientation in order to silence the warning

## How to test
* First checkout the branch, build and run, and check that MediaAssetExporter is not emitting any warnings
* It seems like this code is hit when uploading a product image, so navigate to a product, and add a new image. Publish the product updates and check that the image is still available (pull to refresh for extra credit)

There are no user-facing changes

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
