### PR TITLE
Design enhancement for "Reprint Shipping Label" CTA: hide separator and remove bottom spacing

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
@@ -22,6 +22,13 @@ extension UITableViewCell {
     /// Be careful applying this to a reusable cell where the separator is expected to be shown in some cases.
     ///
     func hideSeparator() {
-        separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
+        separatorInset = UIEdgeInsets(top: 0, left: separatorInset.left, bottom: 0, right: .greatestFiniteMagnitude)
+    }
+
+    /// Shows the separator for a cell.
+    /// The separator inset is only set manually when a custom inset is preferred, or the cell is reusable with a different inset in other use cases.
+    ///
+    func showSeparator(inset: UIEdgeInsets = .init(top: 0, left: 16, bottom: 0, right: 0)) {
+        separatorInset = inset
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -537,7 +537,7 @@ private extension OrderDetailsDataSource {
     private func configureReprintShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
         cell.configure(style: .secondary,
                        title: Titles.reprintShippingLabel,
-                       bottomSpacing: 0) { [weak self] in
+                       bottomSpacing: 8) { [weak self] in
             guard let self = self else { return }
             guard let shippingLabel = self.shippingLabel(at: indexPath) else {
                 return

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -535,13 +535,16 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureReprintShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
-        cell.configure(style: .secondary, title: Titles.reprintShippingLabel) { [weak self] in
+        cell.configure(style: .secondary,
+                       title: Titles.reprintShippingLabel,
+                       bottomSpacing: 0) { [weak self] in
             guard let self = self else { return }
             guard let shippingLabel = self.shippingLabel(at: indexPath) else {
                 return
             }
             self.onCellAction?(.reprintShippingLabel(shippingLabel: shippingLabel), nil)
         }
+        cell.hideSeparator()
     }
 
     private func configureAggregateOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
@@ -590,6 +593,7 @@ private extension OrderDetailsDataSource {
         cell.configure(title: Titles.fulfillTitle) { [weak self] in
             self?.onCellAction?(.fulfill, nil)
         }
+        cell.showSeparator()
     }
 
     private func configureIssueRefundButton(cell: IssueRefundTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -32,14 +32,12 @@ final class ButtonTableViewCell: UITableViewCell {
     ///   - title: Button title.
     ///   - bottomSpacing: If non-nil, the value is set to the spacing between the button bottom edge and cell bottom edge.
     ///   - onButtonTouchUp: Called when the button is tapped.
-    func configure(style: Style = .default, title: String?, bottomSpacing: CGFloat? = nil, onButtonTouchUp: (() -> Void)? = nil) {
+    func configure(style: Style = .default, title: String?, bottomSpacing: CGFloat = Constants.defaultBottomSpacing, onButtonTouchUp: (() -> Void)? = nil) {
         apply(style: style)
         button.setTitle(title, for: .normal)
         self.onButtonTouchUp = onButtonTouchUp
 
-        if let bottomSpacing = bottomSpacing {
-            bottomConstraint.constant = bottomSpacing
-        }
+        bottomConstraint.constant = bottomSpacing
     }
 }
 
@@ -61,5 +59,11 @@ private extension ButtonTableViewCell {
         case .secondary:
             button.applySecondaryButtonStyle()
         }
+    }
+}
+
+private extension ButtonTableViewCell {
+    enum Constants {
+        static let defaultBottomSpacing = CGFloat(20)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -4,6 +4,7 @@ import UIKit
 ///
 final class ButtonTableViewCell: UITableViewCell {
     @IBOutlet private var button: UIButton!
+    @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
 
     /// The style of this view, particularly the button.
     enum Style {
@@ -26,10 +27,19 @@ final class ButtonTableViewCell: UITableViewCell {
 
     /// Define this cell's UI attributes.
     ///
-    func configure(style: Style = .default, title: String?, onButtonTouchUp: (() -> Void)? = nil) {
+    /// - Parameters:
+    ///   - style: The style of the cell.
+    ///   - title: Button title.
+    ///   - bottomSpacing: If non-nil, the value is set to the spacing between the button bottom edge and cell bottom edge.
+    ///   - onButtonTouchUp: Called when the button is tapped.
+    func configure(style: Style = .default, title: String?, bottomSpacing: CGFloat? = nil, onButtonTouchUp: (() -> Void)? = nil) {
         apply(style: style)
         button.setTitle(title, for: .normal)
         self.onButtonTouchUp = onButtonTouchUp
+
+        if let bottomSpacing = bottomSpacing {
+            bottomConstraint.constant = bottomSpacing
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
@@ -18,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-8C-l5l">
-                        <rect key="frame" x="16" y="19" width="299" height="40"/>
+                        <rect key="frame" x="16" y="20" width="299" height="35"/>
                         <state key="normal" title="Button"/>
                         <connections>
                             <action selector="sendButtonTouchUpEvent" destination="KGk-i7-Jjw" eventType="touchUpInside" id="N5x-ry-GxY"/>
@@ -26,9 +26,9 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Rng-8C-l5l" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="Xrm-jK-VNb"/>
+                    <constraint firstItem="Rng-8C-l5l" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="Xrm-jK-VNb"/>
                     <constraint firstItem="Rng-8C-l5l" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="gs6-W7-LJC"/>
-                    <constraint firstAttribute="bottom" secondItem="Rng-8C-l5l" secondAttribute="bottom" constant="16" id="pd5-X4-yaY"/>
+                    <constraint firstAttribute="bottom" secondItem="Rng-8C-l5l" secondAttribute="bottom" constant="20" id="pd5-X4-yaY"/>
                     <constraint firstItem="Rng-8C-l5l" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="unu-fW-cIH"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-8C-l5l">
-                        <rect key="frame" x="16" y="19" width="299" height="37"/>
+                        <rect key="frame" x="16" y="19" width="299" height="40"/>
                         <state key="normal" title="Button"/>
                         <connections>
                             <action selector="sendButtonTouchUpEvent" destination="KGk-i7-Jjw" eventType="touchUpInside" id="N5x-ry-GxY"/>
@@ -28,12 +28,13 @@
                 <constraints>
                     <constraint firstItem="Rng-8C-l5l" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="Xrm-jK-VNb"/>
                     <constraint firstItem="Rng-8C-l5l" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="gs6-W7-LJC"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="Rng-8C-l5l" secondAttribute="bottom" constant="8" id="pd5-X4-yaY"/>
+                    <constraint firstAttribute="bottom" secondItem="Rng-8C-l5l" secondAttribute="bottom" constant="16" id="pd5-X4-yaY"/>
                     <constraint firstItem="Rng-8C-l5l" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="unu-fW-cIH"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomConstraint" destination="pd5-X4-yaY" id="ly8-CL-KSD"/>
                 <outlet property="button" destination="Rng-8C-l5l" id="GrA-wO-Ocb"/>
             </connections>
             <point key="canvasLocation" x="39.200000000000003" y="75.112443778110944"/>


### PR DESCRIPTION
Part of #3334 

## Why

According to design, there is no separator and only ~10px spacing between the bottom of "Reprint Shipping Label" CTA and the top of  "Don’t know how to print from your phone?" info row.

<img width="300" alt="Screen Shot 2021-01-06 at 3 15 41 PM" src="https://user-images.githubusercontent.com/1945542/103740507-4e77e800-5032-11eb-97e8-b78aed739440.png">

In our table view implementation, "Reprint Shipping Label" CTA and  "Don’t know how to print from your phone?" info row are two separate table view cells with their own vertical spacing within the cell. In order to achieve the design specs, this PR updates the "Reprint Shipping Label" CTA row (`ButtonTableViewCell`):

- Hides the separator (and calls `showSeparator` for another `ButtonTableViewCell` use case for "Begin Fulfillment" CTA in order details)
- Removes the bottom spacing (the top and bottom constraints in `ButtonTableViewCell.xib` are updated to 20px to the superview instead of 8px to layout margins, otherwise we can't completely remove the bottom spacing)

## Testing

Please check the affected use cases:

- Orders tab > order with at least one non-refunded shipping label --> "Reprint Shipping Label" CTA and  "Don’t know how to print from your phone?" should look as design
- Orders tab > order that can be fulfilled --> "Begin Fulfillment" CTA should look as before
- Products tab > edit product > edit linked products --> the button cells should look as before

## Example screenshots

screen | before | after
-- | -- | --
Order details > Reprint Shipping Label CTA --> there is no separator and bottom spacing anymore | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 14 56 23](https://user-images.githubusercontent.com/1945542/103739833-2a67d700-5031-11eb-822a-08d919c3b89e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 14 59 52](https://user-images.githubusercontent.com/1945542/103739835-2b990400-5031-11eb-9a7f-634ab7d1431d.png)
Order details > Begin Fulfillment CTA | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 15 12 38](https://user-images.githubusercontent.com/1945542/103740128-a82be280-5031-11eb-8459-5b1bd17545ae.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 14 59 59](https://user-images.githubusercontent.com/1945542/103739908-48353c00-5031-11eb-95ae-1ca340fe603d.png)
Edit product > linked products | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 14 54 04](https://user-images.githubusercontent.com/1945542/103740184-c1cd2a00-5031-11eb-90ad-5ed395d16298.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-06 at 14 58 45](https://user-images.githubusercontent.com/1945542/103740192-c42f8400-5031-11eb-8589-f79940ee134d.png)







Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
