### PR TITLE
Add networking and Yosemite for creating a new Customer

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -246,6 +246,10 @@
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
 		AE0C144D258BC4E80023C0F8 /* CustomerMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0C144C258BC4E80023C0F8 /* CustomerMapper.swift */; };
+		AE0C1451258BCA0E0023C0F8 /* CustomerMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0C1450258BCA0E0023C0F8 /* CustomerMapperTests.swift */; };
+		AE0C1457258BCB700023C0F8 /* customer.json in Resources */ = {isa = PBXBuildFile; fileRef = AE0C1454258BCAA50023C0F8 /* customer.json */; };
+		AE0C149B258BCB7A0023C0F8 /* customers-extra.json in Resources */ = {isa = PBXBuildFile; fileRef = AE9CEC78258913D5000F3CAB /* customers-extra.json */; };
+		AE0C149C258BCB7D0023C0F8 /* customers-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = AE9CEC79258913D8000F3CAB /* customers-empty.json */; };
 		AE2D0E932582321C00B8EC48 /* CustomerRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D0E922582321B00B8EC48 /* CustomerRole.swift */; };
 		AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E026F2580BA8E00EDB637 /* Customer.swift */; };
 		AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02732580C03400EDB637 /* CustomersListMapper.swift */; };
@@ -660,6 +664,8 @@
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		AE0C144C258BC4E80023C0F8 /* CustomerMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerMapper.swift; sourceTree = "<group>"; };
+		AE0C1450258BCA0E0023C0F8 /* CustomerMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerMapperTests.swift; sourceTree = "<group>"; };
+		AE0C1454258BCAA50023C0F8 /* customer.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = customer.json; sourceTree = "<group>"; };
 		AE2D0E922582321B00B8EC48 /* CustomerRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRole.swift; sourceTree = "<group>"; };
 		AE6E026F2580BA8E00EDB637 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		AE6E02732580C03400EDB637 /* CustomersListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapper.swift; sourceTree = "<group>"; };
@@ -1236,6 +1242,7 @@
 				74C9477E2193A6C60024CB60 /* comment-moderate-trash.json */,
 				74C947812193A6C70024CB60 /* comment-moderate-unapproved.json */,
 				740211DE2193985A002248DA /* comment-moderate-spam.json */,
+				AE0C1454258BCAA50023C0F8 /* customer.json */,
 				AE6E02772580C31A00EDB637 /* customers-all.json */,
 				AE9CEC78258913D5000F3CAB /* customers-extra.json */,
 				AE9CEC79258913D8000F3CAB /* customers-empty.json */,
@@ -1460,6 +1467,7 @@
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
+				AE0C1450258BCA0E0023C0F8 /* CustomerMapperTests.swift */,
 				AE6E02812580C89C00EDB637 /* CustomersListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
@@ -1644,6 +1652,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE0C1457258BCB700023C0F8 /* customer.json in Resources */,
 				74C8F07020EEC3A800B6EDC9 /* broken-notes.json in Resources */,
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
@@ -1705,6 +1714,7 @@
 				022902D622E2436400059692 /* no_stats_permission_error.json in Resources */,
 				261CF2CB255C50010090D8D3 /* payment-gateway-list-half.json in Resources */,
 				02C254D72563999300A04423 /* order-shipping-labels.json in Resources */,
+				AE0C149B258BCB7A0023C0F8 /* customers-extra.json in Resources */,
 				45B204BC24890B1200FE6526 /* category.json in Resources */,
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,
@@ -1764,6 +1774,7 @@
 				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
 				45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */,
+				AE0C149C258BCB7D0023C0F8 /* customers-empty.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2083,6 +2094,7 @@
 				74C8F06E20EEC1E800B6EDC9 /* OrderNotesMapperTests.swift in Sources */,
 				45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */,
 				020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */,
+				AE0C1451258BCA0E0023C0F8 /* CustomerMapperTests.swift in Sources */,
 				AE6E027C2580C35C00EDB637 /* CustomerRemoteTests.swift in Sources */,
 				74ABA1D5213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift in Sources */,
 				74AB5B5121AF426D00859C12 /* SiteAPIRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
+		AE0C144D258BC4E80023C0F8 /* CustomerMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0C144C258BC4E80023C0F8 /* CustomerMapper.swift */; };
 		AE2D0E932582321C00B8EC48 /* CustomerRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D0E922582321B00B8EC48 /* CustomerRole.swift */; };
 		AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E026F2580BA8E00EDB637 /* Customer.swift */; };
 		AE6E02742580C03400EDB637 /* CustomersListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E02732580C03400EDB637 /* CustomersListMapper.swift */; };
