### PR TITLE
Order Details > Products: update header background to match cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
@@ -74,7 +74,7 @@ private extension PrimarySectionHeaderView {
 
 private extension PrimarySectionHeaderView {
     enum Colors {
-        static let containerViewBackgroundColor = UIColor.basicBackground
+        static let containerViewBackgroundColor = UIColor.listForeground
     }
 }
 


### PR DESCRIPTION
Closes #2662 

### Why
When looking at the order details in dark mode, there is no space between the Product header and the product list. It doesn't happen in light mode because background is the same for the Product header and the product list.
This PR updates background of the Product header to match the background of the product list, which makes it look like there is a padding in between :-)

The changes are only in dark mode, but I took screenshots in light mode just in case.

|Before|After|
|-|-|
|![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 15 46 12](https://user-images.githubusercontent.com/54751/101672966-d203e080-3a56-11eb-9506-329962ab5903.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 15 44 05](https://user-images.githubusercontent.com/54751/101673151-13948b80-3a57-11eb-86b2-c3da2978576c.png)|
|![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 15 46 14](https://user-images.githubusercontent.com/54751/101672956-ce705980-3a56-11eb-85b6-816b95433346.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-09 at 15 44 08](https://user-images.githubusercontent.com/54751/101673150-12fbf500-3a57-11eb-82b3-81ba0d919cfe.png)|

### Test
1. Open an order details

- [ ] Check that the Product header and the product list have the same background

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
