### PR TITLE
Shipping Labels M1: UI to refund a shipping label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -375,8 +375,13 @@ private extension OrderDetailsViewController {
 
         actionSheet.addCancelActionWithTitle(Localization.ShippingLabelMoreMenu.cancelAction)
 
-        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { _ in
-            // TODO-2168: refund a shipping label
+        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelMoreMenu.requestRefundAction) { [weak self] _ in
+            let refundViewController = RefundShippingLabelViewController(shippingLabel: shippingLabel) { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            // Disables the bottom bar (tab bar) when requesting a refund.
+            refundViewController.hidesBottomBarWhenPushed = true
+            self?.show(refundViewController, sender: self)
         }
 
         let popoverController = actionSheet.popoverPresentationController

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
@@ -10,17 +10,17 @@ final class RefundShippingLabelViewController: UIViewController {
     private let viewModel: RefundShippingLabelViewModel
     private let rows: [Row]
     private let noticePresenter: NoticePresenter
-    private let onDismiss: () -> Void
+    private let onComplete: () -> Void
 
     init(shippingLabel: ShippingLabel,
          currencyFormatter: CurrencyFormatter = .init(currencySettings: ServiceLocator.currencySettings),
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
-         onDismiss: @escaping () -> Void) {
+         onComplete: @escaping () -> Void) {
         self.shippingLabel = shippingLabel
         self.viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel, currencyFormatter: currencyFormatter)
         self.rows = [.purchaseDate, .refundableAmount]
         self.noticePresenter = noticePresenter
-        self.onDismiss = onDismiss
+        self.onComplete = onComplete
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -44,7 +44,7 @@ private extension RefundShippingLabelViewController {
             self.showRefundResultNotice(result: result)
         }
         ServiceLocator.stores.dispatch(action)
-        onDismiss()
+        onComplete()
     }
 
     func showRefundResultNotice(result: Result<Yosemite.ShippingLabelRefund, Error>) {
@@ -72,7 +72,7 @@ private extension RefundShippingLabelViewController {
         tableView.delegate = self
         registerTableViewCellsAndHeader()
 
-        tableView.tableFooterView = UIView()
+        tableView.applyFooterViewForHidingExtraRowPlaceholders()
         tableView.backgroundColor = .basicBackground
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.sectionHeaderHeight = UITableView.automaticDimension
@@ -113,14 +113,10 @@ extension RefundShippingLabelViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let row = rowAtIndexPath(indexPath)
+        let row = rows[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
         configure(cell, for: row)
         return cell
-    }
-
-    private func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
-        rows[indexPath.row]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
@@ -40,14 +40,13 @@ final class RefundShippingLabelViewController: UIViewController {
 // MARK: Action Handling
 private extension RefundShippingLabelViewController {
     func refundShippingLabel() {
-        let action = ShippingLabelAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
+        viewModel.refundShippingLabel { result in
             self.showRefundResultNotice(result: result)
         }
-        ServiceLocator.stores.dispatch(action)
         onComplete()
     }
 
-    func showRefundResultNotice(result: Result<Yosemite.ShippingLabelRefund, Error>) {
+    func showRefundResultNotice(result: Result<ShippingLabelRefund, Error>) {
         let notice: Notice
         switch result {
         case .success:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.swift
@@ -1,0 +1,204 @@
+import UIKit
+import Yosemite
+
+/// Displays information about the refund with a CTA to request a refund.
+final class RefundShippingLabelViewController: UIViewController {
+    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var refundButton: UIButton!
+
+    private let shippingLabel: ShippingLabel
+    private let viewModel: RefundShippingLabelViewModel
+    private let rows: [Row]
+    private let noticePresenter: NoticePresenter
+    private let onDismiss: () -> Void
+
+    init(shippingLabel: ShippingLabel,
+         currencyFormatter: CurrencyFormatter = .init(currencySettings: ServiceLocator.currencySettings),
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+         onDismiss: @escaping () -> Void) {
+        self.shippingLabel = shippingLabel
+        self.viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel, currencyFormatter: currencyFormatter)
+        self.rows = [.purchaseDate, .refundableAmount]
+        self.noticePresenter = noticePresenter
+        self.onDismiss = onDismiss
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureTableView()
+        configureRefundButton()
+    }
+}
+
+// MARK: Action Handling
+private extension RefundShippingLabelViewController {
+    func refundShippingLabel() {
+        let action = ShippingLabelAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
+            self.showRefundResultNotice(result: result)
+        }
+        ServiceLocator.stores.dispatch(action)
+        onDismiss()
+    }
+
+    func showRefundResultNotice(result: Result<Yosemite.ShippingLabelRefund, Error>) {
+        let notice: Notice
+        switch result {
+        case .success:
+            let title = String.localizedStringWithFormat(Localization.refundSuccessNoticeFormat, shippingLabel.serviceName, viewModel.refundableAmount)
+            notice = Notice(title: title, feedbackType: .success)
+        case .failure(let error):
+            DDLogError("⛔️ Failed to request a refund for shipping label \(shippingLabel.shippingLabelID): \(error)")
+            notice = Notice(title: Localization.refundErrorNotice, feedbackType: .error)
+        }
+        noticePresenter.enqueue(notice: notice)
+    }
+}
+
+// MARK: Configuration
+private extension RefundShippingLabelViewController {
+    func configureNavigationBar() {
+        navigationItem.title = Localization.navigationBarTitle
+    }
+
+    func configureTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        registerTableViewCellsAndHeader()
+
+        tableView.tableFooterView = UIView()
+        tableView.backgroundColor = .basicBackground
+        tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.bounces = false
+    }
+
+    func registerTableViewCellsAndHeader() {
+        // Rows.
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+        // Header.
+        tableView.register(PlainTextSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: PlainTextSectionHeaderView.reuseIdentifier)
+    }
+
+    func configureRefundButton() {
+        refundButton.applyPrimaryButtonStyle()
+        refundButton.setTitle(viewModel.refundButtonTitle, for: .normal)
+        refundButton.on(.touchUpInside) { [weak self] _ in
+            self?.refundShippingLabel()
+        }
+    }
+
+    func configureCellCommonProperties(_ cell: ValueOneTableViewCell) {
+        cell.detailTextLabel?.textColor = Constants.cellValueTextColor
+        cell.selectionStyle = .none
+        cell.accessoryType = .none
+    }
+}
+
+extension RefundShippingLabelViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row)
+        return cell
+    }
+
+    private func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        rows[indexPath.row]
+    }
+}
+
+extension RefundShippingLabelViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerID = PlainTextSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? PlainTextSectionHeaderView else {
+            fatalError()
+        }
+        headerView.label.applySubheadlineStyle()
+        headerView.label.text = Localization.headerText
+        headerView.label.textColor = Constants.cellValueTextColor
+        return headerView
+    }
+}
+
+private extension RefundShippingLabelViewController {
+    func configure(_ cell: UITableViewCell, for row: Row) {
+        switch cell {
+        case let cell as ValueOneTableViewCell where row == .purchaseDate:
+            configurePurchaseDate(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .refundableAmount:
+            configureRefundableAmount(cell: cell)
+        default:
+            break
+        }
+    }
+
+    func configurePurchaseDate(cell: ValueOneTableViewCell) {
+        cell.textLabel?.text = Localization.purchaseDateTitle
+        cell.detailTextLabel?.text = viewModel.purchaseDate
+        configureCellCommonProperties(cell)
+    }
+
+    func configureRefundableAmount(cell: ValueOneTableViewCell) {
+        cell.textLabel?.text = Localization.refundableAmountTitle
+        cell.detailTextLabel?.text = viewModel.refundableAmount
+        configureCellCommonProperties(cell)
+    }
+}
+
+private extension RefundShippingLabelViewController {
+    enum Constants {
+        static let cellValueTextColor = UIColor.systemColor(.secondaryLabel)
+        static let sectionHeight = CGFloat(44)
+    }
+
+    enum Localization {
+        static let navigationBarTitle = NSLocalizedString("Request a Refund",
+                                                          comment: "Navigation bar title to request a refund for a shipping label")
+        static let headerText = NSLocalizedString(
+            "You can request a refund for a shipping label that has not been used to ship a package.\nIt will take a least 14 days to process.",
+            comment: "Header text in Refund Shipping Label screen")
+        static let purchaseDateTitle = NSLocalizedString("Purchase Date",
+                                                         comment: "Title of shipping label purchase date in Refund Shipping Label screen")
+        static let refundableAmountTitle = NSLocalizedString("Amount Eligible For Refund",
+                                                             comment: "Title of shipping label eligible refund amount in Refund Shipping Label screen")
+        static let refundSuccessNoticeFormat =
+            NSLocalizedString("%1$@ refund requested (%2$@)",
+                              comment: "Notice format when a shipping label refund request is successful. " +
+                                "The first variable shows the shipping label service name (e.g. USPS Priority Mail). " +
+                                "The second variable shows the formatted amount that is eligible for refund  (e.g. $7.50).")
+        static let refundErrorNotice = NSLocalizedString("Something went wrong with the refund. Please try again.",
+                                                         comment: "Notice format when a shipping label refund request fails.")
+    }
+}
+
+private extension RefundShippingLabelViewController {
+    enum Row: CaseIterable {
+        case purchaseDate
+        case refundableAmount
+
+        var type: UITableViewCell.Type {
+            ValueOneTableViewCell.self
+        }
+
+        var reuseIdentifier: String {
+            type.reuseIdentifier
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewController.xib
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RefundShippingLabelViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="refundButton" destination="Xtq-cg-LPJ" id="TgA-e6-M9e"/>
+                <outlet property="tableView" destination="oAv-5x-x0C" id="YjU-DB-5bQ"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="7Ke-Ve-FAo">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <subviews>
+                        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="oAv-5x-x0C">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="690"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        </tableView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OSb-oo-w4C">
+                            <rect key="frame" x="0.0" y="690" width="414" height="128"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xtq-cg-LPJ">
+                                    <rect key="frame" x="16" y="16" width="382" height="96"/>
+                                    <state key="normal" title="Button"/>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="Xtq-cg-LPJ" secondAttribute="bottom" constant="16" id="KAp-UK-3Zk"/>
+                                <constraint firstItem="Xtq-cg-LPJ" firstAttribute="leading" secondItem="OSb-oo-w4C" secondAttribute="leading" constant="16" id="SaT-XA-dYx"/>
+                                <constraint firstAttribute="trailing" secondItem="Xtq-cg-LPJ" secondAttribute="trailing" constant="16" id="ej0-5l-Jc2"/>
+                                <constraint firstItem="Xtq-cg-LPJ" firstAttribute="top" secondItem="OSb-oo-w4C" secondAttribute="top" constant="16" id="lCh-xX-d0c"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="7Ke-Ve-FAo" secondAttribute="bottom" id="0dY-cn-bhJ"/>
+                <constraint firstItem="7Ke-Ve-FAo" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="4nK-LF-C4l"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="7Ke-Ve-FAo" secondAttribute="trailing" id="Shd-Ex-lzr"/>
+                <constraint firstItem="7Ke-Ve-FAo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="tCb-RD-sn1"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="129"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/RefundShippingLabelViewModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+import struct Yosemite.ShippingLabel
+
+/// View model for `RefundShippingLabelViewController` that provides data that are ready for display in the view.
+struct RefundShippingLabelViewModel {
+    let purchaseDate: String
+    let refundableAmount: String
+    let refundButtonTitle: String
+
+    init(shippingLabel: ShippingLabel, currencyFormatter: CurrencyFormatter) {
+        self.purchaseDate = shippingLabel.dateCreated.toString(dateStyle: .medium, timeStyle: .short)
+        self.refundableAmount = currencyFormatter.formatAmount(Decimal(shippingLabel.refundableAmount), with: shippingLabel.currency) ?? ""
+        self.refundButtonTitle = String.localizedStringWithFormat(Localization.refundButtonTitleFormat, refundableAmount)
+    }
+}
+
+private extension RefundShippingLabelViewModel {
+    enum Localization {
+        static let refundButtonTitleFormat =
+            NSLocalizedString("Refund Label (%1$@)",
+                              comment: "Button title for requesting a refund for a shipping label. " +
+                                "The variable is a formatted amount that is eligible for refund (e.g. $7.50).")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PlainTextSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PlainTextSectionHeaderView.swift
@@ -26,6 +26,12 @@ private extension PlainTextSectionHeaderView {
         label.numberOfLines = 0
 
         contentView.addSubview(label)
-        contentView.pinSubviewToAllEdges(label, insets: .init(top: 16, left: 16, bottom: 16, right: 16))
+        contentView.pinSubviewToAllEdges(label, insets: Constants.contentViewMargin)
+    }
+}
+
+private extension PlainTextSectionHeaderView {
+    enum Constants {
+        static let contentViewMargin = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PlainTextSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PlainTextSectionHeaderView.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+/// `UITableView` section header view that displays a text label.
+/// The `label: UILabel` property can be configured by the consumer where it is used.
+final class PlainTextSectionHeaderView: UITableViewHeaderFooterView {
+    private(set) lazy var label: UILabel = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        configureBackground()
+        configureLabel()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension PlainTextSectionHeaderView {
+    func configureBackground() {
+        contentView.backgroundColor = .basicBackground
+    }
+
+    func configureLabel() {
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+
+        contentView.addSubview(label)
+        contentView.pinSubviewToAllEdges(label, insets: .init(top: 16, left: 16, bottom: 16, right: 16))
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D4A8B2526FD1700108626 /* SettingsViewController.swift */; };
 		027D4A8E2526FD1800108626 /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 027D4A8C2526FD1700108626 /* SettingsViewController.xib */; };
 		027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */; };
+		027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */; };
 		02817B39242B34560050AD8B /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02817B38242B34560050AD8B /* ToolbarView.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */; };
 		028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EA237D28B600E84012 /* TextViewViewController.swift */; };
@@ -1267,6 +1268,7 @@
 		027D4A8B2526FD1700108626 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		027D4A8C2526FD1700108626 /* SettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
 		027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterTypeViewModel+Helpers.swift"; sourceTree = "<group>"; };
+		027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
 		02817B38242B34560050AD8B /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HeaderFooterHelpers.swift"; sourceTree = "<group>"; };
 		028296EA237D28B600E84012 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
@@ -2949,6 +2951,7 @@
 			isa = PBXGroup;
 			children = (
 				02F67FF425806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift */,
+				027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */,
 			);
 			path = "Shipping Label";
 			sourceTree = "<group>";
@@ -6274,6 +6277,7 @@
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
 				573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */,
+				027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */,
 				D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */,
 				02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -49,11 +49,11 @@
 		020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
+		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
+		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */; };
 		0211254225778BDF0075AD2A /* ShippingLabelDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0211254025778BDF0075AD2A /* ShippingLabelDetailsViewController.xib */; };
 		021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021125472577CC650075AD2A /* ShippingLabelDetailsViewModel.swift */; };
