### PR TITLE
Fix broken constraints when order list is reloaded with animations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -66,7 +66,7 @@
                     <constraint firstItem="w2s-RF-ahH" firstAttribute="top" secondItem="C8B-hF-50d" secondAttribute="topMargin" constant="8" id="PYm-SD-sSv"/>
                     <constraint firstItem="w2s-RF-ahH" firstAttribute="leading" secondItem="C8B-hF-50d" secondAttribute="leadingMargin" id="Vj7-Ev-DBC"/>
                     <constraint firstAttribute="trailing" secondItem="w2s-RF-ahH" secondAttribute="trailing" constant="8" id="Wgd-sx-xWk"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="w2s-RF-ahH" secondAttribute="bottom" constant="8" id="YAb-lm-rXp"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="w2s-RF-ahH" secondAttribute="bottom" priority="999" constant="8" id="YAb-lm-rXp"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>


### PR DESCRIPTION
### What

This PR fixes "Unable to simultaneously satisfy constraints" warnings that can be seen in Xcode console when order list is reloaded with animations.

Looks like it happens because reload animations reduce cells height and the main stack view inside the cell is not able to fit in provided height. 

The solution here is to lower priority of the bottom margin constraint between stack view and cells content view. This will allow cell to shrink past the size of the stack view and not cause constraints breakdown.


### Test

1. Open orders screen with a few orders there
2. Pull to refresh
3. Check that there are no constraints related warnings in the console

```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600001870a00 UIStackView:0x7ff584c90f00.top == UITableViewCellContentView:0x7ff584c936b0.topMargin + 8   (active)>",
    "<NSLayoutConstraint:0x600001871180 UITableViewCellContentView:0x7ff584c936b0.bottomMargin == UIStackView:0x7ff584c90f00.bottom + 8   (active)>",
    "<NSLayoutConstraint:0x600001867020 'UISV-canvas-connection' UIStackView:0x7ff584c8f9b0.top == UILabel:0x7ff584c65f50.top   (active)>",
    "<NSLayoutConstraint:0x6000018671b0 'UISV-canvas-connection' V:[UIView:0x7ff594c80870]-(0)-|   (active, names: '|':UIStackView:0x7ff584c8f9b0 )>",
    "<NSLayoutConstraint:0x600001865c20 'UISV-canvas-connection' UIStackView:0x7ff584c90f00.top == UIStackView:0x7ff584c8f9b0.top   (active)>",
    "<NSLayoutConstraint:0x600001867110 'UISV-canvas-connection' V:[UIStackView:0x7ff584c8f9b0]-(0)-|   (active, names: '|':UIStackView:0x7ff584c90f00 )>",
    "<NSLayoutConstraint:0x600001865220 'UISV-distributing-edge' V:[UILabel:0x7ff584c65f50]-(0)-[_UIOLAGapGuide:0x6000007a8400'UISV-distributing']   (active)>",
    "<NSLayoutConstraint:0x600001866260 'UISV-distributing-edge' _UIOLAGapGuide:0x6000007a8400'UISV-distributing'.bottom == UILabel:0x7ff594c8dfd0.top   (active)>",
    "<NSLayoutConstraint:0x600001866080 'UISV-distributing-edge' V:[UILabel:0x7ff594c8dfd0]-(0)-[_UIOLAGapGuide:0x6000007a8600'UISV-distributing']   (active)>",
    "<NSLayoutConstraint:0x600001866710 'UISV-distributing-edge' _UIOLAGapGuide:0x6000007a8600'UISV-distributing'.bottom == UIView:0x7ff594c80870.top   (active)>",
    "<NSLayoutConstraint:0x6000018663f0 'UISV-fill-equally' _UIOLAGapGuide:0x6000007a8600'UISV-distributing'.height == _UIOLAGapGuide:0x6000007a8400'UISV-distributing'.height   (active)>",
    "<NSLayoutConstraint:0x600001867160 'UISV-spacing' V:[UILabel:0x7ff594c8dfd0]-(>=6)-[UIView:0x7ff594c80870]   (active)>",
    "<NSLayoutConstraint:0x600001870280 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x6000002bd7a0'UIViewLayoutMarginsGuide']-(11)-|   (active, names: '|':UITableViewCellContentView:0x7ff584c936b0 )>",
    "<NSLayoutConstraint:0x600001864aa0 'UIView-Encapsulated-Layout-Height' UITableViewCellContentView:0x7ff584c936b0.height == 44   (active)>",
    "<NSLayoutConstraint:0x600001872210 'UIView-topMargin-guide-constraint' V:|-(11)-[UILayoutGuide:0x6000002bd7a0'UIViewLayoutMarginsGuide']   (active, names: '|':UITableViewCellContentView:0x7ff584c936b0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001867160 'UISV-spacing' V:[UILabel:0x7ff594c8dfd0]-(>=6)-[UIView:0x7ff594c80870]   (active)>
```

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
