### PR TITLE
🚨 Fix the build

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -997,6 +997,9 @@
 		D8CD710F237A49DB007148B9 /* UIColor+SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CD710E237A49DB007148B9 /* UIColor+SemanticColors.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
+		D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
+		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
+		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
@@ -2077,6 +2080,9 @@
 		D8CD710E237A49DB007148B9 /* UIColor+SemanticColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SemanticColors.swift"; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		D8F3A972258862BE0085859B /* PrologueScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrologueScreen.swift; sourceTree = "<group>"; };
+		D8F3A9782588659E0085859B /* GetStartedScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStartedScreen.swift; sourceTree = "<group>"; };
+		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
@@ -5000,6 +5006,9 @@
 				F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */,
 				F997171923DBCD6000592D8E /* LoginUsernamePasswordScreen.swift */,
 				F997172023DBCD6100592D8E /* WelcomeScreen.swift */,
+				D8F3A972258862BE0085859B /* PrologueScreen.swift */,
+				D8F3A9782588659E0085859B /* GetStartedScreen.swift */,
+				D8F3A97E258865BD0085859B /* PasswordScreen.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -6365,15 +6374,18 @@
 				CCDC49E22400011F003166BA /* LoginEmailScreen.swift in Sources */,
 				CCDC49E32400011F003166BA /* LoginEpilogueScreen.swift in Sources */,
 				CCDC49E42400011F003166BA /* LoginPasswordScreen.swift in Sources */,
+				D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */,
 				CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */,
 				CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */,
 				CCDC49E72400011F003166BA /* WelcomeScreen.swift in Sources */,
+				D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */,
 				CCDC49E92400011F003166BA /* BaseScreen.swift in Sources */,
 				CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */,
 				CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */,
 				CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */,
 				CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */,
 				CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */,
