### PR TITLE
Shipping Labels M1: add feature announcement banner to order details with non-refunded shipping labels

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -8,4 +8,8 @@ public enum FeedbackType: String, Codable {
     /// identifier for the products m4 beta feedback survey
     ///
     case productsM4
+
+    /// identifier for the shipping labels m1 feedback survey
+    ///
+    case shippingLabelsRelease1
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -60,8 +60,7 @@ extension WooAnalyticsEvent {
         /// Shown in products banner for Milestone 4 features. New product banners should have
         /// their own `FeedbackContext` option.
         case productsM4 = "products_m4"
-        /// Shown in shipping labels banner for Milestone 1 features. New product banners should have
-        /// their own `FeedbackContext` option.
+        /// Shown in shipping labels banner for Milestone 1 features.
         case shippingLabelsRelease1 = "shipping_labels_m1"
     }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -60,6 +60,9 @@ extension WooAnalyticsEvent {
         /// Shown in products banner for Milestone 4 features. New product banners should have
         /// their own `FeedbackContext` option.
         case productsM4 = "products_m4"
+        /// Shown in shipping labels banner for Milestone 1 features. New product banners should have
+        /// their own `FeedbackContext` option.
+        case shippingLabelsRelease1 = "shipping_labels_m1"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,6 +83,10 @@ extension WooConstants {
         ///
         case productsM4Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
+        /// URL for the shipping labels M1 feedback survey
+        ///
+        case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -85,7 +85,11 @@ extension WooConstants {
 
         /// URL for the shipping labels M1 feedback survey
         ///
+#if DEBUG
+        case shippingLabelsRelease1Feedback = "http://automattic.survey.fm/woo-app-testing-feature-feedback-shipping-labels"
+#else
         case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
+#endif
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -86,7 +86,7 @@ extension WooConstants {
         /// URL for the shipping labels M1 feedback survey
         ///
 #if DEBUG
-        case shippingLabelsRelease1Feedback = "http://automattic.survey.fm/woo-app-testing-feature-feedback-shipping-labels"
+        case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-testing-feature-feedback-shipping-labels"
 #else
         case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
 #endif

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -80,7 +80,10 @@ final class OrderDetailsDataSource: NSObject {
         return resultsControllers.refunds
     }
 
-    private var shippingLabels: [ShippingLabel] = []
+    /// Shipping Labels for an Order
+    ///
+    private(set) var shippingLabels: [ShippingLabel] = []
+
     private var shippingLabelOrderItemsAggregator: AggregatedShippingLabelOrderItems = AggregatedShippingLabelOrderItems.empty
 
     /// Shipping Lines from an Order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -234,6 +234,8 @@ private extension OrderDetailsViewController {
         }
 
         self.topBannerView = topBannerView
+        // A frame-based container view is needed for table view's `tableHeaderView` and its height is recalculated in `viewDidLayoutSubviews`, so that the
+        // top banner view can be Auto Layout based with dynamic height.
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
         headerContainer.pinSubviewToSafeArea(topBannerView, insets: Constants.headerContainerInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -11,7 +11,7 @@ final class OrderDetailsViewController: UIViewController {
 
     /// Main TableView.
     ///
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
 
     /// Pull To Refresh Support.
     ///
@@ -20,6 +20,10 @@ final class OrderDetailsViewController: UIViewController {
         refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
         return refreshControl
     }()
+
+    /// Top banner that announces shipping labels features.
+    ///
+    private var topBannerView: TopBannerView?
 
     /// EntityListener: Update / Deletion Notifications.
     ///
@@ -55,6 +59,7 @@ final class OrderDetailsViewController: UIViewController {
         registerTableViewHeaderFooters()
         configureEntityListener()
         configureViewModel()
+        updateTopBannerView()
 
         // FIXME: this is a hack. https://github.com/woocommerce/woocommerce-ios/issues/1779
         reloadTableViewSectionsAndData()
@@ -70,6 +75,11 @@ final class OrderDetailsViewController: UIViewController {
             syncShippingLabels()
         }
         syncTrackingsHidingAddButtonIfNecessary()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.updateHeaderHeight()
     }
 
     private func syncTrackingsHidingAddButtonIfNecessary() {
@@ -148,6 +158,8 @@ private extension OrderDetailsViewController {
         }
 
         tableView.reloadData()
+
+        updateTopBannerView()
     }
 
     /// Reloads the tableView's sections and data.
@@ -191,6 +203,62 @@ private extension OrderDetailsViewController {
         notices.displayDeleteErrorNotice(order: order, tracking: tracking) { [weak self] in
             self?.deleteTracking(tracking)
         }
+    }
+}
+
+// MARK: - Top Banner
+//
+private extension OrderDetailsViewController {
+    func updateTopBannerView() {
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: viewModel.dataSource.shippingLabels)
+        let isExpanded = topBannerView?.isExpanded ?? false
+        factory.createTopBannerIfNeeded(isExpanded: isExpanded,
+                                        expandedStateChangeHandler: { [weak self] in
+                                            self?.tableView.updateHeaderHeight()
+                                        }, onGiveFeedbackButtonPressed: { [weak self] in
+                                            self?.presentShippingLabelsFeedbackSurvey()
+                                        }, onDismissButtonPressed: { [weak self] in
+                                            self?.dismissTopBanner()
+                                        }, onCompletion: { [weak self] topBannerView in
+                                            if let topBannerView = topBannerView {
+                                                self?.showTopBannerView(topBannerView)
+                                            } else {
+                                                self?.hideTopBannerView()
+                                            }
+                                        })
+    }
+
+    func showTopBannerView(_ topBannerView: TopBannerView) {
+        guard tableView.tableHeaderView == nil else {
+            return
+        }
+
+        self.topBannerView = topBannerView
+        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
+        headerContainer.addSubview(topBannerView)
+        headerContainer.pinSubviewToSafeArea(topBannerView, insets: Constants.headerContainerInsets)
+        tableView.tableHeaderView = headerContainer
+        tableView.updateHeaderHeight()
+    }
+
+    func hideTopBannerView() {
+        guard tableView.tableHeaderView != nil else {
+            return
+        }
+
+        topBannerView?.removeFromSuperview()
+        topBannerView = nil
+        tableView.tableHeaderView = nil
+        tableView.updateHeaderHeight()
+    }
+
+    func presentShippingLabelsFeedbackSurvey() {
+        let navigationController = SurveyCoordinatingController(survey: .shippingLabelsRelease1Feedback)
+        present(navigationController, animated: true, completion: nil)
+    }
+
+    func dismissTopBanner() {
+        hideTopBannerView()
     }
 }
 
@@ -573,6 +641,8 @@ private extension OrderDetailsViewController {
     }
 
     enum Constants {
+        static let headerDefaultHeight = CGFloat(130)
+        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
@@ -1,0 +1,113 @@
+import Yosemite
+
+/// Creates a top banner for shipping labels asynchronously based on the shipping labels and app settings.
+/// The top banner has two actions: "give feedback" and "dismiss".
+/// This class is not meant to be retained since it uses strong `self` in action handling, so that it has the same life cycle as the top banner.
+final class ShippingLabelsTopBannerFactory {
+    private let shippingLabels: [ShippingLabel]
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    init(shippingLabels: [ShippingLabel],
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.shippingLabels = shippingLabels
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    /// Creates a top banner asynchronously based on the shipping labels and app settings.
+    /// - Parameters:
+    ///   - isExpanded: whether the top banner is expanded by default.
+    ///   - expandedStateChangeHandler: called when the top banner expanded state changes.
+    ///   - onGiveFeedbackButtonPressed: called when the give feedback button is pressed.
+    ///   - onDismissButtonPressed: called when the dismiss button is pressed.
+    ///   - onCompletion: called when it finishes determining whether the top banner is being shown, and an optional top banner is returned.
+    func createTopBannerIfNeeded(isExpanded: Bool,
+                                 expandedStateChangeHandler: @escaping () -> Void,
+                                 onGiveFeedbackButtonPressed: @escaping () -> Void,
+                                 onDismissButtonPressed: @escaping () -> Void,
+                                 onCompletion: @escaping (TopBannerView?) -> Void) {
+        determineIfTopBannerShouldBeShown { [weak self] shouldShow in
+            guard let self = self else { return }
+
+            guard shouldShow else {
+                onCompletion(nil)
+                return
+            }
+
+            onCompletion(self.createTopBanner(isExpanded: isExpanded,
+                                              expandedStateChangeHandler: expandedStateChangeHandler,
+                                              onGiveFeedbackButtonPressed: onGiveFeedbackButtonPressed,
+                                              onDismissButtonPressed: onDismissButtonPressed))
+        }
+    }
+}
+
+private extension ShippingLabelsTopBannerFactory {
+    func determineIfTopBannerShouldBeShown(onCompletion: @escaping (_ shouldShow: Bool) -> Void) {
+        guard shippingLabels.nonRefunded.isNotEmpty else {
+            onCompletion(false)
+            return
+        }
+
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .shippingLabelsRelease1) { result in
+            switch result {
+            case .success(let visible):
+                onCompletion(visible)
+            case.failure:
+                onCompletion(false)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    func createTopBanner(isExpanded: Bool,
+                         expandedStateChangeHandler: @escaping () -> Void,
+                         onGiveFeedbackButtonPressed: @escaping () -> Void,
+                         onDismissButtonPressed: @escaping () -> Void) -> TopBannerView {
+        let title = Localization.title
+        let icon: UIImage = .megaphoneIcon
+        let infoText = Localization.info
+        let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
+            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease1, action: .gaveFeedback))
+            onGiveFeedbackButtonPressed()
+        }
+        let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
+            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease1, action: .dismissed))
+            let action = AppSettingsAction.updateFeedbackStatus(type: .shippingLabelsRelease1, status: .dismissed) { result in
+                onDismissButtonPressed()
+            }
+            self.stores.dispatch(action)
+        }
+        let actions = [giveFeedbackAction, dismissAction]
+        let viewModel = TopBannerViewModel(title: title,
+                                           infoText: infoText,
+                                           icon: icon,
+                                           isExpanded: isExpanded,
+                                           topButton: .chevron(handler: expandedStateChangeHandler),
+                                           actionButtons: actions)
+        let topBannerView = TopBannerView(viewModel: viewModel)
+        topBannerView.translatesAutoresizingMaskIntoConstraints = false
+
+        return topBannerView
+    }
+}
+
+private extension ShippingLabelsTopBannerFactory {
+    enum Localization {
+        static let title =
+            NSLocalizedString("Print shipping labels from your device!",
+                              comment: "The title of the shipping labels top banner in order details")
+        static let info =
+            NSLocalizedString(
+                "We are working on making it easier for you to print shipping labels directly from your device! "
+                    + "For now, if you have created labels for an order in your store admin with WooCommerce Shipping, "
+                    + "you can print them in your Order details here.",
+                comment: "The info of the shipping labels top banner in order details")
+        static let giveFeedback =
+            NSLocalizedString("Give feedback",
+                              comment: "The title of the button to give feedback about shipping labels features on the banner in order details")
+        static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the banner in order details")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -82,6 +82,7 @@ extension SurveyViewController {
                 return WooConstants.URLs.shippingLabelsRelease1Feedback
                     .asURL()
                     .tagPlatform("ios")
+                    .tagShippingLabelsMilestone("1")
             }
         }
 
@@ -148,6 +149,10 @@ extension URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestProductMilestoneTag, value: milestone))
     }
 
