### PR TITLE
[Variations] Adds ProductAttributeTerms Entity

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		26B6453C259B8C0D00EF3FB3 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
 		26B64540259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */; };
 		26B64544259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */; };
+		26B64548259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64547259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift */; };
+		26B6454E259BF81400EF3FB3 /* product-attribute-terms.json in Resources */ = {isa = PBXBuildFile; fileRef = 26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -511,6 +513,8 @@
 		26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTerm.swift; sourceTree = "<group>"; };
 		26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermMapper.swift; sourceTree = "<group>"; };
 		26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermListMapper.swift; sourceTree = "<group>"; };
+		26B64547259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermListMapperTests.swift; sourceTree = "<group>"; };
+		26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-attribute-terms.json"; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -1218,6 +1222,7 @@
 				2683D70F24456EE4002A1589 /* categories-extra.json */,
 				2683D70D24456DB7002A1589 /* categories-empty.json */,
 				45B204BB24890B1200FE6526 /* category.json */,
+				26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */,
 				74C9477F2193A6C60024CB60 /* comment-moderate-approved.json */,
 				74C9477E2193A6C60024CB60 /* comment-moderate-trash.json */,
 				74C947812193A6C70024CB60 /* comment-moderate-unapproved.json */,
@@ -1457,6 +1462,7 @@
 				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
 				45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */,
 				45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */,
+				26B64547259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift */,
 				45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */,
 				26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */,
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
@@ -1703,6 +1709,7 @@
 				D823D90722376B4800C90817 /* shipment_tracking_new_custom_provider.json in Resources */,
 				268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */,
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,
+				26B6454E259BF81400EF3FB3 /* product-attribute-terms.json in Resources */,
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */,
 				02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */,
@@ -2058,6 +2065,7 @@
 				453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */,
 				CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
+				26B64548259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift in Sources */,
 				B554FA8B2180B1D500C54DFF /* NotificationsRemoteTests.swift in Sources */,
 				B518662A20A09C6F00037A38 /* OrdersRemoteTests.swift in Sources */,
 				B5969E1520A47F99005E9DF1 /* RemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		26B2F74B24C696C00065CCC8 /* LeaderboardRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */; };
 		26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */; };
 		26B6453C259B8C0D00EF3FB3 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
+		26B64540259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */; };
+		26B64544259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -507,6 +509,8 @@
 		26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardRow.swift; sourceTree = "<group>"; };
 		26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardRowContent.swift; sourceTree = "<group>"; };
 		26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTerm.swift; sourceTree = "<group>"; };
+		26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermMapper.swift; sourceTree = "<group>"; };
+		26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermListMapper.swift; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -1348,6 +1352,8 @@
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
 				45152810257A81730076B03C /* ProductAttributeMapper.swift */,
 				4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */,
+				26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */,
+				26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
 				45B204B72489095100FE6526 /* ProductCategoryMapper.swift */,
 				26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */,
@@ -1849,6 +1855,7 @@
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,
 				7452387221124B7700A973CD /* AnyEncodable.swift in Sources */,
+				26B64544259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift in Sources */,
 				740CF89921937A030023ED3A /* CommentRemote.swift in Sources */,
 				025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */,
 				74ABA1CD213F1B6B00FFAD30 /* TopEarnerStats.swift in Sources */,
@@ -2000,6 +2007,7 @@
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
 				029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,
+				26B64540259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift in Sources */,
 				CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */,
 				028296F7237D588700E84012 /* ProductVariation.swift in Sources */,
 			);

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		26B2F74924C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */; };
 		26B2F74B24C696C00065CCC8 /* LeaderboardRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */; };
 		26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */; };
+		26B6453C259B8C0D00EF3FB3 /* ProductAttributeTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -505,6 +506,7 @@
 		26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemoteTests.swift; sourceTree = "<group>"; };
 		26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardRow.swift; sourceTree = "<group>"; };
 		26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardRowContent.swift; sourceTree = "<group>"; };
+		26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTerm.swift; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -1489,6 +1491,7 @@
 			children = (
 				CE6BFEE42236BF05005C79FB /* Product.swift */,
 				CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */,
