### PR TITLE
Account header: Replace brand(purple) help button color with accent(pink)

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -100,9 +100,7 @@ private extension AccountHeaderView {
 
     func setupHelpButton() {
         helpButton.setTitle(Strings.helpButtonTitle, for: .normal)
-        helpButton.setTitle(Strings.helpButtonTitle, for: .highlighted)
         helpButton.setTitleColor(.accent, for: .normal)
-        helpButton.setTitleColor(.accent, for: .highlighted)
         helpButton.on(.touchUpInside) { [weak self] control in
             ServiceLocator.analytics.track(.sitePickerHelpButtonTapped)
             self?.handleHelpButtonTapped(control)

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -101,8 +101,8 @@ private extension AccountHeaderView {
     func setupHelpButton() {
         helpButton.setTitle(Strings.helpButtonTitle, for: .normal)
         helpButton.setTitle(Strings.helpButtonTitle, for: .highlighted)
-        helpButton.setTitleColor(.primary, for: .normal)
-        helpButton.setTitleColor(.textSubtle, for: .highlighted)
+        helpButton.setTitleColor(.accent, for: .normal)
+        helpButton.setTitleColor(.accent, for: .highlighted)
         helpButton.on(.touchUpInside) { [weak self] control in
             ServiceLocator.analytics.track(.sitePickerHelpButtonTapped)
             self?.handleHelpButtonTapped(control)


### PR DESCRIPTION
Fixes #3406 

To test:

- Log out
- Log in
- Observe that the help button is no longer purple but pink:

<img width="1016" alt="Screen Shot 2021-01-05 at 2 45 56 PM" src="https://user-images.githubusercontent.com/1595739/103708275-1e164800-4f65-11eb-8b7b-23933c3a5f57.png">

cc @ctarda @Ecarrion @woocommerce/mobile 

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
