### PR TITLE
Enabled Products M5 features for all the users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 5.8
 -----
-- [***] Products M5 features are now available to all. Products M5 features: add and edit linked products, add and edit downloadable files, product deletion.
+- [***] Products M5 features are now available to all. Products M5 features: add and edit linked products, add and edit downloadable files, product deletion. [https://github.com/woocommerce/woocommerce-ios/pull/3420]
 
 
 5.7

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 5.8
 -----
+- [***] Products M5 features are now available to all. Products M5 features: add and edit linked products, add and edit downloadable files, product deletion.
 
 
 5.7

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -5,8 +5,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .editProductsRelease5:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .addProductVariations:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease1:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -10,10 +10,6 @@ enum FeatureFlag: Int {
     ///
     case barcodeScanner
 
-    /// Edit products - release 5
-    ///
-    case editProductsRelease5
-
     /// Add Product Variations
     ///
     case addProductVariations

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -56,18 +56,15 @@ private extension AddProductCoordinator {
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                                   product: model)
-        let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
         let isAddProductVariationsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                             productImageActionHandler: productImageActionHandler)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                        isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -12,7 +12,6 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     //
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
-    private let isEditProductsRelease5Enabled: Bool
     private let isAddProductVariationsEnabled: Bool
 
     init(product: ProductFormDataModel,
@@ -22,7 +21,6 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.currency = currency
         self.currencyFormatter = currencyFormatter
-        self.isEditProductsRelease5Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
         self.isAddProductVariationsEnabled = featureFlagService.isFeatureFlagEnabled(.addProductVariations)
         configureSections(product: product, actionsFactory: actionsFactory)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool)
+    init(_ settings: ProductSettings, productType: ProductType)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,13 +20,13 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool) {
+        init(_ settings: ProductSettings, productType: ProductType) {
             if productType == .simple {
                 let tempRows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
                         ProductSettingsRows.VirtualProduct(settings),
-                        isEditProductsRelease5Enabled ? ProductSettingsRows.DownloadableProduct(settings) : nil
+                        ProductSettingsRows.DownloadableProduct(settings)
                 ]
                 rows = tempRows.compactMap { $0 }
             } else {
@@ -43,7 +43,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool) {
+        init(_ settings: ProductSettings, productType: ProductType) {
             rows = [ProductSettingsRows.ReviewsAllowed(settings),
             ProductSettingsRows.Slug(settings),
             ProductSettingsRows.PurchaseNote(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -24,13 +24,11 @@ final class ProductSettingsViewController: UIViewController {
     init(product: Product,
          password: String?,
          formType: ProductFormType,
-         isEditProductsRelease5Enabled: Bool,
          completion: @escaping Completion,
          onPasswordRetrieved: @escaping PasswordRetrievedCompletion) {
         viewModel = ProductSettingsViewModel(product: product,
                                              password: password,
-                                             formType: formType,
-                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                             formType: formType)
         onCompletion = completion
         onPasswordCompletion = onPasswordRetrieved
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -12,8 +12,7 @@ final class ProductSettingsViewModel {
     var productSettings: ProductSettings {
         didSet {
             sections = Self.configureSections(productSettings,
-                                              productType: product.productType,
-                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                              productType: product.productType)
         }
     }
 
@@ -29,12 +28,10 @@ final class ProductSettingsViewModel {
     var onReload: (() -> Void)?
     var onPasswordRetrieved: ((_ password: String) -> Void)?
 
-    private let isEditProductsRelease5Enabled: Bool
 
-    init(product: Product, password: String?, formType: ProductFormType, isEditProductsRelease5Enabled: Bool) {
+    init(product: Product, password: String?, formType: ProductFormType) {
         self.product = product
         self.password = password
-        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         productSettings = ProductSettings(from: product, password: password)
 
         switch formType {
@@ -42,12 +39,10 @@ final class ProductSettingsViewModel {
             self.password = ""
             productSettings.password = ""
             sections = Self.configureSections(productSettings,
-                                              productType: product.productType,
-                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                              productType: product.productType)
         case .edit:
             sections = Self.configureSections(productSettings,
-                                              productType: product.productType,
-                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                              productType: product.productType)
             /// If nil, we fetch the password from site post API because it was never fetched
             if password == nil {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
@@ -61,14 +56,12 @@ final class ProductSettingsViewModel {
                     self.password = password
                     self.productSettings.password = password
                     self.sections = Self.configureSections(self.productSettings,
-                                                           productType: product.productType,
-                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                           productType: product.productType)
                 }
             }
         case .readonly:
             sections = Self.configureSections(productSettings,
-                                              productType: product.productType,
-                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                              productType: product.productType)
         }
     }
 
@@ -112,14 +105,11 @@ private extension ProductSettingsViewModel {
 //
 private extension ProductSettingsViewModel {
     static func configureSections(_ settings: ProductSettings,
-                                  productType: ProductType,
-                                  isEditProductsRelease5Enabled: Bool) -> [ProductSettingsSectionMediator] {
+                                  productType: ProductType) -> [ProductSettingsSectionMediator] {
         return [ProductSettingsSections.PublishSettings(settings,
-                                                        productType: productType,
-                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled),
+                                                        productType: productType),
                 ProductSettingsSections.MoreOptions(settings,
-                                                    productType: productType,
-                                                    isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                    productType: productType)
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -34,15 +34,11 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let product: EditableProductModel
     private let formType: ProductFormType
     private let editable: Bool
-    private let isEditProductsRelease5Enabled: Bool
 
-    init(product: EditableProductModel,
-         formType: ProductFormType,
-         isEditProductsRelease5Enabled: Bool) {
+    init(product: EditableProductModel, formType: ProductFormType) {
         self.product = product
         self.formType = formType
         self.editable = formType != .readonly
-        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -93,8 +89,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowProductTypeRow = formType != .add
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
-        let shouldShowDownloadableProduct = isEditProductsRelease5Enabled && product.downloadable
-        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
+        let shouldShowDownloadableProduct = product.downloadable
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
@@ -105,7 +100,7 @@ private extension ProductFormActionsFactory {
             .tags(editable: editable),
             shouldShowDownloadableProduct ? .downloadableFiles: nil,
             .shortDescription(editable: editable),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .linkedProducts(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
@@ -116,7 +111,6 @@ private extension ProductFormActionsFactory {
         let shouldShowExternalURLRow = editable || product.product.externalURL?.isNotEmpty == true
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let shouldShowProductTypeRow = formType != .add
-        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
@@ -126,7 +120,7 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .linkedProducts(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
@@ -136,7 +130,6 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let shouldShowProductTypeRow = formType != .add
-        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts(editable: editable),
@@ -145,7 +138,7 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .linkedProducts(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
@@ -154,7 +147,6 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowProductTypeRow = formType != .add
-        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             .variations,
@@ -164,7 +156,7 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .linkedProducts(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
         return actions.compactMap { $0 }
@@ -173,7 +165,6 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
-        let shouldShowLinkedProducts = isEditProductsRelease5Enabled
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: false): nil,
@@ -182,7 +173,7 @@ private extension ProductFormActionsFactory {
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),
-            shouldShowLinkedProducts ? .linkedProducts(editable: editable): nil,
+            .linkedProducts(editable: editable),
             .productType(editable: false)
         ]
         return actions.compactMap { $0 }
@@ -220,10 +211,10 @@ private extension ProductFormActionsFactory {
         case .tags:
             return product.product.tags.isNotEmpty
         case .linkedProducts:
-            return isEditProductsRelease5Enabled && (product.upsellIDs.count > 0 || product.crossSellIDs.count > 0)
+            return (product.upsellIDs.count > 0 || product.crossSellIDs.count > 0)
         // Downloadable files. Only core product types for downloadable files are able to handle downloadable files.
         case .downloadableFiles:
-            return isEditProductsRelease5Enabled && product.downloadable
+            return product.downloadable
         case .shortDescription:
             return product.shortDescription.isNilOrEmpty == false
         // Affiliate products only.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -39,7 +39,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let productUIImageLoader: ProductUIImageLoader
 
     private let currency: String
-    private let isEditProductsRelease5Enabled: Bool
     private let isAddProductVariationsEnabled: Bool
 
     private lazy var exitForm: () -> Void = {
@@ -60,13 +59,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          presentationStyle: ProductFormPresentationStyle,
-         isEditProductsRelease5Enabled: Bool,
          isAddProductVariationsEnabled: Bool) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
-        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
@@ -357,7 +354,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
                                                                                formType: viewModel.formType,
-                                                                               isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)
             case .status, .noPriceWarning:
@@ -716,7 +712,6 @@ private extension ProductFormViewController {
         let viewController = ProductSettingsViewController(product: product.product,
                                                            password: password,
                                                            formType: viewModel.formType,
-                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                            completion: { [weak self] (productSettings) in
             guard let self = self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -59,8 +59,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
             }
 
             actionsFactory = ProductFormActionsFactory(product: product,
-                                                       formType: formType,
-                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                       formType: formType)
             productSubject.send(product)
         }
     }
@@ -81,22 +80,18 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     private let productImageActionHandler: ProductImageActionHandler
-    private let isEditProductsRelease5Enabled: Bool
 
     private var cancellable: ObservationToken?
 
     init(product: EditableProductModel,
          formType: ProductFormType,
-         productImageActionHandler: ProductImageActionHandler,
-         isEditProductsRelease5Enabled: Bool) {
+         productImageActionHandler: ProductImageActionHandler) {
         self.formType = formType
         self.productImageActionHandler = productImageActionHandler
-        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.originalProduct = product
         self.product = product
         self.actionsFactory = ProductFormActionsFactory(product: product,
-                                                        formType: formType,
-                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                                        formType: formType)
         self.isUpdateEnabledSubject = PublishSubject<Bool>()
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
@@ -135,7 +130,6 @@ extension ProductFormViewModel {
     }
 
     func canDeleteProduct() -> Bool {
-        isEditProductsRelease5Enabled &&
         formType == .edit
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -20,7 +20,6 @@ struct ProductDetailsFactory {
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
                                 isEditProductsEnabled: forceReadOnly ? false: true,
-                                isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5),
                                 isAddProductVariationsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations))
         onCompletion(vc)
     }
@@ -31,7 +30,6 @@ private extension ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
-                               isEditProductsRelease5Enabled: Bool,
                                isAddProductVariationsEnabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
@@ -40,13 +38,11 @@ private extension ProductDetailsFactory {
         let formType: ProductFormType = isEditProductsEnabled ? .edit: .readonly
         let viewModel = ProductFormViewModel(product: productModel,
                                              formType: formType,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
+                                             productImageActionHandler: productImageActionHandler)
         vc = ProductFormViewController(viewModel: viewModel,
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
                                        presentationStyle: presentationStyle,
-                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                        isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -21,7 +21,6 @@ struct ProductVariationDetailsFactory {
                                          presentationStyle: presentationStyle,
                                          currencySettings: currencySettings,
                                          isEditProductsEnabled: forceReadOnly ? false: true,
-                                         isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5),
                                          isAddProductVariationsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addProductVariations))
         onCompletion(vc)
     }
@@ -33,7 +32,6 @@ private extension ProductVariationDetailsFactory {
                                         presentationStyle: ProductFormPresentationStyle,
                                         currencySettings: CurrencySettings,
                                         isEditProductsEnabled: Bool,
-                                        isEditProductsRelease5Enabled: Bool,
                                         isAddProductVariationsEnabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
@@ -51,7 +49,6 @@ private extension ProductVariationDetailsFactory {
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
                                        presentationStyle: presentationStyle,
-                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                        isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -81,16 +81,14 @@ final class ProductVariationsViewController: UIViewController {
     private let formType: ProductFormType
 
     private let imageService: ImageService = ServiceLocator.imageService
-    private let isEditProductsRelease5Enabled: Bool
     private let isAddProductVariationsEnabled: Bool
 
-    init(product: Product, formType: ProductFormType, isEditProductsRelease5Enabled: Bool, isAddProductVariationsEnabled: Bool) {
+    init(product: Product, formType: ProductFormType, isAddProductVariationsEnabled: Bool) {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
         self.parentProductSKU = product.sku
         self.formType = formType
-        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         super.init(nibName: nil, bundle: nil)
     }
@@ -304,7 +302,6 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                        isAddProductVariationsEnabled: isAddProductVariationsEnabled)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+AddProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+AddProductTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Yosemite
 
 final class ProductFormActionsFactory_AddProductTests: XCTestCase {
+
     func test_add_simple_product_form_actions_has_no_product_type_row() {
         // Arrange
         let product = Fixtures.physicalSimpleProductWithoutImages
@@ -11,8 +12,7 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .add,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .add)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -24,7 +24,8 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
-                                                                       .shortDescription(editable: true)]
+                                                                       .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -38,8 +39,7 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .add,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .add)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -47,7 +47,8 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
                                                                        .reviews,
-                                                                       .externalURL(editable: true)]
+                                                                       .externalURL(editable: true),
+                                                                       .linkedProducts(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editShortDescription]
@@ -61,14 +62,13 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .add,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .add)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts(editable: true), .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts(editable: true), .reviews, .linkedProducts(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editShortDescription]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -11,8 +11,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.name(editable: false)]
@@ -26,8 +25,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -40,6 +38,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -56,8 +55,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -70,6 +68,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -84,8 +83,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -96,6 +94,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -112,8 +111,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -125,6 +123,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -139,8 +138,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -151,6 +149,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -167,8 +166,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .readonly,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .readonly)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
@@ -181,6 +179,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
                                                                        .shortDescription(editable: false),
+                                                                       .linkedProducts(editable: false),
                                                                        .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
@@ -12,8 +12,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true)))
@@ -26,8 +25,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true)))
@@ -42,8 +40,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.inventorySettings(editable: true)))
@@ -57,8 +54,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.inventorySettings(editable: true)))
@@ -74,8 +70,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.shippingSettings(editable: true)))
@@ -89,8 +84,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.shippingSettings(editable: true)))
@@ -106,8 +100,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.categories(editable: true)))
@@ -121,8 +114,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.categories(editable: true)))
@@ -138,8 +130,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.shortDescription(editable: true)))
@@ -153,8 +144,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.shortDescription(editable: true)))
@@ -170,8 +160,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.downloadableFiles))
@@ -184,8 +173,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.downloadableFiles))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -11,8 +11,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -25,6 +24,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -39,8 +39,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -53,6 +52,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -67,8 +67,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -80,6 +79,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -94,8 +94,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -121,8 +120,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -150,8 +148,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -179,8 +176,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -192,6 +188,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -206,8 +203,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -216,6 +212,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
                                                                        .reviews,
                                                                        .externalURL(editable: true),
