### PR TITLE
Shipping Labels M1: handle A4 paper size (not supported in mobile yet)

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaperSize.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaperSize.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Paper size options for printing a shipping label.
 public enum ShippingLabelPaperSize {
+    case a4
     case label
     case legal
     case letter
@@ -13,6 +14,8 @@ extension ShippingLabelPaperSize: RawRepresentable {
     ///
     public init(rawValue: String) {
         switch rawValue {
+        case Keys.a4:
+            self = .a4
         case Keys.label:
             self = .label
         case Keys.legal:
@@ -29,6 +32,8 @@ extension ShippingLabelPaperSize: RawRepresentable {
     ///
     public var rawValue: String {
         switch self {
+        case .a4:
+            return Keys.a4
         case .label:
             return Keys.label
         case .legal:
@@ -41,6 +46,7 @@ extension ShippingLabelPaperSize: RawRepresentable {
 
 /// Contains the supported ShippingLabelPaperSize values.
 private enum Keys {
+    static let a4 = "a4"
     static let label = "label"
     static let legal = "legal"
     static let letter = "letter"

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
@@ -10,6 +10,9 @@ extension ShippingLabelPaperSize {
             return NSLocalizedString("Legal (8.5 x 14 in)", comment: "Title of legal paper size option for printing a shipping label")
         case .letter:
             return NSLocalizedString("Letter (8.5 x 11 in)", comment: "Title of letter paper size option for printing a shipping label")
+        default:
+            assertionFailure("Unexpected paper size: \(self)")
+            return ""
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionView.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionView.swift
@@ -17,6 +17,8 @@ struct ShippingLabelPaperSizeOptionView: View {
         case .letter:
             title = Localization.letterSizeTitle
             image = PaperSizeImage.letter
+        default:
+            fatalError("Unexpected paper size: \(paperSize)")
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ReprintShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/ReprintShippingLabelViewModelTests.swift
@@ -70,6 +70,34 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
         XCTAssertEqual(paperSizeValues, [nil, .letter])
     }
 
+    func test_loadShippingLabelSettingsForDefaultPaperSize_with_unsupported_paper_size_sets_selectedPaperSize_to_the_first_option() {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
+        // A4 paper size is not supported in mobile yet.
+        let shippingLabelSettings = ShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID, paperSize: .a4)
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .loadShippingLabelSettings(_, completion):
+                completion(shippingLabelSettings)
+            default:
+                break
+            }
+        }
+
+        var paperSizeValues = [ShippingLabelPaperSize?]()
+        viewModel.$selectedPaperSize.sink { paperSize in
+            paperSizeValues.append(paperSize)
+        }.store(in: &cancellables)
+
+        // When
+        viewModel.loadShippingLabelSettingsForDefaultPaperSize()
+
+        // Then
+        XCTAssertEqual(paperSizeValues, [nil, .legal])
+    }
+
     func test_updateSelectedPaperSize_sets_selectedPaperSize_to_selected_value() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()


### PR DESCRIPTION
Fixes #3340 

## Why

Right now, only stores in the US can create a shipping label with 3 paper size options: legal, letter, and label. However, after a shipping label is created, if the store country is changed to outside of US, CA, MX, DO (ref CKNC7KACA/p1607010932150400?thread_ts=1606980019.149700&cid=CKNC7KACA-slack) A4 paper size becomes available.

This is still an edge case as most stores don't change the store country and reprint an existing shipping label. In the future, we might want to support A4 paper size if it is the shipping label preference (that we fetch in `ShippingLabelSettings`).

## Changes

- Added a new case `ShippingLabelPaperSize.a4`
- In the UI side, `ReprintShippingLabelViewModel` already detects an unsupported paper size and defaults to the first paper size option (`legal`) in the following code. This PR added a test case for this scenario
https://github.com/woocommerce/woocommerce-ios/blob/f09cd9ca3777cd0583452c208b9001dc8c253fa0/WooCommerce/Classes/ViewModels/Order%20Details/Shipping%20Labels/ReprintShippingLabelViewModel.swift#L33-L35

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/). You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- In wp-admin, create a shipping label for an order
- Change store country to outside of US, CA, MX, DO (e.g. UK) in WooCommerce settings
- Go back to the order, and try reprinting a shipping label --> A4 paper size appears in the paper size menu
- Reprint with A4 paper size or set the default paper size to A4 in WooCommerce settings > Shipping > WooCommerce Shipping
- Launch the app
- Go to the orders tab, and tap on the same order
- Tap "Reprint Shipping Label" --> the app used to crash in `develop` in debug mode, and now it should not crash and the paper size is default to "Legal"

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
