### PR TITLE
Fix: billing information action sheets are not presented correctly on iPad

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 
 5.9
 -----
- 
+ - [*] Fix: billing information action sheets now are presented correctly on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3457]
+
 
 5.8
 -----


### PR DESCRIPTION
Fixes #3358 

## Description
It seems that we didn't manage properly the action sheet on iPad in the Order Billing Information screen. It turned out that the entire contact details section doesn't present the action sheet (both for the phone number and email fields) in the correct way.

## Testing
1. Go to Order Details on iPad.
2. Open Billing Information.
3. Tap on the first row of contact details.
4. The action sheet should appear normally also on the iPad.
5. Do the same with the second row of contact details (email). -> The action sheet should appear normally also on iPad.

## Screenshots
| Before            |  After (Phone Number) | After (Email address) |
:-------------------------:|:-------------------------:|:-------------------------:
![102331408-1cbbb600-3f8b-11eb-9f5f-f695eb18b404](https://user-images.githubusercontent.com/495617/104347528-03157c00-5501-11eb-9f00-eccbc404f951.jpeg) | ![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-01-12 at 17 56 09](https://user-images.githubusercontent.com/495617/104347538-06106c80-5501-11eb-9a22-ffd12f78d2d9.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-01-12 at 17 57 48](https://user-images.githubusercontent.com/495617/104347543-07da3000-5501-11eb-8b65-7e4e477174de.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
