### PR TITLE
Fix: rows in the product search list have double separators

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 5.9
 -----
+ - [*] fix: the rows in the product search list now don't have double separators. [https://github.com/woocommerce/woocommerce-ios/pull/3456]
  
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -65,7 +65,8 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
 
         let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: siteID,
                                                                                                   command: OrderSearchUICommand(siteID: siteID),
-                                                                                                  cellType: OrderTableViewCell.self)
+                                                                                                  cellType: OrderTableViewCell.self,
+                                                                                                  cellSeparator: .singleLine)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
         present(navigationController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -18,7 +18,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         return label
     }()
 
-    /// We use a custom view isntead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
+    /// We use a custom view instead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
     private let bottomBorderView: UIView = {
         return UIView(frame: .zero)
     }()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
@@ -69,7 +69,8 @@ private extension ProductListSelectorViewController {
         }
         let searchViewController = SearchViewController(storeID: siteID,
                                                         command: searchProductsCommand,
-                                                        cellType: ProductsTabProductTableViewCell.self)
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
         searchProductsCommand.configurePresentingViewControllerForDiscardChangesAlert(presentingViewController: navigationController)
         present(navigationController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -181,7 +181,8 @@ private extension ProductsViewController {
 
         let searchViewController = SearchViewController(storeID: siteID,
                                                         command: ProductSearchUICommand(siteID: siteID),
-                                                        cellType: ProductsTabProductTableViewCell.self)
+                                                        cellType: ProductsTabProductTableViewCell.self,
+                                                        cellSeparator: .none)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
         present(navigationController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -90,17 +90,20 @@ where Cell.SearchModel == Command.CellViewModel {
     }()
 
     private let searchUICommand: Command
+    private let tableViewSeparatorStyle: UITableViewCell.SeparatorStyle
 
 
     /// Designated Initializer
     ///
     init(storeID: Int64,
          command: Command,
-         cellType: Cell.Type) {
+         cellType: Cell.Type,
+         cellSeparator: UITableViewCell.SeparatorStyle) {
         self.resultsController = command.createResultsController()
         self.resultsPredicate = resultsController.predicate
         self.searchUICommand = command
         self.storeID = storeID
+        tableViewSeparatorStyle = cellSeparator
         super.init(nibName: "SearchViewController", bundle: nil)
     }
 
@@ -259,6 +262,7 @@ private extension SearchViewController {
         tableView.estimatedRowHeight = Settings.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.tableFooterView = footerSpinnerView
+        tableView.separatorStyle = tableViewSeparatorStyle
     }
 
     /// Setup: Search Bar


### PR DESCRIPTION
Fixes #3273 

## Description
When searching for a product, each row has 2 separators, one is left aligned with the image, the other is left-aligned with the text. After some investigations, come out that we add a custom view (that is a custom bottom separator) in the product cell, and we also use the separator of the tableview.

## The solution
Since we use the `SearchViewController` in 3 differents points right now (Orders, Products, Linked Products) and in some screens, the separator appear to be correct (like when you search an Order), I decided to pass in the initialized of the `SearchViewController` the separator style. In that way, we can use cells with and without separators.

## Testing
1. Open the product list, and tap the search icon. -> The product cells should appear with just one separator.
2. Tap the Linked Products rows, and try to select a product tapping the search. -> The product cells should appear with just one separator.
3. Open the Orders and try to search for an order. -> The cells should appear like before (with just one separator).

## Screenshots
| Before (double separator)             |  After (single separator) |
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/495617/104340118-aa41e580-54f8-11eb-8c40-0fe0d327146d.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-01-12 at 16 56 24](https://user-images.githubusercontent.com/495617/104340602-263c2d80-54f9-11eb-8a54-da9ddc6afc20.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
