### PR TITLE
Design enhancement for printing instructions info CTA: hide separator

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -461,12 +461,13 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureShippingLabelPrintingInfo(cell: ImageAndTitleAndTextTableViewCell) {
-        let viewModel = ImageAndTitleAndTextTableViewCell.TopLeftImageViewModel(icon: .infoOutlineFootnoteImage,
-                                                                                iconColor: .systemColor(.secondaryLabel),
-                                                                                title: Title.shippingLabelPrintingInfoAction,
-                                                                                isFootnoteStyle: true)
-
-        cell.updateUI(topLeftImageViewModel: viewModel)
+        cell.update(with: .imageAndTitleOnly(fontStyle: .footnote),
+                    data: .init(title: Title.shippingLabelPrintingInfoAction,
+                                image: .infoOutlineFootnoteImage,
+                                imageTintColor: .systemColor(.secondaryLabel),
+                                numberOfLinesForTitle: 0,
+                                isActionable: false,
+                                showsSeparator: false))
 
         cell.selectionStyle = .default
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
@@ -204,8 +204,8 @@ private extension ReprintShippingLabelViewController {
                                 image: .infoOutlineImage,
                                 imageTintColor: .systemColor(.secondaryLabel),
                                 numberOfLinesForTitle: 0,
-                                isActionable: false))
-        cell.hideSeparator()
+                                isActionable: false,
+                                showsSeparator: false))
     }
 
     func configurePaperSize(cell: TitleAndValueTableViewCell) {
@@ -228,7 +228,8 @@ private extension ReprintShippingLabelViewController {
                                 image: .pagesFootnoteImage,
                                 imageTintColor: .systemColor(.secondaryLabel),
                                 numberOfLinesForTitle: 0,
-                                isActionable: false))
+                                isActionable: false,
+                                showsSeparator: false))
         configureCommonStylesForInfoLinkCell(cell)
     }
 
@@ -239,12 +240,12 @@ private extension ReprintShippingLabelViewController {
                                 image: .infoOutlineFootnoteImage,
                                 imageTintColor: .systemColor(.secondaryLabel),
                                 numberOfLinesForTitle: 0,
-                                isActionable: false))
+                                isActionable: false,
+                                showsSeparator: false))
         configureCommonStylesForInfoLinkCell(cell)
     }
 
     func configureCommonStylesForInfoLinkCell(_ cell: ImageAndTitleAndTextTableViewCell) {
-        cell.hideSeparator()
         cell.selectionStyle = .default
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -117,12 +117,6 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
 
-    /// A custom border view is used instead of the default cell separator so that we can show/hide the separator while keeping its alignment when
-    /// it is shown and reused.
-    /// This view is added/configured in code manually because the view has to be added to the cell view in order to extend to the cell trailing edge to include
-    /// potential accessory view. In xib, we can only add a subview to cell's `contentView`.
-    private var bottomBorderView = UIView(frame: .zero)
-
     /// Disabled by default. When active, image is constrained to 24pt
     @IBOutlet private var contentImageViewWidthConstraint: NSLayoutConstraint!
 
@@ -133,7 +127,6 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureContentStackView()
         configureTitleAndTextStackView()
         applyDefaultBackgroundStyle()
-        configureBottomBorderView()
     }
 }
 
@@ -167,7 +160,11 @@ extension ImageAndTitleAndTextTableViewCell {
 
         contentImageViewWidthConstraint.isActive = false
 
-        bottomBorderView.isHidden = viewModel.showsSeparator == false
+        if viewModel.showsSeparator {
+            showSeparator()
+        } else {
+            hideSeparator()
+        }
     }
 
     func updateUI(switchableViewModel: SwitchableViewModel) {
@@ -279,20 +276,5 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
-    }
-
-    func configureBottomBorderView() {
-        bottomBorderView.backgroundColor = .systemColor(.separator)
-        addSubview(bottomBorderView)
-        bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            bottomBorderView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor, constant: 0),
-            trailingAnchor.constraint(equalTo: bottomBorderView.trailingAnchor, constant: 0),
-            bottomAnchor.constraint(equalTo: bottomBorderView.bottomAnchor, constant: 0),
-            bottomBorderView.heightAnchor.constraint(equalToConstant: 0.5)
-            ])
-
-        // Hides system cell separator since we are using a custom view for the separator.
-        hideSeparator()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -26,6 +26,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         let numberOfLinesForTitle: Int
         let numberOfLinesForText: Int
         let isActionable: Bool
