### PR TITLE
Improvements to Notice Present for preventing to add similar Notices in the queue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Removed fulfillment screen and moved fulfillment to the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3453]
 - [*] Fix: billing information action sheets now are presented correctly on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3457]
 - [*] fix: the rows in the product search list now don't have double separators. [https://github.com/woocommerce/woocommerce-ios/pull/3456]
+- [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 
 
 5.8

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -28,6 +28,7 @@ class DefaultNoticePresenter: NoticePresenter {
     /// Enqueues the specified Notice for display.
     ///
     func enqueue(notice: Notice) {
+        guard !notices.contains(notice) else { return }
         notices.append(notice)
         presentNextNoticeIfPossible()
     }

--- a/WooCommerce/Classes/Tools/Notices/Notice.swift
+++ b/WooCommerce/Classes/Tools/Notices/Notice.swift
@@ -48,3 +48,13 @@ struct Notice {
         self.actionHandler = actionHandler
     }
 }
+
+extension Notice: Equatable {
+    static func == (lhs: Notice, rhs: Notice) -> Bool {
+        return lhs.title == rhs.title &&
+            lhs.message == rhs.message &&
+            lhs.feedbackType == rhs.feedbackType &&
+            lhs.notificationInfo?.identifier == rhs.notificationInfo?.identifier &&
+            lhs.actionTitle == rhs.actionTitle
+    }
+}


### PR DESCRIPTION
Fixes #1752 

## Description
This is a small improvement, that has a big impact on our user experience. In fact, there are some cases where we use the `NoticePresenter` for presenting some alerts to our users, but sometimes it happens that we present the same error notice multiple times because we don't have any check on the queue before adding the same notice. One of these cases happens for example in **_Products > Edit Product > Edit Price_**: if you try to insert a sale price higher than the regular price, and you press save, we show an error notice. If you press the save button multiple times, you will see a lot of similar Notices. 
Now the `Notice` struct conforms to `Equatable`, and we check if a similar `Notice` is already in the queue.

## Testing
1. Open a product
2. Click on 'Price'
3. Set 'sale' price higher than 'regular' price
4. Press 'Done' button multiple times
5. Notice the error message
6. Leave the screen
7. Notice that the message disappears, and no other similar messages are shown.

## Screenshots
<img src="https://user-images.githubusercontent.com/495617/104602186-6a573b80-567b-11eb-92ce-432ffc799a38.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
