### PR TITLE
Override "find your site address" button

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -49,4 +49,11 @@ struct AuthenticationConstants {
         "Enter Your Store Address",
         comment: "Button title. Takes the user to the login by store address flow."
     )
+
+    /// Title of "Find your store address" button in Unified Login flow
+    //
+    static let findYourStoreAddressButtonTitle = NSLocalizedString(
+        "Find your store address",
+        comment: "The hint button's title text to help users find their store address."
+    )
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -77,7 +77,8 @@ class AuthenticationManager: Authentication {
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
                                                                   continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtonTitle,
-                                                                  enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle)
+                                                                  enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle,
+                                                                  findSiteButtonTitle: AuthenticationConstants.findYourStoreAddressButtonTitle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,


### PR DESCRIPTION
Closes #3323 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/101828431-817ea700-3b6c-11eb-9c57-59c68c029fd8.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/101828422-7f1c4d00-3b6c-11eb-8812-0f26aa930af3.png" width="350"/> |

## Changes
* Declare a new string constant and provide it to WPAuthenticator

## How to test
* Checkout the branch, run `bundle exec pod install`
* Log out if necessary. Log in with Store Address. Notice the button title.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
