### PR TITLE
Product Variations: Add Attribute Options screen (WIP)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,8 +1,17 @@
 import UIKit
+import Yosemite
 
 final class AddAttributeOptionsViewController: UIViewController {
 
+    @IBOutlet weak var tableView: UITableView!
+
     private let viewModel: AddAttributeOptionsViewModel
+
+    /// Keyboard management
+    ///
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+        self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+    }
 
     /// Init
     ///
@@ -17,7 +26,169 @@ final class AddAttributeOptionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
+        registerTableViewHeaderSections()
+        registerTableViewCells()
+        startListeningToNotifications()
+    }
+}
 
+// MARK: - View Configuration
+//
+private extension AddAttributeOptionsViewController {
+
+    func configureNavigationBar() {
+        title = viewModel.newAttributeName ?? viewModel.attribute?.name
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(doneButtonPressed))
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewHeaderSections() {
+        let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
+        tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension AddAttributeOptionsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = viewModel.sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension AddAttributeOptionsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return 44
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let leftText = viewModel.sections[section].header else {
+            return nil
+        }
+
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
+            assertionFailure("Could not find section header view for reuseIdentifier \(headerID)")
+            return nil
+        }
+
+        headerView.leftText = leftText
+        headerView.rightText = nil
+
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return viewModel.sections[section].footer
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension AddAttributeOptionsViewController {
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextFieldTableViewCell where row == .termTextField:
+            configureTextField(cell: cell)
+        case let cell as BasicTableViewCell where row == .selectedTerms:
+            configureOption(cell: cell)
+        case let cell as BasicTableViewCell where row == .existingTerms:
+            configureOption(cell: cell)
+        default:
+            fatalError()
+            break
+        }
+    }
+
+    func configureTextField(cell: TextFieldTableViewCell) {
+        let viewModel = TextFieldTableViewCell.ViewModel(text: nil,
+                                                         placeholder: Localization.titleCellPlaceholder,
+                                                         onTextChange: { newAttributeOption in
+
+            }, onTextDidBeginEditing: {
+        }, inputFormatter: nil, keyboardType: .default)
+        cell.configure(viewModel: viewModel)
+        cell.applyStyle(style: .body)
+    }
+
+    func configureOption(cell: BasicTableViewCell) {
+        cell.textLabel?.text = "Work in progress" //TODO: to be implemented
+    }
+}
+
+// MARK: - Keyboard management
+//
+private extension AddAttributeOptionsViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        keyboardFrameObserver.startObservingKeyboardFrame()
+    }
+}
+
+extension AddAttributeOptionsViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
+    }
+}
+
+
+// MARK: - Navigation actions handling
+//
+extension AddAttributeOptionsViewController {
+
+    @objc private func doneButtonPressed() {
+        // TODO: to be implemented
     }
 }
 