+        let showsSeparator: Bool
 
         init(title: String?,
              text: String? = nil,
@@ -34,7 +35,8 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
              imageTintColor: UIColor? = nil,
              numberOfLinesForTitle: Int = 1,
              numberOfLinesForText: Int = 1,
-             isActionable: Bool = true) {
+             isActionable: Bool = true,
+             showsSeparator: Bool = true) {
             self.title = title
             self.text = text
             self.textTintColor = textTintColor
@@ -43,6 +45,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
             self.numberOfLinesForTitle = numberOfLinesForTitle
             self.numberOfLinesForText = numberOfLinesForText
             self.isActionable = isActionable
+            self.showsSeparator = showsSeparator
         }
     }
 
@@ -55,6 +58,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         let numberOfLinesForTitle: Int
         let numberOfLinesForText: Int
         let isActionable: Bool
+        let showsSeparator: Bool
 
         init(title: String?,
              text: String?,
@@ -63,7 +67,8 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
              imageTintColor: UIColor? = nil,
              numberOfLinesForTitle: Int = 1,
              numberOfLinesForText: Int = 1,
-             isActionable: Bool = true) {
+             isActionable: Bool = true,
+             showsSeparator: Bool = true) {
             self.title = title
             self.text = text
             self.textTintColor = textTintColor
@@ -72,6 +77,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
             self.numberOfLinesForTitle = numberOfLinesForTitle
             self.numberOfLinesForText = numberOfLinesForText
             self.isActionable = isActionable
+            self.showsSeparator = showsSeparator
         }
     }
 
@@ -111,6 +117,12 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
 
+    /// A custom border view is used instead of the default cell separator so that we can show/hide the separator while keeping its alignment when
+    /// it is shown and reused.
+    /// This view is added/configured in code manually because the view has to be added to the cell view in order to extend to the cell trailing edge to include
+    /// potential accessory view. In xib, we can only add a subview to cell's `contentView`.
+    private var bottomBorderView = UIView(frame: .zero)
+
     /// Disabled by default. When active, image is constrained to 24pt
     @IBOutlet private var contentImageViewWidthConstraint: NSLayoutConstraint!
 
@@ -121,6 +133,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureContentStackView()
         configureTitleAndTextStackView()
         applyDefaultBackgroundStyle()
+        configureBottomBorderView()
     }
 }
 
@@ -153,6 +166,8 @@ extension ImageAndTitleAndTextTableViewCell {
         contentView.backgroundColor = nil
 
         contentImageViewWidthConstraint.isActive = false
+
+        bottomBorderView.isHidden = viewModel.showsSeparator == false
     }
 
     func updateUI(switchableViewModel: SwitchableViewModel) {
@@ -235,7 +250,8 @@ private extension ImageAndTitleAndTextTableViewCell {
                                   imageTintColor: data.imageTintColor,
                                   numberOfLinesForTitle: data.numberOfLinesForTitle,
                                   numberOfLinesForText: data.numberOfLinesForText,
-                                  isActionable: data.isActionable)
+                                  isActionable: data.isActionable,
+                                  showsSeparator: data.showsSeparator)
         updateUI(viewModel: viewModel)
     }
 }
@@ -263,5 +279,20 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
+    }
+
+    func configureBottomBorderView() {
+        bottomBorderView.backgroundColor = .systemColor(.separator)
+        addSubview(bottomBorderView)
+        bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bottomBorderView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor, constant: 0),
+            trailingAnchor.constraint(equalTo: bottomBorderView.trailingAnchor, constant: 0),
+            bottomAnchor.constraint(equalTo: bottomBorderView.bottomAnchor, constant: 0),
+            bottomBorderView.heightAnchor.constraint(equalToConstant: 0.5)
+            ])
+
+        // Hides system cell separator since we are using a custom view for the separator.
+        hideSeparator()
     }
 }


### PR DESCRIPTION
Part of #3334 

## Why