-		0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252725773F220075AD2A /* Models+Copiable.generated.swift */; };
-		0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */; };
 		0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */; };
 		0212275E2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */; };
 		0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */; };
@@ -70,6 +70,8 @@
 		0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */; };
 		0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */; };
 		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
+		021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */; };
+		021A84E1257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */; };
 		021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */; };
 		021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */; };
 		021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */; };
@@ -233,6 +235,8 @@
 		028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */; };
 		028BAC4522F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
+		028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */; };
+		028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */; };
 		0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */; };
 		0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */; };
 		0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */; };
@@ -1096,11 +1100,11 @@
 		020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
+		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
+		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0211253F25778BDF0075AD2A /* ShippingLabelDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDetailsViewController.swift; sourceTree = "<group>"; };
 		0211254025778BDF0075AD2A /* ShippingLabelDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelDetailsViewController.xib; sourceTree = "<group>"; };
 		021125472577CC650075AD2A /* ShippingLabelDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDetailsViewModel.swift; sourceTree = "<group>"; };
-		0211252725773F220075AD2A /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
-		0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAggregateOrderItem.swift; sourceTree = "<group>"; };
 		0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorSectionHeaderView.swift; sourceTree = "<group>"; };
 		0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorSectionHeaderView.xib; sourceTree = "<group>"; };
 		0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -1117,6 +1121,8 @@
 		0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0218B4EB242E06F00083A847 /* MediaType+WPMediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaType+WPMediaType.swift"; sourceTree = "<group>"; };
 		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
+		021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewController.swift; sourceTree = "<group>"; };
+		021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundShippingLabelViewController.xib; sourceTree = "<group>"; };
 		021AEF9B2407B07300029D28 /* ProductImageStatus+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductImageStatus+HelpersTests.swift"; sourceTree = "<group>"; };
 		021AEF9D2407F55C00029D28 /* PHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageLoader.swift; sourceTree = "<group>"; };
 		021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewController.swift; sourceTree = "<group>"; };
@@ -1280,6 +1286,8 @@
 		028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
 		028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StoreStatsV4PeriodViewController.xib; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
+		028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModel.swift; sourceTree = "<group>"; };
+		028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextSectionHeaderView.swift; sourceTree = "<group>"; };
 		0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectorViewController.swift; sourceTree = "<group>"; };
 		0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewController.swift; sourceTree = "<group>"; };
 		0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -2265,6 +2273,16 @@
 				02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */,
 			);
 			path = "Edit Product";
