### PR TITLE
Update WP Auth to 1.33.0-beta.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,7 +38,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.33.0-beta.3'
+  pod 'WordPressAuthenticator', '~> 1.33.0-beta.4'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.33.0-beta.3):
+  - WordPressAuthenticator (1.33.0-beta.4):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.24.0-beta.4):
+  - WordPressKit (4.24.0-beta.6):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.33.0-beta.3)
+  - WordPressAuthenticator (~> 1.33.0-beta.4)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -182,8 +182,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a5f882e72e44eece01fadf94ffbd5abf57456274
-  WordPressKit: d084acd74bafd78d70ccb95686ceb927c825324e
+  WordPressAuthenticator: fe072b0b693f28c8bec7085bc0fc1522b0e9efd3
+  WordPressKit: 6fde9c226f9570e7c440c315a93b58a507dc8db1
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 39841385f72bbd459a4c906cd5abed5ead63204d
+PODFILE CHECKSUM: 74663f042afc01395118c584503a062bf245f152
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
Updates WP Auth version to pick up fix for "the the"
- https://github.com/woocommerce/woocommerce-ios/pull/3329#pullrequestreview-549902541
- https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/556

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@woocommerce/mobile @woocommerce/ios-developers 

<img src="https://user-images.githubusercontent.com/1595739/104049436-d3c9dc80-5199-11eb-851d-fee73bbc6206.png" width="350"/>