@@ -658,6 +659,7 @@
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		AE0C144C258BC4E80023C0F8 /* CustomerMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerMapper.swift; sourceTree = "<group>"; };
 		AE2D0E922582321B00B8EC48 /* CustomerRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRole.swift; sourceTree = "<group>"; };
 		AE6E026F2580BA8E00EDB637 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		AE6E02732580C03400EDB637 /* CustomersListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListMapper.swift; sourceTree = "<group>"; };
@@ -1348,6 +1350,7 @@
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
+				AE0C144C258BC4E80023C0F8 /* CustomerMapper.swift */,
 				AE6E02732580C03400EDB637 /* CustomersListMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
@@ -1847,6 +1850,7 @@
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
 				26731337255ACA850026F7EF /* PaymentGatewayListMapper.swift in Sources */,
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
+				AE0C144D258BC4E80023C0F8 /* CustomerMapper.swift in Sources */,
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				AE6E02702580BA8E00EDB637 /* Customer.swift in Sources */,

--- a/Networking/Networking/Mapper/CustomerMapper.swift
+++ b/Networking/Networking/Mapper/CustomerMapper.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+
+/// Mapper: Customer
+///
+struct CustomerMapper: Mapper {
+
+    /// Site Identifier associated to the refund that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Customer Endpoints.
+    ///
+    let siteID: Int64
+
+
+    /// (Attempts) to convert a dictionary into a single Customer.
+    ///
+    func map(response: Data) throws -> Customer {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(CustomerEnvelope.self, from: response).customer
+    }
+
+    /// (Attempts) to encode a Customer object into JSONEncoded data.
+    ///
+    func map(customer: Customer) throws -> Data {
+        let encoder = JSONEncoder()
+
+        return try encoder.encode(customer)
+    }
+}
+
+
+/// CustomerEnvelope Disposable Entity:
+/// `Create Customer` endpoint returns the created customer document in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct CustomerEnvelope: Decodable {
+    let customer: Customer
+
+    private enum CodingKeys: String, CodingKey {
+        case customer = "data"
+    }
+}

--- a/Networking/Networking/Mapper/CustomerMapper.swift
+++ b/Networking/Networking/Mapper/CustomerMapper.swift
@@ -22,14 +22,6 @@ struct CustomerMapper: Mapper {
 
         return try decoder.decode(CustomerEnvelope.self, from: response).customer
     }
-
-    /// (Attempts) to encode a Customer object into JSONEncoded data.
-    ///
-    func map(customer: Customer) throws -> Data {
-        let encoder = JSONEncoder()
-
-        return try encoder.encode(customer)
-    }
 }
 
 

--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Address Entity.
 ///
-public struct Address: Decodable {
+public struct Address: Codable {
     public let firstName: String
     public let lastName: String
     public let company: String?

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -97,6 +97,18 @@ public struct Customer: Codable, Equatable {
                   billingAddress: billingAddress,
                   shippingAddress: shippingAddress)
     }
+
+    /// The public encoder for Customer.
+    ///
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(email, forKey: .email)
+        try container.encode(firstName, forKey: .firstName)
+        try container.encode(lastName, forKey: .lastName)
+        try container.encode(billingAddress, forKey: .billingAddress)
+        try container.encode(shippingAddress, forKey: .shippingAddress)
+    }
 }
 
 /// Defines all of the Customer CodingKeys

--- a/Networking/Networking/Model/Customer.swift
+++ b/Networking/Networking/Model/Customer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represent a Customer Entity.
 ///
