### PR TITLE
Customers fetching networking

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -245,6 +245,9 @@
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
+		AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E026F2580BA8E00EDB637 /* Customer.swift */; };
+		AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02732580C03400EDB637 /* CustomersListMapper.swift */; };
+		AE7AB5E8257FF2E5005E3E21 /* CustomerRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */; };
 		B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */; };
 		B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CE20BEE38B00BB1B69 /* Account.swift */; };
 		B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D020BEE39600BB1B69 /* AccountRemote.swift */; };
@@ -651,6 +654,9 @@
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		AE6E026F2580BA8E00EDB637 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		AE6E02732580C03400EDB637 /* CustomersListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapper.swift; sourceTree = "<group>"; };
+		AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRemote.swift; sourceTree = "<group>"; };
 		B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountMapper.swift; sourceTree = "<group>"; };
 		B505F6CE20BEE38B00BB1B69 /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		B505F6D020BEE39600BB1B69 /* AccountRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountRemote.swift; sourceTree = "<group>"; };
@@ -1091,6 +1097,7 @@
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
+				AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
@@ -1155,6 +1162,7 @@
 				B505F6CE20BEE38B00BB1B69 /* Account.swift */,
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
+				AE6E026F2580BA8E00EDB637 /* Customer.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -1325,6 +1333,7 @@
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
+				AE6E02732580C03400EDB637 /* CustomersListMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
@@ -1823,6 +1832,7 @@
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
+				AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
 				020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */,
@@ -1896,6 +1906,7 @@
 				02C254B0256378D000A04423 /* ShippingLabelRefundStatus.swift in Sources */,
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
+				AE7AB5E8257FF2E5005E3E21 /* CustomerRemote.swift in Sources */,
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,
 				02C254A4256371B200A04423 /* ShippingLabelSettings.swift in Sources */,
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
@@ -1989,6 +2000,7 @@
 				26B2F74324C545D50065CCC8 /* Leaderboard.swift in Sources */,
 				B59325C7217E22FC000B0E8E /* Note.swift in Sources */,
 				CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */,
+				AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */,
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
 				029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -248,6 +248,9 @@
 		AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E026F2580BA8E00EDB637 /* Customer.swift */; };
 		AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02732580C03400EDB637 /* CustomersListMapper.swift */; };
 		AE7AB5E8257FF2E5005E3E21 /* CustomerRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */; };
+		AE6E02782580C31A00EDB637 /* customers-all.json in Resources */ = {isa = PBXBuildFile; fileRef = AE6E02772580C31A00EDB637 /* customers-all.json */; };
+		AE6E027C2580C35C00EDB637 /* CustomerRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E027B2580C35C00EDB637 /* CustomerRemoteTests.swift */; };
+		AE6E02822580C89C00EDB637 /* CustomersListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02812580C89C00EDB637 /* CustomersListMapperTests.swift */; };
 		B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */; };
 		B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CE20BEE38B00BB1B69 /* Account.swift */; };
 		B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D020BEE39600BB1B69 /* AccountRemote.swift */; };
@@ -657,6 +660,9 @@
 		AE6E026F2580BA8E00EDB637 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		AE6E02732580C03400EDB637 /* CustomersListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapper.swift; sourceTree = "<group>"; };
 		AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRemote.swift; sourceTree = "<group>"; };
+		AE6E02772580C31A00EDB637 /* customers-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "customers-all.json"; sourceTree = "<group>"; };
+		AE6E027B2580C35C00EDB637 /* CustomerRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRemoteTests.swift; sourceTree = "<group>"; };
+		AE6E02812580C89C00EDB637 /* CustomersListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapperTests.swift; sourceTree = "<group>"; };
 		B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountMapper.swift; sourceTree = "<group>"; };
 		B505F6CE20BEE38B00BB1B69 /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		B505F6D020BEE39600BB1B69 /* AccountRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountRemote.swift; sourceTree = "<group>"; };
@@ -979,6 +985,7 @@
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
+				AE6E027B2580C35C00EDB637 /* CustomerRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
@@ -1222,6 +1229,7 @@
 				74C9477E2193A6C60024CB60 /* comment-moderate-trash.json */,
 				74C947812193A6C70024CB60 /* comment-moderate-unapproved.json */,
 				740211DE2193985A002248DA /* comment-moderate-spam.json */,