+			sourceTree = "<group>";
+		};
+		021A84DD257DFBDA00BC71D1 /* Shipping Labels */ = {
+			isa = PBXGroup;
+			children = (
+				021A84DE257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift */,
+				021A84DF257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib */,
+				028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */,
+			);
+			path = "Shipping Labels";
 			sourceTree = "<group>";
 		};
 		021E2A1223A9FBF200B1DE07 /* Inventory Settings */ = {
@@ -3415,6 +3433,7 @@
 			children = (
 				57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */,
 				57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */,
+				028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */,
 			);
 			path = "Section Headers";
 			sourceTree = "<group>";
@@ -4502,6 +4521,7 @@
 				CE35F10D2343E613007B2A6B /* Shipment Tracking Section */,
 				26E1BEC7251BE50C0096D0A1 /* Issue Refunds */,
 				CE35F10A2343E4E6007B2A6B /* Order Notes Section */,
+				021A84DD257DFBDA00BC71D1 /* Shipping Labels */,
 			);
 			path = "Order Details";
 			sourceTree = "<group>";
@@ -5271,6 +5291,7 @@
 				260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */,
 				7493BB8F2149852A003071A9 /* TopPerformersHeaderView.xib in Resources */,
 				CE21B3E120FFC59700A259D5 /* ProductDetailsTableViewCell.xib in Resources */,
