### PR TITLE
Reprint Shipping Label: paper size selector

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ReprintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ReprintShippingLabelViewController.swift
@@ -48,6 +48,14 @@ private extension ReprintShippingLabelViewController {
     func reprintShippingLabel() {
         // TODO-2169: reprint action
     }
+
+    func showPaperSizeSelector() {
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: viewModel.paperSizeOptions, selected: selectedPaperSize)
+        let listSelector = ListSelectorViewController(command: command) { [weak self] paperSize in
+            self?.viewModel.updateSelectedPaperSize(paperSize)
+        }
+        show(listSelector, sender: self)
+    }
 }
 
 // MARK: Configuration
@@ -81,7 +89,7 @@ private extension ReprintShippingLabelViewController {
 
     func observeSelectedPaperSize() {
         viewModel.loadShippingLabelSettingsForDefaultPaperSize()
-        viewModel.$selectedPaperSize.sink { [weak self] paperSize in
+        viewModel.$selectedPaperSize.removeDuplicates().sink { [weak self] paperSize in
             guard let self = self else { return }
             self.selectedPaperSize = paperSize
             self.tableView.reloadData()
@@ -117,8 +125,7 @@ extension ReprintShippingLabelViewController: UITableViewDelegate {
 
         switch row {
         case .paperSize:
-            // TODO-2169: Navigate to paper size selector
-            break
+            showPaperSizeSelector()
         case .paperSizeOptions:
             // TODO-2169: Present paper size options modal
             break

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ReprintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ReprintShippingLabelViewModel.swift
@@ -37,4 +37,9 @@ extension ReprintShippingLabelViewModel {
         }
         stores.dispatch(action)
     }
+
+    /// Updates the selected paper size (e.g. from paper size list selector).
+    func updateSelectedPaperSize(_ selectedPaperSize: ShippingLabelPaperSize?) {
+        self.selectedPaperSize = selectedPaperSize
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeListSelectorCommand.swift
@@ -28,7 +28,7 @@ final class ShippingLabelPaperSizeListSelectorCommand: ListSelectorCommand {
     }
 
     func configureCell(cell: BasicTableViewCell, model: ShippingLabelPaperSize) {
-        cell.textLabel?.text = "\(model.description)"
+        cell.textLabel?.text = model.description
     }
 
     init(paperSizeOptions: [ShippingLabelPaperSize], selected: ShippingLabelPaperSize?) {

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeListSelectorCommand.swift
@@ -1,0 +1,45 @@
+import Foundation
+import enum Yosemite.ShippingLabelPaperSize
+
+/// Command to populate the shipping label paper size list selector
+///
+final class ShippingLabelPaperSizeListSelectorCommand: ListSelectorCommand {
+    typealias Model = ShippingLabelPaperSize
+    typealias Cell = BasicTableViewCell
+
+    /// Data to display
+    ///
+    let data: [ShippingLabelPaperSize]
+
+    /// Holds the current selected state
+    ///
+    private(set) var selected: ShippingLabelPaperSize?
+
+    /// Navigation bar title
+    ///
+    let navigationBarTitle: String? = Localization.navigationBarTitle
+
+    func handleSelectedChange(selected: ShippingLabelPaperSize, viewController: ViewController) {
+        self.selected = selected
+    }
+
+    func isSelected(model: ShippingLabelPaperSize) -> Bool {
+        selected == model
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ShippingLabelPaperSize) {
+        cell.textLabel?.text = "\(model.description)"
+    }
+
+    init(paperSizeOptions: [ShippingLabelPaperSize], selected: ShippingLabelPaperSize?) {
+        self.data = paperSizeOptions
+        self.selected = selected
+    }
+}
+
+// MARK: Constants
+private extension ShippingLabelPaperSizeListSelectorCommand {
+    enum Localization {
+        static let navigationBarTitle = NSLocalizedString("Choose Paper Size", comment: "Navigation title on the shipping label paper size selector screen")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
+		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
 		023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */; };
 		023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */; };
 		023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */; };
@@ -1191,6 +1192,7 @@
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
+		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewModelTests.swift; sourceTree = "<group>"; };
 		023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductSKUValidationStoresManager.swift; sourceTree = "<group>"; };
 		023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductInventorySettingsViewModel+VariationTests.swift"; sourceTree = "<group>"; };
@@ -3002,6 +3004,7 @@
 				02F67FF425806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift */,
 				027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */,
 				023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */,
+				023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */,
 			);
 			path = "Shipping Label";
 			sourceTree = "<group>";
@@ -6378,6 +6381,7 @@
 				45FBDF34238D33F100127F77 /* MockProduct.swift in Sources */,
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
+				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
+		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */; };
 		023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */; };
 		023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */; };
