### PR TITLE
[Variations] Create product attribute term

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */; };
 		26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */; };
 		2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2661547A242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift */; };
+		266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */ = {isa = PBXBuildFile; fileRef = 266C7F9125AD3C87006ED243 /* attribute-term.json */; };
 		267313312559CC930026F7EF /* PaymentGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267313302559CC930026F7EF /* PaymentGateway.swift */; };
 		26731337255ACA850026F7EF /* PaymentGatewayListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */; };
 		2683D70E24456DB8002A1589 /* categories-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70D24456DB7002A1589 /* categories-empty.json */; };
@@ -499,6 +500,7 @@
 		26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListMapper.swift; sourceTree = "<group>"; };
 		26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoyListMapperTests.swift; sourceTree = "<group>"; };
 		2661547A242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemoteTests.swift; sourceTree = "<group>"; };
+		266C7F9125AD3C87006ED243 /* attribute-term.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "attribute-term.json"; sourceTree = "<group>"; };
 		267313302559CC930026F7EF /* PaymentGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGateway.swift; sourceTree = "<group>"; };
 		26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayListMapper.swift; sourceTree = "<group>"; };
 		2683D70D24456DB7002A1589 /* categories-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-empty.json"; sourceTree = "<group>"; };
@@ -1228,6 +1230,7 @@
 				2683D70F24456EE4002A1589 /* categories-extra.json */,
 				2683D70D24456DB7002A1589 /* categories-empty.json */,
 				45B204BB24890B1200FE6526 /* category.json */,
+				266C7F9125AD3C87006ED243 /* attribute-term.json */,
 				26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */,
 				74C9477F2193A6C60024CB60 /* comment-moderate-approved.json */,
 				74C9477E2193A6C60024CB60 /* comment-moderate-trash.json */,
@@ -1724,6 +1727,7 @@
 				02698CFC24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
 				74159623224D2C86003C21CF /* settings-product.json in Resources */,
+				266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */,
 				CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */,
 				D8FBFF1522D3BE09006E3336 /* order-stats-v4-defaults.json in Resources */,
 				7495AACF225D366D00801A89 /* variation-as-product.json in Resources */,

--- a/Networking/Networking/Remote/ProductAttributeTermRemote.swift
+++ b/Networking/Networking/Remote/ProductAttributeTermRemote.swift
@@ -36,6 +36,29 @@ public final class ProductAttributeTermRemote: Remote {
             }
         }
     }
+
+    /// Create a new `ProductAttributeTerm`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll add a new product attribute terms.
+    ///     - name: Product attribute term name.
+    ///     - attributeID: The ID for the parent product attribute.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createProductAttributeTerm(for siteID: Int64,
+                                           attributeID: Int64,
+                                           name: String,
+                                           completion: @escaping (Result<ProductAttributeTerm, Error>) -> Void) {
+        let parameters = [
+            ParameterKey.name: name
+        ]
+
+        let path = Path.terms(attributeID: attributeID)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductAttributeTermMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: - Constants
@@ -54,5 +77,6 @@ public extension ProductAttributeTermRemote {
     private enum ParameterKey {
         static let page: String = "page"
         static let perPage: String = "per_page"
+        static let name: String = "name"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift
@@ -59,4 +59,40 @@ final class ProductAttributeTermRemoteTests: XCTestCase {
         let error = try XCTUnwrap(result.failure) as NSError
         XCTAssertEqual(expectedError, error)
     }
+
+    func test_createProductAttributeTerm_returns_parsed_term() throws {
+        // Given
+        let expectedTerm = ProductAttributeTerm(siteID: sampleSiteID, termID: 23, name: "XXS", slug: "xxs", count: 1)
+        let remote = ProductAttributeTermRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", filename: "attribute-term")
+
+        // When
+        let result: Result<ProductAttributeTerm, Error> = try waitFor { promise in
+            remote.createProductAttributeTerm(for: self.sampleSiteID, attributeID: self.sampleAttributeID, name: "XXS") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let term = try result.get()
+        XCTAssertEqual(term, expectedTerm)
+    }
+
+    func test_createProductAttributeTerm_relays_networking_error() throws {
+        // Given
+        let remote = ProductAttributeTermRemote(network: network)
+        let expectedError = NSError(domain: #function, code: 0, userInfo: nil)
+        network.simulateError(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", error: expectedError)
+
+        // When
+        let result: Result<ProductAttributeTerm, Error> = try waitFor { promise in
+            remote.createProductAttributeTerm(for: self.sampleSiteID, attributeID: self.sampleAttributeID, name: "XXS") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure) as NSError
+        XCTAssertEqual(expectedError, error)
+    }
 }

--- a/Networking/NetworkingTests/Responses/attribute-term.json
+++ b/Networking/NetworkingTests/Responses/attribute-term.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "id": 23,
+    "name": "XXS",
+    "slug": "xxs",
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms/23"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/attributes/2/terms"
+        }
+      ]
+    }
+  }
+}

--- a/Yosemite/Yosemite/Actions/ProductAttributeTermAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAttributeTermAction.swift
@@ -10,10 +10,10 @@ public enum ProductAttributeTermAction: Action {
     ///
     case synchronizeProductAttributeTerms(siteID: Int64, attributeID: Int64, onCompletion: (Result<Void, ProductAttributeTermActionError>) -> Void)
 
-    /// Create a new product attribute term associated with a given Site ID.
+    /// Create a new product attribute term associated with a given `Site ID` and `attribute ID`.
     /// `onCompletion` will be invoked when the add operation finishes.
     ///
-    case createProductAttributeTerm(siteID: Int64, attributeID: Int64, onCompletion: (Result<ProductAttributeTerm, Error>) -> Void)
+    case createProductAttributeTerm(siteID: Int64, attributeID: Int64, name: String, onCompletion: (Result<ProductAttributeTerm, Error>) -> Void)
 }
 
 /// Defines all errors that a `ProductAttributeTermAction` can return