+				AE6E02772580C31A00EDB637 /* customers-all.json */,
 				B524194621AC643900D6FC0A /* device-settings.json */,
 				24F98C612502EFF600F49B68 /* feature-flags-load-all.json */,
 				268B68FA24C87384007EBF1D /* leaderboards-products.json */,
@@ -1442,6 +1450,7 @@
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
+				AE6E02812580C89C00EDB637 /* CustomersListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
@@ -1692,6 +1701,7 @@
 				74046E21217A73D0007DD7BF /* settings-general.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
+				AE6E02782580C31A00EDB637 /* customers-all.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
@@ -2015,6 +2025,7 @@
 			files = (
 				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
+				AE6E02822580C89C00EDB637 /* CustomersListMapperTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
@@ -2060,6 +2071,7 @@
 				74C8F06E20EEC1E800B6EDC9 /* OrderNotesMapperTests.swift in Sources */,
 				45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */,
 				020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */,
+				AE6E027C2580C35C00EDB637 /* CustomerRemoteTests.swift in Sources */,
 				74ABA1D5213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift in Sources */,
 				74AB5B5121AF426D00859C12 /* SiteAPIRemoteTests.swift in Sources */,
 				4599FC6624A633A10056157A /* ProductTagsRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
+		AE2D0E932582321C00B8EC48 /* CustomerRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D0E922582321B00B8EC48 /* CustomerRole.swift */; };
 		AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E026F2580BA8E00EDB637 /* Customer.swift */; };
 		AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02732580C03400EDB637 /* CustomersListMapper.swift */; };
 		AE7AB5E8257FF2E5005E3E21 /* CustomerRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */; };
@@ -657,6 +658,7 @@
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		AE2D0E922582321B00B8EC48 /* CustomerRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRole.swift; sourceTree = "<group>"; };
 		AE6E026F2580BA8E00EDB637 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		AE6E02732580C03400EDB637 /* CustomersListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapper.swift; sourceTree = "<group>"; };
 		AE7AB5E7257FF2E5005E3E21 /* CustomerRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRemote.swift; sourceTree = "<group>"; };
@@ -1170,6 +1172,7 @@
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
 				AE6E026F2580BA8E00EDB637 /* Customer.swift */,
+				AE2D0E922582321B00B8EC48 /* CustomerRole.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -2002,6 +2005,7 @@
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
 				B567AF2B20A0FA4200AB6C62 /* OrderListMapper.swift in Sources */,
+				AE2D0E932582321C00B8EC48 /* CustomerRole.swift in Sources */,
 				021A84DA257DF92800BC71D1 /* ShippingLabelRefundMapper.swift in Sources */,
 				02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */,
 				B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */,