+                                                                       .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
@@ -230,14 +227,16 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts(editable: true), .reviews, .productType(editable: true)]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts(editable: true),
+                                                                       .reviews,
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editShortDescription]
@@ -251,8 +250,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -263,6 +261,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
             .reviews,
             .shippingSettings(editable: true),
             .inventorySettings(editable: true),
+            .linkedProducts(editable: true),
             .productType(editable: true)
         ]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
@@ -278,8 +277,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -290,6 +288,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
             .reviews,
             .shippingSettings(editable: true),
             .inventorySettings(editable: true),
+            .linkedProducts(editable: true),
             .productType(editable: true)
         ]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
@@ -305,14 +304,16 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews, .inventorySettings(editable: false), .productType(editable: false)]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
@@ -326,8 +327,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -337,6 +337,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
             .priceSettings(editable: false),
             .reviews,
             .inventorySettings(editable: false),
+            .linkedProducts(editable: true),
             .productType(editable: false)
         ]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -10,11 +10,13 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true), .reviews, .productType(editable: true)]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .reviews,
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings,
@@ -32,11 +34,13 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: false)
+                                                formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true), .reviews, .productType(editable: true)]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .reviews,
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editShortDescription]
@@ -50,8 +54,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
 
         // Action
         let factory = ProductFormActionsFactory(product: model,
-                                                formType: .edit,
-                                                isEditProductsRelease5Enabled: true)
+                                                formType: .edit)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -12,8 +12,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                    stockStatusKey: ProductStockStatus.onBackOrder.rawValue)
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model,
-                                                       formType: .edit,
-                                                       isEditProductsRelease5Enabled: false)
+                                                       formType: .edit)
 
         // Action
         let tableViewModel = DefaultProductFormTableViewModel(product: model, actionsFactory: actionsFactory, currency: "")
