### PR TITLE
Added tracking events for Product Deletion

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -291,6 +291,7 @@ public enum WooAnalyticsStat: String {
     case productPriceSettingsDoneButtonTapped   = "product_price_settings_done_button_tapped"
     case productShippingSettingsDoneButtonTapped = "product_shipping_settings_done_button_tapped"
     case productInventorySettingsDoneButtonTapped = "product_inventory_settings_done_button_tapped"
+    case productDetailProductDeleted = "product_detail_product_deleted"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -227,7 +227,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         if viewModel.canDeleteProduct() {
             actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.delete) { [weak self] _ in
-                // TODO: Analytics M5
                 self?.displayDeleteProductAlert()
             }
         }
@@ -695,6 +694,7 @@ private extension ProductFormViewController {
                         self?.displayError(error: error)
                     }
                 case .success:
+                    ServiceLocator.analytics.track(.productDetailProductDeleted)
                     // Dismisses the in-progress UI.
                     self.navigationController?.dismiss(animated: true, completion: nil)
                     // Dismiss or Pop the Product Form


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/3388

## Description
Added the event when a product is moved into the trash.
The deletion feature will be enabled for everyone at the end of milestone 5. https://github.com/woocommerce/woocommerce-ios/issues/3400

## Testing
1. Try to delete a product.
2. In the console log the event `product_detail_product_deleted` should be fired.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
