### PR TITLE
Do not hardcode a site as not self-hosted

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -217,7 +217,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
-        let isSelfHosted = false
+        let isSelfHosted = site.isWP && !site.isWPCom
         let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: isSelfHosted)
         onCompletion(authenticationResult)
     }


### PR DESCRIPTION
Closes #3362 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/102440904-177a6c00-405c-11eb-9877-e2e85b9ca5a4.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/102440900-11848b00-405c-11eb-9aac-fd180fcb2fe4.gif" width="350"/> |

## The bug

When we attempt to login with a Store Address, and WPAuthenticator notifies us that the site has a valid Jetpack installation, we were handing control over to WPAuthenticator to allow users to log in with login and password.

When doing so, we were always marking the site as "not self hosted"

## Changes
* Check that the site is actually a WordPress site, and if it is hosted in WP.com or not before handing over control to WPAuthenticator, and pass the result of that check

## How to test
* Checkout the branch. Run `bundle exec pod install`
* Attempt to login with Store Address
* Enter the address of a self-hosted site that has Jetpack installed, configured, and activated.
* Notice if the app navigates to the UI to enter username and password matching the new look and feel

cc @rachelmcr 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