-public struct Customer: Decodable, Equatable {
+public struct Customer: Codable, Equatable {
 
     public let siteID: Int64
     public let userID: Int64

--- a/Networking/Networking/Model/CustomerRole.swift
+++ b/Networking/Networking/Model/CustomerRole.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents a Customer.Role Entity.
 ///
 extension Customer {
-    public enum Role: Decodable, Hashable {
+    public enum Role: Codable, Hashable {
         case administrator
         case editor
         case author

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -4,30 +4,6 @@ import Foundation
 ///
 public class CustomerRemote: Remote {
 
-    /// Create a customer.
-    ///
-    /// - Parameters:
-    ///     - siteID: Site for which we'll create a customer.
-    ///     - customer: The Customer model used to create the custom entity for the request.
-    ///     - completion: Closure to be executed upon completion.
-    ///
-    public func createCustomer(for siteID: Int64,
-                               customer: Customer,
-                               completion: @escaping (Result<Customer, Error>) -> Void) {
-        let path = Path.customers
-        let mapper = CustomerMapper(siteID: siteID)
-
-        do {
-            let parameters = try customer.toDictionary()
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
-
-            enqueue(request, mapper: mapper, completion: completion)
-        } catch {
-            completion(.failure(error))
-            DDLogError("Unable to serialize data for customer: \(error)")
-        }
-    }
-
     /// Retrieves all of the customers available.
     ///
     /// - Parameters:
@@ -53,6 +29,30 @@ public class CustomerRemote: Remote {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = CustomersListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Create a customer.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll create a customer.
+    ///     - customer: The Customer model used to create the custom entity for the request.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createCustomer(for siteID: Int64,
+                               customer: Customer,
+                               completion: @escaping (Result<Customer, Error>) -> Void) {
+        let path = Path.customers
+        let mapper = CustomerMapper(siteID: siteID)
+
+        do {
+            let parameters = try customer.toDictionary()
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+            DDLogError("Unable to serialize data for customer: \(error)")
+        }
     }
 }
 

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -4,6 +4,31 @@ import Foundation
 ///
 public class CustomerRemote: Remote {
 
+    /// Create a customer.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll create a customer.
+    ///     - customer: The Customer model used to create the custom entity for the request.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createCustomer(for siteID: Int64,
+                               customer: Customer,
+                               completion: @escaping (Result<Customer, Error>) -> Void) {
+        let path = Path.customers
+        let mapper = CustomerMapper(siteID: siteID)
+
+        do {
+            let encodedJson = try mapper.map(customer: customer)
+            let parameters: [String: Any]? = try JSONSerialization.jsonObject(with: encodedJson, options: []) as? [String: Any]
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+            DDLogError("Unable to serialize data for refunds: \(error)")
+        }
+    }
+
     /// Retrieves all of the customers available.
     ///
     /// - Parameters:

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -18,14 +18,13 @@ public class CustomerRemote: Remote {
         let mapper = CustomerMapper(siteID: siteID)
 
         do {
-            let encodedJson = try mapper.map(customer: customer)
-            let parameters: [String: Any]? = try JSONSerialization.jsonObject(with: encodedJson, options: []) as? [String: Any]
+            let parameters = try customer.toDictionary()
             let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
 
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))
-            DDLogError("Unable to serialize data for refunds: \(error)")
+            DDLogError("Unable to serialize data for customer: \(error)")
         }
     }
 

--- a/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
@@ -1,23 +1,46 @@
 import XCTest
 @testable import Networking
 
-/// CustomersListMapper Unit Tests
+/// CustomersMapper Unit Tests
 ///
-final class CustomersListMapperTests: XCTestCase {
+final class CustomerMapperTests: XCTestCase {
 
     /// Site ID for testing.
     private let sampleSiteID: Int64 = 1234
 
-    func test_customers_list_is_properly_parsed() throws {
+    func test_customer_is_properly_parsed() throws {
         // Given
-        let jsonData = try XCTUnwrap(Loader.contentsOf("customers-all"))
+        let jsonData = try XCTUnwrap(Loader.contentsOf("customer"))
 
         // When
-        let response = try CustomersListMapper(siteID: sampleSiteID).map(response: jsonData)
+        let responseCustomer = try CustomerMapper(siteID: sampleSiteID).map(response: jsonData)
 
         // Then
-        XCTAssertEqual(response.count, 2)
+        let johnDoe = try sampleCustomer()
+        XCTAssertEqual(responseCustomer, johnDoe)
+    }
 
+    func test_customer_is_correctly_encoded() throws {
+        // Given
+        let johnDoe = try sampleCustomer()
+
+        // When
+        let encodedCustomerData = try CustomerMapper(siteID: sampleSiteID).map(customer: johnDoe)
+        let customerDictionary = try JSONSerialization.jsonObject(with: encodedCustomerData) as? [String: Any]
+
+        // Then
+        XCTAssertEqual(customerDictionary?["first_name"] as? String, "John")
+        let billingAddressDictionary = try XCTUnwrap(customerDictionary?["billing"] as? [String: Any])
+        XCTAssertEqual(billingAddressDictionary["first_name"] as? String, "John")
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension CustomerMapperTests {
+
+    func sampleCustomer() throws -> Customer {
         let billingAddress = Address(firstName: "John",
                                      lastName: "Doe",
                                      company: "",
@@ -59,10 +82,6 @@ final class CustomersListMapperTests: XCTestCase {
                                billingAddress: billingAddress,
                                shippingAddress: shippingAddress)
 
-        guard let expectedCustomer = response.first(where: { $0.userID == johnDoeID }) else {
-            XCTFail("Customer with id \(johnDoeID) should exist")
-            return
-        }
-        XCTAssertEqual(expectedCustomer, johnDoe)
+        return johnDoe
     }
 }

--- a/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
@@ -19,20 +19,6 @@ final class CustomerMapperTests: XCTestCase {
         let johnDoe = try sampleCustomer()
         XCTAssertEqual(responseCustomer, johnDoe)
     }
-
-    func test_customer_is_correctly_encoded() throws {
-        // Given
-        let johnDoe = try sampleCustomer()
-
-        // When
-        let encodedCustomerData = try CustomerMapper(siteID: sampleSiteID).map(customer: johnDoe)
-        let customerDictionary = try JSONSerialization.jsonObject(with: encodedCustomerData) as? [String: Any]
-
-        // Then
-        XCTAssertEqual(customerDictionary?["first_name"] as? String, "John")
-        let billingAddressDictionary = try XCTUnwrap(customerDictionary?["billing"] as? [String: Any])
-        XCTAssertEqual(billingAddressDictionary["first_name"] as? String, "John")
-    }
 }
 
 

--- a/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
@@ -17,6 +17,44 @@ final class CustomerRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
+    // MARK: - Create Customer
+
+    func test_createCustomers_returns_parsed_customer() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
+
+        // When
+        let customer = try sampleCustomer()
+        let result = try waitFor { promise in
+            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let responseCustomer = try XCTUnwrap(result.get())
+        XCTAssertEqual(responseCustomer, customer)
+    }
+
+    func test_createCustomer_relays_networking_error() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+
+        // When
+        let customer = try sampleCustomer()
+        let result = try waitFor { promise in
+            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    // MARK: - Get All Customers
+
     func test_getAllCustomers_returns_parsed_customers() throws {
         // Given
         let remote = CustomerRemote(network: network)
@@ -55,5 +93,55 @@ final class CustomerRemoteTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension CustomerRemoteTests {
+
+    func sampleCustomer() throws -> Customer {
+        let billingAddress = Networking.Address(firstName: "John",
+                                                lastName: "Doe",
+                                                company: "",
+                                                address1: "969 Market",
+                                                address2: "",
+                                                city: "San Francisco",
+                                                state: "CA",
+                                                postcode: "94103",
+                                                country: "US",
+                                                phone: "(555) 555-5555",
+                                                email: "john.doe@example.com")
+
+        let shippingAddress = Networking.Address(firstName: "John",
+                                                 lastName: "Doe",
+                                                 company: "",
+                                                 address1: "969 Market",
+                                                 address2: "",
+                                                 city: "San Francisco",
+                                                 state: "CA",
+                                                 postcode: "94103",
+                                                 country: "US",
+                                                 phone: nil,
+                                                 email: nil)
+
+        let johnDoeID: Int64 = 25
+        let dateCreated = try XCTUnwrap(DateFormatter.Defaults.dateTimeFormatter.date(from: "2017-03-21T19:09:28"))
+        let dateModified = try XCTUnwrap(DateFormatter.Defaults.dateTimeFormatter.date(from: "2017-03-21T19:09:30"))
+        let johnDoe = Networking.Customer(siteID: sampleSiteID,
+                                          userID: johnDoeID,
+                                          dateCreated: dateCreated,
+                                          dateModified: dateModified,
+                                          email: "john.doe@example.com",
+                                          username: "john.doe",
+                                          firstName: "John",
+                                          lastName: "Doe",
+                                          avatarUrl: "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+                                          role: .customer,
+                                          isPaying: false,
+                                          billingAddress: billingAddress,
+                                          shippingAddress: shippingAddress)
+        return johnDoe
     }
 }

--- a/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CustomerRemoteTests.swift
@@ -17,42 +17,6 @@ final class CustomerRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
-    // MARK: - Create Customer
-
-    func test_createCustomers_returns_parsed_customer() throws {
-        // Given
-        let remote = CustomerRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
-
-        // When
-        let customer = try sampleCustomer()
-        let result = try waitFor { promise in
-            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        let responseCustomer = try XCTUnwrap(result.get())
-        XCTAssertEqual(responseCustomer, customer)
-    }
-
-    func test_createCustomer_relays_networking_error() throws {
-        // Given
-        let remote = CustomerRemote(network: network)
-
-        // When
-        let customer = try sampleCustomer()
-        let result = try waitFor { promise in
-            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-    }
-
     // MARK: - Get All Customers
 
     func test_getAllCustomers_returns_parsed_customers() throws {
@@ -87,6 +51,42 @@ final class CustomerRemoteTests: XCTestCase {
         // When
         let result = try waitFor { promise in
             remote.getAllCustomers(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    // MARK: - Create Customer
+
+    func test_createCustomers_returns_parsed_customer() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
+
+        // When
+        let customer = try sampleCustomer()
+        let result = try waitFor { promise in
+            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let responseCustomer = try XCTUnwrap(result.get())
+        XCTAssertEqual(responseCustomer, customer)
+    }
+
+    func test_createCustomer_relays_networking_error() throws {
+        // Given
+        let remote = CustomerRemote(network: network)
+
+        // When
+        let customer = try sampleCustomer()
+        let result = try waitFor { promise in
+            remote.createCustomer(for: self.sampleSiteID, customer: customer) { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Responses/customer.json
+++ b/Networking/NetworkingTests/Responses/customer.json
@@ -1,0 +1,53 @@
+{
+    "data": {
+        "id": 25,
+        "date_created": "2017-03-21T16:09:28",
+        "date_created_gmt": "2017-03-21T19:09:28",
+        "date_modified": "2017-03-21T16:09:30",
+        "date_modified_gmt": "2017-03-21T19:09:30",
+        "email": "john.doe@example.com",
+        "first_name": "John",
+        "last_name": "Doe",
+        "role": "customer",
+        "username": "john.doe",
+        "billing": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "company": "",
+            "address_1": "969 Market",
+            "address_2": "",
+            "city": "San Francisco",
+            "state": "CA",
+            "postcode": "94103",
+            "country": "US",
+            "email": "john.doe@example.com",
+            "phone": "(555) 555-5555"
+        },
+        "shipping": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "company": "",
+            "address_1": "969 Market",
+            "address_2": "",
+            "city": "San Francisco",
+            "state": "CA",
+            "postcode": "94103",
+            "country": "US"
+        },
+        "is_paying_customer": false,
+        "avatar_url": "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/25"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers"
+                }
+            ]
+        }
+    }
+}

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -4,11 +4,11 @@ import Foundation
 ///
 public enum CustomerAction: Action {
 
-    /// Creates a new Customer for the provided siteID
-    ///
-    case createCustomer(siteID: Int64, customer: Customer, completion: (Result<Customer, Error>) -> Void)
-
     /// Synchronizes all customers for the provided siteID
     ///
     case synchronizeAllCustomers(siteID: Int64, completion: (Result<Void, Error>) -> Void)
+
+    /// Creates a new Customer for the provided siteID
+    ///
+    case createCustomer(siteID: Int64, customer: Customer, completion: (Result<Customer, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -4,6 +4,10 @@ import Foundation
 ///
 public enum CustomerAction: Action {
 
+    /// Creates a new Customer for the provided siteID
+    ///
+    case createCustomer(siteID: Int64, customer: Customer, completion: (Result<Customer, Error>) -> Void)
+
     /// Synchronizes all customers for the provided siteID
     ///
     case synchronizeAllCustomers(siteID: Int64, completion: (Result<Void, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -31,10 +31,10 @@ public class CustomerStore: Store {
         }
 
         switch action {
-        case .createCustomer(let siteID, let customer, let completion):
-            createCustomer(siteID: siteID, customer: customer, completion: completion)
         case .synchronizeAllCustomers(let siteID, let completion):
             synchronizeAllCustomers(siteID: siteID, completion: completion)
+        case .createCustomer(let siteID, let customer, let completion):
+            createCustomer(siteID: siteID, customer: customer, completion: completion)
         }
     }
 }
@@ -43,22 +43,7 @@ public class CustomerStore: Store {
 //
 private extension CustomerStore {
 
-    /// Creates a new Customer.
-    ///
-    func createCustomer(siteID: Int64, customer: Customer, completion: @escaping (Result<Customer, Error>) -> Void) {
-        remote.createCustomer(for: siteID, customer: customer) { [weak self] result in
-            guard let self = self else { return }
-
-            switch result {
-            case .failure(let error):
-                completion(.failure(error))
-            case .success(let response):
-                self.upsertCustomersInBackground(siteID: siteID, customers: [response]) {
-                    completion(.success(response))
-                }
-            }
-        }
-    }
+    // MARK: - Synchronize Customers
 
     /// Retrieves all of the customers associated with a given Site ID (if any!).
     ///
@@ -96,6 +81,25 @@ private extension CustomerStore {
                 completion(.failure(error))
             case .success(let response):
                 self.upsertCustomersInBackground(siteID: siteID, customers: response) {
+                    completion(.success(response))
+                }
+            }
+        }
+    }
+
+    // MARK: - Create Customer
+
+    /// Creates a new Customer.
+    ///
+    func createCustomer(siteID: Int64, customer: Customer, completion: @escaping (Result<Customer, Error>) -> Void) {
+        remote.createCustomer(for: siteID, customer: customer) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let response):
+                self.upsertCustomersInBackground(siteID: siteID, customers: [response]) {
                     completion(.success(response))
                 }
             }

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -48,50 +48,6 @@ final class CustomerStoreTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - CustomerAction.createCustomer
-
-    func test_createCustomer_persists_customer() throws {
-        // Given
-        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
-
-        // When
-        let customer = try sampleCustomer()
-        let result: Result<Networking.Customer, Error> = try waitFor { promise in
-            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
-                promise(result)
-            }
-            store.onAction(action)
-        }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 1)
-    }
-
-    func test_createCustomer_returns_error_on_failure() throws {
-        // Given
-        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectedError = NetworkError.notFound
-        network.simulateError(requestUrlSuffix: "customers", error: expectedError)
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
-
-        // When
-        let customer = try sampleCustomer()
-        let result: Result<Networking.Customer, Error> = try waitFor { promise in
-            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
-                promise(result)
-            }
-            store.onAction(action)
-        }
-
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssertEqual(error as? NetworkError, expectedError)
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
-    }
-
     // MARK: - CustomerAction.synchronizeAllCustomers
 
     func test_synchronizeAllCustomers_persists_all_pages_of_customers_on_success() throws {
@@ -150,6 +106,50 @@ final class CustomerStoreTests: XCTestCase {
         // When
         let result: Result<Void, Error> = try waitFor { promise in
             let action = CustomerAction.synchronizeAllCustomers(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+    }
+
+    // MARK: - CustomerAction.createCustomer
+
+    func test_createCustomer_persists_customer() throws {
+        // Given
+        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+
+        // When
+        let customer = try sampleCustomer()
+        let result: Result<Networking.Customer, Error> = try waitFor { promise in
+            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 1)
+    }
+
+    func test_createCustomer_returns_error_on_failure() throws {
+        // Given
+        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedError = NetworkError.notFound
+        network.simulateError(requestUrlSuffix: "customers", error: expectedError)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+
+        // When
+        let customer = try sampleCustomer()
+        let result: Result<Networking.Customer, Error> = try waitFor { promise in
+            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
                 promise(result)
             }
             store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -48,6 +48,50 @@ final class CustomerStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - CustomerAction.createCustomer
+
+    func test_createCustomer_persists_customer() throws {
+        // Given
+        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "customer")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+
+        // When
+        let customer = try sampleCustomer()
+        let result: Result<Networking.Customer, Error> = try waitFor { promise in
+            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 1)
+    }
+
+    func test_createCustomer_returns_error_on_failure() throws {
+        // Given
+        let store = CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedError = NetworkError.notFound
+        network.simulateError(requestUrlSuffix: "customers", error: expectedError)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+
+        // When
+        let customer = try sampleCustomer()
+        let result: Result<Networking.Customer, Error> = try waitFor { promise in
+            let action = CustomerAction.createCustomer(siteID: self.sampleSiteID, customer: customer) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Customer.self), 0)
+    }
+
     // MARK: - CustomerAction.synchronizeAllCustomers
 
     func test_synchronizeAllCustomers_persists_all_pages_of_customers_on_success() throws {


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3242.
[API doc](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-customer)

### Changes

This PR adds `createCustomer ` method on `CustomerAction`, including all related tests.
API returns created object that is saved to storage on completion.

### Testing

Check the code and run tests. No actions exposed to UI yet.
