### PR TITLE
List Existing Attributes in Variations: ProductAttributeStore tests

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		453305F7245AE68C00264E50 /* SitePostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305F6245AE68C00264E50 /* SitePostStore.swift */; };
 		453305F9245AE6B200264E50 /* SitePostAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305F8245AE6B200264E50 /* SitePostAction.swift */; };
 		453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305FA245AEDCB00264E50 /* SitePostStoreTests.swift */; };
+		4552073D25811B4E001CF873 /* ProductAttributeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */; };
 		45739F372437680F00480C95 /* ProductSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45739F362437680F00480C95 /* ProductSettings.swift */; };
 		45AB8B1524AA4A1E00B5B36E /* ProductTagAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AB8B1424AA4A1E00B5B36E /* ProductTagAction.swift */; };
 		45AB8B1724AA4B3D00B5B36E /* ProductTagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AB8B1624AA4B3D00B5B36E /* ProductTagStore.swift */; };
@@ -368,6 +369,7 @@
 		453305F6245AE68C00264E50 /* SitePostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostStore.swift; sourceTree = "<group>"; };
 		453305F8245AE6B200264E50 /* SitePostAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostAction.swift; sourceTree = "<group>"; };
 		453305FA245AEDCB00264E50 /* SitePostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostStoreTests.swift; sourceTree = "<group>"; };
+		4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeStoreTests.swift; sourceTree = "<group>"; };
 		45739F362437680F00480C95 /* ProductSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSettings.swift; sourceTree = "<group>"; };
 		45AB8B1424AA4A1E00B5B36E /* ProductTagAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagAction.swift; sourceTree = "<group>"; };
 		45AB8B1624AA4B3D00B5B36E /* ProductTagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagStore.swift; sourceTree = "<group>"; };
@@ -988,6 +990,7 @@
 				7455262F22305F88003F8932 /* OrderStatusStoreTests.swift */,
 				261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */,
 				744914F6224AD2AF00546DE4 /* ProductStoreTests.swift */,
+				4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */,
 				D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */,
 				265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */,
 				45AB8B1D24AB363D00B5B36E /* ProductTagStoreTests.swift */,
@@ -1542,6 +1545,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4552073D25811B4E001CF873 /* ProductAttributeStoreTests.swift in Sources */,
 				022F00C524728B0C008CD97F /* SiteNotificationCountFileContentsTests.swift in Sources */,
 				7499A9ED2220527500D8FDFA /* ShipmentStoreTests.swift in Sources */,
 				0212AC64242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift in Sources */,

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -70,6 +70,16 @@ extension MockStorageManager {
         return newProductTag
     }
 
+    /// Inserts a new (Sample) ProductAttribute into the specified context.
+    ///
+    @discardableResult
+    func insertSampleProductAttribute(readOnlyProductAttribute: ProductAttribute) -> StorageProductAttribute {
+        let newProductAttribute = viewStorage.insertNewObject(ofType: StorageProductAttribute.self)
+        newProductAttribute.update(with: readOnlyProductAttribute)
+
+        return newProductAttribute
+    }
+
     /// Inserts a new (Sample) Order into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
@@ -119,30 +119,51 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
         XCTAssertTrue(result.isFailure)
     }
