### PR TITLE
fix: Order Notes → Toggling Sending To Customer Deletes the Text

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Removed fulfillment screen and moved fulfillment to the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3453]
 - [*] Fix: billing information action sheets now are presented correctly on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3457]
 - [*] fix: the rows in the product search list now don't have double separators. [https://github.com/woocommerce/woocommerce-ios/pull/3456]
+- [*] fix: when adding a note to an order, the text gets no more deleted if you tap on “Email note to customer”. [https://github.com/woocommerce/woocommerce-ios/pull/3473]
 
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -167,7 +167,6 @@ private extension NewNoteViewController {
             }
 
             self.isCustomerNote = newValue
-            self.refreshTextViewCell()
 
             cell.accessibilityLabel = String.localizedStringWithFormat(
                 NSLocalizedString("Email note to customer %@", comment: ""),


### PR DESCRIPTION
Fixes #3446

## Description
When adding a note to an order, the text gets deleted if you tap on “Email note to customer”. This does not happen in Android.
This was a simple fix. 😸 


## Testing
1. Navigate to an order.
2. Tap Add a note.
3. Type something.
4. Tap “Email note to customer”. -> The written note should not disappear.


## Screenshot
<img src="https://user-images.githubusercontent.com/495617/104596566-6d9af900-5674-11eb-96a9-7a47fb162c0e.png" width=300 />



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