+				26B6453B259B8C0D00EF3FB3 /* ProductAttributeTerm.swift */,
 				CE132BB9223851F80029DB6C /* ProductCategory.swift */,
 				CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */,
 				CE6BFEE72236D133005C79FB /* ProductDimensions.swift */,
@@ -1927,6 +1930,7 @@
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
+				26B6453C259B8C0D00EF3FB3 /* ProductAttributeTerm.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
@@ -22,7 +22,7 @@ struct ProductAttributeTermListMapper: Mapper {
 }
 
 /// ProductAttributeTermListEnvelope Disposable Entity:
-/// `Load All Products Categories` endpoint returns the updated products document in the `data` key.
+/// `Load All ProductsAttributeTerm` endpoint returns the updated products document in the `data` key.
 /// This entity allows us to do parse all the things with JSONDecoder.
 ///
 private struct ProductAttributeTermListEnvelope: Decodable {

--- a/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeTermListMapper.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Mapper: ProductAttributeTerm List
+///
+struct ProductAttributeTermListMapper: Mapper {
+    /// Site Identifier associated to the `ProductAttributeTermList`s that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the ProductAttributeTerm Endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into `[ProductAttributeTerm]`.
+    ///
+    func map(response: Data) throws -> [ProductAttributeTerm] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductAttributeTermListEnvelope.self, from: response).productAttributeTerms
+    }
+}
+
+/// ProductAttributeTermListEnvelope Disposable Entity:
+/// `Load All Products Categories` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductAttributeTermListEnvelope: Decodable {
+    let productAttributeTerms: [ProductAttributeTerm]
+
+    private enum CodingKeys: String, CodingKey {
+        case productAttributeTerms = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductAttributeTermMapper.swift
+++ b/Networking/Networking/Mapper/ProductAttributeTermMapper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Mapper: ProductAttributeTerm
+///
+struct ProductAttributeTermMapper: Mapper {
+
+    /// Site Identifier associated to the `ProductAttributeTerm`s that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the `ProductAttributeTerm` Endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into `ProductAttributeTerm`.
+    ///
+    func map(response: Data) throws -> ProductAttributeTerm {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductAttributeTermEnvelope.self, from: response).productAttributeTerm
+    }
+}
+
+
+/// ProductAttributeTermEnvelope Disposable Entity:
+/// `Load ProductProductAttributeTerm` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductAttributeTermEnvelope: Decodable {
+    let productAttributeTerm: ProductAttributeTerm
+
+    private enum CodingKeys: String, CodingKey {
+        case productAttributeTerm = "data"
+    }
+}

--- a/Networking/Networking/Model/Product/ProductAttributeTerm.swift
+++ b/Networking/Networking/Model/Product/ProductAttributeTerm.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Represents a `ProductAttributeTerm` entity.
+///
+public struct ProductAttributeTerm: Equatable {
+    public let siteID: Int64
+    public let termID: Int64
+    public let name: String
+    public let slug: String
+    public let count: Int
+
+    /// Member wise initializer.
+    ///
+    public init(siteID: Int64, termID: Int64, name: String, slug: String, count: Int) {
+        self.siteID = siteID
+        self.termID = termID
+        self.name = name
+        self.slug = slug
+        self.count = count
+    }
+}
+
+// MARK: Codable Conformance
+extension ProductAttributeTerm: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case termID = "id"
+        case name
+        case slug
+        case count
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ProductCategoryDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let termID = try container.decode(Int64.self, forKey: .termID)
+        let name = try container.decode(String.self, forKey: .name)
+        let slug = try container.decode(String.self, forKey: .slug)
+        let count = try container.decode(Int.self, forKey: .count)
+
+        self.init(siteID: siteID, termID: termID, name: name, slug: slug, count: count)
+    }
+}
+
+// MARK: Decoding Errors
+//
+enum ProductAttributeTermDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Networking
+
+final class ProductAttributeTermListMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    func test_productAttributeTerm_fields_are_correctly_mapped() throws {
+        let terms = try mapLoadAllProductAttributeTermsResponse()
+        XCTAssertEqual(terms.count, 3)
+
+        let secondTerm = terms[1]
+        XCTAssertEqual(secondTerm.siteID, dummySiteID)
+        XCTAssertEqual(secondTerm.termID, 27)
+        XCTAssertEqual(secondTerm.name, "Medium")
+        XCTAssertEqual(secondTerm.slug, "medium")
+        XCTAssertEqual(secondTerm.count, 1)
+    }
+}
+
+// MARK: Helpers
+private extension ProductAttributeTermListMapperTests {
+    func mapProductAttributeTerms(from filename: String) throws -> [ProductAttributeTerm] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try ProductAttributeTermListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    func mapLoadAllProductAttributeTermsResponse() throws -> [ProductAttributeTerm] {
+        return try mapProductAttributeTerms(from: "product-attribute-terms")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductAttributeTermListMapperTests.swift
@@ -11,11 +11,9 @@ final class ProductAttributeTermListMapperTests: XCTestCase {
         XCTAssertEqual(terms.count, 3)
 
         let secondTerm = terms[1]
-        XCTAssertEqual(secondTerm.siteID, dummySiteID)
-        XCTAssertEqual(secondTerm.termID, 27)
-        XCTAssertEqual(secondTerm.name, "Medium")
-        XCTAssertEqual(secondTerm.slug, "medium")
-        XCTAssertEqual(secondTerm.count, 1)
+        let expectedTerm = ProductAttributeTerm(siteID: dummySiteID, termID: 27, name: "Medium", slug: "medium", count: 1)
+
+        XCTAssertEqual(secondTerm, expectedTerm)
     }
 }
 

--- a/Networking/NetworkingTests/Responses/categories-all.json
+++ b/Networking/NetworkingTests/Responses/categories-all.json
@@ -1,61 +1,61 @@
 {
   "data": [
     {
-      "id": 26,
-      "name": "Large",
-      "slug": "large",
+      "id": 104,
+      "name": "Dress",
+      "slug": "Shirt",
+      "parent": 0,
       "description": "",
+      "display": "default",
+      "image": {
+        "id": 1310,
+        "date_created": "2018-08-28T13:09:22",
+        "date_created_gmt": "2018-08-28T17:09:22",
+        "date_modified": "2018-08-28T13:09:22",
+        "date_modified_gmt": "2018-08-28T17:09:22",
+        "src": "https://some-website.com/2018.jpg",
+        "name": "2018",
+        "alt": ""
+      },
       "menu_order": 0,
       "count": 1,
       "_links": {
         "self": [
           {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/26"
+            "href": "https://some-website.com/products/categories/104"
           }
         ],
         "collection": [
           {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+            "href": "https://some-website.com/products/categories"
           }
         ]
       }
     },
     {
-      "id": 27,
-      "name": "Medium",
-      "slug": "medium",
+      "id": 20,
+      "name": "American",
+      "slug": "american",
+      "parent": 17,
       "description": "",
-      "menu_order": 0,
-      "count": 1,
+      "display": "default",
+      "image": null,
+      "menu_order": 5,
+      "count": 0,
       "_links": {
         "self": [
           {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/27"
+            "href": "https://some-website.com/products/categories/20"
           }
         ],
         "collection": [
           {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
-          }
-        ]
-      }
-    },
-    {
-      "id": 28,
-      "name": "Small",
-      "slug": "small",
-      "description": "",
-      "menu_order": 0,
-      "count": 1,
-      "_links": {
-        "self": [
-          {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/28"
+            "href": "https://some-website.com/products/categories"
           }
         ],
-        "collection": [
+        "up": [
           {
-            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+            "href": "https://some-website.com/products/categories/17"
           }
         ]
       }

--- a/Networking/NetworkingTests/Responses/categories-all.json
+++ b/Networking/NetworkingTests/Responses/categories-all.json
@@ -1,61 +1,61 @@
 {
   "data": [
     {
-      "id": 104,
-      "name": "Dress",
-      "slug": "Shirt",
-      "parent": 0,
+      "id": 26,
+      "name": "Large",
+      "slug": "large",
       "description": "",
-      "display": "default",
-      "image": {
-        "id": 1310,
-        "date_created": "2018-08-28T13:09:22",
-        "date_created_gmt": "2018-08-28T17:09:22",
-        "date_modified": "2018-08-28T13:09:22",
-        "date_modified_gmt": "2018-08-28T17:09:22",
-        "src": "https://some-website.com/2018.jpg",
-        "name": "2018",
-        "alt": ""
-      },
       "menu_order": 0,
       "count": 1,
       "_links": {
         "self": [
           {
-            "href": "https://some-website.com/products/categories/104"
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/26"
           }
         ],
         "collection": [
           {
-            "href": "https://some-website.com/products/categories"
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
           }
         ]
       }
     },
     {
-      "id": 20,
-      "name": "American",
-      "slug": "american",
-      "parent": 17,
+      "id": 27,
+      "name": "Medium",
+      "slug": "medium",
       "description": "",
-      "display": "default",
-      "image": null,
-      "menu_order": 5,
-      "count": 0,
+      "menu_order": 0,
+      "count": 1,
       "_links": {
         "self": [
           {
-            "href": "https://some-website.com/products/categories/20"
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/27"
           }
         ],
         "collection": [
           {
-            "href": "https://some-website.com/products/categories"
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+          }
+        ]
+      }
+    },
+    {
+      "id": 28,
+      "name": "Small",
+      "slug": "small",
+      "description": "",
+      "menu_order": 0,
+      "count": 1,
+      "_links": {
+        "self": [
+          {
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/28"
           }
         ],
-        "up": [
+        "collection": [
           {
-            "href": "https://some-website.com/products/categories/17"
+            "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
           }
         ]
       }

--- a/Networking/NetworkingTests/Responses/product-attribute-terms.json
+++ b/Networking/NetworkingTests/Responses/product-attribute-terms.json
@@ -1,0 +1,64 @@
+{
+    "data": [
+      {
+        "id": 26,
+        "name": "Large",
+        "slug": "large",
+        "description": "",
+        "menu_order": 0,
+        "count": 1,
+        "_links": {
+          "self": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/26"
+            }
+          ],
+          "collection": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+            }
+          ]
+        }
+      },
+      {
+        "id": 27,
+        "name": "Medium",
+        "slug": "medium",
+        "description": "",
+        "menu_order": 0,
+        "count": 1,
+        "_links": {
+          "self": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/27"
+            }
+          ],
+          "collection": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+            }
+          ]
+        }
+      },
+      {
+        "id": 28,
+        "name": "Small",
+        "slug": "small",
+        "description": "",
+        "menu_order": 0,
+        "count": 1,
+        "_links": {
+          "self": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms/28"
+            }
+          ],
+          "collection": [
+            {
+              "href": "https://dulces.mystagingwebsite.com/wp-json/wc/v3/products/attributes/2/terms"
+            }
+          ]
+        }
+      }
+    ]
+}


### PR DESCRIPTION
part of #3112 

# Why 

In order to support the screen where the store manager can add a new term to a product attribute, we need first to introduce the necessary API entity that will allow us to fetch and create new terms.

<img width="590" alt="Screen Shot 2020-12-30 at 11 03 37 AM" src="https://user-images.githubusercontent.com/562080/103365712-b48ec900-4a8e-11eb-8646-4a955a6acc92.png">

# How

- Added `ProductAttributeTerm` entity and it's mappers.
- Added `product-attribute-terms.json` to support tests.

# Testing
- Nothing yet, just make sure the unit tests pass.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
