### PR TITLE
Shipping Labels > Paper Size Options: dynamic type layout polishes

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/GridStackView.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/GridStackView.swift
@@ -4,12 +4,13 @@ import SwiftUI
 struct GridStackView<Content: View>: View {
     private let rows: Int
     private let columns: Int
+    private let spacingBetweenColumns: CGFloat
     private let content: (Int, Int) -> Content
 
     var body: some View {
         VStack(alignment: .leading) {
             ForEach(0 ..< rows, id: \.self) { row in
-                HStack(alignment: .top) {
+                HStack(alignment: .top, spacing: spacingBetweenColumns) {
                     ForEach(0 ..< columns, id: \.self) { column in
                         content(row, column)
                     }
@@ -21,10 +22,12 @@ struct GridStackView<Content: View>: View {
     /// - Parameters:
     ///   - rows: Number of rows in the grid.
     ///   - columns: Number of columns in the grid.
+    ///   - spacingBetweenColumns: Spacing between columns in the same row.
     ///   - content: Provides the view for a given coordinate `(row, column)`.
-    init(rows: Int, columns: Int, @ViewBuilder content: @escaping (Int, Int) -> Content) {
+    init(rows: Int, columns: Int, spacingBetweenColumns: CGFloat = 0, @ViewBuilder content: @escaping (Int, Int) -> Content) {
         self.rows = rows
         self.columns = columns
+        self.spacingBetweenColumns = spacingBetweenColumns
         self.content = content
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionListView.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionListView.swift
@@ -14,7 +14,7 @@ struct ShippingLabelPaperSizeOptionListView: View {
 
     var body: some View {
         ScrollView {
-            GridStackView(rows: numberOfRows, columns: numberOfColumnsPerRow) { row, col in
+            GridStackView(rows: numberOfRows, columns: numberOfColumnsPerRow, spacingBetweenColumns: 20) { row, col in
                 let index = row * numberOfColumnsPerRow + col
                 if let paperSize = paperSizeOptions[safe: index] {
                     ShippingLabelPaperSizeOptionView(paperSize: paperSize)
@@ -23,7 +23,7 @@ struct ShippingLabelPaperSizeOptionListView: View {
                     Spacer()
                         .frame(maxWidth: .infinity)
                 }
-            }
+            }.padding(.init(top: 0, leading: 28, bottom: 25, trailing: 28))
         }.background(Color(UIColor.basicBackground))
     }
 }
@@ -39,6 +39,12 @@ struct ShippingLabelPaperSizeOptionListView_Previews: PreviewProvider {
             .environment(\.colorScheme, .light)
         ShippingLabelPaperSizeOptionListView(paperSizeOptions: paperSizeOptions)
             .environment(\.colorScheme, .dark)
+        ShippingLabelPaperSizeOptionListView(paperSizeOptions: paperSizeOptions)
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            .previewLayout(.fixed(width: 414, height: 768))
+        ShippingLabelPaperSizeOptionListView(paperSizeOptions: paperSizeOptions)
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            .previewLayout(.fixed(width: 896, height: 600))
         ShippingLabelPaperSizeOptionListView(paperSizeOptions: paperSizeOptions)
             .previewLayout(.fixed(width: 1024, height: 768))
         ShippingLabelPaperSizeOptionListView(paperSizeOptions: [.legal, .letter])

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionView.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSizeOptionView.swift
@@ -23,11 +23,18 @@ struct ShippingLabelPaperSizeOptionView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Spacer().frame(height: 25)
-            Text(title)
-                .fixedSize(horizontal: false, vertical: true)
-            image
+        HStack {
+            Spacer()
+            VStack(alignment: .leading) {
+                Spacer().frame(height: 25)
+                Text(title)
+                    .fixedSize(horizontal: false, vertical: true)
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+            .frame(maxWidth: 200)
+            Spacer()
         }
     }
 }


### PR DESCRIPTION
Part of #3334 

## Why

The paper size options screen (a static screen) looks not so polished in larger font size. To better support dynamic type, this PR updated the SwiftUI layout so that the screen looks nicer with different font sizes.

## Changes

I've tried a few different layout approaches, and settled on the one in the PR (since we don't really have layout rules in the design regarding how each element grows to any optional max size). I capped the content width to 200px, because otherwise the images look unnecessarily huge in landscape.

This PR also added SwiftUI previews when the font size is XXXL and in portrait and landscape mode.

If you have other ideas for the layout, please feel free to suggest!

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label. You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label
- After shipping labels are synced, tap "Reprint Shipping Label" in the non-refunded shipping label card
- Tap "See layout and paper size options" row
- Try adjusting system font size from small to large, rotating the device --> the layout should look reasonably nice (I noticed some minor leading misalignment in the first column in one system font size in iPhone 11 iOS 14.1 sim, might be an edge case)

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 50 05](https://user-images.githubusercontent.com/1945542/104437689-150f2180-55ca-11eb-82f2-2f4cd17e87a0.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 52 26](https://user-images.githubusercontent.com/1945542/104437713-1a6c6c00-55ca-11eb-9c6e-fe05f9d2fc4a.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 50 12](https://user-images.githubusercontent.com/1945542/104437702-180a1200-55ca-11eb-96f7-87844ebaa929.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 52 31](https://user-images.githubusercontent.com/1945542/104437718-1b9d9900-55ca-11eb-80cd-4df6380b9767.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 50 15](https://user-images.githubusercontent.com/1945542/104437709-193b3f00-55ca-11eb-9e8f-abf7f635bc37.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 17 52 34](https://user-images.githubusercontent.com/1945542/104437726-1ccec600-55ca-11eb-90ee-2abb26ab76f9.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
