### PR TITLE
Make UL error view support rotation only for iPad, in order to blend in with the rest of WPAuthenticator

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -17,6 +17,10 @@ final class ULErrorViewController: UIViewController {
     @IBOutlet private weak var errorMessage: UILabel!
     @IBOutlet private weak var extraInfoButton: UIButton!
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIDevice.isPad() ? .all : .portrait
+    }
+
     init(viewModel: ULErrorViewModel) {
         self.viewModel = viewModel
         super.init(nibName: Self.nibName, bundle: nil)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -18,7 +18,7 @@ final class ULErrorViewController: UIViewController {
     @IBOutlet private weak var extraInfoButton: UIButton!
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return UIDevice.isPad() ? .all : .portrait
+        UIDevice.isPad() ? .all : .portrait
     }
 
     init(viewModel: ULErrorViewModel) {


### PR DESCRIPTION
Closes #3286 

The Unified login flow supports device rotation only in tablets. However, the custom UI WooCommerce injects into WPAuthenticator for error handling is supporting rotation also in phones. 

## Changes

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101585003-da89f600-3a19-11eb-879a-d2c5df815dbb.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101584996-d78f0580-3a19-11eb-8b11-8bb45af6e1da.png" width="350"/> |

## Testing
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary
* Attempt to log in again. Trigger an error (either by login in with a Store Address with a url that does not have Jetpack installed, or by logging in with a WordPress.com account, providing a non valid email address)
* Rotate the device. On an iPhone, the screen should not rotate. On a tablet, it should rotate, but the margins will be incorrect, as reported in #3224 


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