--- a/Networking/Networking/Mapper/CustomersListMapper.swift
+++ b/Networking/Networking/Mapper/CustomersListMapper.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+
+/// Mapper: Customers List
+///
+struct CustomersListMapper: Mapper {
+
+    /// Site Identifier associated to the API information that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into [Customer].
+    ///
+    func map(response: Data) throws -> [Customer] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(CustomersListEnvelope.self, from: response).customers
+    }
+}
+
+
+/// CustomersListEnvelope Disposable Entity:
+/// `Load All Customers` endpoint returns the customers document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct CustomersListEnvelope: Decodable {
+    let customers: [Customer]
+
+    private enum CodingKeys: String, CodingKey {
+        case customers = "data"
+    }
+}

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Represent a Customer Entity.
+///
+public struct Customer: Decodable {
+
+    public let siteID: Int64
+    public let userID: Int64
+
+    public let dateCreated: Date    // gmt
+    public let dateModified: Date?  // gmt
+
+    public let email: String
+    public let username: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let gravatarUrl: String?
+
+    public let isPaying: Bool
+
+    public let billingAddress: Address?
+    public let shippingAddress: Address?
+
+
+    /// Struct initializer for Customer.
+    ///
+    public init(siteID: Int64,
+                userID: Int64,
+                dateCreated: Date,
+                dateModified: Date?,
+                email: String,
+                username: String?,
+                firstName: String?,
+                lastName: String?,
+                gravatarUrl: String?,
+                isPaying: Bool,
+                billingAddress: Address?,
+                shippingAddress: Address?) {
+        self.siteID = siteID
+        self.userID = userID
+
+        self.dateCreated = dateCreated
+        self.dateModified = dateModified
+
+        self.email = email
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.gravatarUrl = gravatarUrl
+
+        self.isPaying = isPaying
+
+        self.billingAddress = billingAddress
+        self.shippingAddress = shippingAddress
+    }
+
+    /// The public initializer for Customer.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw CustomerDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let userID = try container.decode(Int64.self, forKey: .userID)
+
+        let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
+        let dateModified = try container.decodeIfPresent(Date.self, forKey: .dateModified)
+
+        let email = try container.decode(String.self, forKey: .email)
+        let username = try container.decodeIfPresent(String.self, forKey: .username)
+        let firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
+        let lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
+        let gravatarUrl = try container.decodeIfPresent(String.self, forKey: .gravatarUrl)
+
+        let isPaying = try container.decode(Bool.self, forKey: .isPaying)
+
+        let billingAddress = try container.decodeIfPresent(Address.self, forKey: .billingAddress)
+        let shippingAddress = try container.decodeIfPresent(Address.self, forKey: .shippingAddress)
+
+        self.init(siteID: siteID,
+                  userID: userID,
+                  dateCreated: dateCreated,
+                  dateModified: dateModified,
+                  email: email,
+                  username: username,
+                  firstName: firstName,
+                  lastName: lastName,
+                  gravatarUrl: gravatarUrl,
+                  isPaying: isPaying,
+                  billingAddress: billingAddress,
+                  shippingAddress: shippingAddress)
+    }
+}
+
+// MARK: - Equatable Conformance
+//
+extension Customer: Equatable {
+
+    public static func == (lhs: Customer, rhs: Customer) -> Bool {
+        return lhs.siteID == rhs.siteID &&
+            lhs.userID == rhs.userID &&
+            lhs.dateCreated == rhs.dateCreated &&
+            lhs.dateModified == rhs.dateModified &&
+            lhs.email == rhs.email &&
+            lhs.username == rhs.username &&
+            lhs.firstName == rhs.firstName &&
+            lhs.lastName == rhs.lastName &&
+            lhs.gravatarUrl == rhs.gravatarUrl &&
+            lhs.isPaying == rhs.isPaying &&
+            lhs.billingAddress == rhs.billingAddress &&
+            lhs.shippingAddress == rhs.shippingAddress
+    }
+}
+
+/// Defines all of the Customer CodingKeys
+///
+private extension Customer {
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "id"
+
+        case dateCreated = "date_created_gmt"
+        case dateModified = "date_modified_gmt"
+
+        case email
+        case username
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case gravatarUrl = "avatar_url"
+        case isPaying = "is_paying_customer"
+
+        case billingAddress = "billing"
+        case shippingAddress = "shipping"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum CustomerDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -14,7 +14,7 @@ public struct Customer: Decodable, Equatable {
     public let username: String?
     public let firstName: String?
     public let lastName: String?
-    public let gravatarUrl: String?
+    public let avatarUrl: String?
 
     public let role: Role
     public let isPaying: Bool
@@ -33,7 +33,7 @@ public struct Customer: Decodable, Equatable {
                 username: String?,
                 firstName: String?,
                 lastName: String?,
-                gravatarUrl: String?,
+                avatarUrl: String?,
                 role: Role,
                 isPaying: Bool,
                 billingAddress: Address?,
@@ -48,7 +48,7 @@ public struct Customer: Decodable, Equatable {
         self.username = username
         self.firstName = firstName
         self.lastName = lastName
-        self.gravatarUrl = gravatarUrl
+        self.avatarUrl = avatarUrl
 
         self.role = role
         self.isPaying = isPaying
@@ -75,7 +75,7 @@ public struct Customer: Decodable, Equatable {
         let username = try container.decodeIfPresent(String.self, forKey: .username)
         let firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
         let lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
-        let gravatarUrl = try container.decodeIfPresent(String.self, forKey: .gravatarUrl)
+        let avatarUrl = try container.decodeIfPresent(String.self, forKey: .avatarUrl)
 
         let role = try container.decode(Role.self, forKey: .role)
         let isPaying = try container.decode(Bool.self, forKey: .isPaying)
@@ -91,7 +91,7 @@ public struct Customer: Decodable, Equatable {
                   username: username,
                   firstName: firstName,
                   lastName: lastName,
-                  gravatarUrl: gravatarUrl,
+                  avatarUrl: avatarUrl,
                   role: role,
                   isPaying: isPaying,
                   billingAddress: billingAddress,
@@ -113,7 +113,7 @@ private extension Customer {
         case username
         case firstName = "first_name"
         case lastName = "last_name"
-        case gravatarUrl = "avatar_url"
+        case avatarUrl = "avatar_url"
 
         case role
         case isPaying = "is_paying_customer"

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represent a Customer Entity.
 ///
-public struct Customer: Decodable {
+public struct Customer: Decodable, Equatable {
 
     public let siteID: Int64
     public let userID: Int64
@@ -96,27 +96,6 @@ public struct Customer: Decodable {
                   isPaying: isPaying,
                   billingAddress: billingAddress,
                   shippingAddress: shippingAddress)
-    }
-}
-
-// MARK: - Equatable Conformance
-//
-extension Customer: Equatable {
-
-    public static func == (lhs: Customer, rhs: Customer) -> Bool {
-        return lhs.siteID == rhs.siteID &&
-            lhs.userID == rhs.userID &&
-            lhs.dateCreated == rhs.dateCreated &&
-            lhs.dateModified == rhs.dateModified &&
-            lhs.email == rhs.email &&
-            lhs.username == rhs.username &&
-            lhs.firstName == rhs.firstName &&
-            lhs.lastName == rhs.lastName &&
-            lhs.gravatarUrl == rhs.gravatarUrl &&
-            lhs.role == rhs.role &&
-            lhs.isPaying == rhs.isPaying &&
-            lhs.billingAddress == rhs.billingAddress &&
-            lhs.shippingAddress == rhs.shippingAddress
     }
 }
 

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -16,6 +16,7 @@ public struct Customer: Decodable {
     public let lastName: String?
     public let gravatarUrl: String?
 
+    public let role: Role
     public let isPaying: Bool
 
     public let billingAddress: Address?
@@ -33,6 +34,7 @@ public struct Customer: Decodable {
                 firstName: String?,
                 lastName: String?,
                 gravatarUrl: String?,
+                role: Role,
                 isPaying: Bool,
                 billingAddress: Address?,
                 shippingAddress: Address?) {
@@ -48,6 +50,7 @@ public struct Customer: Decodable {
         self.lastName = lastName
         self.gravatarUrl = gravatarUrl
 
+        self.role = role
         self.isPaying = isPaying
 
         self.billingAddress = billingAddress
@@ -74,6 +77,7 @@ public struct Customer: Decodable {
         let lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
         let gravatarUrl = try container.decodeIfPresent(String.self, forKey: .gravatarUrl)
 
+        let role = try container.decode(Role.self, forKey: .role)
         let isPaying = try container.decode(Bool.self, forKey: .isPaying)
 
         let billingAddress = try container.decodeIfPresent(Address.self, forKey: .billingAddress)
@@ -88,6 +92,7 @@ public struct Customer: Decodable {
                   firstName: firstName,
                   lastName: lastName,
                   gravatarUrl: gravatarUrl,
+                  role: role,
                   isPaying: isPaying,
                   billingAddress: billingAddress,
                   shippingAddress: shippingAddress)
@@ -108,6 +113,7 @@ extension Customer: Equatable {
             lhs.firstName == rhs.firstName &&
             lhs.lastName == rhs.lastName &&
             lhs.gravatarUrl == rhs.gravatarUrl &&
+            lhs.role == rhs.role &&
             lhs.isPaying == rhs.isPaying &&
             lhs.billingAddress == rhs.billingAddress &&
             lhs.shippingAddress == rhs.shippingAddress
@@ -129,6 +135,8 @@ private extension Customer {
         case firstName = "first_name"
         case lastName = "last_name"
         case gravatarUrl = "avatar_url"
+
+        case role
         case isPaying = "is_paying_customer"
 
         case billingAddress = "billing"

--- a/Networking/Networking/Model/CustomerRole.swift
+++ b/Networking/Networking/Model/CustomerRole.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Represents a Customer.Role Entity.
+///
+extension Customer {
+    public enum Role: Decodable, Hashable {
+        case administrator
+        case editor
+        case author
+        case contributor
+        case subscriber
+        case customer
+        case shop_manager
+        case custom(String) // catch-all
+    }
+}
+
+/// RawRepresentable Conformance
+///
+extension Customer.Role: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.administrator:
+            self = .administrator
+        case Keys.editor:
+            self = .editor
+        case Keys.author:
+            self = .author
+        case Keys.contributor:
+            self = .contributor
+        case Keys.subscriber:
+            self = .subscriber
+        case Keys.customer:
+            self = .customer
+        case Keys.shop_manager:
+            self = .shop_manager
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .administrator: return Keys.administrator
+        case .editor: return Keys.editor
+        case .author: return Keys.author
+        case .contributor: return Keys.contributor
+        case .subscriber: return Keys.subscriber
+        case .customer: return Keys.customer
+        case .shop_manager: return Keys.shop_manager
+        case .custom(let payload): return payload
+        }
+    }
+}
+
+/// Enum containing the Customer.Role keys the app currently uses
+///
+private enum Keys {
+    static let administrator = "administrator"
+    static let editor        = "editor"
+    static let author        = "author"
+    static let contributor   = "contributor"
+    static let subscriber    = "subscriber"
+    static let customer      = "customer"
+    static let shop_manager  = "shop_manager"
+}

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Customer: Remote Endpoints
+///
+public class CustomerRemote: Remote {
+
+    /// Retrieves all of the customers available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote customers.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func getAllCustomers(for siteID: Int64,
+                                completion: @escaping (Result<[Customer], Error>) -> Void) {
+        let path = Path.customers
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path)
+        let mapper = CustomersListMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants
+//
+private extension CustomerRemote {
+
+    private enum Path {
+        static let customers = "customers"
+    }
+}

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -8,12 +8,25 @@ public class CustomerRemote: Remote {
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote customers.
+    ///     - context: view or edit. Scope under which the request is made;
+    ///                determines fields present in response. Default is view.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of Customers to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func getAllCustomers(for siteID: Int64,
+                                context: ContextType = Default.context,
+                                pageNumber: Int = Default.pageNumber,
+                                pageSize: Int = Default.pageSize,
                                 completion: @escaping (Result<[Customer], Error>) -> Void) {
+        let parameters = [
+            ParameterKey.context: context.rawValue,
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize)
+        ]
+
         let path = Path.customers
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = CustomersListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -22,9 +35,26 @@ public class CustomerRemote: Remote {
 
 // MARK: - Constants
 //
-private extension CustomerRemote {
+public extension CustomerRemote {
+
+    enum ContextType: String {
+        case view
+        case edit
+    }
+
+    enum Default {
+        public static let context: ContextType = .view
+        public static let pageSize: Int        = 25
+        public static let pageNumber: Int      = Remote.Default.firstPageNumber
+    }
 
     private enum Path {
         static let customers = "customers"
+    }
+
+    private enum ParameterKey {
+        static let context: String = "context"
+        static let page: String    = "page"
+        static let perPage: String = "per_page"
     }
 }

--- a/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
@@ -53,6 +53,7 @@ final class CustomersListMapperTests: XCTestCase {
                                firstName: "John",
                                lastName: "Doe",
                                gravatarUrl: "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+                               role: .customer,
                                isPaying: false,
                                billingAddress: billingAddress,
                                shippingAddress: shippingAddress)

--- a/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Networking
+
+/// CustomersListMapper Unit Tests
+///
+final class CustomersListMapperTests: XCTestCase {
+    /// Site ID for testing.
+    private let sampleSiteID: Int64 = 1234
+
+    func test_customers_list_is_properly_parsed() throws {
+        // Given
+        let jsonData = try XCTUnwrap(Loader.contentsOf("customers-all"))
+
+        // When
+        let response = try CustomersListMapper(siteID: sampleSiteID).map(response: jsonData)
+
+        // Then
+        XCTAssertEqual(response.count, 2)
+
+        let billingAddress = Address(firstName: "John",
+                                     lastName: "Doe",
+                                     company: "",
+                                     address1: "969 Market",
+                                     address2: "",
+                                     city: "San Francisco",
+                                     state: "CA",
+                                     postcode: "94103",
+                                     country: "US",
+                                     phone: "(555) 555-5555",
+                                     email: "john.doe@example.com")
+
+        let shippingAddress = Address(firstName: "John",
+                                      lastName: "Doe",
+                                      company: "",
+                                      address1: "969 Market",
+                                      address2: "",
+                                      city: "San Francisco",
+                                      state: "CA",
+                                      postcode: "94103",
+                                      country: "US",
+                                      phone: nil,
+                                      email: nil)
+
+        let johnDoeID: Int64 = 25
+        let dateCreated = try XCTUnwrap(DateFormatter.Defaults.dateTimeFormatter.date(from: "2017-03-21T19:09:28"))
+        let dateModified = try XCTUnwrap(DateFormatter.Defaults.dateTimeFormatter.date(from: "2017-03-21T19:09:30"))
+        let johnDoe = Customer(siteID: sampleSiteID,
+                               userID: johnDoeID,
+                               dateCreated: dateCreated,
+                               dateModified: dateModified,
+                               email: "john.doe@example.com",
+                               username: "john.doe",
+                               firstName: "John",
+                               lastName: "Doe",
+                               gravatarUrl: "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+                               isPaying: false,
+                               billingAddress: billingAddress,
+                               shippingAddress: shippingAddress)
+
+        guard let expectedCustomer = response.first(where: { $0.userID == johnDoeID }) else {
+            XCTFail("Customer with id \(johnDoeID) should exist")
+            return
+        }
+        XCTAssertEqual(expectedCustomer, johnDoe)
+    }
+}

--- a/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomersListMapperTests.swift
@@ -52,7 +52,7 @@ final class CustomersListMapperTests: XCTestCase {
                                username: "john.doe",
                                firstName: "John",
                                lastName: "Doe",
-                               gravatarUrl: "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+                               avatarUrl: "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
                                role: .customer,
                                isPaying: false,
                                billingAddress: billingAddress,

--- a/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import TestKit
+@testable import Networking
+
+/// CustomerRemote Unit Tests
+///
+final class CustomerRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    let network = MockNetwork()
+
+    /// Dummy Site ID
+    let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    func test_getAllCustomers_returns_parsed_customers() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "customers-all")
+
+        // When
+        let result = try waitFor { promise in
+            remote.getAllCustomers(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response.count, 2)
+
+        let expectedId: Int64 = 25
+        guard let expectedCustomer = response.first(where: { $0.userID == expectedId }) else {
+            XCTFail("Customer with id \(expectedId) should exist")
+            return
+        }
+        XCTAssertEqual(expectedCustomer.siteID, self.sampleSiteID)
+        XCTAssertEqual(expectedCustomer.username, "john.doe")
+    }
+}

--- a/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
@@ -41,4 +41,19 @@ final class CustomerRemoteTests: XCTestCase {
         XCTAssertEqual(expectedCustomer.siteID, self.sampleSiteID)
         XCTAssertEqual(expectedCustomer.username, "john.doe")
     }
+
+    func test_getAllCustomers_relays_networking_error() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+
+        // When
+        let result = try waitFor { promise in
+            remote.getAllCustomers(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
 }

--- a/Networking/NetworkingTests/Responses/customers-all.json
+++ b/Networking/NetworkingTests/Responses/customers-all.json
@@ -1,0 +1,106 @@
+{
+    "data": [
+        {
+            "id": 26,
+            "date_created": "2017-03-21T16:11:14",
+            "date_created_gmt": "2017-03-21T19:11:14",
+            "date_modified": "2017-03-21T16:11:16",
+            "date_modified_gmt": "2017-03-21T19:11:16",
+            "email": "joao.silva@example.com",
+            "first_name": "João",
+            "last_name": "Silva",
+            "role": "customer",
+            "username": "joao.silva",
+            "billing": {
+                "first_name": "João",
+                "last_name": "Silva",
+                "company": "",
+                "address_1": "Av. Brasil, 432",
+                "address_2": "",
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "postcode": "12345-000",
+                "country": "BR",
+                "email": "joao.silva@example.com",
+                "phone": "(55) 5555-5555"
+            },
+            "shipping": {
+                "first_name": "João",
+                "last_name": "Silva",
+                "company": "",
+                "address_1": "Av. Brasil, 432",
+                "address_2": "",
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "postcode": "12345-000",
+                "country": "BR"
+            },
+            "is_paying_customer": false,
+            "avatar_url": "https://secure.gravatar.com/avatar/be7b5febff88a2d947c3289e90cdf017?s=96",
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/customers/26"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/customers"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 25,
+            "date_created": "2017-03-21T16:09:28",
+            "date_created_gmt": "2017-03-21T19:09:28",
+            "date_modified": "2017-03-21T16:09:30",
+            "date_modified_gmt": "2017-03-21T19:09:30",
+            "email": "john.doe@example.com",
+            "first_name": "John",
+            "last_name": "Doe",
+            "role": "customer",
+            "username": "john.doe",
+            "billing": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "company": "",
+                "address_1": "969 Market",
+                "address_2": "",
+                "city": "San Francisco",
+                "state": "CA",
+                "postcode": "94103",
+                "country": "US",
+                "email": "john.doe@example.com",
+                "phone": "(555) 555-5555"
+            },
+            "shipping": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "company": "",
+                "address_1": "969 Market",
+                "address_2": "",
+                "city": "San Francisco",
+                "state": "CA",
+                "postcode": "94103",
+                "country": "US"
+            },
+            "is_paying_customer": false,
+            "avatar_url": "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/customers/25"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/customers"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Part of #3241.

### Changes

This PR adds
- `Customer` entity
- `Customer.Role` nested enum case (with custom values handling)
- `CustomersListMapper` to decode array of customers (+ tests)
- `CustomerRemote` to request network (+ tests)

Sorry for >500 lines of changes, but it's mostly lightweight - including test cases and test JSON.

### Testing

Just check the code. No actions exposed to UI yet.

### Questions

1. `siteID` added because I see it injected in many other entities. Is it correct decision?