### PR TITLE
[Platform] Update L10n Linter strategy to allow retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 2f7ef851ed51fee6b5b8075056d5359c9e6277ea
-  tag: 0.11.0
+  revision: a932bd25320f2b82be0774b66e550c6862cd8765
+  tag: 0.12.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.11.0)
+    fastlane-plugin-wpmreleasetoolkit (0.12.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
-      jsonlint
-      nokogiri (>= 1.10.4)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
       octokit (~> 4.18)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
@@ -165,7 +165,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.7.0)
+    git (1.8.1)
       rchardet (~> 1.8)
     google-api-client (0.38.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -210,7 +210,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -219,12 +219,13 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
-    octokit (4.19.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.16)
+    oj (3.10.18)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -234,6 +235,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (4.0.6)
+    racc (1.5.2)
     rake (12.3.3)
     rake-compiler (1.1.1)
       rake

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,11 +150,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   lane :new_beta_release do | options |
     ios_betabuild_prechecks(options)
     ios_update_metadata(options)
-    violations = ios_lint_localizations(input_dir: 'WooCommerce/Resources', abort_on_violations: false)
-    unless (violations.nil? || violations.empty?)
-      abort = UI.confirm("Violations found, we suggest fixing them in GlotPress first and retrying the beta afterwards. Abort?")
-      UI.abort_with_message!("Aborting the beta due to localization violations. Reach out to i18n folks to help you fix them.") if abort
-    end
+    ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
     ios_bump_version_beta()
     ios_tag_build()
   end
@@ -212,7 +208,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     ios_finalize_prechecks(options)
     unless ios_current_branch_is_hotfix
       ios_update_metadata(options)
-      ios_lint_localizations(input_dir: 'WooCommerce/Resources')
+      ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
       ios_bump_version_beta()
     end
     ios_final_tag(options)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.11.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.12.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
This PR takes advantage of the new mode of the `ios_lint_localizations` action [recently added in release-toolkit 0.12.0](https://github.com/wordpress-mobile/release-toolkit/pull/182).

[Internal ref: paaHJt-1Fn-p2#comment-3524]

## What changed?

After this PR, if a localization violation is found, we will now be given the possibility to fix the violation locally and retry until we get it right – as opposed to waiting for it to be fixed in GlotPress.

This new strategy applies to **both** the `new_beta_release` and `finalize_release`.

_Note: Ideally this is still better to solve the violations at their source in GlotPress first then re-run the lanes from scratch. But it's also not always possible to wait for someone to be available to solve it in GlotPress for us; so this new behavior gives us an escape hatch when we can't wait for a fix of the copy in GP. We should still ping someone to fix the issue in GP in all cases._

## Target branch

This PR intentionally targets the ~`release/5.7`~ `release/5.8` branch and not `develop` because we're hoping to already use this new behavior for the upcoming release of 5.7, instead of waiting for the next code freeze to include it.
[EDIT: We apparently failed to get it reviewed in time 😅; now rebased and targeting `release/5.8`, hopefully we'll get it reviewed this time around 😄 ].

## To Test

The test steps are similar to the ones from https://github.com/wordpress-mobile/release-toolkit/pull/182:

 - Introduce a violation (incorrect `%d`/`%@`/… placeholders) in one of the `.strings` file
 - Make a temporary edit to the `finalize_release` lane to test the PR:
   - Comment the `ios_update_metadata()` call (to avoid your temporary violation from step above to be overwritten)
   - Replace the `ios_bump_version_beta()` and `ios_tag_build()` calls with something like `UI.message("And now new version is tagged")` (to be able to see if/when the next steps after `ios_lint_localizations` will be called as expected)
 - Run the modified lane: `bundle exec fastlane finalize_release` and ensure it finds the violations you introduced on purpose earlier.
 - Fix the violation in the local `.strings` file, then choose "Retry".
 - Check that the linter pass on this second try after violation has been fixed.

## Other: Security Fix

This PR will also incidentally close [this Dependabot security alert](https://github.com/woocommerce/woocommerce-ios/security/dependabot/Gemfile.lock/nokogiri/open) from our repo – which was a dependency of `release-toolkit`, which has been fixed in its version 0.12.0.