+				021A84E1257DFC2A00BC71D1 /* RefundShippingLabelViewController.xib in Resources */,
 				CE35F11C2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.xib in Resources */,
 				451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */,
 				CE85FD5320F677770080B73E /* Dashboard.storyboard in Resources */,
@@ -5502,6 +5523,7 @@
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
+				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
@@ -5805,6 +5827,7 @@
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
+				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
@@ -5970,6 +5993,7 @@
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
+				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/RefundShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/RefundShippingLabelViewModelTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class RefundShippingLabelViewModelTests: XCTestCase {
+    func test_refundableAmount_is_formatted_correctly() {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refundableAmount: 16.331134)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel, currencyFormatter: currencyFormatter)
+
+        // When
+        let refundableAmount = viewModel.refundableAmount
+
+        // Then
+        XCTAssertEqual(refundableAmount, "$16.33")
+    }
+
+    func test_refundButtonTitle_is_formatted_correctly() {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refundableAmount: 1000.331134)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel, currencyFormatter: currencyFormatter)
+
+        // When
+        let refundButtonTitle = viewModel.refundButtonTitle
+
+        // Then
+        let expectedTitle = String.localizedStringWithFormat(RefundShippingLabelViewModel.Localization.refundButtonTitleFormat, "$1,000.33")
+        XCTAssertEqual(refundButtonTitle, expectedTitle)
+    }
+
+    func test_refundShippingLabel_returns_success_result_on_success() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refundableAmount: 1000.331134)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let expectedRefund = ShippingLabelRefund(dateRequested: Date(), status: .pending)
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .refundShippingLabel(_, onCompletion):
+                onCompletion(.success(expectedRefund))
+            default:
+                break
+            }
+        }
+        let viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel,
+                                                     currencyFormatter: CurrencyFormatter(currencySettings: .init()),
+                                                     stores: stores)
+
+        // When
+        let refundResult = try waitFor { promise in
+            viewModel.refundShippingLabel { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(refundResult.get()), expectedRefund)
+    }
+
+    func test_refundShippingLabel_returns_error_result_on_failure() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refundableAmount: 1000.331134)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let expectedError = RefundError.unknown
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .refundShippingLabel(_, onCompletion):
+                onCompletion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+        let viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel,
+                                                     currencyFormatter: CurrencyFormatter(currencySettings: .init()),
+                                                     stores: stores)
+
+        // When
+        let refundResult = try waitFor { promise in
+            viewModel.refundShippingLabel { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(refundResult.failure) as? RefundError, expectedError)
+    }
+}
+
+private extension RefundShippingLabelViewModelTests {
+    enum RefundError: Error, Equatable {
+        case unknown
+    }
+}


