### PR TITLE
Refund Shipping Label: update header implementation so that it is scrollable in large font size

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Refund Shipping Label/RefundShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Refund Shipping Label/RefundShippingLabelViewController.swift
@@ -18,7 +18,7 @@ final class RefundShippingLabelViewController: UIViewController {
          onComplete: @escaping () -> Void) {
         self.shippingLabel = shippingLabel
         self.viewModel = RefundShippingLabelViewModel(shippingLabel: shippingLabel, currencyFormatter: currencyFormatter)
-        self.rows = [.purchaseDate, .refundableAmount]
+        self.rows = [.headerInfo, .purchaseDate, .refundableAmount]
         self.noticePresenter = noticePresenter
         self.onComplete = onComplete
         super.init(nibName: nil, bundle: nil)
@@ -68,23 +68,17 @@ private extension RefundShippingLabelViewController {
 
     func configureTableView() {
         tableView.dataSource = self
-        tableView.delegate = self
-        registerTableViewCellsAndHeader()
+        registerTableViewCells()
 
         tableView.applyFooterViewForHidingExtraRowPlaceholders()
         tableView.backgroundColor = .basicBackground
-        tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
-        tableView.sectionHeaderHeight = UITableView.automaticDimension
         tableView.bounces = false
     }
 
-    func registerTableViewCellsAndHeader() {
-        // Rows.
+    func registerTableViewCells() {
         for row in Row.allCases {
             tableView.registerNib(for: row.type)
         }
-        // Header.
-        tableView.register(PlainTextSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: PlainTextSectionHeaderView.reuseIdentifier)
     }
 
     func configureRefundButton() {
@@ -119,22 +113,11 @@ extension RefundShippingLabelViewController: UITableViewDataSource {
     }
 }
 
-extension RefundShippingLabelViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerID = PlainTextSectionHeaderView.reuseIdentifier
-        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? PlainTextSectionHeaderView else {
-            fatalError()
-        }
-        headerView.label.applySubheadlineStyle()
-        headerView.label.text = Localization.headerText
-        headerView.label.textColor = Constants.cellValueTextColor
-        return headerView
-    }
-}
-
 private extension RefundShippingLabelViewController {
     func configure(_ cell: UITableViewCell, for row: Row) {
         switch cell {
+        case let cell as BasicTableViewCell where row == .headerInfo:
+            configureHeaderInfo(cell: cell)
         case let cell as ValueOneTableViewCell where row == .purchaseDate:
             configurePurchaseDate(cell: cell)
         case let cell as ValueOneTableViewCell where row == .refundableAmount:
@@ -142,6 +125,14 @@ private extension RefundShippingLabelViewController {
         default:
             break
         }
+    }
+
+    func configureHeaderInfo(cell: BasicTableViewCell) {
+        cell.textLabel?.applySubheadlineStyle()
+        cell.textLabel?.text = Localization.headerText
+        cell.textLabel?.textColor = Constants.cellValueTextColor
+        cell.textLabel?.numberOfLines = 0
+        cell.hideSeparator()
     }
 
     func configurePurchaseDate(cell: ValueOneTableViewCell) {
@@ -185,11 +176,17 @@ private extension RefundShippingLabelViewController {
 
 private extension RefundShippingLabelViewController {
     enum Row: CaseIterable {
+        case headerInfo
         case purchaseDate
         case refundableAmount
 
         var type: UITableViewCell.Type {
-            ValueOneTableViewCell.self
+            switch self {
+            case .headerInfo:
+                return BasicTableViewCell.self
+            case .purchaseDate, .refundableAmount:
+                return ValueOneTableViewCell.self
+            }
         }
 
         var reuseIdentifier: String {


### PR DESCRIPTION
Part of #3334 

## Why

The header info text in Refund Shipping Label screen was originally implemented by a section header, which is sticky when scrolling through cells of the same section. Due to the length of the header text, it could grow very tall and prevent the user from scrolling to see the rest of the content with large font size.

This PR updated the header implementation from section header to a cell (`BasicTableViewCell`) so that it scrolls with the rest of the cells.

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label
- Tap the ellipsis menu ("...") at the top of the non-refunded shipping label card
- Tap "Request a Refund" in the action sheet
- Try various system font sizes --> the whole table view should be scrollable

## Example screenshots

(The header text is also left aligned with the cells below now!)

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 17 56 39](https://user-images.githubusercontent.com/1945542/104001986-65a60980-51db-11eb-921c-80f5e8e584d2.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 17 56 43](https://user-images.githubusercontent.com/1945542/104002024-735b8f00-51db-11eb-9d26-1fa6204b7fd6.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 17 57 02](https://user-images.githubusercontent.com/1945542/104002031-75255280-51db-11eb-9924-a4f0a24c8737.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-08 at 17 57 15](https://user-images.githubusercontent.com/1945542/104002034-76ef1600-51db-11eb-9ffb-96e63f738088.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