We want to hide the separator to [match design](https://github.com/woocommerce/woocommerce-ios/pull/3430#issuecomment-755831580) in order details.

## Changes

- In `ImageAndTitleAndTextTableViewCell`, added `showsSeparator: Bool = true` to show/hide the separator
- Passed `showsSeparator: false` for rows where the separator should be hidden in order details and reprint shipping label

## Testing

- Orders tab > order with a non-refunded shipping label --> the printing instructions row doesn't have a separator anymore, and the tracking number row should look as before

Feel free to optionally test other affected screens for confidence check:

- Orders tab > order with a non-refunded shipping label > shipment details --> the rows should look as before
- Orders tab > order with a non-refunded shipping label > Reprint Shipping Label --> the rows should look as before
- Orders tab > order with a refunded shipping label --> the refunded row should look as before
- Orders tab > order with a customer note and is fulfillable > Begin Fulfillment --> the customer note row should look as before
- Orders tab > order with multiple shipping methods --> the shipping notice at the top should look as before
- Orders tab > refunded order with a refund reason > refund details --> the refund reason row should look as before
- Products tab > product --> the rows with an image icon should look as before
- Products tab > product > edit linked products --> the rows with an image icon should look as before
- Products tab > product > Add more details --> the bottom sheet should look as before
- Products tab > product > edit product type --> the bottom sheet should look as before
- Products tab > product > downloadable files --> the rows with an image icon should look as before
- Products tab > product > downloadable files > Add File --> the bottom sheet should look as before

## Example screenshots

screen | before | after
-- | -- | --
Order details > shipping label (the separator in the printing instructions row is gone) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 14 02 28](https://user-images.githubusercontent.com/1945542/103857291-28654d00-50f1-11eb-94e8-d99bf8960ab9.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 14 03 03](https://user-images.githubusercontent.com/1945542/103857297-2bf8d400-50f1-11eb-875f-7cf2132ba619.png)




Other affected screens (no changes are expected):

(Please focus on the rows with an image, title, and optional text)

screen | before | after
-- | -- | --
Orders tab > order with a non-refunded shipping label > shipment details | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 43 17](https://user-images.githubusercontent.com/1945542/103855954-c572b680-50ee-11eb-878a-29eb1bc9bc4d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 49 27](https://user-images.githubusercontent.com/1945542/103856340-724d3380-50ef-11eb-95fc-6aa7d4baf469.png)
Orders tab > order with a non-refunded shipping label > Reprint Shipping Label | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 43 49](https://user-images.githubusercontent.com/1945542/103855960-c86da700-50ee-11eb-8fbc-91c03bec3b4d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 49 36](https://user-images.githubusercontent.com/1945542/103856350-75482400-50ef-11eb-8cb4-d88a0c8dbb20.png)
Orders tab > order with a refunded shipping label | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 44 23](https://user-images.githubusercontent.com/1945542/103855964-c9063d80-50ee-11eb-8171-a64ce5d74933.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 49 47](https://user-images.githubusercontent.com/1945542/103856352-76795100-50ef-11eb-97b0-a584b4ce7d20.png)
Orders tab > order with a customer note and is fulfillable > Begin Fulfillment | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 46 25](https://user-images.githubusercontent.com/1945542/103856023-e509df00-50ee-11eb-9c6a-08fda7ef334e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 50 07](https://user-images.githubusercontent.com/1945542/103856353-7711e780-50ef-11eb-9ddf-4c444fb4b117.png)
Orders tab > order with multiple shipping methods | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 45 56](https://user-images.githubusercontent.com/1945542/103856041-efc47400-50ee-11eb-851c-4c7f54665a25.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 50 28](https://user-images.githubusercontent.com/1945542/103856356-77aa7e00-50ef-11eb-9fc0-9b5b12890e68.png)
Orders tab > refunded order with a refund reason > refund details | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 45 22](https://user-images.githubusercontent.com/1945542/103856038-ef2bdd80-50ee-11eb-92c8-dad8be96085c.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 50 52](https://user-images.githubusercontent.com/1945542/103856358-77aa7e00-50ef-11eb-86de-1c2ffa635fa5.png)
Products tab > product | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 17](https://user-images.githubusercontent.com/1945542/103856714-10d99480-50f0-11eb-8022-aaa472c7542f.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 30](https://user-images.githubusercontent.com/1945542/103856720-159e4880-50f0-11eb-83ca-1f15fdfaa9b3.png)
Products tab > product > edit linked products | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 39](https://user-images.githubusercontent.com/1945542/103856736-1fc04700-50f0-11eb-8009-77602b7d23ef.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 46](https://user-images.githubusercontent.com/1945542/103856742-2353ce00-50f0-11eb-8279-1cf19f9738ef.png)
Products tab > product > Add more details | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 54](https://user-images.githubusercontent.com/1945542/103856774-2ea6f980-50f0-11eb-85da-6c7c29cf35a4.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 54 59](https://user-images.githubusercontent.com/1945542/103856780-336bad80-50f0-11eb-9b49-f26e682a802c.png)
Products tab > product > edit product type | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 13](https://user-images.githubusercontent.com/1945542/103856782-34044400-50f0-11eb-8dfd-88f0958b89a7.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 22](https://user-images.githubusercontent.com/1945542/103856785-349cda80-50f0-11eb-9308-b109cba322e5.png)
Products tab > product > downloadable files | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 33](https://user-images.githubusercontent.com/1945542/103856786-35357100-50f0-11eb-800b-97ab90f27d92.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 39](https://user-images.githubusercontent.com/1945542/103856789-36669e00-50f0-11eb-8883-968591f93e54.png)
Products tab > product > downloadable files > Add File | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 46](https://user-images.githubusercontent.com/1945542/103856790-36ff3480-50f0-11eb-81e7-e2adce62eef3.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-07 at 13 55 50](https://user-images.githubusercontent.com/1945542/103856792-3797cb00-50f0-11eb-848a-93312a3b1a84.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