+    func tagShippingLabelsMilestone(_ milestone: String) -> URL {
+        appendingQueryItem(URLQueryItem(name: Tags.surveyRequestShippingLabelsMilestoneTag, value: milestone))
+    }
+
     private func appendingQueryItem(_ queryItem: URLQueryItem) -> URL {
         guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             assertionFailure("Cannot create URL components from \(self)")
@@ -165,6 +170,7 @@ extension URL {
     private enum Tags {
         static let surveyRequestPlatformTag = "woo-mobile-platform"
         static let surveyRequestProductMilestoneTag = "product-milestone"
+        static let surveyRequestShippingLabelsMilestoneTag = "shipping_label_milestone"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -64,6 +64,7 @@ extension SurveyViewController {
     enum Source {
         case inAppFeedback
         case productsM4Feedback
+        case shippingLabelsRelease1Feedback
 
         fileprivate var url: URL {
             switch self {
@@ -77,6 +78,10 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagProductMilestone("4")
+            case .shippingLabelsRelease1Feedback:
+                return WooConstants.URLs.shippingLabelsRelease1Feedback
+                    .asURL()
+                    .tagPlatform("ios")
             }
         }
 
@@ -84,7 +89,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsM4Feedback:
+            case .productsM4Feedback, .shippingLabelsRelease1Feedback:
                 return Localization.giveFeedback
             }
         }
@@ -96,6 +101,8 @@ extension SurveyViewController {
                 return .general
             case .productsM4Feedback:
                 return .productsM4
+            case .shippingLabelsRelease1Feedback:
+                return .shippingLabelsRelease1
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -263,6 +263,8 @@
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
 		029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EB24FE38C900D242F8 /* ScrollWatcher.swift */; };
 		029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */; };
+		0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0298430B259351F100979CAE /* ShippingLabelsTopBannerFactory.swift */; };
+		0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0298431125936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift */; };
 		029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */; };
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */; };
@@ -1358,6 +1360,8 @@
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
 		029700EB24FE38C900D242F8 /* ScrollWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcher.swift; sourceTree = "<group>"; };
 		029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcherTests.swift; sourceTree = "<group>"; };
+		0298430B259351F100979CAE /* ShippingLabelsTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelsTopBannerFactory.swift; sourceTree = "<group>"; };
+		0298431125936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelsTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+TitleAndImage.swift"; sourceTree = "<group>"; };
@@ -2369,6 +2373,7 @@
 			children = (
 				023D69BA2589BF2500F7DA72 /* Refund Shipping Label */,
 				023D69C52589BF5F00F7DA72 /* Reprint Shipping Label */,
