### PR TITLE
Moved the Add Product Variations flow under a dedicated feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,6 +7,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease5:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .addProductVariations:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -14,6 +14,10 @@ enum FeatureFlag: Int {
     ///
     case editProductsRelease5
 
+    /// Add Product Variations
+    ///
+    case addProductVariations
+
     /// Product Reviews
     ///
     case reviews

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -57,6 +57,7 @@ private extension AddProductCoordinator {
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                                   product: model)
         let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
+        let isAddProductVariationsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler,
@@ -66,7 +67,8 @@ private extension AddProductCoordinator {
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
+                                                       isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -13,6 +13,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
     private let isEditProductsRelease5Enabled: Bool
+    private let isAddProductVariationsEnabled: Bool
 
     init(product: ProductFormDataModel,
          actionsFactory: ProductFormActionsFactoryProtocol,
@@ -21,7 +22,8 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.currency = currency
         self.currencyFormatter = currencyFormatter
-            self.isEditProductsRelease5Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
+        self.isEditProductsRelease5Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
+        self.isAddProductVariationsEnabled = featureFlagService.isFeatureFlagEnabled(.addProductVariations)
         configureSections(product: product, actionsFactory: actionsFactory)
     }
 }
@@ -370,7 +372,7 @@ private extension DefaultProductFormTableViewModel {
 
     func variationsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.variationsImage
-        let title = (product.variations.isEmpty && isEditProductsRelease5Enabled) ? Localization.addVariationsTitle : Localization.variationsTitle
+        let title = (product.variations.isEmpty && isAddProductVariationsEnabled) ? Localization.addVariationsTitle : Localization.variationsTitle
 
         let details: String
         let format = NSLocalizedString("%1$@ (%2$ld options)", comment: "Format for each Product attribute")
@@ -381,7 +383,7 @@ private extension DefaultProductFormTableViewModel {
                 .map({ String.localizedStringWithFormat(format, $0.name, $0.options.count) })
                 .joined(separator: "\n")
         default:
-            if isEditProductsRelease5Enabled {
+            if isAddProductVariationsEnabled {
                 details = ""
             }
             else {
@@ -389,7 +391,7 @@ private extension DefaultProductFormTableViewModel {
             }
         }
 
-        let isActionable = product.variations.isNotEmpty || (product.variations.isEmpty && isEditProductsRelease5Enabled)
+        let isActionable = product.variations.isNotEmpty || (product.variations.isEmpty && isAddProductVariationsEnabled)
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -40,6 +40,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let currency: String
     private let isEditProductsRelease5Enabled: Bool
+    private let isAddProductVariationsEnabled: Bool
 
     private lazy var exitForm: () -> Void = {
         presentationStyle.createExitForm(viewController: self)
@@ -59,12 +60,14 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          presentationStyle: ProductFormPresentationStyle,
-         isEditProductsRelease5Enabled: Bool) {
+         isEditProductsRelease5Enabled: Bool,
+         isAddProductVariationsEnabled: Bool) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
         self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
+        self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
@@ -346,7 +349,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 guard product.product.variations.isNotEmpty else {
-                    if isEditProductsRelease5Enabled {
+                    if isAddProductVariationsEnabled {
                         let viewModel = AddAttributeViewModel(product: product.product)
                         let addAttributeViewController = AddAttributeViewController(viewModel: viewModel)
                         navigationController?.pushViewController(addAttributeViewController, animated: true)
@@ -355,7 +358,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
                                                                                formType: viewModel.formType,
-                                                                               isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                                               isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
+                                                                               isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)
             case .status, .noPriceWarning:
                 break

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -20,7 +20,8 @@ struct ProductDetailsFactory {
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
                                 isEditProductsEnabled: forceReadOnly ? false: true,
-                                isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
+                                isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5),
+                                isAddProductVariationsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations))
         onCompletion(vc)
     }
 }
@@ -30,7 +31,8 @@ private extension ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
-                               isEditProductsRelease5Enabled: Bool) -> UIViewController {
+                               isEditProductsRelease5Enabled: Bool,
+                               isAddProductVariationsEnabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
@@ -44,7 +46,8 @@ private extension ProductDetailsFactory {
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
                                        presentationStyle: presentationStyle,
-                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
+                                       isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -21,7 +21,8 @@ struct ProductVariationDetailsFactory {
                                          presentationStyle: presentationStyle,
                                          currencySettings: currencySettings,
                                          isEditProductsEnabled: forceReadOnly ? false: true,
-                                         isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
+                                         isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5),
+                                         isAddProductVariationsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations))
         onCompletion(vc)
     }
 }
@@ -32,7 +33,8 @@ private extension ProductVariationDetailsFactory {
                                         presentationStyle: ProductFormPresentationStyle,
                                         currencySettings: CurrencySettings,
                                         isEditProductsEnabled: Bool,
-                                        isEditProductsRelease5Enabled: Bool) -> UIViewController {
+                                        isEditProductsRelease5Enabled: Bool,
+                                        isAddProductVariationsEnabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
                                                                   allAttributes: parentProduct.attributes,
@@ -49,7 +51,8 @@ private extension ProductVariationDetailsFactory {
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
                                        presentationStyle: presentationStyle,
-                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
+                                       isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -82,14 +82,16 @@ final class ProductVariationsViewController: UIViewController {
 
     private let imageService: ImageService = ServiceLocator.imageService
     private let isEditProductsRelease5Enabled: Bool
+    private let isAddProductVariationsEnabled: Bool
 
-    init(product: Product, formType: ProductFormType, isEditProductsRelease5Enabled: Bool) {
+    init(product: Product, formType: ProductFormType, isEditProductsRelease5Enabled: Bool, isAddProductVariationsEnabled: Bool) {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
         self.parentProductSKU = product.sku
         self.formType = formType
         self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
+        self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -302,7 +304,8 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
+                                                       isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         navigationController?.pushViewController(viewController, animated: true)
     }
 


### PR DESCRIPTION
## Description
As discussed [here](https://a8c.slack.com/archives/CGPNUU63E/p1608386588040300), we decided to move the Add Product Variation (WIP) under a separate feature flag, removing it from M5. 
In this PR I introduced this new feature flag, and I moved all the things regarding the Add Product Variation flow under the flag `addProductVariations`.

## Testing
#### Case 1
1. Pull this branch, and run the app.
2. Open a variable product without variations.
3. You should see the "Add Variations" row, and tapping it the Add Product Variations flow should be displayed.

#### Case 2
1. Inside the code, under the `DefaultFeatureFlagService` struct, pass false to the `addProductVariations` feature flag.
2. Open a variable product without variations.
3. You should see the "Variations - No variations yet" row. Tapping it, nothing should happen.


| `addProductVariations` disabled             |  `addProductVariations` enabled |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2020-12-22 at 12 17 35](https://user-images.githubusercontent.com/495617/102884532-09f52580-4452-11eb-872d-fd576b554399.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2020-12-22 at 12 18 08](https://user-images.githubusercontent.com/495617/102884537-0bbee900-4452-11eb-8495-2174581d008e.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