-//
-//    func testAddProductTagAddsStoredTagSuccessfulResponse() {
-//        // Given a stubed product tag network response
-//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "product-tags-created")
-//
-//        // When dispatching a `addProductTags` action
-//        var result: Result<[Yosemite.ProductTag], Error>?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
-//                result = aResult
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then the tag should be added
-//        let addedTag = viewStorage.loadProductTag(siteID: sampleSiteID, tagID: 36)
-//        XCTAssertNotNil(addedTag)
-//        XCTAssertEqual(addedTag?.siteID, sampleSiteID)
-//        XCTAssertEqual(addedTag?.tagID, 36)
-//        XCTAssertEqual(addedTag?.name, "Round toe")
-//        XCTAssertEqual(addedTag?.slug, "round-toe")
-//        XCTAssertNil(result?.failure)
-//    }
+
+    func test_add_product_attribute_stored_attribute_upon_successful_response() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attribute-create")
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+            let action = ProductAttributeAction.addProductAttribute(siteID: self.sampleSiteID, name: "Color") { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedProductAttributesCount, 1)
+        let addedAttribute = viewStorage.loadProductAttribute(siteID: sampleSiteID, attributeID: 1)
+        XCTAssertNotNil(addedAttribute)
+        XCTAssertEqual(addedAttribute?.siteID, sampleSiteID)
+        XCTAssertEqual(addedAttribute?.attributeID, 1)
+        XCTAssertEqual(addedAttribute?.name, "Color")
+        XCTAssertEqual(addedAttribute?.visible, true)
+        XCTAssertEqual(addedAttribute?.variation, true)
+        XCTAssertEqual(addedAttribute?.options, [])
+    }
+
+    func test_add_product_attribute_returns_error_upon_response_error() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "generic_error")
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+            let action = ProductAttributeAction.addProductAttribute(siteID: self.sampleSiteID, name: "Color") { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(storedProductAttributesCount, 0)
+    }
+
 //
 //    func testAddProductTagReturnsErrorUponResponseError() {
 //        // Given a stubed generic-error network response

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
@@ -1,0 +1,282 @@
+import XCTest
+@testable import Yosemite
+@testable import Storage
+@testable import Networking
+
+
+/// ProductAttributeStore Unit Tests
+///
+final class ProductAttributeStoreTests: XCTestCase {
+    /// Mock Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockNetwork!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Convenience Property: Returns the StorageType associated with the main thread.
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Convenience Property: Returns stored product attributes count.
+    ///
+    private var storedProductAttributesCount: Int {
+        return viewStorage.countObjects(ofType: Storage.ProductAttribute.self)
+    }
+
+    /// Store
+    ///
+    private var store: ProductAttributeStore!
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID: Int64 = 123
+
+    /// Testing Page Number
+    ///
+    private let defaultPageNumber = 1
+
+    // MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork(useResponseQueue: true)
+        storageManager = MockStorageManager()
+        store = ProductAttributeStore(dispatcher: Dispatcher(),
+                                     storageManager: storageManager,
+                                     network: network)
+    }
+
+    override func tearDown() {
+        store = nil
+        network = nil
+        storageManager = nil
+
+        super.tearDown()
+    }
+
+    func test_synchronize_product_attributes_returns_attributes_upon_successful_response() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attributes-all")
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+            let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedProductAttributesCount, 2)
+    }
+
+    func test_synchronize_product_attributes_updates_stored_attributes_upon_successful_response() throws {
+        // Given
+        let initialAttribute = sampleProductAttribute(attributeID: 1)
+        storageManager.insertSampleProductAttribute(readOnlyProductAttribute: initialAttribute)
+        network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attributes-all")
+        XCTAssertEqual(storedProductAttributesCount, 1)
+
+        // When
+        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+            let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedProductAttributesCount, 2)
+        let updatedAttribute = viewStorage.loadProductAttribute(siteID: sampleSiteID, attributeID: initialAttribute.attributeID)
+        XCTAssertEqual(initialAttribute.siteID, updatedAttribute?.siteID)
+        XCTAssertEqual(initialAttribute.attributeID, updatedAttribute?.attributeID)
+        XCTAssertNotEqual(initialAttribute.name, updatedAttribute?.name)
+        XCTAssertNotEqual(initialAttribute.visible, updatedAttribute?.visible)
+        XCTAssertNotEqual(initialAttribute.variation, updatedAttribute?.variation)
+        XCTAssertEqual(initialAttribute.options, updatedAttribute?.options)
+    }
+
+    func test_synchronize_product_attributes_returns_error_upon_empty_response() throws {
+        // Given
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+            let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(storedProductAttributesCount, 0)
+        XCTAssertTrue(result.isFailure)
+    }
+//
+//    func testAddProductTagAddsStoredTagSuccessfulResponse() {
+//        // Given a stubed product tag network response
+//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "product-tags-created")
+//
+//        // When dispatching a `addProductTags` action
+//        var result: Result<[Yosemite.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then the tag should be added
+//        let addedTag = viewStorage.loadProductTag(siteID: sampleSiteID, tagID: 36)
+//        XCTAssertNotNil(addedTag)
+//        XCTAssertEqual(addedTag?.siteID, sampleSiteID)
+//        XCTAssertEqual(addedTag?.tagID, 36)
+//        XCTAssertEqual(addedTag?.name, "Round toe")
+//        XCTAssertEqual(addedTag?.slug, "round-toe")
+//        XCTAssertNil(result?.failure)
+//    }
+//
+//    func testAddProductTagReturnsErrorUponResponseError() {
+//        // Given a stubed generic-error network response
+//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "generic_error")
+//        XCTAssertEqual(storedProductTagsCount, 0)
+//
+//        // When dispatching a `addProductTags` action
+//        var result: Result<[Networking.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then no tags should be stored
+//        XCTAssertEqual(storedProductTagsCount, 0)
+//        XCTAssertNotNil(result?.failure)
+//    }
+//
+//    func testAddProductTagReturnsErrorUponEmptyResponse() {
+//        // Given an empty network response
+//        XCTAssertEqual(storedProductTagsCount, 0)
+//
+//        // When dispatching a `addProductTags` action
+//        var result: Result<[Networking.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then no tags should be stored
+//        XCTAssertEqual(storedProductTagsCount, 0)
+//        XCTAssertNotNil(result?.failure)
+//    }
+//
+//    func testSynchronizeProductTagsDeletesUnusedTags() {
+//        // Given some stored product tags without product relationships
+//        let sampleTags = (1...5).map { id in
+//            return sampleTag(tagID: id)
+//        }
+//        sampleTags.forEach { tag in
+//            storageManager.insertSampleProductTag(readOnlyProductTag: tag)
+//        }
+//        XCTAssertEqual(storedProductTagsCount, sampleTags.count)
+//
+//        // When dispatching a `synchronizeAllProductTags` action
+//        network.simulateResponse(requestUrlSuffix: "products/tags", filename: "product-tags-all")
+//        network.simulateResponse(requestUrlSuffix: "products/tags", filename: "product-tags-empty")
+//
+//        var errorResponse: ProductTagActionError?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
+//                errorResponse = error
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then new tag should be stored and old tags should be deleted
+//        XCTAssertEqual(storedProductTagsCount, 4)
+//        XCTAssertNil(errorResponse)
+//    }
+//
+//    func testDeleteProductTagDeleteStoredTagSuccessfulResponse() {
+//        // Given a stubed product tag network response and a product tag stored locally
+//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "product-tags-deleted")
+//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
+//
+//        XCTAssertEqual(storedProductTagsCount, 1)
+//
+//        // When dispatching a `deleteProductTags` action
+//        var result: Result<[Yosemite.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then the tag should be removed
+//        XCTAssertEqual(storedProductTagsCount, 0)
+//        XCTAssertNil(result?.failure)
+//    }
+//
+//    func testDeleteProductTagReturnsErrorUponResponseError() {
+//        // Given a stubed generic-error network response
+//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "generic_error")
+//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
+//        XCTAssertEqual(storedProductTagsCount, 1)
+//
+//        // When dispatching a `deleteProductTags` action
+//        var result: Result<[Yosemite.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then one tags should be continue to be stored
+//        XCTAssertEqual(storedProductTagsCount, 1)
+//        XCTAssertNotNil(result?.failure)
+//    }
+//
+//    func testDeleteProductTagReturnsErrorUponEmptyResponse() {
+//        // Given an empty network response
+//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
+//        XCTAssertEqual(storedProductTagsCount, 1)
+//
+//        // When dispatching a `deleteProductTags` action
+//        var result: Result<[Yosemite.ProductTag], Error>?
+//        waitForExpectation { (exp) in
+//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+//                result = aResult
+//                exp.fulfill()
+//            }
+//            store.onAction(action)
+//        }
+//
+//        // Then one tags should be continue to be stored
+//        XCTAssertEqual(storedProductTagsCount, 1)
+//        XCTAssertNotNil(result?.failure)
+//    }
+}
+
+private extension ProductAttributeStoreTests {
+    func sampleProductAttribute(attributeID: Int64) -> Networking.ProductAttribute {
+        return Networking.ProductAttribute(siteID: sampleSiteID, attributeID: attributeID, name: "Sample", position: 0, visible: false, variation: false, options: [])
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
@@ -261,120 +261,70 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
     }
 
+    func test_delete_product_attribute_stored_attribute_upon_successful_response() throws {
+        // Given
+        let initialAttribute = sampleProductAttribute(attributeID: 1)
+        storageManager.insertSampleProductAttribute(readOnlyProductAttribute: initialAttribute)
+        network.simulateResponse(requestUrlSuffix: "products/attributes/1", filename: "product-attribute-delete")
+        XCTAssertEqual(storedProductAttributesCount, 1)
 
-//    func testAddProductTagReturnsErrorUponEmptyResponse() {
-//        // Given an empty network response
-//        XCTAssertEqual(storedProductTagsCount, 0)
-//
-//        // When dispatching a `addProductTags` action
-//        var result: Result<[Networking.ProductTag], Error>?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
-//                result = aResult
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then no tags should be stored
-//        XCTAssertEqual(storedProductTagsCount, 0)
-//        XCTAssertNotNil(result?.failure)
-//    }
-//
-//    func testSynchronizeProductTagsDeletesUnusedTags() {
-//        // Given some stored product tags without product relationships
-//        let sampleTags = (1...5).map { id in
-//            return sampleTag(tagID: id)
-//        }
-//        sampleTags.forEach { tag in
-//            storageManager.insertSampleProductTag(readOnlyProductTag: tag)
-//        }
-//        XCTAssertEqual(storedProductTagsCount, sampleTags.count)
-//
-//        // When dispatching a `synchronizeAllProductTags` action
-//        network.simulateResponse(requestUrlSuffix: "products/tags", filename: "product-tags-all")
-//        network.simulateResponse(requestUrlSuffix: "products/tags", filename: "product-tags-empty")
-//
-//        var errorResponse: ProductTagActionError?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
-//                errorResponse = error
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then new tag should be stored and old tags should be deleted
-//        XCTAssertEqual(storedProductTagsCount, 4)
-//        XCTAssertNil(errorResponse)
-//    }
-//
-//    func testDeleteProductTagDeleteStoredTagSuccessfulResponse() {
-//        // Given a stubed product tag network response and a product tag stored locally
-//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "product-tags-deleted")
-//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
-//
-//        XCTAssertEqual(storedProductTagsCount, 1)
-//
-//        // When dispatching a `deleteProductTags` action
-//        var result: Result<[Yosemite.ProductTag], Error>?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
-//                result = aResult
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then the tag should be removed
-//        XCTAssertEqual(storedProductTagsCount, 0)
-//        XCTAssertNil(result?.failure)
-//    }
-//
-//    func testDeleteProductTagReturnsErrorUponResponseError() {
-//        // Given a stubed generic-error network response
-//        network.simulateResponse(requestUrlSuffix: "products/tags/batch", filename: "generic_error")
-//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
-//        XCTAssertEqual(storedProductTagsCount, 1)
-//
-//        // When dispatching a `deleteProductTags` action
-//        var result: Result<[Yosemite.ProductTag], Error>?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
-//                result = aResult
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then one tags should be continue to be stored
-//        XCTAssertEqual(storedProductTagsCount, 1)
-//        XCTAssertNotNil(result?.failure)
-//    }
-//
-//    func testDeleteProductTagReturnsErrorUponEmptyResponse() {
-//        // Given an empty network response
-//        storageManager.insertSampleProductTag(readOnlyProductTag: sampleTag(tagID: 35))
-//        XCTAssertEqual(storedProductTagsCount, 1)
-//
-//        // When dispatching a `deleteProductTags` action
-//        var result: Result<[Yosemite.ProductTag], Error>?
-//        waitForExpectation { (exp) in
-//            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
-//                result = aResult
-//                exp.fulfill()
-//            }
-//            store.onAction(action)
-//        }
-//
-//        // Then one tags should be continue to be stored
-//        XCTAssertEqual(storedProductTagsCount, 1)
-//        XCTAssertNotNil(result?.failure)
-//    }
+        // When
+        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+            let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedProductAttributesCount, 0)
+    }
+
+    func test_delete_product_attribute_returns_error_upon_response_error() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "products/attributes/1", filename: "generic_error")
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+            let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(storedProductAttributesCount, 0)
+    }
+
+    func test_delete_product_attribute_returns_error_upon_empty_response() throws {
+        // Given
+        XCTAssertEqual(storedProductAttributesCount, 0)
+
+        // When
+        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+            let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(storedProductAttributesCount, 0)
+    }
 }
 
 private extension ProductAttributeStoreTests {
     func sampleProductAttribute(attributeID: Int64) -> Networking.ProductAttribute {
-        return Networking.ProductAttribute(siteID: sampleSiteID, attributeID: attributeID, name: "Sample", position: 0, visible: false, variation: false, options: [])
+        return Networking.ProductAttribute(siteID: sampleSiteID,
+                                           attributeID: attributeID,
+                                           name: "Sample",
+                                           position: 0,
+                                           visible: false,
+                                           variation: false,
+                                           options: [])
     }
 }


### PR DESCRIPTION
Part of #3181

After having implemented the Yosemite and the Storage layers for managing the Product Attributes, in this PR I added the unit tests for the `ProductAttributeStore` class, which had not been implemented due to the magnitude of the previous PR.

## Testing
- Just CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
