### PR TITLE
Localize fullName in Address

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -7,10 +7,14 @@ import Yosemite
 //
 extension Address {
 
-    /// Returns the First + LastName combined.
+    /// Returns the First + LastName combined according to users Locale.
     ///
     var fullName: String {
-        return firstName + " " + lastName
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
     }
 
     /// Returns the `fullName` and `company` (on a new line). If either the `fullname` or `company` is empty,

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -7,7 +7,7 @@ import Yosemite
 //
 extension Address {
 
-    /// Returns the First + LastName combined according to users Locale.
+    /// Returns the First + LastName combined according to language rules and Locale.
     ///
     var fullName: String {
         var components = PersonNameComponents()

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -70,6 +70,6 @@ private extension OrderListCellViewModel {
             return String.localizedStringWithFormat(format, orderNumber, customerName)
         }
 
-        static let guestName = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no name and last name.")
+        static let guestName = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no first and last name.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -127,13 +127,14 @@ private extension OrderTableViewCell {
     /// For example, #560 Pamela Nguyen
     ///
     func title(for order: Order) -> String {
-        if let billingAddress = order.billingAddress, billingAddress.firstName.isNotEmpty || billingAddress.lastName.isNotEmpty {
-            return Localization.title(orderNumber: order.number,
-                                      firstName: billingAddress.firstName,
-                                      lastName: billingAddress.lastName)
-        }
+        let customerName: String = {
+            if let fullName = order.billingAddress?.fullName, fullName.isNotEmpty {
+                return fullName
+            }
+            return Localization.guestName
+        }()
 
-        return Localization.title(orderNumber: order.number)
+        return Localization.title(orderNumber: order.number, customerName: customerName)
     }
 }
 
@@ -163,22 +164,14 @@ private extension OrderTableViewCell {
 
 private extension OrderTableViewCell {
     enum Localization {
-        static func title(orderNumber: String, firstName: String, lastName: String) -> String {
-            let format = NSLocalizedString("#%1$@ %2$@ %3$@", comment: "In Order List,"
-                + " the pattern to show the order number and the full name. For example, “#123 John Doe”."
-                + " The %1$@ is the order number. The %2$@ is the first name. The %3$@ is the last name.")
-
-            return String.localizedStringWithFormat(format, orderNumber, firstName, lastName)
-        }
-
-        static func title(orderNumber: String) -> String {
+        static func title(orderNumber: String, customerName: String) -> String {
             let format = NSLocalizedString("#%@ %@", comment: "In Order List,"
                 + " the pattern to show the order number. For example, “#123456”."
                 + " The %@ placeholder is the order number.")
 
-            let guestName: String = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no name and last name.")
-
-            return String.localizedStringWithFormat(format, orderNumber, guestName)
+            return String.localizedStringWithFormat(format, orderNumber, customerName)
         }
+
+        static let guestName = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no name and last name.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -39,10 +39,8 @@ struct SummaryTableViewCellViewModel {
     /// The full name from the billing address
     ///
     var billedPersonName: String {
-        if let billingAddress = billingAddress,
-            billingAddress.firstName.isNotEmpty || billingAddress.lastName.isNotEmpty {
-            return Localization.billedPerson(firstName: billingAddress.firstName,
-                                             lastName: billingAddress.lastName)
+        if let fullName = billingAddress?.fullName, fullName.isNotEmpty {
+            return fullName
         } else {
             return Localization.guestName
         }
@@ -193,14 +191,6 @@ private extension SummaryTableViewCell {
 
 private extension SummaryTableViewCellViewModel {
     enum Localization {
-        static func billedPerson(firstName: String, lastName: String) -> String {
-            let format = NSLocalizedString("%1$@ %2$@", comment: "In Order Details,"
-                + " the pattern to show the billed person's full name. For example, “John Doe”."
-                + " The %1$@ is the first name. The %2$@ is the last name.")
-
-            return String.localizedStringWithFormat(format, firstName, lastName)
-        }
-
         static let guestName: String = NSLocalizedString("Guest",
                                                          comment: "In Order Details, the name of the billed person when there are no name and last name.")
     }


### PR DESCRIPTION
Closes #2314 

### What

Display localized name of the customer based on the language rules, phone locale and settings.
I'm switching the code to using `PersonNameComponentsFormatter` instead of `NSLocalizedString` because it takes into account:
* Characters used in the name. For Chinese, Japanese and Korean names there are strict ordering rules that can't be overridden by a selected locale
* Current locale (that's the only similar part to `NSLocalizedString`)
* User specified preferences. Users can override the default sort and display order of given and family names for their current locale.

The Chinese name on the screenshots is `张三` and should always be written in this order. (https://en.wikipedia.org/wiki/List_of_placeholder_names_by_language)

|Before|After|
|-|-|
|![Simulator Screen Shot - iPhone 11 - 2020-12-21 at 16 20 46](https://user-images.githubusercontent.com/54751/102792769-3bfe7d00-43a9-11eb-8880-d59a5f8d2679.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-21 at 16 19 41](https://user-images.githubusercontent.com/54751/102792761-3a34b980-43a9-11eb-8bda-e810e0975902.png)|

### Testing

1. Open order list
2. Check that first/last names are in the same order as in contacts app on the phone
3. Open one of the orders
4. Check shipping and billing addresses

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
