### PR TITLE
Change title: Get started to Log In

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -49,4 +49,11 @@ struct AuthenticationConstants {
         "Enter Your Store Address",
         comment: "Button title. Takes the user to the login by store address flow."
     )
+
+    /// Title of views in Unified Login
+    //
+    static let loginTitle = NSLocalizedString(
+        "Log In",
+        comment: "View title during the log in process."
+    )
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -77,7 +77,8 @@ class AuthenticationManager: Authentication {
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
                                                                   continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtonTitle,
-                                                                  enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle)
+                                                                  enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle,
+                                                                  getStartedTitle: AuthenticationConstants.loginTitle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,


### PR DESCRIPTION
Closes #3324 

| Before  | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101827375-387a2300-3b6b-11eb-8fae-3ec6d2359372.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101827368-34e69c00-3b6b-11eb-90dd-f9e1a0d6207a.png" width="350"/> |

## Changes
* Declare a new string constant and pass it to WPAuthenticator

## How to test
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary. Log in with WordPress.com account. Notice the title of the first view controller

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
