### PR TITLE
Setup `ImageAndTitleAndTextTableViewCell` with warning style

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -15,6 +15,8 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     enum Style {
         /// Only the image and title label are displayed with a given font style for the title.
         case imageAndTitleOnly(fontStyle: FontStyle)
+        /// The cell's title, image, and background color are set to warning style.
+        case warning
     }
 
     /// Contains configurable properties for the cell.
@@ -95,12 +97,6 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
             self.isActionable = isActionable
             self.onSwitchChange = onSwitchChange
         }
-    }
-
-    /// View model for warning UI.
-    struct WarningViewModel {
-        let icon: UIImage
-        let title: String?
     }
 
     /// View model to replace TopLeftImageTableViewCell
@@ -192,20 +188,6 @@ extension ImageAndTitleAndTextTableViewCell {
         contentView.backgroundColor = nil
     }
 
-    func updateUI(warningViewModel: WarningViewModel) {
-        let viewModel = ViewModel(title: warningViewModel.title,
-                                  text: nil,
-                                  textTintColor: .warning,
-                                  image: warningViewModel.icon,
-                                  imageTintColor: .warning,
-                                  isActionable: false)
-        updateUI(viewModel: viewModel)
-
-        titleLabel.textColor = .text
-        titleLabel.numberOfLines = 0
-        contentView.backgroundColor = .warningBackground
-    }
-
     func updateUI(topLeftImageViewModel: TopLeftImageViewModel) {
         let viewModel = ViewModel(title: topLeftImageViewModel.title,
                                   text: nil,
@@ -229,6 +211,8 @@ extension ImageAndTitleAndTextTableViewCell {
         switch style {
         case .imageAndTitleOnly(let fontStyle):
             applyImageAndTitleOnlyStyle(fontStyle: fontStyle, data: data)
+        case .warning:
+            applyWarningStyle(data: data)
         }
         applyAccessibilityChanges(contentSizeCategory: traitCollection.preferredContentSizeCategory)
         observeContentSizeCategoryChanges()
@@ -259,6 +243,14 @@ private extension ImageAndTitleAndTextTableViewCell {
         }
         applyDefaultStyle(data: data)
         contentImageViewWidthConstraint.isActive = true
+    }
+
+    func applyWarningStyle(data: DataConfiguration) {
+        applyDefaultStyle(data: data)
+
+        titleLabel.textColor = .text
+        contentImageView.tintColor = .warning
+        contentView.backgroundColor = .warningBackground
     }
 
     func applyDefaultStyle(data: DataConfiguration) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -13,12 +13,6 @@ private extension ProductFormSection.SettingsRow.ViewModel {
     }
 }
 
-private extension ProductFormSection.SettingsRow.WarningViewModel {
-    func toCellViewModel() -> ImageAndTitleAndTextTableViewCell.WarningViewModel {
-        return ImageAndTitleAndTextTableViewCell.WarningViewModel(icon: icon, title: title)
-    }
-}
-
 /// Configures the sections and rows of Product form table view based on the view model.
 ///
 final class ProductFormTableViewDataSource: NSObject {
@@ -269,6 +263,10 @@ private extension ProductFormTableViewDataSource {
         guard let cell = warningCell as? ImageAndTitleAndTextTableViewCell else {
             fatalError("Unexpected cell type \(warningCell) for view model: \(viewModel)")
         }
-        cell.updateUI(warningViewModel: viewModel.toCellViewModel())
+        cell.update(with: .warning,
+                    data: .init(title: viewModel.title,
+                                image: viewModel.icon,
+                                numberOfLinesForTitle: 0,
+                                isActionable: false))
     }
 }


### PR DESCRIPTION
Part of #3419 

## Why

This is part of #3419 to refactor different `ImageAndTitleAndTextTableViewCell` view models with `Style` enum and default data configurations. Each style sets a subset of styling properties with optional parameters. This implementation simplifies different `*ViewModel` structs with enum cases, and allows other data configurations to be set to any value like `showSeparator` and `numberOfLines*` which could differ in each use case.

## Changes

This PR added a new style `warning` to replace `WarningViewModel` and updated its existing usage (missing price info row in Product Variation screen).

## Testing

Please do a confidence check on the only usage of warning style:

- Go to the Products tab
- Tap on a variable product with a variation that does not have a price
- Tap on the Variations row
- Tap on the variation without a price --> the warning row should look as before (no changes are expected)

## Example screenshots

The price warning row should look the same as `develop`.

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2021-01-14 at 15 22 32](https://user-images.githubusercontent.com/1945542/104559738-ce7bfe80-567f-11eb-921c-b282e2fa6826.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-14 at 15 34 16](https://user-images.githubusercontent.com/1945542/104559745-d176ef00-567f-11eb-9c15-560b2e7eb2e9.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-14 at 15 34 53](https://user-images.githubusercontent.com/1945542/104559750-d2a81c00-567f-11eb-8978-125d9ab04b56.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-14 at 15 35 01](https://user-images.githubusercontent.com/1945542/104559751-d340b280-567f-11eb-848b-1b2aa2a92569.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
