### PR TITLE
Order Details: filter deleted refunds and update refund list order

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
+		A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */; };
 		B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */; };
 		B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CE20BEE38B00BB1B69 /* Account.swift */; };
 		B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D020BEE39600BB1B69 /* AccountRemote.swift */; };
@@ -651,6 +652,7 @@
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-deleted-refunds.json"; sourceTree = "<group>"; };
 		B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountMapper.swift; sourceTree = "<group>"; };
 		B505F6CE20BEE38B00BB1B69 /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		B505F6D020BEE39600BB1B69 /* AccountRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountRemote.swift; sourceTree = "<group>"; };
@@ -1246,6 +1248,7 @@
 				CE19CB10222486A500E8AF7A /* order-statuses.json */,
 				0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */,
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
+				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
@@ -1710,6 +1713,7 @@
 				74ABA1C5213F17AA00FFAD30 /* top-performers-day.json in Resources */,
 				26B2F74724C55A6E0065CCC8 /* leaderboards-year.json in Resources */,
 				2683D71024456EE4002A1589 /* categories-extra.json in Resources */,
+				A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */,
 				453305F52459ED2700264E50 /* site-post-update.json in Resources */,
 				CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */,
 				02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */,

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -139,7 +139,10 @@ public struct Order: Decodable, GeneratedCopiable {
         let coupons = try container.decode([OrderCouponLine].self, forKey: .couponLines)
 
         // The refunds field will not always exist in the response, so let's default to an empty array.
-        let refunds = try container.decodeIfPresent([OrderRefundCondensed].self, forKey: .refunds) ?? []
+        var refunds = try container.decodeIfPresent([OrderRefundCondensed].self, forKey: .refunds) ?? []
+
+        // Filter out refunds with ID equal to 0 (deleted).
+        refunds = refunds.filter({ $0.refundID != 0 })
 
         self.init(siteID: siteID,
                   orderID: orderID,

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -199,16 +199,14 @@ final class OrderMapperTests: XCTestCase {
 
     /// Verifies that an Order ignores deleted refunds.
     ///
-    func test_Order_deleted_refund_fields_are_ignored() {
-        guard let order = mapLoadOrderWithDeletedRefundsResponse() else {
-            XCTFail()
-            return
-        }
+    func test_Order_deleted_refund_fields_are_ignored() throws {
+        // When
+        let order = try XCTUnwrap(mapLoadOrderWithDeletedRefundsResponse())
 
-        let refunds = order.refunds
-        XCTAssertEqual(refunds.count, 1)
+        // Then
+        XCTAssertEqual(order.refunds.count, 1)
 
-        let refund = refunds[0]
+        let refund = try XCTUnwrap(order.refunds.first)
         XCTAssertEqual(refund.refundID, 73)
         XCTAssertEqual(refund.reason, "Cap!")
         XCTAssertEqual(refund.total, "-16.00")

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -197,6 +197,23 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(partialRefund2.total, "-8.10")
     }
 
+    /// Verifies that an Order ignores deleted refunds.
+    ///
+    func test_Order_deleted_refund_fields_are_ignored() {
+        guard let order = mapLoadOrderWithDeletedRefundsResponse() else {
+            XCTFail()
+            return
+        }
+
+        let refunds = order.refunds
+        XCTAssertEqual(refunds.count, 1)
+
+        let refund = refunds[0]
+        XCTAssertEqual(refund.refundID, 73)
+        XCTAssertEqual(refund.reason, "Cap!")
+        XCTAssertEqual(refund.total, "-16.00")
+    }
+
     func test_taxes_are_parsed_correctly() throws {
         // When
         let order = try XCTUnwrap(mapLoadOrderResponse())
@@ -291,4 +308,11 @@ private extension OrderMapperTests {
     func mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse() -> Order? {
         return mapOrder(from: "order-with-line-item-attributes-before-API-support")
     }
+
+    /// Returns the OrderMapper output upon receiving `order-with-deleted-refunds`
+    ///
+    func mapLoadOrderWithDeletedRefundsResponse() -> Order? {
+        return mapOrder(from: "order-with-deleted-refunds")
+    }
+
 }

--- a/Networking/NetworkingTests/Responses/order-with-deleted-refunds.json
+++ b/Networking/NetworkingTests/Responses/order-with-deleted-refunds.json
@@ -1,0 +1,152 @@
+{
+    "data": {
+        "id": 3207,
+        "parent_id": 0,
+        "number": "3207",
+        "order_key": "",
+        "created_via": "checkout",
+        "version": "4.7.0",
+        "status": "processing",
+        "currency": "USD",
+        "date_created": "2020-10-28T13:23:18",
+        "date_created_gmt": "2020-10-28T05:23:18",
+        "date_modified": "2020-10-28T13:23:21",
+        "date_modified_gmt": "2020-10-28T05:23:21",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "7.90",
+        "shipping_tax": "0.67",
+        "cart_tax": "11.35",
+        "total": "153.42",
+        "total_tax": "12.02",
+        "prices_include_tax": false,
+        "customer_id": 0,
+        "customer_note": "",
+        "billing": {
+            "first_name": "",
+            "last_name": "",
+            "company": "",
+            "address_1": "",
+            "address_2": "",
+            "city": "",
+            "state": "",
+            "postcode": "",
+            "country": "",
+            "email": "",
+            "phone": ""
+        },
+        "shipping": {
+            "first_name": "",
+            "last_name": "",
+            "company": "",
+            "address_1": "",
+            "address_2": "",
+            "city": "",
+            "state": "",
+            "postcode": "",
+            "country": ""
+        },
+        "payment_method": "stripe",
+        "payment_method_title": "Credit Card (Stripe)",
+        "transaction_id": "",
+        "date_paid": "2020-10-28T13:23:21",
+        "date_paid_gmt": "2020-10-28T05:23:21",
+        "date_completed": null,
+        "date_completed_gmt": null,
+        "cart_hash": "",
+        "meta_data": [],
+        "line_items": [
+            {
+                "id": 762,
+                "name": "&lt;Variable&gt; Fun Pens! - Orange, Mitsubishi",
+                "product_id": 2832,
+                "variation_id": 2906,
+                "quantity": 1,
+                "tax_class": "",
+                "subtotal": "88.00",
+                "subtotal_tax": "7.48",
+                "total": "88.00",
+                "total_tax": "7.48",
+                "taxes": [
+                    {
+                        "id": 1,
+                        "total": "7.48",
+                        "subtotal": "7.48"
+                    }
+                ],
+                "meta_data": [
+                    {
+                        "id": 6377,
+                        "key": "color",
+                        "value": "orange",
+                        "display_key": "Color",
+                        "display_value": "Orange"
+                    },
+                    {
+                        "id": 6378,
+                        "key": "brand",
+                        "value": "woo",
+                        "display_key": "Brand",
+                        "display_value": "Woo"
+                    },
+                    {
+                        "id": 6546,
+                        "key": "_square_item_variation_id",
+                        "value": "aweiotjo",
+                        "display_key": "_square_item_variation_id",
+                        "display_value": "aweiotjo"
+                    },
+                    {
+                        "id": 6411,
+                        "key": "_reduced_stock",
+                        "value": "1",
+                        "display_key": "_reduced_stock",
+                        "display_value": "1"
+                    }
+                ],
+                "sku": "pen",
+                "price": 88,
+                "parent_name": "&lt;Variable&gt; Fun Pens!"
+            },
+            {
+                "id": 764,
+                "name": "(Downloadable) food",
+                "product_id": 3122,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "",
+                "subtotal": "23.50",
+                "subtotal_tax": "2.00",
+                "total": "23.50",
+                "total_tax": "2.00",
+                "taxes": [
+                    {
+                        "id": 1,
+                        "total": "1.9975",
+                        "subtotal": "1.9975"
+                    }
+                ],
+                "meta_data": [],
+                "sku": "",
+                "price": 23.5,
+                "parent_name": null
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [
+            {
+                "id": 73,
+                "reason": "Cap!",
+                "total": "-16.00"
+            },
+            {
+                "id": 0,
+                "reason": "",
+                "total": "-0.00"
+            }
+        ],
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -121,7 +121,7 @@ final class OrderDetailsDataSource: NSObject {
     /// All the condensed refunds in an order
     ///
     var condensedRefunds: [OrderRefundCondensed] {
-        return order.refunds
+        return order.refunds.sorted(by: { $0.refundID > $1.refundID })
     }
 
     /// Notes of an Order
@@ -807,8 +807,8 @@ extension OrderDetailsDataSource {
 
         let payment: Section = {
             var rows: [Row] = [.payment, .customerPaid]
-            if order.refunds.count > 0 {
-                let refunds = Array<Row>(repeating: .refund, count: order.refunds.count)
+            if !condensedRefunds.isEmpty {
+                let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
                 rows.append(contentsOf: refunds)
                 rows.append(.netAmount)
             }
@@ -873,7 +873,7 @@ extension OrderDetailsDataSource {
 
     func refund(at indexPath: IndexPath) -> Refund? {
         let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
-        let condensedRefund = order.refunds[index]
+        let condensedRefund = condensedRefunds[index]
         let refund = refunds.first { $0.refundID == condensedRefund.refundID }
 
         guard let refundFound = refund else {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -807,7 +807,7 @@ extension OrderDetailsDataSource {
 
         let payment: Section = {
             var rows: [Row] = [.payment, .customerPaid]
-            if !condensedRefunds.isEmpty {
+            if condensedRefunds.isNotEmpty {
                 let refunds = Array<Row>(repeating: .refund, count: condensedRefunds.count)
                 rows.append(contentsOf: refunds)
                 rows.append(.netAmount)


### PR DESCRIPTION
Closes #3055

## What

### Filter out deleted refunds
In a some scenarios when fetching an order or an order list Core would send refunds with `refundID` and `total` being zero. Those refunds are deleted and we don't want to show them to the user.

My first attempt to fix this was to add a code to filter refunds in `OrdersUpsertUseCase` when we update the data in the storage. This approach didn't work in all cases. I discovered that when I pull-to-refresh the order, the updated order still has refunds that I thought should be filtered out. This happens because when we sync an order, the callback passes the model that was created from the network response and not the one that is fetched from the storage.

Because of that, in my second attempt, I moved the code to filter out deleted refunds to `Order`. And it works :-)

### Refund list order

Because there is no `dateCreated` in `OrderRefundCondensed` I thought to keep it simple and order refunds by `refundID` as it seems to be an auto incremental field in Core. The order should be the same as if it is ordered by `dateCreated`.
This way refund list is in the same order as it is in Core.

## Test
1. Create an order
2. Make several refunds in Core
3. Open this order in the app
4. Check that the order of refunds is the same as in Core
5. Delete one of refunds in Core
6. Pull to refresh the order in the app. Refund should be gone.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
