### PR TITLE
Edge to edge cells in landscape on Settings / Refunded Products / Fulfill screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,18 +22,23 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="qd5-Nc-d2w">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="qd5-Nc-d2w" secondAttribute="bottom" id="BGZ-kZ-1cI"/>
-                <constraint firstItem="qd5-Nc-d2w" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="U40-r9-s1C"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="qd5-Nc-d2w" secondAttribute="trailing" id="vgq-RE-crj"/>
+                <constraint firstItem="qd5-Nc-d2w" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="U40-r9-s1C"/>
+                <constraint firstAttribute="trailing" secondItem="qd5-Nc-d2w" secondAttribute="trailing" id="vgq-RE-crj"/>
                 <constraint firstItem="qd5-Nc-d2w" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="wdp-Jy-QPG"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="139" y="101"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,21 +22,26 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="PZK-nf-bse">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="uI8-cL-jw9"/>
                     </connections>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="PZK-nf-bse" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Eyd-Jr-8Fu"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="PZK-nf-bse" secondAttribute="bottom" id="jin-np-8Ra"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="PZK-nf-bse" secondAttribute="trailing" id="uvd-ff-hsA"/>
-                <constraint firstItem="PZK-nf-bse" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="zI7-3y-T9L"/>
+                <constraint firstAttribute="trailing" secondItem="PZK-nf-bse" secondAttribute="trailing" id="uvd-ff-hsA"/>
+                <constraint firstItem="PZK-nf-bse" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="zI7-3y-T9L"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="139" y="100"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -32,8 +32,8 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="TsO-Qh-HeU" firstAttribute="top" secondItem="NOa-Wc-6dg" secondAttribute="top" id="FWT-AI-lfG"/>
-                <constraint firstItem="NOa-Wc-6dg" firstAttribute="trailing" secondItem="TsO-Qh-HeU" secondAttribute="trailing" id="JsN-no-dch"/>
-                <constraint firstItem="TsO-Qh-HeU" firstAttribute="leading" secondItem="NOa-Wc-6dg" secondAttribute="leading" id="bAJ-fO-k5E"/>
+                <constraint firstAttribute="trailing" secondItem="TsO-Qh-HeU" secondAttribute="trailing" id="JsN-no-dch"/>
+                <constraint firstItem="TsO-Qh-HeU" firstAttribute="leading" secondItem="xri-bp-stu" secondAttribute="leading" id="bAJ-fO-k5E"/>
                 <constraint firstItem="NOa-Wc-6dg" firstAttribute="bottom" secondItem="TsO-Qh-HeU" secondAttribute="bottom" id="qSJ-tY-aue"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>


### PR DESCRIPTION
Closes #2943 

### What
In this PR we're making cells go edge to edge in landscape on iPhones with a notch. 
Original issue talks only about Fulfill screen, but I updated a few other simple screens as well.
More screens can be updated to support edge to edge cells, but many requires some input from a designer.

|Before|After|
|-|-|
|<img width="971" alt="Screenshot 2020-12-21 at 11 50 28" src="https://user-images.githubusercontent.com/54751/102776658-6c392200-438f-11eb-9486-f817cc34f250.png">|<img width="1062" alt="Screenshot 2020-12-21 at 11 47 10" src="https://user-images.githubusercontent.com/54751/102776669-70fdd600-438f-11eb-926c-515f963a5ec4.png">|
|<img width="1062" alt="Screenshot 2020-12-21 at 11 50 00" src="https://user-images.githubusercontent.com/54751/102776712-8a068700-438f-11eb-91bf-711af1249611.png">|<img width="1018" alt="Screenshot 2020-12-21 at 11 46 55" src="https://user-images.githubusercontent.com/54751/102776727-8f63d180-438f-11eb-8de3-435ca8bbe176.png">|

### How

Connecting leading and trailing constraints directly to the superview and not a safe area will make cells go edge to edge. Content view of the cells will still follow safe area guidelines in this case.

### Testing (iPhone with a notch and iPhone without a notch)

Check that the cells are edge to edge and content is following the safe area guidelines on the following screens:
* Order -> Order Details -> Refunded Products
* Order -> Order Details -> Fulfill Order
* Settings

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
