### PR TITLE
Don't dismiss order details and show error message if order is deleted

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
@@ -2,21 +2,6 @@ import Foundation
 import Yosemite
 
 final class OrderDetailsNotices {
-    /// Displays a Notice onscreen, indicating that the current Order has been deleted from the Store.
-    ///
-    func displayOrderDeletedNotice(order: Order) {
-        let message = String.localizedStringWithFormat(
-            NSLocalizedString(
-                "Order %@ has been deleted from your store",
-                comment: "Displayed whenever an Order gets deleted. It reads: Order {order number} has been deleted from your store."
-            ),
-            order.number
-        )
-
-        let notice = Notice(title: message, feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
-    }
-
     /// Displays the `Unable to delete tracking` Notice.
     ///
     func displayDeleteErrorNotice(order: Order, tracking: ShipmentTracking, onAction: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -37,6 +37,11 @@ final class OrderDetailsViewController: UIViewController {
 
     private let notices = OrderDetailsNotices()
 
+    /// Timer is used to delay popping the screen and showing a message to the user.
+    /// It is used to prevent a dismiss when all orders are temporarily deleted during sync.
+    ///
+    private var orderDeletedTimer: Timer?
+
     // MARK: - View Lifecycle
 
     /// Create an instance of `Self` from its corresponding storyboard.
@@ -70,6 +75,11 @@ final class OrderDetailsViewController: UIViewController {
             syncShippingLabels()
         }
         syncTrackingsHidingAddButtonIfNecessary()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        invalidateOrderDeletedTimer()
     }
 
     private func syncTrackingsHidingAddButtonIfNecessary() {
@@ -117,16 +127,12 @@ private extension OrderDetailsViewController {
             guard let self = self else {
                 return
             }
+            self.invalidateOrderDeletedTimer()
             self.viewModel.updateOrderStatus(order: order)
             self.reloadTableViewSectionsAndData()
         }
         entityListener.onDelete = { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.navigationController?.popViewController(animated: true)
-            self.displayOrderDeletedNotice(order: self.viewModel.order)
+            self?.handleDeletedOrderDelayed()
         }
     }
 
@@ -175,6 +181,31 @@ private extension OrderDetailsViewController {
     ///
     func registerTableViewHeaderFooters() {
         viewModel.registerTableViewHeaderFooters(tableView)
+    }
+}
+
+
+// MARK: - Handling deleted order
+//
+private extension OrderDetailsViewController {
+
+    func handleDeletedOrderDelayed() {
+        invalidateOrderDeletedTimer()
+        orderDeletedTimer = Timer.scheduledTimer(withTimeInterval: Constants.orderDeletedTimeout, repeats: false) { [weak self] (_) in
+            self?.handleDeletedOrder()
+        }
+    }
+
+    func handleDeletedOrder() {
+        invalidateOrderDeletedTimer()
+
+        navigationController?.popViewController(animated: true)
+        displayOrderDeletedNotice(order: viewModel.order)
+    }
+
+    func invalidateOrderDeletedTimer() {
+        orderDeletedTimer?.invalidate()
+        orderDeletedTimer = nil
     }
 }
 
@@ -583,6 +614,7 @@ private extension OrderDetailsViewController {
     }
 
     enum Constants {
+        static let orderDeletedTimeout = TimeInterval(0.5)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -120,14 +120,6 @@ private extension OrderDetailsViewController {
             self.viewModel.updateOrderStatus(order: order)
             self.reloadTableViewSectionsAndData()
         }
-        entityListener.onDelete = { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.navigationController?.popViewController(animated: true)
-            self.displayOrderDeletedNotice(order: self.viewModel.order)
-        }
     }
 
     private func configureViewModel() {
@@ -192,12 +184,6 @@ private extension OrderDetailsViewController {
 // MARK: - Notices
 //
 private extension OrderDetailsViewController {
-
-    /// Displays a Notice onscreen, indicating that the current Order has been deleted from the Store.
-    ///
-    func displayOrderDeletedNotice(order: Order) {
-        notices.displayOrderDeletedNotice(order: order)
-    }
 
     /// Displays the `Unable to delete tracking` Notice.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
@@ -117,15 +117,6 @@ private extension RefundedProductsViewController {
             self.viewModel.updateOrderStatus(order: order)
             self.reloadTableViewSectionsAndData()
         }
-
-        entityListener.onDelete = { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.navigationController?.popViewController(animated: true)
-            self.displayOrderDeletedNotice(order: self.viewModel.order)
-        }
     }
 
     /// Setup: Configure viewModel
@@ -157,17 +148,6 @@ extension RefundedProductsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return viewModel.dataSource.viewForHeaderInSection(section, tableView: tableView)
-    }
-}
-
-
-// MARK: - Notices
-//
-private extension RefundedProductsViewController {
-    /// Displays a Notice onscreen, indicating that the current Order has been deleted from the Store.
-    ///
-    func displayOrderDeletedNotice(order: Order) {
-        notices.displayOrderDeletedNotice(order: order)
     }
 }
 


### PR DESCRIPTION
Closes #2369 

The issue is that the app shows an "Order has been deleted from your store" notice and pops the view controller even though the order was not really deleted from the store. It happens for example when we sync orders and entries are temporarily removed from the database.

In this PR we're fixing this by removing `onDelete` handling.

The motivation behind it is as mentioned by @shiki: It's confusing and scary to merchants if they come up. If a merchant has deleted an order, they would know anyway and they don't need to be reminded of it.

## Tests

Follow a steps to reproduce from #2369 or update `fetchFilteredAndAllOrders` method in `OrderStore` and change 
`serialQueue.async { [weak self] in` 
to 
`serialQueue.asyncAfter(deadline: .now() + 3.0) { [weak self] in`

### Order Details

1. Navigate to Orders
2. Pull to refresh
3. Pick any Order
4. Verify that Order is not dismissed and "Order has been deleted from your store" notice is not shown (wait for a few seconds)

### Refunded Products

1. Make sure there is an order with refunded products
2. Navigate to Orders
2. Pull to refresh
3. Pick an Order from Step 1
4. Open Refunded Products
4. Verify that Order is not dismissed and "Order has been deleted from your store" notice is not shown (wait for a few seconds)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