+				0298430B259351F100979CAE /* ShippingLabelsTopBannerFactory.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -2719,6 +2724,7 @@
 			children = (
 				0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */,
 				025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */,
+				0298431125936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -6144,6 +6150,7 @@
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
+				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
@@ -6316,6 +6323,7 @@
 				4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */,
 				0212683724C049F000F8A892 /* ProductListMultiSelectorDataSourceTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
+				0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
+    func test_creating_top_banner_with_empty_shipping_labels_returns_nil() throws {
+        // Given
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [])
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNil(topBannerView)
+    }
+
+    func test_creating_top_banner_with_a_refunded_shipping_label_returns_nil() throws {
+        // Given
+        let refundedShippingLabel = MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending))
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [refundedShippingLabel])
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNil(topBannerView)
+    }
+
+    func test_creating_top_banner_with_a_non_refunded_shipping_label_and_visible_feedback_settings_returns_banner() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = createStores(feedbackVisibilityResult: .success(true))
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNotNil(topBannerView)
+    }
+
+    func test_creating_top_banner_with_a_non_refunded_shipping_label_and_invisible_feedback_settings_returns_nil() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = createStores(feedbackVisibilityResult: .success(false))
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNil(topBannerView)
+    }
+
+    func test_creating_top_banner_with_a_non_refunded_shipping_label_and_failed_feedback_settings_returns_nil() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = createStores(feedbackVisibilityResult: .failure(SampleError.first))
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNil(topBannerView)
+    }
+
+    func test_top_banner_has_two_actions() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = createStores(feedbackVisibilityResult: .success(true))
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
+
+        // When
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        XCTAssertNotNil(topBannerView)
+        let view = try XCTUnwrap(topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: view)
+        XCTAssertEqual(mirrorView.actionButtons.count, 2)
+        mirrorView.actionButtons.first?.sendActions(for: .touchUpInside)
+    }
+
+    func test_tapping_top_banner_give_feedback_button_triggers_callback_and_logs_analytics() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = createStores(feedbackVisibilityResult: .success(true))
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores, analytics: analytics)
+
+        // When
+        var isGiveFeedbackButtonPressed = false
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onGiveFeedbackButtonPressed: {
+                                                isGiveFeedbackButtonPressed = true
+                                            },
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        let view = try XCTUnwrap(topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: view)
+        mirrorView.actionButtons.first?.sendActions(for: .touchUpInside)
+        XCTAssertTrue(isGiveFeedbackButtonPressed)
+
+        // Analytics
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch["action"] as? String, "gave_feedback")
+        XCTAssertEqual(firstPropertiesBatch["context"] as? String, "shipping_labels_m1")
+    }
+
+    func test_tapping_top_banner_dismiss_button_updates_feedback_status_and_triggers_callback_and_logs_analytics() throws {
+        // Given
+        let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadFeedbackVisibility(_, onCompletion):
+                onCompletion(.success(true))
+            case let .updateFeedbackStatus(type, status, onCompletion):
+                XCTAssertEqual(type, .shippingLabelsRelease1)
+                XCTAssertEqual(status, .dismissed)
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores, analytics: analytics)
+
+        // When
+        var isDismissButtonPressed = false
+        let topBannerView = try waitFor { promise in
+            factory.createTopBannerIfNeeded(isExpanded: false,
+                                            onDismissButtonPressed: {
+                                                isDismissButtonPressed = true
+                                            },
+                                            onCompletion: { topBannerView in
+                                                promise(topBannerView)
+                                            })
+        }
+
+        // Then
+        let view = try XCTUnwrap(topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: view)
+        mirrorView.actionButtons[1].sendActions(for: .touchUpInside)
+        XCTAssertTrue(isDismissButtonPressed)
+        XCTAssertEqual(stores.receivedActions.count, 2)
+
+        // Analytics
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch["action"] as? String, "dismissed")
+        XCTAssertEqual(firstPropertiesBatch["context"] as? String, "shipping_labels_m1")
+    }
+}
+
+private extension ShippingLabelsTopBannerFactoryTests {
+    func createStores(feedbackVisibilityResult: Result<Bool, Error>) -> StoresManager {
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadFeedbackVisibility(_, onCompletion):
+                onCompletion(feedbackVisibilityResult)
+            default:
+                break
+            }
+        }
+        return stores
+    }
+}
+
+private extension ShippingLabelsTopBannerFactory {
+    func createTopBannerIfNeeded(isExpanded: Bool,
+                                 expandedStateChangeHandler: (() -> Void)? = nil,
+                                 onGiveFeedbackButtonPressed: (() -> Void)? = nil,
+                                 onDismissButtonPressed: (() -> Void)? = nil,
+                                 onCompletion: @escaping (TopBannerView?) -> Void) {
+        createTopBannerIfNeeded(isExpanded: isExpanded,
+                                expandedStateChangeHandler: expandedStateChangeHandler ?? {},
+                                onGiveFeedbackButtonPressed: onGiveFeedbackButtonPressed ?? {},
+                                onDismissButtonPressed: onDismissButtonPressed ?? {},
+                                onCompletion: onCompletion)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
@@ -23,6 +23,14 @@ final class URL_SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(expectedURL, actualURL)
     }
 
+    func test_tagging_shipping_labels_milestone_appends_the_correct_tag_data() throws {
+        let expectedURL = "https://testurl.com?shipping_label_milestone=test"
+
+        let actualURL = URL(string: "https://testurl.com")?.tagShippingLabelsMilestone("test").absoluteString
+
+        XCTAssertEqual(expectedURL, actualURL)
+    }
+
     func test_tagging_platform_and_tagging_product_milestone_does_stack() throws {
             let actualURL =
                 URL(string: "https://testurl.com")?

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -39,6 +39,8 @@ struct InAppFeedbackCardVisibilityUseCase {
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
         case .productsM4:
             return shouldProductsFeedbackBeVisible()
+        case .shippingLabelsRelease1:
+            return shouldShippingLabelsRelease1FeedbackBeVisible()
         }
     }
 
@@ -67,6 +69,12 @@ struct InAppFeedbackCardVisibilityUseCase {
     /// Returns whether the productsM4 feedback request should be displayed
     ///
     private func shouldProductsFeedbackBeVisible() -> Bool {
+        return settings.feedbackStatus(of: feedbackType) == .pending
+    }
+
+    /// Returns whether the shippingLabelsRelease1 feedback request should be displayed
+    ///
+    private func shouldShippingLabelsRelease1FeedbackBeVisible() -> Bool {
         return settings.feedbackStatus(of: feedbackType) == .pending
     }
 


### PR DESCRIPTION
Fixes #2995 

## Why

If an order has at least one non-refunded shipping label, we show a top banner that informs the user about the shipping labels M1 features.

## Changes

- Added a new `FeedbackType` enum case for shipping labels M1 (I kept the name `*Release1` to be consistent with `FeatureFlag.shippingLabelsRelease1` even though we call it M1). Also added related changes for feedback survey in https://github.com/woocommerce/woocommerce-ios/commit/61c15c323ae4f2731dc6e0599185f22f7c8a0f20 and https://github.com/woocommerce/woocommerce-ios/commit/61e646e6d72312c4bd8c3b5ecd6d86e9f508b4ec
- Created `ShippingLabelsTopBannerFactory` to determine whether to return a top banner based on shipping labels and app settings (whether the feedback card has been dismissed similar to the products tab) + unit tests https://github.com/woocommerce/woocommerce-ios/commit/ce5acad714bc46b64addaea001a1ec308a961dd4
- Integration with order details in https://github.com/woocommerce/woocommerce-ios/commit/9585ae23227187d61ce8dc1b57cf39f414916e95

## Testing

Prerequisite: the shipping labels top banner has not been dismissed in the app. If it has, you can reinstall the app to clear the app settings.

### Order without shipping labels

- Go to the orders tab
- Tap on an order without any shipping labels --> there should **not** be a shipping labels top banner

### Order with refunded shipping label(s) only

- Go to the orders tab
- Tap on an order where all the shipping label(s) have been refunded --> there should **not** be a shipping labels top banner

### Order with non-refunded shipping labels

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label --> there should be a shipping labels top banner after syncing (the shipping label card should appear as well)
- Tap "Give feedback" --> a feedback survey should be presented
- Type something in the survey and submit the survey if you like 😄 
- Tap "Back to store" on the submission confirmation screen
- Tap "Dismiss" --> the top banner should be hidden
- Go back to the orders tab and tap on the same order again --> the top banner should not be shown anymore

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/103068832-0059f200-45f9-11eb-99ff-4f13bae2522a.gif)


light | dark
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 52 42](https://user-images.githubusercontent.com/1945542/103068369-f257a180-45f7-11eb-9814-044cd2c9a8c9.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 53 25](https://user-images.githubusercontent.com/1945542/103068373-f683bf00-45f7-11eb-8780-dd5483110fad.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 52 44](https://user-images.githubusercontent.com/1945542/103068372-f5529200-45f7-11eb-9075-73fff851e63d.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 53 27](https://user-images.githubusercontent.com/1945542/103068376-f71c5580-45f7-11eb-84a1-677fe7c8bd35.png)

landscape (expanded) | landscape (collapsed) | large font size | iPad
-- | -- | -- | --
![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 52 59](https://user-images.githubusercontent.com/1945542/103068460-1e732280-45f8-11eb-9358-b5c448680105.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 53 04](https://user-images.githubusercontent.com/1945542/103068468-229f4000-45f8-11eb-9493-6e1c87177bd5.png) | ![Simulator Screen Shot - iPhone 11 - 2020-12-24 at 14 53 55](https://user-images.githubusercontent.com/1945542/103068516-419dd200-45f8-11eb-9b76-1e23dc10b767.png) | ![Simulator Screen Shot - iPad Air (3rd generation) - 2020-12-24 at 14 56 17](https://user-images.githubusercontent.com/1945542/103068491-3480e300-45f8-11eb-9ca5-e333bc85290a.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