@@ -41,8 +40,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                    stockStatusKey: ProductStockStatus.onBackOrder.rawValue)
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model,
-                                                       formType: .edit,
-                                                       isEditProductsRelease5Enabled: false)
+                                                       formType: .edit)
 
         // Action
         let tableViewModel = DefaultProductFormTableViewModel(product: model, actionsFactory: actionsFactory, currency: "")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -15,8 +15,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
 
         // Action
@@ -54,8 +53,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateName("this new product name")
@@ -71,8 +69,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let settings = ProductSettings(from: product, password: "secret secret")
@@ -89,8 +86,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         let expectation = self.expectation(description: "Wait for image upload")
         productImageActionHandler.addUpdateObserver(self) { statuses in
             if statuses.productImageStatuses.isNotEmpty {
@@ -113,8 +109,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let productImage = ProductImage(imageID: 6,
@@ -136,8 +131,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateDescription("Another way to describe the product?")
@@ -153,8 +147,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let categoryID = Int64(1234)
@@ -175,8 +168,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let tagID = Int64(1234)
@@ -196,8 +188,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateShortDescription("A short one")
@@ -213,8 +204,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
@@ -230,8 +220,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: true, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)
@@ -247,8 +236,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateShippingSettings(weight: "88888",
@@ -267,8 +255,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateDownloadableFiles(downloadableFiles: MockProduct().sampleDownloadsMutated(), downloadLimit: 1, downloadExpiry: 1)
@@ -284,8 +271,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateDownloadableFiles(downloadableFiles: MockProduct().sampleDownloads(), downloadLimit: 5, downloadExpiry: 1)
@@ -301,8 +287,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         viewModel.updateDownloadableFiles(downloadableFiles: MockProduct().sampleDownloads(), downloadLimit: 1, downloadExpiry: 5)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -30,8 +30,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
         cancellableProduct = viewModel.observableProduct.subscribe { _ in
             // Assert
@@ -82,8 +81,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true
@@ -124,8 +122,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true
@@ -162,8 +159,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         // The password is set from a separate DotCom API.
         viewModel.resetPassword("134")
 
@@ -207,8 +203,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -123,7 +123,6 @@ private extension ProductFormViewModel_SaveTests {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
-                                    productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease5Enabled: true)
+                                    productImageActionHandler: productImageActionHandler)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -13,8 +13,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newName = "<p> cool product </p>"
@@ -31,8 +30,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newDescription = "<p> cool product </p>"
@@ -49,8 +47,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newWeight = "9999.88"
@@ -83,8 +80,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newRegularPrice = "32.45"
@@ -116,8 +112,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newSKU = "94115"
@@ -149,8 +144,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newImage = ProductImage(imageID: 17,
@@ -173,8 +167,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let categoryID = Int64(1234)
@@ -195,8 +188,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let tagID = Int64(1234)
@@ -216,8 +208,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newShortDescription = "<p> deal of the day! </p>"
@@ -234,8 +225,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newStatus = "pending"
@@ -277,8 +267,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let sku = "woooo"
@@ -295,8 +284,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let externalURL = "woo.com"
@@ -315,8 +303,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let groupedProductIDs: [Int64] = [630, 22]
@@ -333,8 +320,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
-                                             productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: false)
+                                             productImageActionHandler: productImageActionHandler)
 
         // Action
         let newDownloadableFiles = MockProduct().sampleDownloadsMutated()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -161,7 +161,6 @@ private extension ProductFormViewModelTests {
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
-                                    productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease5Enabled: true)
+                                    productImageActionHandler: productImageActionHandler)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -22,8 +22,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
         // When
         let section = ProductSettingsSections.PublishSettings(settings,
-                                                              productType: productType,
-                                                              isEditProductsRelease5Enabled: true)
+                                                              productType: productType)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -47,8 +46,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
         // When
         let section = ProductSettingsSections.PublishSettings(settings,
-                                                              productType: productType,
-                                                              isEditProductsRelease5Enabled: true)
+                                                              productType: productType)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
@@ -72,8 +70,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
           // When
          let section = ProductSettingsSections.PublishSettings(settings,
-                                                               productType: productType,
-                                                               isEditProductsRelease5Enabled: true)
+                                                               productType: productType)
 
           // Then
          XCTAssertNil(section.rows.first(where: {
@@ -97,37 +94,11 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
           // When
          let section = ProductSettingsSections.PublishSettings(settings,
-                                                               productType: productType,
-                                                               isEditProductsRelease5Enabled: true)
+                                                               productType: productType)
 
           // Then
          XCTAssertNotNil(section.rows.first(where: {
              $0 is ProductSettingsRows.DownloadableProduct
          }))
      }
-
-    func test_when_isEditProductsRelease5Enabled_is_false_the_downloadable_product_option_is_hidden() {
-        // Given
-        let settings = ProductSettings(status: .draft,
-                                       featured: false,
-                                       password: nil,
-                                       catalogVisibility: .catalog,
-                                       virtual: false,
-                                       reviewsAllowed: false,
-                                       slug: "",
-                                       purchaseNote: nil,
-                                       menuOrder: 0,
-                                       downloadable: false)
-        let productType = ProductType.simple
-
-         // When
-        let section = ProductSettingsSections.PublishSettings(settings,
-                                                              productType: productType,
-                                                              isEditProductsRelease5Enabled: false)
-
-         // Then
-        XCTAssertNil(section.rows.first(where: {
-            $0 is ProductSettingsRows.DownloadableProduct
-        }))
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -70,7 +70,6 @@ private extension ProductSettingsViewModel {
     convenience init(product: Product, password: String?) {
         self.init(product: product,
                   password: password,
-                  formType: .edit,
-                  isEditProductsRelease5Enabled: true)
+                  formType: .edit)
     }
 }


### PR DESCRIPTION
Closes #3400 

## Description
In this PR and in accordance with our [discussion](https://a8c.slack.com/archives/CGPNUU63E/p1608386588040300), we decided to release to all our users the new functionalities under the Products M5. I've removed all the m5 feature flag from our codebase, and update the unit tests in accordance.
**The new functionalities include:**
- Add and edit Linked Products.
- Add and edit Downloadable Files.
- Delete a product.

**Important**: this PR should be merged when we complete the implementation of the tracking events. I'll take care of the missing events.

## Testing
We should test that all the functionalities described above are visible to all our users. As described in the slack discussion, we enabled the functionalities without adding them under the beta screen in the app settings (like we did in the past).
Therefore:
- Make sure that you are able to see the Linked Products row under a product detail.
- Make sure that you are able to see the Downloadable Files flag in Product Settings, and that if you turn on the flag you are able to see the Downloadable Files row under the product detail.
- Make sure that you are able to delete a product.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
