### PR TITLE
Fix “Try another account” button doesn't work after magic link login

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -60,14 +60,9 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
     }
 
     func restartAuthentication() {
-        switch selectedConfiguration {
-        case .standard, .switchingStores:
-            navigationController.dismiss(animated: false) { [weak self] in
-                self?.onDismiss?()
-            }
-        case .login:
-            navigationController.popToRootViewController(animated: true)
-            onDismiss?()
+        navigationController.dismiss(animated: false) { [weak self] in
+            ServiceLocator.stores.deauthenticate()
+            self?.onDismiss?()
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -396,7 +396,6 @@ private extension StorePickerViewController {
             return
         }
 
-        ServiceLocator.stores.deauthenticate()
         delegate?.restartAuthentication()
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -27,7 +27,7 @@ final class AppCoordinator {
             guard let self = self else { return }
 
             if isLoggedIn == false {
-                let animated = self.isLoggedIn == true
+                let animated = self.isLoggedIn == true && self.stores.needsDefaultStore == false
                 self.displayAuthenticator(animated: animated)
             } else if self.stores.needsDefaultStore {
                 self.displayStorePicker()


### PR DESCRIPTION
Fixes #3367 

## Why it only breaks for magic link flow

When the app is logged out, we call [`WordPressAuthenticator.showLogin`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/7099abe30d93fe4f4ab22a02ca1ab6576d1cfa97/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift#L162-L177) with a `from: UIViewController` parameter to present a navigation controller `LoginNavigationController` for the login flow that begins with `LoginPrologueViewController` from `Login.storyboard`.

Normally, all the subsequent view controllers are pushed to this navigation controller. For example, when logging in with email/password, the navigation controller looks like the following when reaching the store picker:

```
    ▿ 0 : <WordPressAuthenticator.LoginPrologueViewController: 0x120035800>
    ▿ 1 : <WordPressAuthenticator.GetStartedViewController: 0x120102a00>
    ▿ 2 : <WordPressAuthenticator.PasswordViewController: 0x120903a00>
    ▿ 3 : <WordPressAuthenticator.TwoFAViewController: 0x1200f7200>
    ▿ 4 : <WooCommerce.StorePickerViewController: 0x120072800>
```

However, when logging in with magic link, [it dismisses the original `LoginNavigationController` and then presents another navigation controller](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/7099abe30d93fe4f4ab22a02ca1ab6576d1cfa97/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift#L353-L368) that contains the following view controllers when reaching the store store picker:

```
    ▿ 0 : <WordPressAuthenticator.NUXLinkAuthViewController: 0x122e342b0>
    ▿ 1 : <WooCommerce.StorePickerViewController: 0x12090be00>
```

In the store picker (all the login flows use `login` configuration), it currently pops the navigation controller to root:

https://github.com/woocommerce/woocommerce-ios/blob/c3b2ca179badd1cae41e9abfc005f7c0f020606f/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift#L68-L71

This works for login flows where the navigation stack has `LoginPrologueViewController` at its root, but not for the magic link flow where the navigation stack no longer starts with `LoginPrologueViewController`. That's why it currently goes back to a blank screen (`NUXLinkAuthViewController`) like the [screencast](https://user-images.githubusercontent.com/8658164/102380644-1136b200-3fc0-11eb-8c76-2f5f371548d3.png) in the issue #3367.

## The fix

The greatest challenge here is that we don't have control over the authentication UI flow (like how each view controller and navigation controller is shown) in the hosting app (WCiOS). When our app is asked to present the epilogue screen (store picker), we are only [given the `UINavigationController`](https://github.com/woocommerce/woocommerce-ios/blob/c3b2ca179badd1cae41e9abfc005f7c0f020606f/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L227) to push the epilogue screen but we don't know whether this navigation controller has the prologue screen at its root.

Without redesigning how the authentication flow and its delegate work, this PR fixes the issue by dismissing the navigation controller instead of popping to its root in `StorePickerCoordinator.restartAuthentication`. In order for the login UI to be shown after the dismissal, `ServiceLocator.stores.deauthenticate()` is also moved to the `dismiss` completion block.

Given time in the future, it might be worth reviewing the architecture of `WPAuthenticator` so that the view controller / navigation controller presentation can be determined by the hosting app. Alternatively, the entire authentication flow can be encapsulated in a `Coordinator` or some form of state machine.

## Side issue

While testing the fix, I noticed an issue similar to https://github.com/woocommerce/woocommerce-ios/issues/3107: there is a split second when the screen is blank before presenting the login UI from `WPAuthenticator` library after tapping "Try another account". I've tried presenting other view controller and there is no delay. It's possible that loading the screen from `Login.storyboard` (it's a giant storyboard) in `WPAuthenticator` takes nontrivial amount of time.

## Testing

### Log in with magic link

1. Start logged out of the app
2. Select the WordPress.com login option
3. Enter a WordPress.com account email address
4. Select the magic login link option
5. Check your email and use the magic login link
6. On the store picker screen, select "Try another account" to log in to a different account --> it should go back to the prologue screen (in `develop`, it gets stuck on a blank screen with a spinner)

### (Confidence check) Log in with email/password or Apple

1. Start logged out of the app
2. Select the WordPress.com login option
3. Select a different way to log in other than email + magic link
4. On the store picker screen, select "Try another account" to log in to a different account --> it should go back to the prologue screen as before


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