--- a/Yosemite/Yosemite/Actions/ProductAttributeTermAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAttributeTermAction.swift
@@ -9,6 +9,11 @@ public enum ProductAttributeTermAction: Action {
     /// `onCompletion` will be invoked when the sync operation finishes. `error` will be nil if the operation succeed.
     ///
     case synchronizeProductAttributeTerms(siteID: Int64, attributeID: Int64, onCompletion: (Result<Void, ProductAttributeTermActionError>) -> Void)
+
+    /// Create a new product attribute term associated with a given Site ID.
+    /// `onCompletion` will be invoked when the add operation finishes.
+    ///
+    case createProductAttributeTerm(siteID: Int64, attributeID: Int64, onCompletion: (Result<ProductAttributeTerm, Error>) -> Void)
 }
 
 /// Defines all errors that a `ProductAttributeTermAction` can return

--- a/Yosemite/Yosemite/Stores/ProductAttributeTermStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductAttributeTermStore.swift
@@ -111,9 +111,10 @@ private extension ProductAttributeTermStore {
                                     name: String,
                                     onCompletion: @escaping (Result<ProductAttributeTerm, Error>) -> Void) {
         remote.createProductAttributeTerm(for: siteID, attributeID: attributeID, name: name) { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case let .success(term):
-                self?.upsertStoredProductAttributeTermsInBackground([term], siteID: siteID, attributeID: attributeID) {
+                self.upsertStoredProductAttributeTermsInBackground([term], siteID: siteID, attributeID: attributeID) {
                     onCompletion(.success(term))
                 }
             case .failure:

--- a/Yosemite/Yosemite/Stores/ProductAttributeTermStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductAttributeTermStore.swift
@@ -39,6 +39,8 @@ public final class ProductAttributeTermStore: Store {
                 }()
                 onCompletion(result)
             }
+        case let .createProductAttributeTerm(siteID, attributeID, name, onCompletion):
+            createProductAttributeTerm(siteID: siteID, attributeID: attributeID, name: name, onCompletion: onCompletion)
         }
     }
 }
@@ -98,6 +100,24 @@ private extension ProductAttributeTermStore {
             case let .failure(error):
                 let error = ProductAttributeTermActionError.termsSynchronization(pageNumber: pageNumber, rawError: error)
                 return onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Creates and stores a new product attribute term and links it to it's parent product attribute.
+    ///
+    func createProductAttributeTerm(siteID: Int64,
+                                    attributeID: Int64,
+                                    name: String,
+                                    onCompletion: @escaping (Result<ProductAttributeTerm, Error>) -> Void) {
+        remote.createProductAttributeTerm(for: siteID, attributeID: attributeID, name: name) { [weak self] result in
+            switch result {
+            case let .success(term):
+                self?.upsertStoredProductAttributeTermsInBackground([term], siteID: siteID, attributeID: attributeID) {
+                    onCompletion(.success(term))
+                }
+            case .failure:
+                onCompletion(result)
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
@@ -154,6 +154,29 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributeTermsCount, 3)
         XCTAssertFalse(result.isFailure)
     }
+
+    func test_createProductAttributeTerm_stores_term_correctly() throws {
+        // Given
+        let expectedTerm = ProductAttributeTerm(siteID: sampleSiteID, termID: 23, name: "XXS", slug: "xxs", count: 1)
+        network.simulateResponse(requestUrlSuffix: sampleTermsPath, filename: "attribute-term")
+
+        // When
+        let result: Result<Yosemite.ProductAttributeTerm, Error> = try waitFor { promise in
+            let action = ProductAttributeTermAction.createProductAttributeTerm(siteID: self.sampleSiteID,
+                                                                               attributeID: self.sampleAttributeID,
+                                                                               name: "XXS") { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+
+        // Then the category should be added
+        let storedTerm = try XCTUnwrap(viewStorage.loadProductAttributeTerm(siteID: sampleSiteID, termID: 23, attributeID: sampleAttributeID))
+        XCTAssertEqual(expectedTerm, storedTerm.toReadOnly())
+        XCTAssertNotNil(storedTerm.attribute)
+        XCTAssertFalse(result.isFailure)
+    }
 }
 
 // MARK: Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
@@ -171,7 +171,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         }
 
 
-        // Then the category should be added
+        // Then
         let storedTerm = try XCTUnwrap(viewStorage.loadProductAttributeTerm(siteID: sampleSiteID, termID: 23, attributeID: sampleAttributeID))
         XCTAssertEqual(expectedTerm, storedTerm.toReadOnly())
         XCTAssertNotNil(storedTerm.attribute)


### PR DESCRIPTION
closes #3412 

# Why

This PR adds the ability to create a new product attribute term that will be used later to create a new product variation.
Ref:

<img width="590" alt="variations-flow" src="https://user-images.githubusercontent.com/562080/104337897-f45ca400-54c3-11eb-9965-44936cea555e.png">

# How
- Updated `ProductAttributeTermRemote` to include a `createProductAttributeTerm` function that creates the term remotely.
- Updated `ProductAttributeTermStore` to include a `createProductAttributeTerm` function that uses the remote function and stores the term internally upon completion.
- Updated `ProductAttributeTermAction` to be able to dispatch the function created on the store.

# Testing Steps
- Make sure unit tests run

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
