### PR TITLE
Order Details > Products: show images for product variations

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Dropped iOS 12 support. From now we support iOS 13 and later. [https://github.com/woocommerce/woocommerce-ios/pull/3216]
 - [*] Fixed spinner appearance in the footer of orders list. [https://github.com/woocommerce/woocommerce-ios/pull/3249]
+- [*] In order details, the image for a line item associated with a variation is shown now after the variation has been synced. [https://github.com/woocommerce/woocommerce-ios/pull/3314]
 - [internal] Refactored Core Data stack so more errors will be propagated. [https://github.com/woocommerce/woocommerce-ios/pull/3267]
 
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -548,10 +548,16 @@ private extension OrderDetailsDataSource {
         cell.selectionStyle = .default
 
         let aggregateItem = aggregateOrderItems[indexPath.row]
-        let product = lookUpProduct(by: aggregateItem.productOrVariationID)
-        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: aggregateItem,
-                                                        currency: order.currency,
-                                                        product: product)
+        let imageURL: URL? = {
+            guard let imageURLString = aggregateItem.variationID != 0 ?
+                    lookUpProductVariation(productID: aggregateItem.productID, variationID: aggregateItem.variationID)?.image?.src:
+                    lookUpProduct(by: aggregateItem.productID)?.images.first?.src else {
+                return nil
+            }
+            return URL(string: imageURLString)
+        }()
+        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: aggregateItem.copy(imageURL: imageURL),
+                                                        currency: order.currency)
 
         cell.configure(item: itemViewModel, imageService: imageService)
     }
@@ -678,6 +684,10 @@ extension OrderDetailsDataSource {
 
     func lookUpProduct(by productID: Int64) -> Product? {
         return products.filter({ $0.productID == productID }).first
+    }
+
+    private func lookUpProductVariation(productID: Int64, variationID: Int64) -> ProductVariation? {
+        return resultsControllers.productVariations.filter({ $0.productID == productID && $0.productVariationID == variationID }).first
     }
 
     func lookUpRefund(by refundID: Int64) -> Refund? {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -275,8 +275,6 @@ private extension OrderDetailsDataSource {
             configureRefund(cell: cell, at: indexPath)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .netAmount:
             configureNetAmount(cell: cell)
-        case let cell as ProductDetailsTableViewCell where row == .orderItem:
-            configureOrderItem(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .shippingLabelProduct:
             configureShippingLabelProduct(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
@@ -435,17 +433,6 @@ private extension OrderDetailsDataSource {
         cell.leftText = Titles.netAmount
         cell.rightText = paymentViewModel.netAmount
         cell.hideFootnote()
-    }
-
-    private func configureOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
-        cell.selectionStyle = .default
-
-        let item = items[indexPath.row]
-        let product = lookUpProduct(by: item.productOrVariationID)
-        let itemViewModel = ProductDetailsCellViewModel(item: item,
-                                                        currency: order.currency,
-                                                        product: product)
-        cell.configure(item: itemViewModel, imageService: imageService)
     }
 
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
@@ -1167,7 +1154,6 @@ extension OrderDetailsDataSource {
     ///
     enum Row {
         case summary
-        case orderItem
         case aggregateOrderItem
         case fulfillButton
         case details
@@ -1198,8 +1184,6 @@ extension OrderDetailsDataSource {
             switch self {
             case .summary:
                 return SummaryTableViewCell.reuseIdentifier
-            case .orderItem:
-                return ProductDetailsTableViewCell.reuseIdentifier
             case .aggregateOrderItem:
                 return ProductDetailsTableViewCell.reuseIdentifier
             case .fulfillButton:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -225,13 +225,6 @@ extension OrderDetailsViewModel {
             let addTracking = ManualTrackingViewController(viewModel: addTrackingViewModel)
             let navController = WooNavigationController(rootViewController: addTracking)
             viewController.present(navController, animated: true, completion: nil)
-        case .orderItem:
-            let item = items[indexPath.row]
-            let loaderViewController = ProductLoaderViewController(model: .init(orderItem: item),
-                                                                   siteID: order.siteID,
-                                                                   forceReadOnly: true)
-            let navController = WooNavigationController(rootViewController: loaderViewController)
-            viewController.present(navController, animated: true, completion: nil)
         case .aggregateOrderItem:
             let item = dataSource.aggregateOrderItems[indexPath.row]
             let loaderViewController = ProductLoaderViewController(model: .init(aggregateOrderItem: item),


### PR DESCRIPTION
Fixes #2113 
Fixes #3269

## Why

When configuring `ProductDetailsCellViewModel` for an `AggregateOrderItem` to display an order line item, we currently only look up the corresponding `Product` but not `ProductVariation`. This PR tries looking up for the corresponding `ProductVariation` when `AggregateOrderItem` is a variation (`variationID != 0`) and setting the `imageURL` explicitly.

## Changes

- In `OrderDetailsDataSource`, added a private helper to look up a `ProductVariation` given the product and variation ID. When configuring `ProductDetailsCellViewModel` for an `AggregateOrderItem` in `configureAggregateOrderItem`, try looking up for a `ProductVariation` or `Product` for the image URL
- Removed unused code (`.orderItem` row isn't used anymore, since we've consolidated to use `AggregateOrderItem`)

## Testing

Prerequisite: the store has an order that contains a variation, and the variation has an image

- Switch to the store if its products & variations haven't been loaded before, or log out and in to the store with (since we don't delete the products/variations locally)
- Go to the orders tab
- Tap on the order that contains a variable product --> the variation image should be loaded shortly without any actions
- Confidence check: go back to the orders tab, and tap on an order with a product (not variation) --> the product image should be loaded as before

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 17 29 45](https://user-images.githubusercontent.com/1945542/101615061-a7129000-3a48-11eb-9fea-e19392e807da.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 17 44 19](https://user-images.githubusercontent.com/1945542/101615079-aaa61700-3a48-11eb-9c76-95eb10cbed5c.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
