### PR TITLE
Remove interpolated strings from localization

### DIFF
--- a/Networking/Networking/Model/DotcomError.swift
+++ b/Networking/Networking/Model/DotcomError.swift
@@ -113,7 +113,11 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Stats Module Disabled", comment: "WordPress.com error thrown when the Jetpack site stats module is disabled.")
         case .unknown(let code, let message):
             let theMessage = message ?? String()
-            return NSLocalizedString("Dotcom Error: [\(code)] \(theMessage)", comment: "WordPress.com (unmapped!) error")
+            let messageFormat = NSLocalizedString(
+                "Dotcom Error: [%1$@] %2$@",
+                comment: "WordPress.com (unmapped!) error. Parameters: %1$@ - code, %2$@ - message"
+            )
+            return String.localizedStringWithFormat(messageFormat, code, theMessage)
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -24,9 +24,11 @@ final class SwitchStoreNoticePresenter {
             return
         }
 
-        let message = NSLocalizedString("Switched to \(newStoreName). You will only receive notifications from this store.",
-            comment: "Message presented after users switch to a new store. "
-                + "Reads like: Switched to {store name}. You will only receive notifications from this store.")
+        let messageFormat = NSLocalizedString("Switched to %1$@. You will only receive notifications from this store.",
+                                              comment: "Message presented after users switch to a new store. "
+                                                + "Reads like: Switched to {store name}. You will only receive notifications from this store. "
+                                                + "Parameters: %1$@ - store name")
+        let message = String.localizedStringWithFormat(messageFormat, newStoreName)
         let notice = Notice(title: message, feedbackType: .success)
 
         noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsNotices.swift
