### PR TITLE
Shipping Labels M1: turn on feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 5.8
 -----
 - [***] Products M5 features are now available to all. Products M5 features: add and edit linked products, add and edit downloadable files, product deletion. [https://github.com/woocommerce/woocommerce-ios/pull/3420]
+- [***] Shipping labels M1 features are now available to all: view shipping label details, request a refund, and reprint a shipping label via AirPrint. [https://github.com/woocommerce/woocommerce-ios/pull/3436]
 
 
 5.7

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -8,7 +8,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .addProductVariations:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }


### PR DESCRIPTION
Fixes #3433

## Why

As the main features are complete for M1, let's turn on the feature flag for beta testing and public if no major showstoppers!

## Changes

Enabled the shipping labels M1 feature flag for all.

## Testing

Full testing guide: p91TBi-3xD-p2

- In Edit Scheme > Run > Build Configuration, you can update the configuration from Debug to Release
- Launch the app
- Go to the Orders tab
- Tap on an order with a shipping label --> shipping label card(s) should appear

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