@@ -1189,6 +1190,7 @@
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
+		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewModelTests.swift; sourceTree = "<group>"; };
 		023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductSKUValidationStoresManager.swift; sourceTree = "<group>"; };
 		023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductInventorySettingsViewModel+VariationTests.swift"; sourceTree = "<group>"; };
@@ -2564,6 +2566,7 @@
 				0259D65B2582248D003B1CD6 /* ReprintShippingLabelViewController.swift */,
 				0259D65C2582248D003B1CD6 /* ReprintShippingLabelViewController.xib */,
 				02535CBA25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift */,
+				023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -6046,6 +6049,7 @@
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
+				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ReprintShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ReprintShippingLabelViewModelTests.swift
@@ -69,4 +69,23 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(paperSizeValues, [nil, .letter])
     }
+
+    func test_updateSelectedPaperSize_sets_selectedPaperSize_to_selected_value() {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel)
+        var paperSizeValues = [ShippingLabelPaperSize?]()
+        viewModel.$selectedPaperSize.sink { paperSize in
+            paperSizeValues.append(paperSize)
+        }.store(in: &cancellables)
+
+        // When
+        viewModel.updateSelectedPaperSize(.label)
+        viewModel.updateSelectedPaperSize(nil)
+        viewModel.updateSelectedPaperSize(.legal)
+        viewModel.updateSelectedPaperSize(.letter)
+
+        // Then
+        XCTAssertEqual(paperSizeValues, [nil, .label, nil, .legal, .letter])
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ShippingLabelPaperSizeListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ShippingLabelPaperSizeListSelectorCommandTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class ShippingLabelPaperSizeListSelectorCommandTests: XCTestCase {
+    func test_data_are_set_to_paperSizeOptions_in_init() {
+        // Given
+        let paperSizeOptions: [ShippingLabelPaperSize] = [.legal, .label, .letter]
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: paperSizeOptions, selected: nil)
+
+        // When
+        let data = command.data
+
+        // Then
+        XCTAssertEqual(data, paperSizeOptions)
+    }
+
+    func test_selected_is_initialized_to_selected_value_in_init() {
+        // Given
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: [.legal, .label, .letter], selected: nil)
+
+        // When
+        let selected = command.selected
+
+        // Then
+        XCTAssertNil(selected)
+    }
+
+    func test_handleSelectedChange_updates_selected_value() {
+        // Given
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: [.legal, .label, .letter], selected: nil)
+        let listSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
+
+        // When
+        command.handleSelectedChange(selected: .label, viewController: listSelector)
+
+        // Then
+        XCTAssertEqual(command.selected, .label)
+    }
+
+    func test_isSelected_with_non_selected_value_returns_false() {
+        // Given
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: [.legal, .label, .letter], selected: nil)
+
+        // When
+        let isSelected = command.isSelected(model: .legal)
+
+        // Then
+        XCTAssertFalse(isSelected)
+    }
+
+    func test_configureCell_sets_cell_text_to_paper_size_description() {
+        // Given
+        let command = ShippingLabelPaperSizeListSelectorCommand(paperSizeOptions: [.legal, .label, .letter], selected: nil)
+        let cell: BasicTableViewCell = BasicTableViewCell.instantiateFromNib()
+
+        // When
+        command.configureCell(cell: cell, model: .letter)
+
+        // Then
+        XCTAssertEqual(cell.textLabel?.text, ShippingLabelPaperSize.letter.description)
+    }
+}


### PR DESCRIPTION
Part of #2169 

## Why

Since a shipping label can be printed on different paper sizes, this PR enables the user to select a paper size supported options (legal, letter, and label for now).

## Changes

- Created `ShippingLabelPaperSizeListSelectorCommand: ListSelectorCommand` as the command for paper size list selector. Added unit tests
- In `ReprintShippingLabelViewModel`, added a function to update the selected paper size
- In `ReprintShippingLabelViewController`, navigates to paper size selector with the selected paper size

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> after syncing, a shipping label card should appear
- Tap on "Reprint Shipping Label" 
- Tap on the paper size row --> it should navigate to a paper size selector, and the pre-selected value should match the one in the reprint main screen
- Select a different value and navigate back --> the selected value should be shown in the reprint main screen

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/102303024-3feb6300-3f95-11eb-9a2e-d5f9859c32ce.gif)

dark | light
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-16 at 11 52 26](https://user-images.githubusercontent.com/1945542/102303094-6ad5b700-3f95-11eb-8946-39adae6225c3.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-16 at 11 52 38](https://user-images.githubusercontent.com/1945542/102303104-6dd0a780-3f95-11eb-95d6-7bd289f41ab6.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