### PR DESCRIPTION
Fixes #2168 

## Why

After the backend support https://github.com/woocommerce/woocommerce-ios/pull/3294, this PR implements the UI integration to request a refund for a shipping label.

## Changes

- Created `RefundShippingLabelViewController` and view model `RefundShippingLabelViewModel` to display refund information with a CTA to request a refund
- Created `PlainTextSectionHeaderView` for displaying plain text in a table view section header. The reasons I didn't create a xib:
  - The view only contains one `UILabel` and the logic was pretty straightforward
  - There is no option to create a xib when creating a `UITableViewHeaderFooterView`
- In `OrderDetailsViewController`, integrated with `RefundShippingLabelViewController` when the user taps on the refund request CTA

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/). You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

Please note that in testing mode, a shipping label refund only works if it is requested **shortly** after label creation.

- Go to the orders tab, open an order with at least one physical product
- In wp-admin, create a shipping label for the order above
- Right after the shipping label is created, go back to the app and pull down to refresh the order details --> a shipping label package should be shown after syncing
- Tap on the ellipsis in the package card section header, then tap "Request a Refund" --> a screen should be shown with purchase date and refundable amount, plus a CTA at the bottom
- Tap "Refund Label ({refundable_amount})" CTA --> it should navigate back to order details, then a success snackbar is shown when the refund is requested. In the meantime, the package card should be updated to refunded state (no order items shown)

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/101447118-8ae6f400-395f-11eb-8a43-f57bb86237ea.gif)

portrait | landscape
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 13 46 17](https://user-images.githubusercontent.com/1945542/101447191-ace07680-395f-11eb-82f1-79e263e16a03.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 13 46 40](https://user-images.githubusercontent.com/1945542/101447198-b073fd80-395f-11eb-8802-22fb082295b3.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 13 47 20](https://user-images.githubusercontent.com/1945542/101447200-b10c9400-395f-11eb-8a06-d85832b41f6f.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 13 47 24](https://user-images.githubusercontent.com/1945542/101447201-b1a52a80-395f-11eb-83b7-ab5274c44877.png)

Please notice the snackbar at the bottom:

error state | success state
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 13 47 03](https://user-images.githubusercontent.com/1945542/101447256-ce416280-395f-11eb-8424-335011049504.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-08 at 14 04 53](https://user-images.githubusercontent.com/1945542/101447263-d1d4e980-395f-11eb-861a-7515fca4136f.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
