### PR TITLE
Fix background color of Prologue buttons in landscape on iPad

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,10 +38,10 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.31.0-beta.4'
+  # pod 'WordPressAuthenticator', '~> 1.31.0-beta.4'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/535-terms-of-service'
-  # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+  pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'
 

--- a/Podfile
+++ b/Podfile
@@ -40,8 +40,8 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 1.31.0-beta.4'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/535-terms-of-service'
-  pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/538-prologue-bgcolor'
+  # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.23.0-beta.6):
+  - WordPressKit (4.23.0-beta.7):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/538-prologue-bgcolor`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -158,7 +158,13 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :path: "../WordPressAuthenticator-iOS"
+    :branch: issue/538-prologue-bgcolor
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: cce7ad59648f5d6b7e597942929135dd9e39c2bc
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -186,7 +192,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 3bc0d09d1617e540c6475cceac62ed6c3755cf22
-  WordPressKit: a511b4d038254afefca7c818723307029fb1a6d1
+  WordPressKit: 95fe61b3e482fb80e8608186fff5e86aa1e2fd3e
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
   WordPressUI: 07ad23f17631bdce0171383e533eb7c4c29280aa
   Wormholy: bfc1c8679eefd0edd92638758e21c3961b1b3b50
@@ -201,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 51c9d4a826f7bd87e3109e5c801c602a6b62c762
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
 
-PODFILE CHECKSUM: 6912a7ce11a6fc616cc589f9085e2bb9cabe233e
+PODFILE CHECKSUM: e9f84ea8a86d2bb19e4779d7aa5ea1a6c9675cf3
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.31.0-beta.4)
+  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.2)
@@ -141,7 +141,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -156,6 +155,10 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :path: "../WordPressAuthenticator-iOS"
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -198,6 +201,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 51c9d4a826f7bd87e3109e5c801c602a6b62c762
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
 
-PODFILE CHECKSUM: fa36bd99e23ff94d6dc2741c3aa3da6e7cbaaf8e
+PODFILE CHECKSUM: 6912a7ce11a6fc616cc589f9085e2bb9cabe233e
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -87,6 +87,7 @@ class AuthenticationManager: Authentication {
                                                               textButtonHighlightColor: .accent,
                                                               viewControllerBackgroundColor: .basicBackground,
                                                               prologueButtonsBackgroundColor: .authPrologueBottomBackgroundColor,
+                                                              prologueViewBackgroundColor: .authPrologueBottomBackgroundColor,
                                                               navBarBackgroundColor: .basicBackground,
                                                               navButtonTextColor: .accent,
                                                               navTitleTextColor: .text)


### PR DESCRIPTION
Closes #3319 
Ref: wordpress-mobile/WordPressAuthenticator-iOS#539

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101725651-feb60780-3aeb-11eb-82ca-42c0d066e228.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101725639-f958bd00-3aeb-11eb-966e-862235b77fbb.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/101725643-fc53ad80-3aeb-11eb-9059-88178e70c8fa.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101725647-fe1d7100-3aeb-11eb-94d8-c38efb4c96f3.png" width="350"/> |

Also, in dark mode:

| Portrait | Landscape |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101725758-2c02b580-3aec-11eb-9822-735520805e03.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101725765-2e650f80-3aec-11eb-91e8-da4f5e1c67fd.png" width="350"/> |


## Changes
* Point WPAuthenticator to the relevant branch
* Pass a background color for the offending view

## How to test
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary. 
* Attempt to log in both on a phone and a tablet. Check that the background color extends all the way to the margins.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