@@ -5,10 +5,13 @@ final class OrderDetailsNotices {
     /// Displays the `Unable to delete tracking` Notice.
     ///
     func displayDeleteErrorNotice(order: Order, tracking: ShipmentTracking, onAction: @escaping () -> Void) {
-        let title = NSLocalizedString(
-            "Unable to delete tracking for order #\(order.orderID)",
-            comment: "Content of error presented when Delete Shipment Tracking Action Failed. It reads: Unable to delete tracking for order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to delete tracking for order #%1$d",
+            comment: "Content of error presented when Delete Shipment Tracking Action Failed. "
+                + "It reads: Unable to delete tracking for order #{order number}. "
+                + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, order.orderID)
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title,
                             message: nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -230,10 +230,13 @@ extension NewNoteViewController: UITableViewDelegate {
 //
 private extension NewNoteViewController {
     func displayErrorNotice() {
-        let title = NSLocalizedString(
-            "Unable to add note to order #\(viewModel.order.orderID)",
-            comment: "Content of error presented when Add Note Action Failed. It reads: Unable to add note to order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to add note to order #%1$d",
+            comment: "Content of error presented when Add Note Action Failed. "
+                + "It reads: Unable to add note to order #{order number}. "
+                + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, viewModel.order.orderID)
 
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
@@ -254,8 +257,8 @@ private extension NewNoteViewController {
     }
 
     func configureTitle() {
-        title = NSLocalizedString("Order #\(viewModel.order.number)",
-            comment: "Add a note screen - title. Example: Order #15")
+        let titleFormat = NSLocalizedString("Order #%1$@", comment: "Add a note screen - title. Example: Order #15. Parameters: %1$@ - order number")
+        title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
     }
 
     func configureDismissButton() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -274,10 +274,13 @@ extension OrderStatusListViewController {
     /// Displays the `Unable to Change Status of Order` Notice.
     ///
     func displayErrorNotice(orderID: Int64) {
-        let title = NSLocalizedString(
-            "Unable to change status of order #\(orderID)",
-            comment: "Content of error presented when updating the status of an Order fails. It reads: Unable to change status of order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to change status of order #%1$d",
+            comment: "Content of error presented when updating the status of an Order fails. "
+            + "It reads: Unable to change status of order #{order number}. "
+            + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, orderID)
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.applyButtonTapped()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -104,7 +104,8 @@ private extension OrderDetailsViewController {
     /// Setup: Navigation
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Order number title")
+        let titleFormat = NSLocalizedString("Order #%1$@", comment: "Order number title. Parameters: %1$@ - order number")
+        title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
 
         // Don't show the Order details title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -126,7 +126,8 @@ private extension FulfillViewController {
     /// Setup: Navigation Item
     ///
     func setupNavigationItem() {
-        title = NSLocalizedString("Fulfill Order #\(order.number)", comment: "Order Fulfillment Title")
+        let format = NSLocalizedString("Fulfill Order #%1$@", comment: "Order Fulfillment Title. Parameters: %1$@ - order number")
+        title = String.localizedStringWithFormat(format, order.number)
     }
 
     /// Setup: Main View
@@ -235,10 +236,13 @@ private extension FulfillViewController {
     /// Displays the `Unable to Fulfill Order` Notice.
     ///
     func displayErrorNotice(orderID: Int64) {
-        let title = NSLocalizedString(
-            "Unable to fulfill order #\(orderID)",
-            comment: "Content of error presented when Fullfill Order Action Failed. It reads: Unable to fulfill order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to fulfill order #%1$d",
+            comment: "Content of error presented when Fullfill Order Action Failed. "
+                + "It reads: Unable to fulfill order #{order number}. "
+                + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, orderID)
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.fulfillWasPressed()
@@ -525,10 +529,13 @@ private extension FulfillViewController {
     /// Displays the `Unable to delete tracking` Notice.
     ///
     func displayDeleteErrorNotice(orderID: Int64, tracking: ShipmentTracking) {
-        let title = NSLocalizedString(
-            "Unable to delete tracking for order #\(orderID)",
-            comment: "Content of error presented when Delete Shipment Tracking Action Failed. It reads: Unable to delete tracking for order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to delete tracking for order #%1$d",
+            comment: "Content of error presented when Delete Shipment Tracking Action Failed. "
+                + "It reads: Unable to delete tracking for order #{order number}. "
+                + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, orderID)
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title,
                             message: nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -30,7 +30,8 @@ private extension ProductListViewController {
     /// Setup: Main View
     ///
     func configureMainView() {
-        title = NSLocalizedString("Details Order #\(viewModel.order.number)", comment: "Screen title: Details Order number (number)")
+        let titleFormat = NSLocalizedString("Details Order #%1$@", comment: "Screen title: Details Order number. Parameters: %1$@ - order number")
+        title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
         view.backgroundColor = .listBackground
 
         // Don't show the Order details title in the next-view's back button

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -584,10 +584,13 @@ private extension ManualTrackingViewController {
     /// Displays the `Unable to Add tracking` Notice.
     ///
     func displayAddErrorNotice(orderID: Int64) {
-        let title = NSLocalizedString(
-            "Unable to add tracking to order #\(orderID)",
-            comment: "Content of error presented when Add Shipment Tracking Action Failed. It reads: Unable to add tracking to order #{order number}"
+        let titleFormat = NSLocalizedString(
+            "Unable to add tracking to order #%1$d",
+            comment: "Content of error presented when Add Shipment Tracking Action Failed. "
+                + "It reads: Unable to add tracking to order #{order number}. "
+                + "Parameters: %1$d - order number"
         )
+        let title = String.localizedStringWithFormat(titleFormat, orderID)
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title,
                             message: nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -285,8 +285,13 @@ private extension ShipmentProvidersViewController {
         }
 
         let emptyState: EmptyListMessageWithActionView = EmptyListMessageWithActionView.instantiateFromNib()
-        emptyState.messageText = NSLocalizedString("No results found for \(term)\nAdd a custom carrier",
-            comment: "Empty state for the list of shipment carriers. It reads: 'No results for DHL. Add a custom carrier'")
+        let messageFormat = NSLocalizedString(
+            "No results found for %1$@\nAdd a custom carrier",
+            comment: "Empty state for the list of shipment carriers. "
+                + "It reads: 'No results for DHL. Add a custom carrier'. "
+                + "Parameters: %1$@ - carrier name"
+        )
+        emptyState.messageText = String.localizedStringWithFormat(messageFormat, term)
         emptyState.actionText = NSLocalizedString("Custom Carrier",
                                                   comment: "Title of button to add a custom tracking carrier if filtering the list yields no results."
         )


### PR DESCRIPTION
Closes #1732 

### What

This PR replaces interpolated strings found in localization files with placeholders.
For example, before:
```
NSLocalizedString("Dotcom Error: [\(code)] \(theMessage)", comment: "WordPress.com (unmapped!) error")
```

After:
```
let messageFormat = NSLocalizedString(
    "Dotcom Error: [%1$@] %2$@",
    comment: "WordPress.com (unmapped!) error. Parameters: %1$@ - code, %2$@ - message"
)
String.localizedStringWithFormat(messageFormat, code, theMessage)
```

### Testing

Not sure what is the best way to test this as it touches different scenarios that can be hard to simulate. Any ideas?

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