@@ -48,5 +219,13 @@ extension AddAttributeOptionsViewController {
         fileprivate var reuseIdentifier: String {
             return type.reuseIdentifier
         }
+    }
+}
+
+private extension AddAttributeOptionsViewController {
+    enum Localization {
+        static let nextNavBarButton = NSLocalizedString("Next", comment: "Next nav bar button title in Add Product Attribute Options screen")
+        static let titleCellPlaceholder = NSLocalizedString("Option name",
+                                                            comment: "Placeholder of cell presenting the title of the new attribute option.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -2,6 +2,16 @@ import UIKit
 
 class AddAttributeOptionsViewController: UIViewController {
 
+    /// Init
+    ///
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,10 +1,13 @@
 import UIKit
 
-class AddAttributeOptionsViewController: UIViewController {
+final class AddAttributeOptionsViewController: UIViewController {
+
+    private let viewModel: AddAttributeOptionsViewModel
 
     /// Init
     ///
-    init() {
+    init(viewModel: AddAttributeOptionsViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -16,5 +19,34 @@ class AddAttributeOptionsViewController: UIViewController {
         super.viewDidLoad()
 
     }
+}
 
+extension AddAttributeOptionsViewController {
+
+    struct Section: Equatable {
+        let header: String?
+        let footer: String?
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case termTextField
+        case selectedTerms
+        case existingTerms
+
+        fileprivate var type: UITableViewCell.Type {
+            switch self {
+            case .termTextField:
+                return TextFieldTableViewCell.self
+            case .selectedTerms:
+                return BasicTableViewCell.self
+            case .existingTerms:
+                return BasicTableViewCell.self
+            }
+        }
+
+        fileprivate var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -46,6 +46,7 @@ private extension AddAttributeOptionsViewController {
                                                            style: .plain,
                                                            target: self,
                                                            action: #selector(doneButtonPressed))
+        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -153,7 +153,7 @@ private extension AddAttributeOptionsViewController {
 
     func configureTextField(cell: TextFieldTableViewCell) {
         let viewModel = TextFieldTableViewCell.ViewModel(text: nil,
-                                                         placeholder: Localization.titleCellPlaceholder,
+                                                         placeholder: Localization.optionNameCellPlaceholder,
                                                          onTextChange: { newAttributeOption in
 
             }, onTextDidBeginEditing: {
@@ -226,7 +226,7 @@ extension AddAttributeOptionsViewController {
 private extension AddAttributeOptionsViewController {
     enum Localization {
         static let nextNavBarButton = NSLocalizedString("Next", comment: "Next nav bar button title in Add Product Attribute Options screen")
-        static let titleCellPlaceholder = NSLocalizedString("Option name",
+        static let optionNameCellPlaceholder = NSLocalizedString("Option name",
                                                             comment: "Placeholder of cell presenting the title of the new attribute option.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 final class AddAttributeOptionsViewController: UIViewController {
 
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak private var tableView: UITableView!
 
     private let viewModel: AddAttributeOptionsViewModel
 
@@ -40,7 +40,7 @@ final class AddAttributeOptionsViewController: UIViewController {
 private extension AddAttributeOptionsViewController {
 
     func configureNavigationBar() {
-        title = viewModel.newAttributeName ?? viewModel.attribute?.name
+        title = viewModel.titleView
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -210,9 +210,7 @@ extension AddAttributeOptionsViewController {
             switch self {
             case .termTextField:
                 return TextFieldTableViewCell.self
-            case .selectedTerms:
-                return BasicTableViewCell.self
-            case .existingTerms:
+            case .selectedTerms, .existingTerms:
                 return BasicTableViewCell.self
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+class AddAttributeOptionsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddAttributeOptionsViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
@@ -1,22 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddAttributeOptionsViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddAttributeOptionsViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="HX8-cS-brJ" id="ot4-Kl-xva"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="HX8-cS-brJ">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="EJy-Kn-N0n"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="HX8-cS-brJ" secondAttribute="bottom" id="FGA-hr-JzF"/>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="H8F-hl-J8P"/>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="pjN-8m-lLX"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="69.642857142857139"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -30,7 +30,21 @@ private extension AddAttributeOptionsViewModel {
 
     /// Updates  data in sections
     ///
-    func updateSections(attributes: [ProductAttribute]) {
-        //TODO: to be implemented
+    func updateSections(attribute: ProductAttribute) {
+        let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField])
+        let selectedTermsSection = Section(header: Localization.headerSelectedTerms, footer: nil, rows: [.selectedTerms])
+        let existingTermsSection = Section(header: Localization.headerExistingTerms, footer: nil, rows: [.existingTerms])
+        sections = [textFieldSection, selectedTermsSection, existingTermsSection].compactMap { $0 }
+    }
+}
+
+private extension AddAttributeOptionsViewModel {
+    enum Localization {
+        static let footerTextField = NSLocalizedString("Add each option and press enter",
+                                                       comment: "Footer of text field section in Add Attribute Options screen")
+        static let headerSelectedTerms = NSLocalizedString("OPTIONS OFFERED",
+                                                           comment: "Header of selected attribute option section in Add Attribute Options screen")
+        static let headerExistingTerms = NSLocalizedString("ADD OPTIONS",
+                                                           comment: "Header of existing attribute option section in Add Attribute Options screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -8,6 +8,9 @@ final class AddAttributeOptionsViewModel {
     typealias Section = AddAttributeOptionsViewController.Section
     typealias Row = AddAttributeOptionsViewController.Row
 
+    var titleView: String? {
+        newAttributeName ?? attribute?.name
+    }
     private(set) var newAttributeName: String?
     private(set) var attribute: ProductAttribute?
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -50,6 +50,6 @@ private extension AddAttributeOptionsViewModel {
         static let headerSelectedTerms = NSLocalizedString("OPTIONS OFFERED",
                                                            comment: "Header of selected attribute options section in Add Attribute Options screen")
         static let headerExistingTerms = NSLocalizedString("ADD OPTIONS",
-                                                           comment: "Header of existing attribute option section in Add Attribute Options screen")
+                                                           comment: "Header of existing attribute options section in Add Attribute Options screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Yosemite
+
+/// Provides view data for Add Attributes, and handles init/UI/navigation actions needed.
+///
+final class AddAttributeOptionsViewModel {
+
+    typealias Section = AddAttributeOptionsViewController.Section
+    typealias Row = AddAttributeOptionsViewController.Row
+
+    private(set) var newAttributeName: String?
+    private(set) var attribute: ProductAttribute?
+
+    private(set) var sections: [Section] = []
+
+    init(newAttribute: String?) {
+        self.newAttributeName = newAttribute
+    }
+
+    init(existingAttribute: ProductAttribute) {
+        self.attribute = existingAttribute
+    }
+
+}
+
+// MARK: - Synchronize Product Attribute terms
+//
+private extension AddAttributeOptionsViewModel {
+    // TODO: to be implemented - fetch of terms
+
+    /// Updates  data in sections
+    ///
+    func updateSections(attributes: [ProductAttribute]) {
+        //TODO: to be implemented
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -15,10 +15,12 @@ final class AddAttributeOptionsViewModel {
 
     init(newAttribute: String?) {
         self.newAttributeName = newAttribute
+        updateSections()
     }
 
     init(existingAttribute: ProductAttribute) {
         self.attribute = existingAttribute
+        updateSections()
     }
 
 }
@@ -30,7 +32,7 @@ private extension AddAttributeOptionsViewModel {
 
     /// Updates  data in sections
     ///
-    func updateSections(attribute: ProductAttribute) {
+    func updateSections() {
         let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField])
         let selectedTermsSection = Section(header: Localization.headerSelectedTerms, footer: nil, rows: [.selectedTerms])
         let existingTermsSection = Section(header: Localization.headerExistingTerms, footer: nil, rows: [.existingTerms])

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -48,7 +48,7 @@ private extension AddAttributeOptionsViewModel {
         static let footerTextField = NSLocalizedString("Add each option and press enter",
                                                        comment: "Footer of text field section in Add Attribute Options screen")
         static let headerSelectedTerms = NSLocalizedString("OPTIONS OFFERED",
-                                                           comment: "Header of selected attribute option section in Add Attribute Options screen")
+                                                           comment: "Header of selected attribute options section in Add Attribute Options screen")
         static let headerExistingTerms = NSLocalizedString("ADD OPTIONS",
                                                            comment: "Header of existing attribute option section in Add Attribute Options screen")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -36,6 +36,7 @@ final class AddAttributeViewController: UIViewController {
         configureTableView()
         configureGhostTableView()
         configureViewModel()
+        enableDoneButton(false)
     }
 
 }
@@ -102,6 +103,10 @@ private extension AddAttributeViewController {
                 self?.removeGhostTableView()
             }
         }
+    }
+
+    func enableDoneButton(_ enabled: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
     }
 }
 
@@ -218,8 +223,9 @@ private extension AddAttributeViewController {
     func configureTextField(cell: TextFieldTableViewCell) {
         let viewModel = TextFieldTableViewCell.ViewModel(text: nil,
                                                          placeholder: Localization.titleCellPlaceholder,
-                                                         onTextChange: { newAttributeName in
-                                                            // TODO: handle new attribute
+                                                         onTextChange: { [weak self] newAttributeName in
+                                                            self?.viewModel.handleNewAttributeNameChange(newAttributeName)
+                                                            self?.enableDoneButton(self?.viewModel.newAttributeName != nil)
 
             }, onTextDidBeginEditing: {
         }, inputFormatter: nil, keyboardType: .default)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -276,7 +276,7 @@ extension AddAttributeViewController {
     }
 
     private func presentAddAttributeOptions(for existingAttribute: ProductAttribute) {
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: self.viewModel.newAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(existingAttribute: existingAttribute)
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -266,7 +266,7 @@ extension AddAttributeViewController: KeyboardScrollable {
 extension AddAttributeViewController {
 
     @objc private func doneButtonPressed() {
-        presentAddAttributeOptions(for: self.viewModel.newAttributeName)
+        presentAddAttributeOptions(for: viewModel.newAttributeName)
     }
 
     private func presentAddAttributeOptions(for newAttribute: String?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -51,7 +51,7 @@ private extension AddAttributeViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,
                                                            target: self,
-                                                           action: #selector(completeUpdating))
+                                                           action: #selector(doneButtonPressed))
     }
 
     func configureMainView() {
@@ -171,6 +171,12 @@ extension AddAttributeViewController: UITableViewDataSource {
 extension AddAttributeViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+
+        let row = viewModel.sections[indexPath.section].rows[indexPath.row]
+        guard row == .existingAttribute else {
+            return
+        }
+        presentAddAttributeOptions(for: viewModel.localAndGlobalAttributes[indexPath.row])
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -259,8 +265,19 @@ extension AddAttributeViewController: KeyboardScrollable {
 //
 extension AddAttributeViewController {
 
-    @objc private func completeUpdating() {
-        let addAttributeOptionsVC = AddAttributeOptionsViewController()
+    @objc private func doneButtonPressed() {
+        presentAddAttributeOptions(for: self.viewModel.newAttributeName)
+    }
+
+    private func presentAddAttributeOptions(for newAttribute: String?) {
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: newAttribute)
+        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
+        navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
+    }
+
+    private func presentAddAttributeOptions(for existingAttribute: ProductAttribute) {
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: self.viewModel.newAttributeName)
+        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -260,7 +260,8 @@ extension AddAttributeViewController: KeyboardScrollable {
 extension AddAttributeViewController {
 
     @objc private func completeUpdating() {
-        // TODO: to be implemented
+        let addAttributeOptionsVC = AddAttributeOptionsViewController()
+        navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -16,6 +16,7 @@ final class AddAttributeViewModel {
     private(set) var localAndGlobalAttributes: [ProductAttribute] = []
 
     var sections: [Section] = []
+    private(set) var newAttributeName: String?
 
     /// Represents the current state of `synchronizeProductAttributes` action. Useful for the consumer to update it's UI upon changes
     ///
@@ -97,6 +98,20 @@ private extension AddAttributeViewModel {
         let attributesSection = attributesRows.count > 0 ? Section(header: Localization.headerAttributes, footer: nil, rows: attributesRows) : nil
 
         sections = [Section(header: nil, footer: Localization.footerTextField, rows: [.attributeTextField]), attributesSection].compactMap { $0 }
+    }
+}
+
+
+// MARK: Actions
+extension AddAttributeViewModel {
+
+    func handleNewAttributeNameChange(_ name: String?) {
+        guard name != nil && name?.isNotEmpty == true else {
+            newAttributeName = nil
+            return
+        }
+
+        newAttributeName = name
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -15,7 +15,7 @@ final class AddAttributeViewModel {
     private let product: Product
     private(set) var localAndGlobalAttributes: [ProductAttribute] = []
 
-    var sections: [Section] = []
+    private(set) var sections: [Section] = []
     private(set) var newAttributeName: String?
 
     /// Represents the current state of `synchronizeProductAttributes` action. Useful for the consumer to update it's UI upon changes

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		451A04F52386F7C900E368C9 /* AddProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04F32386F7C900E368C9 /* AddProductImageCollectionViewCell.xib */; };
 		451B1740258B7EFB00836277 /* AddAttributeOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */; };
 		451B1741258B7EFB00836277 /* AddAttributeOptionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */; };
+		451B1747258BD7B600836277 /* AddAttributeOptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B1746258BD7B600836277 /* AddAttributeOptionsViewModel.swift */; };
 		451C77712404518600413F73 /* ProductSettingsRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C77702404518600413F73 /* ProductSettingsRows.swift */; };
 		451C77732404534000413F73 /* ProductSettingsSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C77722404534000413F73 /* ProductSettingsSections.swift */; };
 		4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4524CD9D242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift */; };
@@ -1517,6 +1518,7 @@
 		451A04F32386F7C900E368C9 /* AddProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewController.swift; sourceTree = "<group>"; };
 		451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddAttributeOptionsViewController.xib; sourceTree = "<group>"; };
+		451B1746258BD7B600836277 /* AddAttributeOptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModel.swift; sourceTree = "<group>"; };
 		451C77702404518600413F73 /* ProductSettingsRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsRows.swift; sourceTree = "<group>"; };
 		451C77722404534000413F73 /* ProductSettingsSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsSections.swift; sourceTree = "<group>"; };
 		4524CD9D242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatusSettingListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -3164,6 +3166,7 @@
 				451526382577D89E0076B03C /* AddAttributeViewModel.swift */,
 				451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */,
 				451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */,
+				451B1746258BD7B600836277 /* AddAttributeOptionsViewModel.swift */,
 			);
 			path = "Add Attributes";
 			sourceTree = "<group>";
@@ -6081,6 +6084,7 @@
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
+				451B1747258BD7B600836277 /* AddAttributeOptionsViewModel.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
 				265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -434,6 +434,8 @@
 		451A04F12386F7B500E368C9 /* ProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04EF2386F7B500E368C9 /* ProductImageCollectionViewCell.xib */; };
 		451A04F42386F7C900E368C9 /* AddProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04F22386F7C900E368C9 /* AddProductImageCollectionViewCell.swift */; };
 		451A04F52386F7C900E368C9 /* AddProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04F32386F7C900E368C9 /* AddProductImageCollectionViewCell.xib */; };
+		451B1740258B7EFB00836277 /* AddAttributeOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */; };
+		451B1741258B7EFB00836277 /* AddAttributeOptionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */; };
 		451C77712404518600413F73 /* ProductSettingsRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C77702404518600413F73 /* ProductSettingsRows.swift */; };
 		451C77732404534000413F73 /* ProductSettingsSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C77722404534000413F73 /* ProductSettingsSections.swift */; };
 		4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4524CD9D242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift */; };
@@ -1513,6 +1515,8 @@
 		451A04EF2386F7B500E368C9 /* ProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		451A04F22386F7C900E368C9 /* AddProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		451A04F32386F7C900E368C9 /* AddProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
+		451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewController.swift; sourceTree = "<group>"; };
+		451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddAttributeOptionsViewController.xib; sourceTree = "<group>"; };
 		451C77702404518600413F73 /* ProductSettingsRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsRows.swift; sourceTree = "<group>"; };
 		451C77722404534000413F73 /* ProductSettingsSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsSections.swift; sourceTree = "<group>"; };
 		4524CD9D242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatusSettingListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -3158,6 +3162,8 @@
 				4515262C2577D56C0076B03C /* AddAttributeViewController.swift */,
 				4515262D2577D56C0076B03C /* AddAttributeViewController.xib */,
 				451526382577D89E0076B03C /* AddAttributeViewModel.swift */,
+				451B173E258B7EFB00836277 /* AddAttributeOptionsViewController.swift */,
+				451B173F258B7EFB00836277 /* AddAttributeOptionsViewController.xib */,
 			);
 			path = "Add Attributes";
 			sourceTree = "<group>";
@@ -5315,6 +5321,7 @@
 				CE22E3FC21714776005A6BEF /* TopLeftImageTableViewCell.xib in Resources */,
 				571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */,
 				B5D1AFB420BC445A00DB0E8C /* Images.xcassets in Resources */,
+				451B1741258B7EFB00836277 /* AddAttributeOptionsViewController.xib in Resources */,
 				CEE005F62076C4040079161F /* Orders.storyboard in Resources */,
 				CE85FD5C20F7A7740080B73E /* TableFooterView.xib in Resources */,
 				773077EF251E943700178696 /* ProductDownloadFileViewController.xib in Resources */,
@@ -5990,6 +5997,7 @@
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
 				45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */,
 				025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */,
+				451B1740258B7EFB00836277 /* AddAttributeOptionsViewController.swift in Sources */,
 				57A5D8D32534F92D00AA54D6 /* TotalRefundedCalculationUseCase.swift in Sources */,
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
 				453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
@@ -66,7 +66,7 @@ final class AddAttributeViewModelTests: XCTestCase {
         XCTAssertEqual(storesManager.numberOfResponsesConsumed, 1)
     }
 
-    func test_handle_valid_new_attribute_name() throws {
+    func test_handle_valid_new_attribute_name() {
         // Given
         let product = MockProduct().product()
         let viewModel = AddAttributeViewModel(storesManager: storesManager, product: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
@@ -65,6 +65,37 @@ final class AddAttributeViewModelTests: XCTestCase {
         XCTAssertTrue(result)
         XCTAssertEqual(storesManager.numberOfResponsesConsumed, 1)
     }
+
+    func test_handle_valid_new_attribute_name() throws {
+        // Given
+        let product = MockProduct().product()
+        let viewModel = AddAttributeViewModel(storesManager: storesManager, product: product)
+
+
+        // When
+        viewModel.handleNewAttributeNameChange("Color")
+
+
+        // Then
+        XCTAssertEqual(viewModel.newAttributeName, "Color")
+    }
+
+    func test_handle_invalid_new_attribute_name() {
+        // Given
+        let product = MockProduct().product()
+        let viewModel = AddAttributeViewModel(storesManager: storesManager, product: product)
+
+
+        // When
+        viewModel.handleNewAttributeNameChange(nil)
+            // Then
+            XCTAssertNil(viewModel.newAttributeName)
+
+        // When
+        viewModel.handleNewAttributeNameChange("")
+            // Then
+            XCTAssertNil(viewModel.newAttributeName)
+    }
 }
 
 /// Mock Product Attribute Store Manager


### PR DESCRIPTION
## Description
As part of #3182, in this PR I implemented the basic components for managing the components of the Attribute Options screen. For the moment, the data showed inside are not related for to real options, and it's not possible to do any action. The action and the data (that should be fetched using an API) will be part of other PRs.

The functionality it's under the M5 feature flag, so it will be not visible to our users, since it's still a WIP.

## Testing
1. Open a Variable Product without variations.
2. Tap the cell "Add variations".
3. The screen "Add Attribute" should be presented.
4. In the "Add Attribute" screen you should see the list of global attributes + local product attributes.
5a. Tap an existing attribute. The new screen should be opened.
5b. Try to write a new attribute in the text field and tap Next. The new screen should be opened.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/102634537-42df8280-4152-11eb-97ad-26d404382673.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
