### PR TITLE
Rename SettingTitleAndValueTableViewCell -> TitleAndValueTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/LinkSettings/LinkSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/LinkSettings/LinkSettingsViewController.swift
@@ -216,9 +216,9 @@ private extension LinkSettingsViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
-        case let cell as SettingTitleAndValueTableViewCell where row == .url:
+        case let cell as TitleAndValueTableViewCell where row == .url:
             configureURL(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .text:
+        case let cell as TitleAndValueTableViewCell where row == .text:
             configureText(cell: cell)
         case let cell as SwitchTableViewCell where row == .openInNewWindow:
             configureOpenInNewWindow(cell: cell)
@@ -229,14 +229,14 @@ private extension LinkSettingsViewController {
         }
     }
 
-    func configureURL(cell: SettingTitleAndValueTableViewCell) {
+    func configureURL(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("URL", comment: "URL text field placeholder")
         let value = linkSettings.url
         cell.updateUI(title: title, value: value)
         cell.accessoryType = .disclosureIndicator
     }
 
-    func configureText(cell: SettingTitleAndValueTableViewCell) {
+    func configureText(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Link Text", comment: "Label for the text of a link in the editor")
         let value = linkSettings.text
         cell.updateUI(title: title, value: value)
@@ -278,9 +278,9 @@ private extension LinkSettingsViewController {
         var type: UITableViewCell.Type {
             switch self {
             case .url:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             case .text:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             case .openInNewWindow:
                 return SwitchTableViewCell.self
             case .removeLink:

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -285,7 +285,7 @@ private extension FilterListViewController {
 
 private extension FilterListViewController {
     final class FilterListSelectorCommand: ListSelectorCommand {
-        typealias Cell = SettingTitleAndValueTableViewCell
+        typealias Cell = TitleAndValueTableViewCell
         typealias Model = FilterTypeViewModel
 
         var navigationBarTitle: String?
@@ -311,7 +311,7 @@ private extension FilterListViewController {
             onItemSelectedSubject.send(selected)
         }
 
-        func configureCell(cell: SettingTitleAndValueTableViewCell, model: FilterTypeViewModel) {
+        func configureCell(cell: TitleAndValueTableViewCell, model: FilterTypeViewModel) {
             cell.selectionStyle = .default
             cell.updateUI(title: model.cellViewModel.title, value: model.cellViewModel.value)
             cell.accessoryType = .disclosureIndicator

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -90,7 +90,7 @@ private extension RefundConfirmationViewController {
     func configureTableView() {
         // Register cells
         [
-            SettingTitleAndValueTableViewCell.self,
+            TitleAndValueTableViewCell.self,
             TitleAndEditableValueTableViewCell.self,
             HeadlineLabelTableViewCell.self,
             WooBasicTableViewCell.self
@@ -150,7 +150,7 @@ extension RefundConfirmationViewController: UITableViewDataSource {
 
         switch row {
         case let row as RefundConfirmationViewModel.TwoColumnRow:
-            let cell = tableView.dequeueReusableCell(SettingTitleAndValueTableViewCell.self, for: indexPath)
+            let cell = tableView.dequeueReusableCell(TitleAndValueTableViewCell.self, for: indexPath)
             cell.updateUI(title: row.title, value: row.value)
             if row.isHeadline {
                 cell.apply(style: .headline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
@@ -165,7 +165,7 @@ private extension ReprintShippingLabelViewController {
             configureHeaderText(cell: cell)
         case let cell as TopLeftImageTableViewCell where row == .infoText:
             configureInfoText(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .paperSize:
+        case let cell as TitleAndValueTableViewCell where row == .paperSize:
             configurePaperSize(cell: cell)
         case let cell as SpacerTableViewCell where row == .spacerBetweenInfoTextAndPaperSizeSelector:
             configureSpacerBetweenInfoTextAndPaperSizeSelector(cell: cell)
@@ -196,7 +196,7 @@ private extension ReprintShippingLabelViewController {
         cell.hideSeparator()
     }
 
-    func configurePaperSize(cell: SettingTitleAndValueTableViewCell) {
+    func configurePaperSize(cell: TitleAndValueTableViewCell) {
         cell.updateUI(title: Localization.paperSizeSelectorTitle, value: selectedPaperSize?.description)
         cell.accessoryType = .disclosureIndicator
     }
@@ -273,7 +273,7 @@ private extension ReprintShippingLabelViewController {
             case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks:
                 return SpacerTableViewCell.self
             case .paperSize:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             case .paperSizeOptions, .printingInstructions:
                 return TopLeftImageTableViewCell.self
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -216,7 +216,7 @@ private extension AddProductCategoryViewController {
         switch cell {
         case let cell as TextFieldTableViewCell where row == .title:
             configureTitle(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .parentCategory:
+        case let cell as TitleAndValueTableViewCell where row == .parentCategory:
             configureParentCategory(cell: cell)
         default:
             fatalError()
@@ -236,7 +236,7 @@ private extension AddProductCategoryViewController {
         cell.applyStyle(style: .body)
     }
 
-    func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
+    func configureParentCategory(cell: TitleAndValueTableViewCell) {
         cell.updateUI(title: Strings.parentCellTitle, value: selectedParentCategory?.name ?? Strings.parentCellPlaceholder)
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
@@ -260,7 +260,7 @@ private extension AddProductCategoryViewController {
             case .title:
                 return TextFieldTableViewCell.self
             case .parentCategory:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -307,19 +307,19 @@ private extension ProductPriceSettingsViewController {
             configureSalePrice(cell: cell)
         case let cell as SwitchTableViewCell where row == .scheduleSale:
             configureScheduleSale(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .scheduleSaleFrom:
+        case let cell as TitleAndValueTableViewCell where row == .scheduleSaleFrom:
             configureScheduleSaleFrom(cell: cell)
         case let cell as DatePickerTableViewCell where row == .datePickerSaleFrom:
             configureSaleFromPicker(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .scheduleSaleTo:
+        case let cell as TitleAndValueTableViewCell where row == .scheduleSaleTo:
             configureScheduleSaleTo(cell: cell)
         case let cell as DatePickerTableViewCell where row == .datePickerSaleTo:
             configureSaleToPicker(cell: cell)
         case let cell as BasicTableViewCell where row == .removeSaleTo:
             configureRemoveSaleTo(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .taxStatus:
+        case let cell as TitleAndValueTableViewCell where row == .taxStatus:
             configureTaxStatus(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .taxClass:
+        case let cell as TitleAndValueTableViewCell where row == .taxClass:
             configureTaxClass(cell: cell)
         default:
             fatalError()
@@ -359,7 +359,7 @@ private extension ProductPriceSettingsViewController {
         }
     }
 
-    func configureScheduleSaleFrom(cell: SettingTitleAndValueTableViewCell) {
+    func configureScheduleSaleFrom(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("From", comment: "Title of the cell in Product Price Settings > Schedule sale from a certain date")
         let placeholder = NSLocalizedString("Select start date",
                                             comment: "Placeholder value of the cell in Product Price Settings > Schedule sale from a certain date")
@@ -382,7 +382,7 @@ private extension ProductPriceSettingsViewController {
         }
     }
 
-    func configureScheduleSaleTo(cell: SettingTitleAndValueTableViewCell) {
+    func configureScheduleSaleTo(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("To", comment: "Title of the cell in Product Price Settings > Schedule sale to a certain date")
         let placeholder = NSLocalizedString("Select end date",
                                             comment: "Placeholder value of the cell in Product Price Settings > Schedule sale to a certain date")
@@ -409,13 +409,13 @@ private extension ProductPriceSettingsViewController {
         cell.textLabel?.applyLinkBodyStyle()
     }
 
-    func configureTaxStatus(cell: SettingTitleAndValueTableViewCell) {
+    func configureTaxStatus(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Tax status", comment: "Title of the cell in Product Price Settings > Tax status")
         cell.updateUI(title: title, value: viewModel.taxStatus.description)
         cell.accessoryType = .disclosureIndicator
     }
 
-    func configureTaxClass(cell: SettingTitleAndValueTableViewCell) {
+    func configureTaxClass(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Tax class", comment: "Title of the cell in Product Price Settings > Tax class")
         cell.updateUI(title: title, value: viewModel.taxClass?.name)
         cell.accessoryType = .disclosureIndicator
@@ -470,11 +470,11 @@ extension ProductPriceSettingsViewController {
             case .scheduleSale:
                 return SwitchTableViewCell.self
             case .scheduleSaleFrom, .scheduleSaleTo:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             case .datePickerSaleFrom, .datePickerSaleTo:
                 return DatePickerTableViewCell.self
             case .taxStatus, .taxClass:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             case .removeSaleTo:
                 return BasicTableViewCell.self
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -259,9 +259,9 @@ private extension ProductInventorySettingsViewController {
             configureLimitOnePerOrder(cell: cell)
         case let cell as UnitInputTableViewCell where row == .stockQuantity:
             configureStockQuantity(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .backorders:
+        case let cell as TitleAndValueTableViewCell where row == .backorders:
             configureBackordersSetting(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .stockStatus:
+        case let cell as TitleAndValueTableViewCell where row == .stockStatus:
             configureStockStatus(cell: cell)
         default:
             fatalError()
@@ -317,7 +317,7 @@ private extension ProductInventorySettingsViewController {
         cell.configure(viewModel: cellViewModel)
     }
 
-    func configureBackordersSetting(cell: SettingTitleAndValueTableViewCell) {
+    func configureBackordersSetting(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Backorders", comment: "Title of the cell in Product Inventory Settings > Backorders")
         cell.updateUI(title: title, value: viewModel.backordersSetting?.description)
         cell.accessoryType = .disclosureIndicator
@@ -325,7 +325,7 @@ private extension ProductInventorySettingsViewController {
 
     // Manage stock disabled.
 
-    func configureStockStatus(cell: SettingTitleAndValueTableViewCell) {
+    func configureStockStatus(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Stock status", comment: "Title of the cell in Product Inventory Settings > Stock status")
         cell.updateUI(title: title, value: viewModel.stockStatus?.description)
         cell.accessoryType = .disclosureIndicator
@@ -412,7 +412,7 @@ extension ProductInventorySettingsViewController {
             case .stockQuantity:
                 return UnitInputTableViewCell.self
             case .stockStatus, .backorders:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -35,7 +35,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -73,9 +73,9 @@ enum ProductSettingsRows {
 
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
 
         /// Utils
         func isStatusPrivate() -> Bool {
@@ -92,7 +92,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -116,9 +116,9 @@ enum ProductSettingsRows {
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
     }
 
     struct CatalogVisibility: ProductSettingsRowMediator {
@@ -130,7 +130,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -149,9 +149,9 @@ enum ProductSettingsRows {
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
     }
 
     struct VirtualProduct: ProductSettingsRowMediator {
@@ -252,7 +252,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -270,9 +270,9 @@ enum ProductSettingsRows {
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
     }
 
     struct PurchaseNote: ProductSettingsRowMediator {
@@ -283,7 +283,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -301,9 +301,9 @@ enum ProductSettingsRows {
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
     }
 
     struct MenuOrder: ProductSettingsRowMediator {
@@ -314,7 +314,7 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+            guard let cell = cell as? TitleAndValueTableViewCell else {
                 return
             }
 
@@ -332,9 +332,9 @@ enum ProductSettingsRows {
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
-        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -198,7 +198,7 @@ private extension ProductShippingSettingsViewController {
             configureWidth(cell: cell)
         case let cell as UnitInputTableViewCell where row == .height:
             configureHeight(cell: cell)
-        case let cell as SettingTitleAndValueTableViewCell where row == .shippingClass:
+        case let cell as TitleAndValueTableViewCell where row == .shippingClass:
             configureShippingClass(cell: cell)
         default:
             fatalError()
@@ -237,7 +237,7 @@ private extension ProductShippingSettingsViewController {
         cell.configure(viewModel: cellViewModel)
     }
 
-    func configureShippingClass(cell: SettingTitleAndValueTableViewCell) {
+    func configureShippingClass(cell: TitleAndValueTableViewCell) {
         let title = NSLocalizedString("Shipping class", comment: "Title of the cell in Product Shipping Settings > Shipping class")
         cell.updateUI(title: title, value: viewModel.shippingClass?.name)
         cell.accessoryType = .disclosureIndicator
@@ -271,7 +271,7 @@ extension ProductShippingSettingsViewController {
             case .weight, .length, .width, .height:
                 return UnitInputTableViewCell.self
             case .shippingClass:
-                return SettingTitleAndValueTableViewCell.self
+                return TitleAndValueTableViewCell.self
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class SettingTitleAndValueTableViewCell: UITableViewCell {
+final class TitleAndValueTableViewCell: UITableViewCell {
 
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var valueLabel: UILabel!
@@ -28,7 +28,7 @@ final class SettingTitleAndValueTableViewCell: UITableViewCell {
 
 // MARK: Updates
 //
-extension SettingTitleAndValueTableViewCell {
+extension TitleAndValueTableViewCell {
     func updateUI(title: String, value: String?) {
         titleLabel.text = title
         valueLabel.text = value

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="SettingTitleAndValueTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TitleAndValueTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -46,7 +46,7 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
     }
 
     private func configureTableView() {
-        tableView.registerNib(for: SettingTitleAndValueTableViewCell.self)
+        tableView.registerNib(for: TitleAndValueTableViewCell.self)
 
         tableView.backgroundColor = .listBackground
         tableView.delegate = self
@@ -64,7 +64,7 @@ extension OrderSearchStarterViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(SettingTitleAndValueTableViewCell.self, for: indexPath)
+        let cell = tableView.dequeueReusableCell(TitleAndValueTableViewCell.self, for: indexPath)
 
         let cellViewModel = viewModel.cellViewModel(at: indexPath)
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -106,9 +106,9 @@
 		02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */; };
 		02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */; };
 		0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */; };
-		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		023078FE25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */; };
 		02307924258731B2008EADEE /* ReprintShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02307923258731B2008EADEE /* ReprintShippingLabelViewModel.swift */; };
+		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */; };
 		0235595124496853004BE2B8 /* BottomSheetListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */; };
 		0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235595224496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift */; };
@@ -338,8 +338,8 @@
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
 		02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */; };
-		02E6B97823853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E6B97623853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift */; };
-		02E6B97923853D81000A36F0 /* SettingTitleAndValueTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02E6B97723853D81000A36F0 /* SettingTitleAndValueTableViewCell.xib */; };
+		02E6B97823853D81000A36F0 /* TitleAndValueTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E6B97623853D81000A36F0 /* TitleAndValueTableViewCell.swift */; };
+		02E6B97923853D81000A36F0 /* TitleAndValueTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02E6B97723853D81000A36F0 /* TitleAndValueTableViewCell.xib */; };
 		02E8B17723E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8B17523E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift */; };
 		02E8B17823E2C49000A43403 /* InProgressProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02E8B17623E2C49000A43403 /* InProgressProductImageCollectionViewCell.xib */; };
 		02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8B17923E2C4BD00A43403 /* CircleSpinnerView.swift */; };
@@ -1201,9 +1201,9 @@
 		0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHorizontalRulerFormatBarCommand.swift; sourceTree = "<group>"; };
 		02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecInsertMoreFormatBarCommand.swift; sourceTree = "<group>"; };
 		0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecSourceCodeFormatBarCommand.swift; sourceTree = "<group>"; };
-		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
 		02307923258731B2008EADEE /* ReprintShippingLabelViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelViewModel.swift; sourceTree = "<group>"; };
+		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewController.swift; sourceTree = "<group>"; };
 		0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorViewController.xib; sourceTree = "<group>"; };
 		0235595224496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewProperties.swift; sourceTree = "<group>"; };
@@ -1433,8 +1433,8 @@
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
 		02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModelTests.swift; sourceTree = "<group>"; };
-		02E6B97623853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleAndValueTableViewCell.swift; sourceTree = "<group>"; };
-		02E6B97723853D81000A36F0 /* SettingTitleAndValueTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingTitleAndValueTableViewCell.xib; sourceTree = "<group>"; };
+		02E6B97623853D81000A36F0 /* TitleAndValueTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndValueTableViewCell.swift; sourceTree = "<group>"; };
+		02E6B97723853D81000A36F0 /* TitleAndValueTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndValueTableViewCell.xib; sourceTree = "<group>"; };
 		02E8B17523E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InProgressProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		02E8B17623E2C49000A43403 /* InProgressProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InProgressProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		02E8B17923E2C4BD00A43403 /* CircleSpinnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleSpinnerView.swift; sourceTree = "<group>"; };
@@ -2642,8 +2642,6 @@
 				0229ECFF258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift */,
 				021125A42578E5730075AD2A /* BoldableTextView.swift */,
 				023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */,
-				0259D65B2582248D003B1CD6 /* ReprintShippingLabelViewController.swift */,
-				0259D65C2582248D003B1CD6 /* ReprintShippingLabelViewController.xib */,
 				02535CBA25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift */,
 				023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */,
 			);
@@ -4930,8 +4928,8 @@
 				B5BE75DC213F1D3D00909A14 /* OverlayMessageView.xib */,
 				CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */,
 				CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */,
-				02E6B97623853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift */,
-				02E6B97723853D81000A36F0 /* SettingTitleAndValueTableViewCell.xib */,
+				02E6B97623853D81000A36F0 /* TitleAndValueTableViewCell.swift */,
+				02E6B97723853D81000A36F0 /* TitleAndValueTableViewCell.xib */,
 				744F00D121B582A9007EFA93 /* StarRatingView.swift */,
 				D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */,
 				D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */,
@@ -5410,7 +5408,7 @@
 				02DD81FC242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib in Resources */,
 				45E9A6E524DAE1EA00A600E8 /* ProductReviewsViewController.xib in Resources */,
 				2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */,
-				02E6B97923853D81000A36F0 /* SettingTitleAndValueTableViewCell.xib in Resources */,
+				02E6B97923853D81000A36F0 /* TitleAndValueTableViewCell.xib in Resources */,
 				CE37C04522984E81008DCB39 /* PickListTableViewCell.xib in Resources */,
 				D85B8334222FABD1002168F3 /* StatusListTableViewCell.xib in Resources */,
 				5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */,
@@ -5807,7 +5805,7 @@
 				02784A03238B8BC800BDD6A8 /* UIView+Border.swift in Sources */,
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
 				45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */,
-				02E6B97823853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift in Sources */,
+				02E6B97823853D81000A36F0 /* TitleAndValueTableViewCell.swift in Sources */,
 				02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */,
 				45CDAFAE2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,


### PR DESCRIPTION
Closes #2211

#### What

As suggested in the issue renaming `SettingTitleAndValueTableViewCell` to `TitleAndValueTableViewCell`

#### Testing 

`TitleAndValueTableViewCell` is used on the following screens, check some of them to see if the cell works:
* Filter list on Search
* Refund confirmation
* Reprint shipping label
* Product price settings
* Add product category

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
