### PR TITLE
Settings: Use accent color for "We're hiring!" text link

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -562,16 +562,18 @@ private extension SettingsViewController {
     /// (which contains a link to the "Work with us" URL)
     ///
     var hiringAttributedText: NSAttributedString {
-        let hiringText = NSLocalizedString("Made with love by Automattic. We’re hiring!",
-                                           comment: "The text 'We're hiring!' links to our jobs page."
+        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
+                                           comment: "It reads 'Made with love by Automattic. We’re hiring!'. Place \'We’re hiring!' between `<a>` and `</a>`"
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,
             .foregroundColor: UIColor.textSubtle
         ]
 
-        let hiringAttrText = NSMutableAttributedString(string: hiringText, attributes: hiringAttributes)
-        hiringAttrText.addAttribute(.link, value: "https://automattic.com/work-with-us", range: NSRange(location: 30, length: 13))
+        let hiringAttrText = NSMutableAttributedString()
+        hiringAttrText.append(hiringText.htmlToAttributedString)
+        let range = NSRange(location: 0, length: hiringAttrText.length)
+        hiringAttrText.addAttributes(hiringAttributes, range: range)
 
         return hiringAttrText
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -562,18 +562,16 @@ private extension SettingsViewController {
     /// (which contains a link to the "Work with us" URL)
     ///
     var hiringAttributedText: NSAttributedString {
-        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "It reads 'Made with love by Automattic. We’re hiring!'. Place \'We’re hiring!' between `<a>` and `</a>`"
+        let hiringText = NSLocalizedString("Made with love by Automattic. We’re hiring!",
+                                           comment: "The text 'We're hiring!' links to our jobs page."
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,
             .foregroundColor: UIColor.textSubtle
         ]
 
-        let hiringAttrText = NSMutableAttributedString()
-        hiringAttrText.append(hiringText.htmlToAttributedString)
-        let range = NSRange(location: 0, length: hiringAttrText.length)
-        hiringAttrText.addAttributes(hiringAttributes, range: range)
+        let hiringAttrText = NSMutableAttributedString(string: hiringText, attributes: hiringAttributes)
+        hiringAttrText.addAttribute(.link, value: "https://automattic.com/work-with-us", range: NSRange(location: 30, length: 13))
 
         return hiringAttrText
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -63,7 +63,7 @@ extension TableFooterView {
         footnote.textContainerInset = .zero
         footnote.textAlignment = .center
         footnote.linkTextAttributes = [
-            .foregroundColor: UIColor.primary,
+            .foregroundColor: UIColor.textLink,
             .underlineColor: UIColor.clear,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]


### PR DESCRIPTION
Fixes: #1620 

## Description

Buttons and text links should use the `.accent` color. The settings footer text link ("We're hiring!") was using the `.primary` color and now uses the `.accent` color.

## Changes

I updated `linkTextAttributes` in `TableFooterView.swift` to use `.accent` instead of `.primary`. This changes the text link color in the Settings footer.

I don't see any other places in the app where we have a table footer with a text link, so the change should be limited to the Settings screen, but even if other footer text links are added on other screens we expect them to use the accent color.

Before|After
-|-
<img src="https://user-images.githubusercontent.com/8658164/104464919-60660780-55ab-11eb-84a2-880330b0812f.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/104464959-6956d900-55ab-11eb-9757-fd4b94840256.png" width="300px">
<img src="https://user-images.githubusercontent.com/8658164/104464927-622fcb00-55ab-11eb-9592-9b865fc10af0.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/104464972-6f4cba00-55ab-11eb-8320-dc9356b6c15d.png" width="300px">


## Testing

1. Open and log in to the app.
2. On the My store tab, tap the Settings icon.
3. At the bottom of the Settings screen, confirm the "We're hiring!" link is pink (accent color).
4. Confirm there are no unexpected changes to the footer on other screens.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
