### PR TITLE
SearchViewController: "fix" agains crashes by using safeObject in didSelectRow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -179,7 +179,9 @@ where Cell.SearchModel == Command.CellViewModel {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let model = resultsController.object(at: indexPath)
+        guard let model = resultsController.safeObject(at: indexPath) else {
+            return
+        }
         searchUICommand.didSelectSearchResult(model: model, from: self, reloadData: { [weak self] in
             self?.tableView.reloadData()
         }, updateActionButton: { [weak self] in


### PR DESCRIPTION
### What

This PR is implementing a solution from #2610 to guard against an "index out of bounds" crash by using `safeObject` method of ResultsController.

Closes #2610 

### Test

1. Open Orders tab
2. Open Search

- [ ] It is possible to search for orders
- [ ] It is possible to open orders from the search

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
