### PR TITLE
Fix margins of custom UI in tablets

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -17,6 +17,9 @@ final class ULErrorViewController: UIViewController {
     @IBOutlet private weak var errorMessage: UILabel!
     @IBOutlet private weak var extraInfoButton: UIButton!
 
+    /// Constraints on the view containing the action buttons
+    /// and the stack view containing the image and error text
+    /// Used to adjust the button width in unified views provided by WPAuthenticator
     @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint!
     @IBOutlet private weak var stackViewLeadingConstraint: NSLayoutConstraint!
@@ -45,17 +48,17 @@ final class ULErrorViewController: UIViewController {
         configurePrimaryButton()
         configureSecondaryButton()
 
-        setButtonViewMargins(forWidth: view.frame.width)
+        setUnifiedMargins(forWidth: view.frame.width)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        setButtonViewMargins(forWidth: view.frame.width)
+        setUnifiedMargins(forWidth: view.frame.width)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        setButtonViewMargins(forWidth: size.width)
+        setUnifiedMargins(forWidth: size.width)
     }
 }
 
@@ -101,7 +104,11 @@ private extension ULErrorViewController {
         }
     }
 
-    func setButtonViewMargins(forWidth viewWidth: CGFloat) {
+
+    /// This logic is lifted from WPAuthenticator's LoginPrologueViewController
+    /// This View Controller will be provided to WPAuthenticator. WPAuthenticator
+    /// will insert it into its own navigation stack, where it is applying a similar logic
+    func setUnifiedMargins(forWidth viewWidth: CGFloat) {
         guard traitCollection.horizontalSizeClass == .regular &&
                 traitCollection.verticalSizeClass == .regular else {
             buttonViewLeadingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -19,6 +19,8 @@ final class ULErrorViewController: UIViewController {
 
     @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var stackViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var stackViewTrailingConstraint: NSLayoutConstraint!
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         UIDevice.isPad() ? .all : .portrait
@@ -101,10 +103,10 @@ private extension ULErrorViewController {
 
     func setButtonViewMargins(forWidth viewWidth: CGFloat) {
         guard traitCollection.horizontalSizeClass == .regular &&
-            traitCollection.verticalSizeClass == .regular else {
+                traitCollection.verticalSizeClass == .regular else {
             buttonViewLeadingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
-                buttonViewTrailingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
-                return
+            buttonViewTrailingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
+            return
         }
 
         let marginMultiplier = UIDevice.current.orientation.isLandscape ?
@@ -115,6 +117,9 @@ private extension ULErrorViewController {
 
         buttonViewLeadingConstraint?.constant = margin
         buttonViewTrailingConstraint?.constant = margin
+
+        stackViewLeadingConstraint?.constant = margin
+        stackViewTrailingConstraint?.constant = margin
     }
 
     private enum ButtonViewMarginMultipliers {
@@ -122,7 +127,6 @@ private extension ULErrorViewController {
         static let ipadLandscape: CGFloat = 0.25
         static let defaultButtonViewMargin: CGFloat = 0.0
     }
-
 }
 
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -11,11 +11,14 @@ final class ULErrorViewController: UIViewController {
     /// and support for user actions
     private let viewModel: ULErrorViewModel
 
-    @IBOutlet private var primaryButton: NUXButton!
-    @IBOutlet private var secondaryButton: NUXButton!
-    @IBOutlet private var imageView: UIImageView!
+    @IBOutlet private weak var primaryButton: NUXButton!
+    @IBOutlet private weak var secondaryButton: NUXButton!
+    @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
     @IBOutlet private weak var extraInfoButton: UIButton!
+
+    @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint!
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         UIDevice.isPad() ? .all : .portrait
@@ -39,6 +42,18 @@ final class ULErrorViewController: UIViewController {
 
         configurePrimaryButton()
         configureSecondaryButton()
+
+        setButtonViewMargins(forWidth: view.frame.width)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setButtonViewMargins(forWidth: view.frame.width)
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        setButtonViewMargins(forWidth: size.width)
     }
 }
 
@@ -83,6 +98,31 @@ private extension ULErrorViewController {
             self?.didTapSecondaryButton()
         }
     }
+
+    func setButtonViewMargins(forWidth viewWidth: CGFloat) {
+        guard traitCollection.horizontalSizeClass == .regular &&
+            traitCollection.verticalSizeClass == .regular else {
+            buttonViewLeadingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
+                buttonViewTrailingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
+                return
+        }
+
+        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
+            ButtonViewMarginMultipliers.ipadLandscape :
+            ButtonViewMarginMultipliers.ipadPortrait
+
+        let margin = viewWidth * marginMultiplier
+
+        buttonViewLeadingConstraint?.constant = margin
+        buttonViewTrailingConstraint?.constant = margin
+    }
+
+    private enum ButtonViewMarginMultipliers {
+        static let ipadPortrait: CGFloat = 0.1667
+        static let ipadLandscape: CGFloat = 0.25
+        static let defaultButtonViewMargin: CGFloat = 0.0
+    }
+
 }
 
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -18,6 +18,8 @@
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
                 <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
+                <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
+                <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -11,6 +11,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ULErrorViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="buttonViewLeadingConstraint" destination="r9Z-y5-j3W" id="bWb-vV-0U2"/>
+                <outlet property="buttonViewTrailingConstraint" destination="3Fe-tr-bmb" id="DjF-95-KFx"/>
                 <outlet property="errorMessage" destination="a2d-le-aKc" id="YgT-Ex-Gwh"/>
                 <outlet property="extraInfoButton" destination="GOR-hg-dbC" id="I7z-hN-FAo"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>


### PR DESCRIPTION
Closes #3224 

| | Before | After |
| ---- | ---- | ---- |
| iPhone | <img src="https://user-images.githubusercontent.com/2722505/101729428-18a71880-3af3-11eb-8991-0e933149d400.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101729435-1a70dc00-3af3-11eb-9f7e-9f9e4e20b84c.png" width="350"/> |
| iPad | <img src="https://user-images.githubusercontent.com/2722505/101729419-15ac2800-3af3-11eb-8e7b-dab0c6b28df9.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101729439-1ba20900-3af3-11eb-8fe0-7824f46378b0.png" width="350"/> |


This is not a great solution, but it is probably the best we can do without making large changes to WPAuthenticator.

The difficult solution is:
* We provide our very own View Controller (`ULErrorViewController`) to WordPressAuthenticator so that it can use it to render custom error messages.
* WordPressAuthenticator is applying a custom margin to all its unified views. However, the view controller we provide will not be applied those margins.

The ideal solution would be, in my opinion:
1. `ULErrorViewController` exposes a public method (i.e. setMargins)
2. WordPressAuthenticator, passes a float to that public method when inserting ULErrorViewController into its navigation stack

However, being able to accommodate that will require an intense rewriting of parts of WPAuthenticator. 

All that being said...

## Changes
* Set the margins of the two main views of ULErrorViewController, mimicking the logic in WPAuthenticator's LoginPrologueViewController

## How to test
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary
* Attempt to log in on an iPad. Trigger an error (by, for example, attempting to login with a Store Address and entering GitHub.com). Notice the margins.
* Attempt to log in on an iPhone. Trigger an error, and notice the margins (which should extend to use all the available width)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
