### PR TITLE
Set background color of StorePickerViewController to match the background color provided by WPAuthenticator

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -185,13 +185,13 @@ class StorePickerViewController: UIViewController {
 private extension StorePickerViewController {
 
     func setupMainView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = backgroundColor()
     }
 
     func setupTableView() {
         tableView.registerNib(for: EmptyStoresTableViewCell.self)
         tableView.registerNib(for: StoreTableViewCell.self)
-        tableView.backgroundColor = .listBackground
+        tableView.backgroundColor = backgroundColor()
     }
 
     func setupAccountHeader() {
@@ -242,6 +242,10 @@ private extension StorePickerViewController {
     func stateWasUpdated() {
         preselectStoreIfPossible()
         reloadInterface()
+    }
+
+    func backgroundColor() -> UIColor {
+        return WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor ?? .listBackground
     }
 }
 


### PR DESCRIPTION
Closes #3364 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/102451915-67652d00-4074-11eb-8e68-ecbfaf6656c5.PNG" width="350" /> | <img src="https://user-images.githubusercontent.com/2722505/102451930-6b914a80-4074-11eb-84c3-8dbf32a44638.png" width="350" /> |

## Changes
* Set the background color of StoresPickerView controller to the background color provided by WPAuthenticator

## How to test
* Checkout the branch, run `bundle exec pod install`
* Follow the repro instructions in the original issue: login with magic link to an account without linked stores

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
