### PR TITLE
Reprint Shipping Label: present printing instructions and paper size options modals

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -221,9 +221,7 @@ extension OrderDetailsViewModel {
             let shippingLabelDetailsViewController = ShippingLabelDetailsViewController(shippingLabel: shippingLabel)
             viewController.show(shippingLabelDetailsViewController, sender: viewController)
         case .shippingLabelPrintingInfo:
-            let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController { [weak viewController] in
-                viewController?.dismiss(animated: true, completion: nil)
-            }
+            let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
             let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)
             viewController.present(navigationController, animated: true, completion: nil)
         case .shippingLabelProduct:

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPrintingInstructionsViewController.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPrintingInstructionsViewController.swift
@@ -3,11 +3,7 @@ import UIKit
 
 /// Displays instructions on how to print a shipping label from an iOS device.
 final class ShippingLabelPrintingInstructionsViewController: UIHostingController<ShippingLabelPrintingInstructionsView> {
-    private let onCloseButtonTapped: () -> Void
-
-    /// - Parameter onCloseButtonTapped: Called when the user taps on the close button in the navigation bar.
-    init(onCloseButtonTapped: @escaping () -> Void) {
-        self.onCloseButtonTapped = onCloseButtonTapped
+    init() {
         super.init(rootView: ShippingLabelPrintingInstructionsView())
         configureNavigationBar()
     }
@@ -20,13 +16,7 @@ final class ShippingLabelPrintingInstructionsViewController: UIHostingController
 private extension ShippingLabelPrintingInstructionsViewController {
     func configureNavigationBar() {
         navigationItem.title = Localization.navigationBarTitle
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: self, action: #selector(closeButtonTapped))
-    }
-}
-
-private extension ShippingLabelPrintingInstructionsViewController {
-    @objc func closeButtonTapped() {
-        onCloseButtonTapped()
+        addCloseNavigationBarButton()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelCoordinator.swift
@@ -30,6 +30,10 @@ final class ReprintShippingLabelCoordinator {
                                            onPaperSizeSelected: onSelection)
             case .reprint(let paperSize):
                 self.reprintShippingLabel(paperSize: paperSize)
+            case .presentPaperSizeOptions:
+                self.presentPaperSizeOptions()
+            case .presentPrintingInstructions:
+                self.presentPrintingInstructions()
             }
         }
 
@@ -80,6 +84,18 @@ private extension ReprintShippingLabelCoordinator {
         let printController = UIPrintInteractionController()
         printController.printingItem = printData.data
         printController.present(animated: true, completionHandler: nil)
+    }
+
+    func presentPaperSizeOptions() {
+        let paperSizeOptionsViewController = ShippingLabelPaperSizeOptionsViewController()
+        let navigationController = WooNavigationController(rootViewController: paperSizeOptionsViewController)
+        sourceViewController.present(navigationController, animated: true, completion: nil)
+    }
+
+    func presentPrintingInstructions() {
+        let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
+        let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)
+        sourceViewController.present(navigationController, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
@@ -56,6 +56,10 @@ extension ReprintShippingLabelViewController {
                                    onSelection: (ShippingLabelPaperSize?) -> Void)
         /// Called when the Reprint CTA is tapped.
         case reprint(paperSize: ShippingLabelPaperSize)
+        /// Called when the "layout and paper size options" row is selected.
+        case presentPaperSizeOptions
+        /// Called when the printing instructions row is selected.
+        case presentPrintingInstructions
     }
 }
 
@@ -74,6 +78,14 @@ private extension ReprintShippingLabelViewController {
                                          onSelection: { [weak self] paperSize in
                                             self?.viewModel.updateSelectedPaperSize(paperSize)
                                          }))
+    }
+
+    func presentPaperSizeOptions() {
+        onAction?(.presentPaperSizeOptions)
+    }
+
+    func presentPrintingInstructions() {
+        onAction?(.presentPrintingInstructions)
     }
 }
 
@@ -146,11 +158,9 @@ extension ReprintShippingLabelViewController: UITableViewDelegate {
         case .paperSize:
             showPaperSizeSelector()
         case .paperSizeOptions:
-            // TODO-2169: Present paper size options modal
-            break
+            presentPaperSizeOptions()
         case .printingInstructions:
-            // TODO-2169: Present printing instructions modal
-            break
+            presentPrintingInstructions()
         default:
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/ReprintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/ReprintShippingLabelCoordinatorTests.swift
@@ -108,6 +108,42 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
         XCTAssertEqual(viewController.presentedViewControllers.count, 1)
         assertThat(viewController.presentedViewControllers[0], isAnInstanceOf: UIAlertController.self)
     }
+
+    // MARK: `presentPaperSizeOptions`
+
+    func test_presentPaperSizeOptions_presents_ShippingLabelPaperSizeOptionsViewController() throws {
+        // Given
+        let viewController = MockSourceViewController()
+        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        coordinator.showReprintUI()
+        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+
+        // When
+        reprintViewController.onAction?(.presentPaperSizeOptions)
+
+        // Then
+        XCTAssertEqual(viewController.presentedViewControllers.count, 1)
+        assertThat((viewController.presentedViewControllers[0] as? UINavigationController)?.topViewController,
+                   isAnInstanceOf: ShippingLabelPaperSizeOptionsViewController.self)
+    }
+
+    // MARK: `presentPrintingInstructions`
+
+    func test_presentPrintingInstructions_presents_ShippingLabelPrintingInstructionsViewController() throws {
+        // Given
+        let viewController = MockSourceViewController()
+        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        coordinator.showReprintUI()
+        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+
+        // When
+        reprintViewController.onAction?(.presentPrintingInstructions)
+
+        // Then
+        XCTAssertEqual(viewController.presentedViewControllers.count, 1)
+        assertThat((viewController.presentedViewControllers[0] as? UINavigationController)?.topViewController,
+                   isAnInstanceOf: ShippingLabelPrintingInstructionsViewController.self)
+    }
 }
 
 private final class MockSourceViewController: UIViewController {


### PR DESCRIPTION
Fixes #2169 

## Why

This PR implements the two remaining actions in the shipping label reprint screen to present info modals about printing instructions and paper size options.

## Changes

- In `ShippingLabelPrintingInstructionsViewController `, replaced manual close action handling with `addCloseNavigationBarButton` helper. Updated existing usage in `OrderDetailsViewModel`
- Added two cases to `ReprintShippingLabelViewController.ActionType`: `presentPaperSizeOptions` and `presentPrintingInstructions`
- In `ReprintShippingLabelCoordinator`, implemented the two action types to present its corresponding static info modal. Added test cases

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label
- After a shipping label package card appears, tap "Reprint Shipping Label"
- Tap "See layout and paper sizes options" --> a modal should be presented about available paper size options
- Tap "X" or swipe down to dismiss the modal
- Tap "Don't know how to print from your device?" --> a modal should be presented about printing instructions
- Tap "X" or swipe down to dismiss the modal

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/102878277-f57d5100-4482-11eb-8339-ebc31638368e.gif)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
