### PR TITLE
Update release notes for 5.7

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -60,7 +60,7 @@ msgstr ""
 msgctxt "v5.7-whats-new"
 msgid ""
 "The app now supports iOS 13 and up which will allow for more rapid feature development.\n"
-"We’ve improved error handling in the login flow, fixed a bug that prevented thumbnail images from appearing for product variations on the order details screen, and centered the footer spinner vertically and horizontally.\n"
+"We've fixed a bug that prevented thumbnail images from appearing for product variations on the order details screen, and centered the footer spinner vertically and horizontally.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,2 +1,2 @@
 The app now supports iOS 13 and up which will allow for more rapid feature development.
-We’ve improved error handling in the login flow, fixed a bug that prevented thumbnail images from appearing for product variations on the order details screen, and centered the footer spinner vertically and horizontally.
+We've fixed a bug that prevented thumbnail images from appearing for product variations on the order details screen, and centered the footer spinner vertically and horizontally.


### PR DESCRIPTION
This PR is a follow up to https://github.com/woocommerce/woocommerce-ios/pull/3405 and updates the release notes we send for translation consequently. 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