+				D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let navBar = "WordPress.GetStartedView"
+    static let emailTextField = "Email address"
+    static let continueButton = "Get Started Email Continue Button"
+}
+
+class GetStartedScreen: BaseScreen {
+    let navBar: XCUIElement
+    let emailTextField: XCUIElement
+    let continueButton: XCUIElement
+
+    init() {
+        let app = XCUIApplication()
+        navBar = app.navigationBars[ElementStringIDs.navBar]
+        emailTextField = app.textFields[ElementStringIDs.emailTextField]
+        continueButton = app.buttons[ElementStringIDs.continueButton]
+
+        super.init(element: emailTextField)
+    }
+
+    func proceedWith(email: String) -> PasswordScreen {
+        emailTextField.tap()
+        emailTextField.typeText(email)
+        continueButton.tap()
+
+        return PasswordScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+
+    static func isEmailEntered() -> Bool {
+        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
+        return emailTextField.value != nil
+    }
+
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
@@ -7,10 +7,10 @@ private struct ElementStringIDs {
     static let continueButton = "Get Started Email Continue Button"
 }
 
-class GetStartedScreen: BaseScreen {
-    let navBar: XCUIElement
-    let emailTextField: XCUIElement
-    let continueButton: XCUIElement
+final class GetStartedScreen: BaseScreen {
+    private let navBar: XCUIElement
+    private let emailTextField: XCUIElement
+    private let continueButton: XCUIElement
 
     init() {
         let app = XCUIApplication()

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -29,21 +29,21 @@ class LoginSiteAddressScreen: BaseScreen {
         super.init(element: siteAddressTextField)
     }
 
-//    func proceedWith(siteUrl: String) -> LoginUsernamePasswordScreen {
-//        siteAddressTextField.tap()
-//        siteAddressTextField.typeText(siteUrl)
-//        nextButton.tap()
-//
-//        return LoginUsernamePasswordScreen()
-//    }
-
-    func proceedWithWP(siteUrl: String) -> GetStartedScreen {
+    func proceedWith(siteUrl: String) -> LoginUsernamePasswordScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
         nextButton.tap()
 
-        return GetStartedScreen()
+        return LoginUsernamePasswordScreen()
     }
+
+//    func proceedWithWP(siteUrl: String) -> GetStartedScreen {
+//        siteAddressTextField.tap()
+//        siteAddressTextField.typeText(siteUrl)
+//        nextButton.tap()
+//
+//        return GetStartedScreen()
+//    }
 
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.nextButton].exists

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -15,10 +15,10 @@ private struct ElementStringIDs {
     static let siteAddressTextField = "Site address"
 }
 
-class LoginSiteAddressScreen: BaseScreen {
-    let navBar: XCUIElement
-    let siteAddressTextField: XCUIElement
-    let nextButton: XCUIElement
+final class LoginSiteAddressScreen: BaseScreen {
+    private let navBar: XCUIElement
+    private let siteAddressTextField: XCUIElement
+    private let nextButton: XCUIElement
 
     init() {
         let app = XCUIApplication()

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -37,14 +37,6 @@ class LoginSiteAddressScreen: BaseScreen {
         return LoginUsernamePasswordScreen()
     }
 
-//    func proceedWithWP(siteUrl: String) -> GetStartedScreen {
-//        siteAddressTextField.tap()
-//        siteAddressTextField.typeText(siteUrl)
-//        nextButton.tap()
-//
-//        return GetStartedScreen()
-//    }
-
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
     }

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -3,14 +3,22 @@ import XCTest
 
 private struct ElementStringIDs {
     static let navBar = "WordPressAuthenticator.LoginSiteAddressView"
-    static let siteAddressTextField = "usernameField"
     static let nextButton = "Site Address Next Button"
+
+    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
+
+    // For original Site Address. This matches accessibilityIdentifier in Login.storyboard.
+    // Leaving here for now in case unifiedSiteAddress is disabled.
+    // static let siteAddressTextField = "usernameField"
+
+    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
+    static let siteAddressTextField = "Site address"
 }
 
-final class LoginSiteAddressScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let siteAddressTextField: XCUIElement
-    private let nextButton: XCUIElement
+class LoginSiteAddressScreen: BaseScreen {
+    let navBar: XCUIElement
+    let siteAddressTextField: XCUIElement
+    let nextButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
@@ -21,12 +29,20 @@ final class LoginSiteAddressScreen: BaseScreen {
         super.init(element: siteAddressTextField)
     }
 
-    func proceedWith(siteUrl: String) -> LoginUsernamePasswordScreen {
+//    func proceedWith(siteUrl: String) -> LoginUsernamePasswordScreen {
+//        siteAddressTextField.tap()
+//        siteAddressTextField.typeText(siteUrl)
+//        nextButton.tap()
+//
+//        return LoginUsernamePasswordScreen()
+//    }
+
+    func proceedWithWP(siteUrl: String) -> GetStartedScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
         nextButton.tap()
 
-        return LoginUsernamePasswordScreen()
+        return GetStartedScreen()
     }
 
     static func isLoaded() -> Bool {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
@@ -8,10 +8,10 @@ private struct ElementStringIDs {
     static let errorLabel = "Password Error"
 }
 
-class PasswordScreen: BaseScreen {
-    let navBar: XCUIElement
-    let passwordTextField: XCUIElement
-    let continueButton: XCUIElement
+final class PasswordScreen: BaseScreen {
+    private let navBar: XCUIElement
+    private let passwordTextField: XCUIElement
+    private let continueButton: XCUIElement
 
     init() {
         let app = XCUIApplication()

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let navBar = "WordPress.PasswordView"
+    static let passwordTextField = "Password"
+    static let continueButton = "Continue Button"
+    static let errorLabel = "Password Error"
+}
+
+class PasswordScreen: BaseScreen {
+    let navBar: XCUIElement
+    let passwordTextField: XCUIElement
+    let continueButton: XCUIElement
+
+    init() {
+        let app = XCUIApplication()
+        navBar = app.navigationBars[ElementStringIDs.navBar]
+        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
+        continueButton = app.buttons[ElementStringIDs.continueButton]
+
+        super.init(element: passwordTextField)
+    }
+
+    func proceedWith(password: String) -> LoginEpilogueScreen {
+        _ = tryProceed(password: password)
+
+        return LoginEpilogueScreen()
+    }
+
+    func tryProceed(password: String) -> PasswordScreen {
+        passwordTextField.tap()
+        passwordTextField.typeText(password)
+        continueButton.tap()
+        if continueButton.exists && !continueButton.isHittable {
+            waitFor(element: continueButton, predicate: "isEnabled == true")
+        }
+        return self
+    }
+
+    func verifyLoginError() -> PasswordScreen {
+        let errorLabel = app.cells[ElementStringIDs.errorLabel]
+        _ = errorLabel.waitForExistence(timeout: 2)
+
+        XCTAssertTrue(errorLabel.exists)
+        return self
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let continueButton = "Prologue Continue Button"
+    static let siteAddressButton = "Prologue Self Hosted Button"
+}
+
+class PrologueScreen: BaseScreen {
+    let continueButton: XCUIElement
+    let siteAddressButton: XCUIElement
+
+    init() {
+        continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]
+        siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
+
+        super.init(element: continueButton)
+    }
+
+//    func selectContinue() -> GetStartedScreen {
+//        continueButton.tap()
+//
+//        return GetStartedScreen()
+//    }
+
+    func selectSiteAddress() -> LoginSiteAddressScreen {
+        siteAddressButton.tap()
+
+        return LoginSiteAddressScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -17,11 +17,11 @@ class PrologueScreen: BaseScreen {
         super.init(element: continueButton)
     }
 
-//    func selectContinue() -> GetStartedScreen {
-//        continueButton.tap()
-//
-//        return GetStartedScreen()
-//    }
+    func selectContinue() -> GetStartedScreen {
+        continueButton.tap()
+
+        return GetStartedScreen()
+    }
 
     func selectSiteAddress() -> LoginSiteAddressScreen {
         siteAddressButton.tap()

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -6,9 +6,9 @@ private struct ElementStringIDs {
     static let siteAddressButton = "Prologue Self Hosted Button"
 }
 
-class PrologueScreen: BaseScreen {
-    let continueButton: XCUIElement
-    let siteAddressButton: XCUIElement
+final class PrologueScreen: BaseScreen {
+    private let continueButton: XCUIElement
+    private let siteAddressButton: XCUIElement
 
     init() {
         continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -27,7 +27,7 @@ final class SettingsScreen: BaseScreen {
     }
 
     @discardableResult
-    func logOut() -> WelcomeScreen {
+    func logOut() -> PrologueScreen {
         logOutButton.tap()
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
@@ -39,7 +39,7 @@ final class SettingsScreen: BaseScreen {
             logOutAlert.buttons.element(boundBy: 1).tap()
         }
 
-        return WelcomeScreen()
+        return PrologueScreen()
     }
 }
 

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -53,6 +53,22 @@ class LoginTests: XCTestCase {
 //        XCTAssert(WelcomeScreen.isLoaded())
 //    }
 
+    func testEmailPasswordLoginLogout() {
+        let prologue = PrologueScreen().selectSiteAddress()
+            .proceedWith(siteUrl: TestCredentials.siteUrl)
+            .proceedWith(username: TestCredentials.emailAddress, password: TestCredentials.password)
+            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+            .continueWithSelectedSite()
+
+            // Log out
+            .openSettingsPane()
+            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+            .logOut()
+
+        XCTAssert(prologue.isLoaded())
+    }
+
+    /**
     // Unified WordPress.com login/out
     // Replaces testWpcomUsernamePasswordLogin
     func testWpcomLogin() {
@@ -66,6 +82,22 @@ class LoginTests: XCTestCase {
             //.dismissNotificationAlertIfNeeded()
 
         //XCTAssert(MySiteScreen().isLoaded())
+
+            // Log out
+            .openSettingsPane()
+            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+            .logOut()
+
+        XCTAssert(prologue.isLoaded())
+    }
+    */
+
+    func testWPComLoginLogout() {
+        let prologue = PrologueScreen().selectContinue()
+            .proceedWith(email: TestCredentials.emailAddress)
+            .proceedWith(password: TestCredentials.password)
+            .continueWithSelectedSite()
+            //.dismissNotificationAlertIfNeeded()
 
             // Log out
             .openSettingsPane()

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -11,23 +11,67 @@ class LoginTests: XCTestCase {
         app.launch()
     }
 
-    func testEmailPasswordLoginLogout() {
-        // Log in with email and password
-        WelcomeScreen()
-        .selectLogin()
-        .proceedWith(email: TestCredentials.emailAddress)
-        .proceedWithPassword()
-        .proceedWith(password: TestCredentials.password)
+//    func testEmailPasswordLoginLogout() {
+//        // Log in with email and password
+//        WelcomeScreen()
+//        .selectLogin()
+//        .proceedWith(email: TestCredentials.emailAddress)
+//        .proceedWithPassword()
+//        .proceedWith(password: TestCredentials.password)
+//
+//        // Login epilogue
+//        .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+//        .continueWithSelectedSite()
+//
+//        // Log out
+//        .openSettingsPane()
+//        .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+//        .logOut()
+//
+//        XCTAssert(WelcomeScreen.isLoaded())
+//    }
 
-        // Login epilogue
-        .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-        .continueWithSelectedSite()
 
-        // Log out
-        .openSettingsPane()
-        .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
-        .logOut()
+    //Modified
+//    func testEmailPasswordLoginLogout() {
+//        // Log in with email and password
+//        PrologueScreen()
+//        .selectLogin()
+//        .proceedWith(email: TestCredentials.emailAddress)
+//        .proceedWithPassword()
+//        .proceedWith(password: TestCredentials.password)
+//
+//        // Login epilogue
+//        .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+//        .continueWithSelectedSite()
+//
+//        // Log out
+//        .openSettingsPane()
+//        .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+//        .logOut()
+//
+//        XCTAssert(WelcomeScreen.isLoaded())
+//    }
 
-        XCTAssert(WelcomeScreen.isLoaded())
+    // Unified WordPress.com login/out
+    // Replaces testWpcomUsernamePasswordLogin
+    func testWpcomLogin() {
+        let prologue = PrologueScreen().selectSiteAddress()
+            .proceedWithWP(siteUrl: TestCredentials.siteUrl)
+            //.proceedWith(username: TestCredentials.emailAddress, password: TestCredentials.password)
+            .proceedWith(email: TestCredentials.emailAddress)
+            .proceedWith(password: TestCredentials.password)
+            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+            .continueWithSelectedSite()
+            //.dismissNotificationAlertIfNeeded()
+
+        //XCTAssert(MySiteScreen().isLoaded())
+
+            // Log out
+            .openSettingsPane()
+            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+            .logOut()
+
+        XCTAssert(prologue.isLoaded())
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-class LoginTests: XCTestCase {
+final class LoginTests: XCTestCase {
 
     override func setUp() {
         continueAfterFailure = false

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -11,93 +11,12 @@ class LoginTests: XCTestCase {
         app.launch()
     }
 
-//    func testEmailPasswordLoginLogout() {
-//        // Log in with email and password
-//        WelcomeScreen()
-//        .selectLogin()
-//        .proceedWith(email: TestCredentials.emailAddress)
-//        .proceedWithPassword()
-//        .proceedWith(password: TestCredentials.password)
-//
-//        // Login epilogue
-//        .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-//        .continueWithSelectedSite()
-//
-//        // Log out
-//        .openSettingsPane()
-//        .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
-//        .logOut()
-//
-//        XCTAssert(WelcomeScreen.isLoaded())
-//    }
-
-
-    //Modified
-//    func testEmailPasswordLoginLogout() {
-//        // Log in with email and password
-//        PrologueScreen()
-//        .selectLogin()
-//        .proceedWith(email: TestCredentials.emailAddress)
-//        .proceedWithPassword()
-//        .proceedWith(password: TestCredentials.password)
-//
-//        // Login epilogue
-//        .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-//        .continueWithSelectedSite()
-//
-//        // Log out
-//        .openSettingsPane()
-//        .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
-//        .logOut()
-//
-//        XCTAssert(WelcomeScreen.isLoaded())
-//    }
-
-    func testEmailPasswordLoginLogout() {
-        let prologue = PrologueScreen().selectSiteAddress()
-            .proceedWith(siteUrl: TestCredentials.siteUrl)
-            .proceedWith(username: TestCredentials.emailAddress, password: TestCredentials.password)
-            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-            .continueWithSelectedSite()
-
-            // Log out
-            .openSettingsPane()
-            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
-            .logOut()
-
-        XCTAssert(prologue.isLoaded())
-    }
-
-    /**
-    // Unified WordPress.com login/out
-    // Replaces testWpcomUsernamePasswordLogin
-    func testWpcomLogin() {
-        let prologue = PrologueScreen().selectSiteAddress()
-            .proceedWithWP(siteUrl: TestCredentials.siteUrl)
-            //.proceedWith(username: TestCredentials.emailAddress, password: TestCredentials.password)
-            .proceedWith(email: TestCredentials.emailAddress)
-            .proceedWith(password: TestCredentials.password)
-            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-            .continueWithSelectedSite()
-            //.dismissNotificationAlertIfNeeded()
-
-        //XCTAssert(MySiteScreen().isLoaded())
-
-            // Log out
-            .openSettingsPane()
-            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
-            .logOut()
-
-        XCTAssert(prologue.isLoaded())
-    }
-    */
-
-    func testWPComLoginLogout() {
+    func testWordPressLoginLogout() {
         let prologue = PrologueScreen().selectContinue()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
+            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
-            //.dismissNotificationAlertIfNeeded()
 
             // Log out
             .openSettingsPane()


### PR DESCRIPTION
Merging UL&S (PR #3332) breaks the build because the UI tests do not pass anymore.

This PR is just a quick fix to pass the build. It removes the UI test covering the login flow that does not work anymore (because the login flow has changed and that's what the UI tests are for) and adds one single test that covers the happy case when logging in with a WordPress.com account.

I have logged #3347 to add more UI tests to cover all the possible flows. I would love to tackle those new tests because I do't have any experience with UI testing, so this would be a great learning opportunity for me.

## Changes
* Remove the failing test, add a single test that should pass

## How to test
Locally:
* checkout the branch
* run `rake mocks`. It there is an error about a jdk missing, run `brew install openjdk`
* Run the test in LoginTests.swift (I have run them on the iPhone 11 simulator with the hardware keyboard attached)

cc @jkmassel @rachelmcr 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
