### PR TITLE
Unit test StorageType+Extension methods

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		02EAB6D72480A86D00FD873C /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAB6D62480A86D00FD873C /* CrashLogger.swift */; };
 		2618707325409C65006522A1 /* ShippingLineTax+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */; };
 		2618707425409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */; };
+		2619F71925AF95030006DAFF /* StorageTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */; };
 		261CF1C4255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */; };
 		261CF1C5255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
@@ -217,6 +218,7 @@
 		261870702540944C006522A1 /* Model 34.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 34.xcdatamodel"; sourceTree = "<group>"; };
 		2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataClass.swift"; sourceTree = "<group>"; };
 		2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTypeExtensionsTests.swift; sourceTree = "<group>"; };
 		261CF1C1255AFDC40090D8D3 /* Model 36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 36.xcdatamodel"; sourceTree = "<group>"; };
 		261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataClass.swift"; sourceTree = "<group>"; };
 		261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				B59E11DF20A9F5E6004121A4 /* Constants.swift */,
 				B54CA5C620A4BFDC00F38CD1 /* DummyStack.swift */,
 				57589E8F252275CA000F22CE /* NSManagedObjectContext+TestHelpers.swift */,
+				2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1091,6 +1094,7 @@
 				B54CA5C220A4BF6900F38CD1 /* NSManagedObjectStorageTests.swift in Sources */,
 				572C099625475208005372E1 /* SpyFileManager.swift in Sources */,
 				5736879024AABE4D00B528FE /* ManagedObjectModelsInventoryTests.swift in Sources */,
+				2619F71925AF95030006DAFF /* StorageTypeExtensionsTests.swift in Sources */,
 				57589E90252275CA000F22CE /* NSManagedObjectContext+TestHelpers.swift in Sources */,
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,
 				B59E11DE20A9F1FB004121A4 /* CoreDataManagerTests.swift in Sources */,

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -34,4 +34,17 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(account, storedAccount)
 
     }
+
+    func test_loadAccountSettings_by_user_ID () throws {
+        // Given
+        let accountSettings = storage.insertNewObject(ofType: AccountSettings.self)
+        let userID: Int64 = 123
+        accountSettings.userID = userID
+
+        // When
+        let storedAccountSettings = try XCTUnwrap(storage.loadAccountSettings(userID: userID))
+
+        // Then
+        XCTAssertEqual(accountSettings, storedAccountSettings)
+    }
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import Storage
+
+class StorageTypeExtensionsTests: XCTestCase {
+
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType! {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = CoreDataManager(name: "WooCommerce", crashLogger: MockCrashLogger())
+    }
+
+    override func tearDown() {
+        storageManager.reset()
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_loadAccount_by_ID() throws {
+        // Given
+        let account = storage.insertNewObject(ofType: Account.self)
+        let userID: Int64 = 123
+        account.userID = userID
+
+        // When
+        let storedAccount = try XCTUnwrap(storage.loadAccount(userID: userID))
+
+        // Then
+        XCTAssertEqual(account, storedAccount)
+
+    }
+}

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -525,6 +525,77 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(product, storedProducts)
     }
 
+    func test_loadProductAttribute_by_siteID_productID_attributeID_name() throws {
+        // Given
+        let productID: Int64 = 123
+        let attributeID: Int64 = 1234
+        let name = "name"
+        let productAttribute = storage.insertNewObject(ofType: ProductAttribute.self)
+        productAttribute.attributeID = attributeID
+        productAttribute.name = name
+
+        let product = storage.insertNewObject(ofType: Product.self)
+        product.siteID = sampleSiteID
+        product.productID = productID
+        product.addToAttributes(productAttribute)
+
+        // When
+        let storedProductAttribute = try XCTUnwrap(storage.loadProductAttribute(siteID: sampleSiteID,
+                                                                                productID: productID,
+                                                                                attributeID: attributeID,
+                                                                                name: name))
+
+        // Then
+        XCTAssertEqual(productAttribute, storedProductAttribute)
+    }
+
+    func test_loadProductAttribute_by_siteID_attributeID() throws {
+        // Given
+        let attributeID: Int64 = 1234
+        let productAttribute = storage.insertNewObject(ofType: ProductAttribute.self)
+        productAttribute.siteID = sampleSiteID
+        productAttribute.attributeID = attributeID
+
+        // When
+        let storedProductAttribute = try XCTUnwrap(storage.loadProductAttribute(siteID: sampleSiteID, attributeID: attributeID))
+
+        // Then
+        XCTAssertEqual(productAttribute, storedProductAttribute)
+    }
+
+    func test_loadProductAttribute_by_siteID() throws {
+        // Given
+        let productAttribute1 = storage.insertNewObject(ofType: ProductAttribute.self)
+        productAttribute1.siteID = sampleSiteID
+
+        let productAttribute2 = storage.insertNewObject(ofType: ProductAttribute.self)
+        productAttribute2.siteID = sampleSiteID
+
+        // When
+        let storedProductAttribute = try XCTUnwrap(storage.loadProductAttributes(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([productAttribute1, productAttribute2], storedProductAttribute)
+    }
+
+    func test_loadProductAttributeTerm_by_siteID_termID_attributeID() throws {
+        // Given
+        let termID: Int64 = 123
+        let attributeID: Int64 = 1234
+        let term = storage.insertNewObject(ofType: ProductAttributeTerm.self)
+        term.termID = termID
+        term.siteID = sampleSiteID
+
+        let attribute = storage.insertNewObject(ofType: ProductAttribute.self)
+        attribute.attributeID = attributeID
+        attribute.addToTerms(term)
+
+        // When
+        let storedTerm = try XCTUnwrap(storage.loadProductAttributeTerm(siteID: sampleSiteID, termID: termID, attributeID: attributeID))
+
+        // Then
+        XCTAssertEqual(term, storedTerm)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -195,6 +195,19 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(shippingLine, storedShippingLine)
     }
 
+    func test_loadOrderNote_by_noteID() throws {
+        // Given
+        let noteID: Int64 = 123
+        let orderNote = storage.insertNewObject(ofType: OrderNote.self)
+        orderNote.noteID = noteID
+
+        // When
+        let storedNote = try XCTUnwrap(storage.loadOrderNote(noteID: noteID))
+
+        // Then
+        XCTAssertEqual(orderNote, storedNote)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -620,6 +620,25 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(productAttribute, storedProductAttribute)
     }
+
+    func test_loadProductImage_by_siteID_productID_imageID() throws {
+        // Given
+        let productID: Int64 = 123
+        let imageID: Int64 = 1234
+        let productImage = storage.insertNewObject(ofType: ProductImage.self)
+        productImage.imageID = imageID
+
+        let product = storage.insertNewObject(ofType: Product.self)
+        product.siteID = sampleSiteID
+        product.productID = productID
+        product.addToImages(productImage)
+
+        // When
+        let storedProductImage = try XCTUnwrap(storage.loadProductImage(siteID: sampleSiteID, productID: productID, imageID: imageID))
+
+        // Then
+        XCTAssertEqual(productImage, storedProductImage)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -276,6 +276,21 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(statsV4, storedStatsV4)
     }
+
+    func test_loadOrderStatuses_by_siteID() throws {
+        // Given
+        let status1 = storage.insertNewObject(ofType: OrderStatus.self)
+        status1.siteID = sampleSiteID
+
+        let status2 = storage.insertNewObject(ofType: OrderStatus.self)
+        status2.siteID = sampleSiteID
+
+        // When
+        let storedStatuses = try XCTUnwrap(storage.loadOrderStatuses(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([status1, status2], storedStatuses)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -762,6 +762,38 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(shippingClass, storedShippingClass)
     }
+
+    func test_loadProductVariations_by_siteID_productID() throws {
+        // Given
+        let productID: Int64 = 123
+        let variation1 = storage.insertNewObject(ofType: ProductVariation.self)
+        variation1.siteID = sampleSiteID
+        variation1.productID = productID
+
+        let variation2 = storage.insertNewObject(ofType: ProductVariation.self)
+        variation2.siteID = sampleSiteID
+        variation2.productID = productID
+
+        // When
+        let storedVariations = try XCTUnwrap(storage.loadProductVariations(siteID: sampleSiteID, productID: productID))
+
+        // Then
+        XCTAssertEqual(Set([variation1, variation2]), Set(storedVariations))
+    }
+
+    func test_loadProductVariation_by_siteID_variationID() throws {
+        // Given
+        let variationID: Int64 = 123
+        let variation = storage.insertNewObject(ofType: ProductVariation.self)
+        variation.siteID = sampleSiteID
+        variation.productVariationID = variationID
+
+        // When
+        let storedVariation = try XCTUnwrap(storage.loadProductVariation(siteID: sampleSiteID, productVariationID: variationID))
+
+        // Then
+        XCTAssertEqual(variation, storedVariation)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class StorageTypeExtensionsTests: XCTestCase {
 
-    private let sampleSiteID: Int64 = 1234
+    private let sampleSiteID: Int64 = 98765
 
     private var storageManager: StorageManagerType!
 
@@ -144,11 +144,28 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(coupon, storedCoupon)
     }
 
+    func test_loadOrderFeeLine_by_siteID_feeID() throws {
+        // Given
+        let feeID: Int64 = 123
+        let feeLine = storage.insertNewObject(ofType: OrderFeeLine.self)
+        feeLine.feeID = feeID
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.addToFees(feeLine)
+
+        // When
+        let storedFeeLine = try XCTUnwrap(storage.loadOrderFeeLine(siteID: sampleSiteID, feeID: feeID))
+
+        // Then
+        XCTAssertEqual(feeLine, storedFeeLine)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given
-        let <#param#>:Int64 = <#param#>
-        let <#param#>:Int64 = <#param#>
+        let <#param#>: Int64 = <#param#>
+        let <#param#>: Int64 = <#param#>
         let <#entity#> = storage.insertNewObject(ofType: <#type#>.self)
         <#entity#>.<#param#> = <#param#>
         <#entity#>.<#param#> = <#param#>

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -263,6 +263,19 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(siteVisitStat, storedSiteVisitStat)
     }
 
+    func test_loadOrderStatsV4_by_siteID_timeRange() throws {
+        // Given
+        let timeRange = "Daily"
+        let statsV4 = storage.insertNewObject(ofType: OrderStatsV4.self)
+        statsV4.siteID = sampleSiteID
+        statsV4.timeRange = timeRange
+
+        // When
+        let storedStatsV4 = try XCTUnwrap(storage.loadOrderStatsV4(siteID: sampleSiteID, timeRange: timeRange))
+
+        // Then
+        XCTAssertEqual(statsV4, storedStatsV4)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -924,6 +924,54 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(gateway, storedGateway)
     }
+
+    func test_loadAllShippingLabels_by_siteID_orderID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let label1 = storage.insertNewObject(ofType: ShippingLabel.self)
+        label1.siteID = sampleSiteID
+        label1.orderID = orderID
+
+        let label2 = storage.insertNewObject(ofType: ShippingLabel.self)
+        label2.siteID = sampleSiteID
+        label2.orderID = orderID
+
+        // When
+        let storedLabels = try XCTUnwrap(storage.loadAllShippingLabels(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual(Set([label1, label2]), Set(storedLabels))
+    }
+
+    func test_loadShippingLabel_by_siteID_orderID_labelID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let labelID: Int64 = 1233
+        let label = storage.insertNewObject(ofType: ShippingLabel.self)
+        label.siteID = sampleSiteID
+        label.orderID = orderID
+        label.shippingLabelID = labelID
+
+        // When
+        let storedLabel = try XCTUnwrap(storage.loadShippingLabel(siteID: sampleSiteID, orderID: orderID, shippingLabelID: labelID))
+
+        // Then
+        XCTAssertEqual(label, storedLabel)
+    }
+
+    func test_loadShippingLabelSettings_by_siteID_orderID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let labelSettings = storage.insertNewObject(ofType: ShippingLabelSettings.self)
+        labelSettings.siteID = sampleSiteID
+        labelSettings.orderID = orderID
+
+        // When
+        let storedLabelSettings = try XCTUnwrap(storage.loadShippingLabelSettings(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual(labelSettings, storedLabelSettings)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -109,6 +109,24 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(orderItem, storedOrderItem)
     }
 
+    func test_loadOrderItemTax_by_itemID_taxID() throws {
+        // Given
+        let itemID: Int64 = 123
+        let taxID: Int64 = 1234
+        let orderItemTax = storage.insertNewObject(ofType: OrderItemTax.self)
+        orderItemTax.taxID = taxID
+
+        let orderItem = storage.insertNewObject(ofType: OrderItem.self)
+        orderItem.itemID = itemID
+        orderItem.addToTaxes(orderItemTax)
+
+        // When
+        let storedItemTax = try XCTUnwrap(storage.loadOrderItemTax(itemID: itemID, taxID: taxID))
+
+        // Then
+        XCTAssertEqual(orderItemTax, storedItemTax)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -352,6 +352,34 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(siteSetting, storedSiteSetting)
     }
+
+    func test_loadNotification_by_noteID() throws {
+        // Given
+        let noteID: Int64 = 123
+        let notification = storage.insertNewObject(ofType: Note.self)
+        notification.noteID = noteID
+
+        // When
+        let storedNotification = try XCTUnwrap(storage.loadNotification(noteID: noteID))
+
+        // Then
+        XCTAssertEqual(notification, storedNotification)
+    }
+
+    func test_loadNotification_by_noteID_noteHash() throws {
+        // Given
+        let noteID: Int64 = 123
+        let noteHash: Int64 = 1234
+        let notification = storage.insertNewObject(ofType: Note.self)
+        notification.noteID = noteID
+        notification.noteHash = noteHash
+
+        // When
+        let storedNotification = try XCTUnwrap(storage.loadNotification(noteID: noteID, noteHash: (Int)(noteHash)))
+
+        // Then
+        XCTAssertEqual(notification, storedNotification)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -35,7 +35,7 @@ class StorageTypeExtensionsTests: XCTestCase {
 
     }
 
-    func test_loadAccountSettings_by_user_ID () throws {
+    func test_loadAccountSettings_by_user_ID() throws {
         // Given
         let accountSettings = storage.insertNewObject(ofType: AccountSettings.self)
         let userID: Int64 = 123
@@ -46,5 +46,18 @@ class StorageTypeExtensionsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(accountSettings, storedAccountSettings)
+    }
+
+    func test_loadSite_by_ID() throws {
+        // Given
+        let site = storage.insertNewObject(ofType: Site.self)
+        let id: Int64 = 123
+        site.siteID = id
+
+        // When
+        let storedSite = try XCTUnwrap(storage.loadSite(siteID: id))
+
+        // Then
+        XCTAssertEqual(site, storedSite)
     }
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -127,10 +127,28 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(orderItemTax, storedItemTax)
     }
 
+    func test_loadOrderCoupon_by_siteID_couponID() throws {
+        // Given
+        let couponID: Int64 = 123
+        let coupon = storage.insertNewObject(ofType: OrderCoupon.self)
+        coupon.couponID = couponID
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.addToCoupons(coupon)
+
+        // When
+        let storedCoupon = try XCTUnwrap(storage.loadOrderCoupon(siteID: sampleSiteID, couponID: couponID))
+
+        // Then
+        XCTAssertEqual(coupon, storedCoupon)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given
-        let <#param#> = <#param#>
+        let <#param#>:Int64 = <#param#>
+        let <#param#>:Int64 = <#param#>
         let <#entity#> = storage.insertNewObject(ofType: <#type#>.self)
         <#entity#>.<#param#> = <#param#>
         <#entity#>.<#param#> = <#param#>

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -639,6 +639,35 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(productImage, storedProductImage)
     }
+
+    func test_loadProductCategories_by_siteID() throws {
+        // Given
+        let category1 = storage.insertNewObject(ofType: ProductCategory.self)
+        category1.siteID = sampleSiteID
+
+        let category2 = storage.insertNewObject(ofType: ProductCategory.self)
+        category2.siteID = sampleSiteID
+
+        // When
+        let storedCategories = try XCTUnwrap(storage.loadProductCategories(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([category1, category2], storedCategories)
+    }
+
+    func test_loadProductCategory_by_siteID_categoryID() throws {
+        // Given
+        let categoryID: Int64 = 123
+        let category = storage.insertNewObject(ofType: ProductCategory.self)
+        category.siteID = sampleSiteID
+        category.categoryID = categoryID
+
+        // When
+        let storedCategory = try XCTUnwrap(storage.loadProductCategory(siteID: sampleSiteID, categoryID: categoryID))
+
+        // Then
+        XCTAssertEqual(category, storedCategory)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -733,6 +733,35 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(productReview, storedProductReview)
     }
+
+    func test_loadProductShippingClasses_by_siteID() throws {
+        // Given
+        let shippingClass1 = storage.insertNewObject(ofType: ProductShippingClass.self)
+        shippingClass1.siteID = sampleSiteID
+
+        let shippingClass2 = storage.insertNewObject(ofType: ProductShippingClass.self)
+        shippingClass2.siteID = sampleSiteID
+
+        // When
+        let storedShippingClasses = try XCTUnwrap(storage.loadProductShippingClasses(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(Set([shippingClass1, shippingClass2]), Set(storedShippingClasses))
+    }
+
+    func test_loadProductShippingClass_by_siteID_classID() throws {
+        // Given
+        let classID: Int64 = 123
+        let shippingClass = storage.insertNewObject(ofType: ProductShippingClass.self)
+        shippingClass.siteID = sampleSiteID
+        shippingClass.shippingClassID = classID
+
+        // When
+        let storedShippingClass = try XCTUnwrap(storage.loadProductShippingClass(siteID: sampleSiteID, remoteID: classID))
+
+        // Then
+        XCTAssertEqual(shippingClass, storedShippingClass)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -662,6 +662,21 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(category, storedCategory)
     }
+
+    func test_loadProductSearchResult_by_keyboard() throws {
+        // Given
+        let keyword = "Keyword"
+        let searchResult = storage.insertNewObject(ofType: ProductSearchResults.self)
+        searchResult.keyword = keyword
+
+        // When
+        let storedSearchResult = try XCTUnwrap(storage.loadProductSearchResults(keyword: keyword))
+
+        // Then
+        XCTAssertEqual(searchResult, storedSearchResult)
+    }
+
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -289,7 +289,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedStatuses = try XCTUnwrap(storage.loadOrderStatuses(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([status1, status2], storedStatuses)
+        XCTAssertEqual(Set([status1, status2]), Set(storedStatuses))
     }
 
     func test_loadOrderStatus_by_siteID_slug() throws {
@@ -318,7 +318,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedSiteSettings = try XCTUnwrap(storage.loadAllSiteSettings(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([siteSetting1, siteSetting2], storedSiteSettings)
+        XCTAssertEqual(Set([siteSetting1, siteSetting2]), Set(storedSiteSettings))
     }
 
     func test_loadAllSiteSettings_by_siteID_groupKey() throws {
@@ -336,7 +336,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedSiteSettings = try XCTUnwrap(storage.loadSiteSettings(siteID: sampleSiteID, settingGroupKey: groupKey))
 
         // Then
-        XCTAssertEqual([siteSetting1, siteSetting2], storedSiteSettings)
+        XCTAssertEqual(Set([siteSetting1, siteSetting2]), Set(storedSiteSettings))
     }
 
     func test_loadSiteSettings_by_siteID_settingID() throws {
@@ -412,7 +412,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedTrackingList = try XCTUnwrap(storage.loadShipmentTrackingList(siteID: sampleSiteID, orderID: orderID))
 
         // Then
-        XCTAssertEqual([shipmentTracking1, shipmentTracking2], storedTrackingList)
+        XCTAssertEqual(Set([shipmentTracking1, shipmentTracking2]), Set(storedTrackingList))
     }
 
     func test_loadShipmentTrackingProviderGroup_by_siteID_groupName() throws {
@@ -433,17 +433,15 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Given
         let shipmentProviderGroup1 = storage.insertNewObject(ofType: ShipmentTrackingProviderGroup.self)
         shipmentProviderGroup1.siteID = sampleSiteID
-        shipmentProviderGroup1.name = "name-1"
 
         let shipmentProviderGroup2 = storage.insertNewObject(ofType: ShipmentTrackingProviderGroup.self)
         shipmentProviderGroup2.siteID = sampleSiteID
-        shipmentProviderGroup2.name = "name-2"
 
         // When
         let storedShipmentProviderGroup = try XCTUnwrap(storage.loadShipmentTrackingProviderGroupList(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([shipmentProviderGroup1, shipmentProviderGroup2], storedShipmentProviderGroup)
+        XCTAssertEqual(Set([shipmentProviderGroup1, shipmentProviderGroup2]), Set(storedShipmentProviderGroup))
     }
 
     func test_loadShipmentTrackingProvider_by_siteID_name() throws {
@@ -464,34 +462,30 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Given
         let trackingProvider1 = storage.insertNewObject(ofType: ShipmentTrackingProvider.self)
         trackingProvider1.siteID = sampleSiteID
-        trackingProvider1.name = "name-1"
 
         let trackingProvider2 = storage.insertNewObject(ofType: ShipmentTrackingProvider.self)
         trackingProvider2.siteID = sampleSiteID
-        trackingProvider2.name = "name-2"
 
         // When
         let storedTrackingProvider = try XCTUnwrap(storage.loadShipmentTrackingProviderList(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([trackingProvider1, trackingProvider2], storedTrackingProvider)
+        XCTAssertEqual(Set([trackingProvider1, trackingProvider2]), Set(storedTrackingProvider))
     }
 
     func test_loadProducts_by_siteID() throws {
         // Given
         let product1 = storage.insertNewObject(ofType: Product.self)
         product1.siteID = sampleSiteID
-        product1.productID = 1
 
         let product2 = storage.insertNewObject(ofType: Product.self)
         product2.siteID = sampleSiteID
-        product2.productID = 2
 
         // When
         let storedProducts = try XCTUnwrap(storage.loadProducts(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([product2, product1], storedProducts)
+        XCTAssertEqual(Set([product2, product1]), Set(storedProducts))
     }
 
     func test_loadProducts_by_siteID_productIDs() throws {
@@ -508,7 +502,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedProducts = try XCTUnwrap(storage.loadProducts(siteID: sampleSiteID, productsIDs: [1, 2]))
 
         // Then
-        XCTAssertEqual([product1, product2], storedProducts)
+        XCTAssertEqual(Set([product1, product2]), Set(storedProducts))
     }
 
     func test_loadProduct_by_siteID_productID() throws {
@@ -575,7 +569,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedProductAttribute = try XCTUnwrap(storage.loadProductAttributes(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([productAttribute1, productAttribute2], storedProductAttribute)
+        XCTAssertEqual(Set([productAttribute1, productAttribute2]), Set(storedProductAttribute))
     }
 
     func test_loadProductAttributeTerm_by_siteID_termID_attributeID() throws {
@@ -652,7 +646,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let storedCategories = try XCTUnwrap(storage.loadProductCategories(siteID: sampleSiteID))
 
         // Then
-        XCTAssertEqual([category1, category2], storedCategories)
+        XCTAssertEqual(Set([category1, category2]), Set(storedCategories))
     }
 
     func test_loadProductCategory_by_siteID_categoryID() throws {

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -676,7 +676,34 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(searchResult, storedSearchResult)
     }
 
+    func test_loadProductTag_by_siteID_tagID() throws {
+        // Given
+        let tagID: Int64 = 123
+        let productTag = storage.insertNewObject(ofType: ProductTag.self)
+        productTag.siteID = sampleSiteID
+        productTag.tagID = tagID
 
+        // When
+        let storedProductTag = try XCTUnwrap(storage.loadProductTag(siteID: sampleSiteID, tagID: tagID))
+
+        // Then
+        XCTAssertEqual(productTag, storedProductTag)
+    }
+
+    func test_loadProductTags_by_siteID() throws {
+        // Given
+        let productTag1 = storage.insertNewObject(ofType: ProductTag.self)
+        productTag1.siteID = sampleSiteID
+
+        let productTag2 = storage.insertNewObject(ofType: ProductTag.self)
+        productTag2.siteID = sampleSiteID
+
+        // When
+        let storedProductTags = try XCTUnwrap(storage.loadProductTags(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(Set([productTag1, productTag2]), Set(storedProductTags))
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -596,6 +596,30 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(term, storedTerm)
     }
+
+    func test_loadProductDefaultAttribute_by_siteID_productID_defaultAttributeID_name() throws {
+        // Given
+        let productID: Int64 = 123
+        let attributeID: Int64 = 1234
+        let name = "name"
+        let productAttribute = storage.insertNewObject(ofType: ProductDefaultAttribute.self)
+        productAttribute.attributeID = attributeID
+        productAttribute.name = name
+
+        let product = storage.insertNewObject(ofType: Product.self)
+        product.siteID = sampleSiteID
+        product.productID = productID
+        product.addToDefaultAttributes(productAttribute)
+
+        // When
+        let storedProductAttribute = try XCTUnwrap(storage.loadProductDefaultAttribute(siteID: sampleSiteID,
+                                                                                       productID: productID,
+                                                                                       defaultAttributeID: attributeID,
+                                                                                       name: name))
+
+        // Then
+        XCTAssertEqual(productAttribute, storedProductAttribute)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -476,6 +476,55 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual([trackingProvider1, trackingProvider2], storedTrackingProvider)
     }
+
+    func test_loadProducts_by_siteID() throws {
+        // Given
+        let product1 = storage.insertNewObject(ofType: Product.self)
+        product1.siteID = sampleSiteID
+        product1.productID = 1
+
+        let product2 = storage.insertNewObject(ofType: Product.self)
+        product2.siteID = sampleSiteID
+        product2.productID = 2
+
+        // When
+        let storedProducts = try XCTUnwrap(storage.loadProducts(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([product2, product1], storedProducts)
+    }
+
+    func test_loadProducts_by_siteID_productIDs() throws {
+        // Given
+        let product1 = storage.insertNewObject(ofType: Product.self)
+        product1.siteID = sampleSiteID
+        product1.productID = 1
+
+        let product2 = storage.insertNewObject(ofType: Product.self)
+        product2.siteID = sampleSiteID
+        product2.productID = 2
+
+        // When
+        let storedProducts = try XCTUnwrap(storage.loadProducts(siteID: sampleSiteID, productsIDs: [1, 2]))
+
+        // Then
+        XCTAssertEqual([product1, product2], storedProducts)
+    }
+
+    func test_loadProduct_by_siteID_productID() throws {
+        // Given
+        let productID: Int64 = 123
+        let product = storage.insertNewObject(ofType: Product.self)
+        product.siteID = sampleSiteID
+        product.productID = productID
+
+        // When
+        let storedProducts = try XCTUnwrap(storage.loadProduct(siteID: sampleSiteID, productID: productID))
+
+        // Then
+        XCTAssertEqual(product, storedProducts)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -235,6 +235,34 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(topEarnerStat, storedTopEarnerStat)
     }
 
+    func test_loadSiteVisitStats_by_granularity() throws {
+        // Given
+        let granularity = "daily"
+        let siteVisitStat = storage.insertNewObject(ofType: SiteVisitStats.self)
+        siteVisitStat.granularity = granularity
+
+        // When
+        let storedSiteVisitStat = try XCTUnwrap(storage.loadSiteVisitStats(granularity: granularity))
+
+        // Then
+        XCTAssertEqual(siteVisitStat, storedSiteVisitStat)
+    }
+
+    func test_loadSiteVisitStats_by_granularity_date() throws {
+        // Given
+        let date = Date().description
+        let granularity = "daily"
+        let siteVisitStat = storage.insertNewObject(ofType: SiteVisitStats.self)
+        siteVisitStat.date = date
+        siteVisitStat.granularity = granularity
+
+        // When
+        let storedSiteVisitStat = try XCTUnwrap(storage.loadSiteVisitStats(granularity: granularity, date: date))
+
+        // Then
+        XCTAssertEqual(siteVisitStat, storedSiteVisitStat)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -380,6 +380,102 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(notification, storedNotification)
     }
+
+    func test_loadShipmentTracking_by_siteID_orderID_trackingID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let trackingID = "1234"
+        let shipmentTracking = storage.insertNewObject(ofType: ShipmentTracking.self)
+        shipmentTracking.siteID = sampleSiteID
+        shipmentTracking.orderID = orderID
+        shipmentTracking.trackingID = trackingID
+
+        // When
+        let storedShipmentTracking = try XCTUnwrap(storage.loadShipmentTracking(siteID: sampleSiteID, orderID: orderID, trackingID: trackingID))
+
+        // Then
+        XCTAssertEqual(shipmentTracking, storedShipmentTracking)
+    }
+
+    func test_loadShipmentTrackingList_by_siteID_orderID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let shipmentTracking1 = storage.insertNewObject(ofType: ShipmentTracking.self)
+        shipmentTracking1.siteID = sampleSiteID
+        shipmentTracking1.orderID = orderID
+
+        let shipmentTracking2 = storage.insertNewObject(ofType: ShipmentTracking.self)
+        shipmentTracking2.siteID = sampleSiteID
+        shipmentTracking2.orderID = orderID
+
+        // When
+        let storedTrackingList = try XCTUnwrap(storage.loadShipmentTrackingList(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual([shipmentTracking1, shipmentTracking2], storedTrackingList)
+    }
+
+    func test_loadShipmentTrackingProviderGroup_by_siteID_groupName() throws {
+        // Given
+        let providerGroup = "group"
+        let shipmentProviderGroup = storage.insertNewObject(ofType: ShipmentTrackingProviderGroup.self)
+        shipmentProviderGroup.siteID = sampleSiteID
+        shipmentProviderGroup.name = providerGroup
+
+        // When
+        let storedShipmentProviderGroup = try XCTUnwrap(storage.loadShipmentTrackingProviderGroup(siteID: sampleSiteID, providerGroupName: providerGroup))
+
+        // Then
+        XCTAssertEqual(shipmentProviderGroup, storedShipmentProviderGroup)
+    }
+
+    func test_loadShipmentTrackingProviderGroupList_by_siteID() throws {
+        // Given
+        let shipmentProviderGroup1 = storage.insertNewObject(ofType: ShipmentTrackingProviderGroup.self)
+        shipmentProviderGroup1.siteID = sampleSiteID
+        shipmentProviderGroup1.name = "name-1"
+
+        let shipmentProviderGroup2 = storage.insertNewObject(ofType: ShipmentTrackingProviderGroup.self)
+        shipmentProviderGroup2.siteID = sampleSiteID
+        shipmentProviderGroup2.name = "name-2"
+
+        // When
+        let storedShipmentProviderGroup = try XCTUnwrap(storage.loadShipmentTrackingProviderGroupList(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([shipmentProviderGroup1, shipmentProviderGroup2], storedShipmentProviderGroup)
+    }
+
+    func test_loadShipmentTrackingProvider_by_siteID_name() throws {
+        // Given
+        let name = "name"
+        let trackingProvider = storage.insertNewObject(ofType: ShipmentTrackingProvider.self)
+        trackingProvider.siteID = sampleSiteID
+        trackingProvider.name = name
+
+        // When
+        let storedTrackingProvider = try XCTUnwrap(storage.loadShipmentTrackingProvider(siteID: sampleSiteID, name: name))
+
+        // Then
+        XCTAssertEqual(trackingProvider, storedTrackingProvider)
+    }
+
+    func test_loadShipmentTrackingProviderList_by_siteID() throws {
+        // Given
+        let trackingProvider1 = storage.insertNewObject(ofType: ShipmentTrackingProvider.self)
+        trackingProvider1.siteID = sampleSiteID
+        trackingProvider1.name = "name-1"
+
+        let trackingProvider2 = storage.insertNewObject(ofType: ShipmentTrackingProvider.self)
+        trackingProvider2.siteID = sampleSiteID
+        trackingProvider2.name = "name-2"
+
+        // When
+        let storedTrackingProvider = try XCTUnwrap(storage.loadShipmentTrackingProviderList(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([trackingProvider1, trackingProvider2], storedTrackingProvider)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -220,6 +220,21 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(orderCount, storedOrderCount)
     }
 
+    func test_loadTopEarnerStats_by_date_granularity() throws {
+        // Given
+        let date = Date().description
+        let granularity = "daily"
+        let topEarnerStat = storage.insertNewObject(ofType: TopEarnerStats.self)
+        topEarnerStat.date = date
+        topEarnerStat.granularity = granularity
+
+        // When
+        let storedTopEarnerStat = try XCTUnwrap(storage.loadTopEarnerStats(date: date, granularity: granularity))
+
+        // Then
+        XCTAssertEqual(topEarnerStat, storedTopEarnerStat)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -208,6 +208,18 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(orderNote, storedNote)
     }
 
+    func test_loadOrderCount_by_siteID() throws {
+        // Given
+        let orderCount = storage.insertNewObject(ofType: OrderCount.self)
+        orderCount.siteID = sampleSiteID
+
+        // When
+        let storedOrderCount = try XCTUnwrap(storage.loadOrderCount(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(orderCount, storedOrderCount)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -808,6 +808,93 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(taxClass, storedTaxClass)
     }
 
+    func test_loadRefunds_by_siteID_orderID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let refund1 = storage.insertNewObject(ofType: Refund.self)
+        refund1.siteID = sampleSiteID
+        refund1.orderID = orderID
+
+        let refund2 = storage.insertNewObject(ofType: Refund.self)
+        refund2.siteID = sampleSiteID
+        refund2.orderID = orderID
+
+        // When
+        let storedRefunds = try XCTUnwrap(storage.loadRefunds(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual(Set([refund1, refund2]), Set(storedRefunds))
+    }
+
+    func test_loadRefund_by_siteID_orderID_refundID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let refundID: Int64 = 1234
+        let refund = storage.insertNewObject(ofType: Refund.self)
+        refund.siteID = sampleSiteID
+        refund.orderID = orderID
+        refund.refundID = refundID
+
+        // When
+        let storedRefund = try XCTUnwrap(storage.loadRefund(siteID: sampleSiteID, orderID: orderID, refundID: refundID))
+
+        // Then
+        XCTAssertEqual(refund, storedRefund)
+    }
+
+    func test_loadRefundItem_by_siteID_refundID_itemID() throws {
+        // Given
+        let refundID: Int64 = 123
+        let itemID: Int64 = 1234
+        let refundItem = storage.insertNewObject(ofType: OrderItemRefund.self)
+        refundItem.itemID = itemID
+
+        let refund = storage.insertNewObject(ofType: Refund.self)
+        refund.siteID = sampleSiteID
+        refund.refundID = refundID
+        refund.addToItems(refundItem)
+
+        // When
+        let storedRefundItem = try XCTUnwrap(storage.loadRefundItem(siteID: sampleSiteID, refundID: refundID, itemID: itemID))
+
+        // Then
+        XCTAssertEqual(refundItem, storedRefundItem)
+    }
+
+    func test_loadRefundShippingLine_by_siteID_shippingID() throws {
+        // Given
+        let shippingID: Int64 = 123
+        let shippingLine = storage.insertNewObject(ofType: ShippingLine.self)
+        shippingLine.shippingID = shippingID
+
+        let refund = storage.insertNewObject(ofType: Refund.self)
+        refund.siteID = sampleSiteID
+        refund.addToShippingLines(shippingLine)
+
+        // When
+        let storedShippingLine = try XCTUnwrap(storage.loadRefundShippingLine(siteID: sampleSiteID, shippingID: shippingID))
+
+        // Then
+        XCTAssertEqual(shippingLine, storedShippingLine)
+    }
+
+    func test_loadRefundItemTax_by_itemID_taxID() throws {
+        // Given
+        let itemID: Int64 = 123
+        let taxID: Int64 = 1234
+        let itemTax = storage.insertNewObject(ofType: OrderItemTaxRefund.self)
+        itemTax.taxID = taxID
+
+        let refundItem = storage.insertNewObject(ofType: OrderItemRefund.self)
+        refundItem.itemID = itemID
+        refundItem.addToTaxes(itemTax)
+
+        // When
+        let storedItemTax = try XCTUnwrap(storage.loadRefundItemTax(itemID: itemID, taxID: taxID))
+
+        // Then
+        XCTAssertEqual(itemTax, storedItemTax)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -89,4 +89,39 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(searchResult, storedSearchResult)
     }
+
+    func test_loadOrderItem_by_siteID_orderID_itemID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let itemID: Int64 = 1234
+        let orderItem = storage.insertNewObject(ofType: OrderItem.self)
+        orderItem.itemID = itemID
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.orderID = orderID
+        order.addToItems(orderItem)
+
+        // When
+        let storedOrderItem = try XCTUnwrap(storage.loadOrderItem(siteID: sampleSiteID, orderID: orderID, itemID: itemID))
+
+        // Then
+        XCTAssertEqual(orderItem, storedOrderItem)
+    }
+
+    /*
+    func test_load<#methodName#>_by_<#params#>() throws {
+        // Given
+        let <#param#> = <#param#>
+        let <#entity#> = storage.insertNewObject(ofType: <#type#>.self)
+        <#entity#>.<#param#> = <#param#>
+        <#entity#>.<#param#> = <#param#>
+
+        // When
+        let stored<#entity#> = try XCTUnwrap(storage.<#loadMethod#>)
+
+        // Then
+        XCTAssertEqual(<#entity#>, stored<#entity#>)
+    }
+     */
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -178,6 +178,23 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(orderRefund, storedOrderRefund)
     }
 
+    func test_loadOrderShippingLine_by_siteID_shippingID() throws {
+        // Given
+        let shippingID: Int64 = 123
+        let shippingLine = storage.insertNewObject(ofType: ShippingLine.self)
+        shippingLine.shippingID = shippingID
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.addToShippingLines(shippingLine)
+
+        // When
+        let storedShippingLine = try XCTUnwrap(storage.loadOrderShippingLine(siteID: sampleSiteID, shippingID: shippingID))
+
+        // Then
+        XCTAssertEqual(shippingLine, storedShippingLine)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -895,6 +895,35 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(itemTax, storedItemTax)
     }
+
+    func test_loadAllPaymentGateways_by_siteID() throws {
+        // Given
+        let gateway1 = storage.insertNewObject(ofType: PaymentGateway.self)
+        gateway1.siteID = sampleSiteID
+
+        let gateway2 = storage.insertNewObject(ofType: PaymentGateway.self)
+        gateway2.siteID = sampleSiteID
+
+        // When
+        let storedGateways = try XCTUnwrap(storage.loadAllPaymentGateways(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(Set([gateway1, gateway2]), Set(storedGateways))
+    }
+
+    func test_loadPaymentGateway_by_siteID_gatewayID() throws {
+        // Given
+        let gatewayID = "gateway"
+        let gateway = storage.insertNewObject(ofType: PaymentGateway.self)
+        gateway.siteID = sampleSiteID
+        gateway.gatewayID = gatewayID
+
+        // When
+        let storedGateway = try XCTUnwrap(storage.loadPaymentGateway(siteID: sampleSiteID, gatewayID: gatewayID))
+
+        // Then
+        XCTAssertEqual(gateway, storedGateway)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -794,6 +794,20 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(variation, storedVariation)
     }
+
+    func test_loadTaxClass_by_slug() throws {
+        // Given
+        let slug = "slug"
+        let taxClass = storage.insertNewObject(ofType: TaxClass.self)
+        taxClass.slug = slug
+
+        // When
+        let storedTaxClass = try XCTUnwrap(storage.loadTaxClass(slug: slug))
+
+        // Then
+        XCTAssertEqual(taxClass, storedTaxClass)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -76,4 +76,17 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(order, storedOrder)
     }
+
+    func test_loadOrderSearchResults_by_keyword() throws {
+        // Given
+        let keyword = "some-keyword"
+        let searchResult = storage.insertNewObject(ofType: OrderSearchResults.self)
+        searchResult.keyword = keyword
+
+        // When
+        let storedSearchResult = try XCTUnwrap(storage.loadOrderSearchResults(keyword: keyword))
+
+        // Then
+        XCTAssertEqual(searchResult, storedSearchResult)
+    }
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -277,6 +277,21 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(statsV4, storedStatsV4)
     }
 
+    func test_loadOrderStatsV4_by_interval_orderStats() throws {
+        // Given
+        let interval = "24-31"
+        let orderStats = storage.insertNewObject(ofType: OrderStatsV4.self)
+        let statsInterval = storage.insertNewObject(ofType: OrderStatsV4Interval.self)
+        statsInterval.interval = interval
+        statsInterval.stats = orderStats
+
+        // When
+        let storedStatsInterval = try XCTUnwrap(storage.loadOrderStatsInterval(interval: interval, orderStats: orderStats))
+
+        // Then
+        XCTAssertEqual(statsInterval, storedStatsInterval)
+    }
+
     func test_loadOrderStatuses_by_siteID() throws {
         // Given
         let status1 = storage.insertNewObject(ofType: OrderStatus.self)
@@ -972,20 +987,4 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(labelSettings, storedLabelSettings)
     }
-    /*
-    func test_load<#methodName#>_by_<#params#>() throws {
-        // Given
-        let <#param#>: Int64 = <#param#>
-        let <#param#>: Int64 = <#param#>
-        let <#entity#> = storage.insertNewObject(ofType: <#type#>.self)
-        <#entity#>.<#param#> = <#param#>
-        <#entity#>.<#param#> = <#param#>
-
-        // When
-        let stored<#entity#> = try XCTUnwrap(storage.<#loadMethod#>)
-
-        // Then
-        XCTAssertEqual(<#entity#>, stored<#entity#>)
-    }
-     */
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 class StorageTypeExtensionsTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 1234
+
     private var storageManager: StorageManagerType!
 
     private var storage: StorageType! {
@@ -59,5 +61,19 @@ class StorageTypeExtensionsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(site, storedSite)
+    }
+
+    func test_loadOrder_by_siteID_and_orderID() throws {
+        // Given
+        let orderID: Int64 = 123
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.orderID = orderID
+
+        // When
+        let storedOrder = try XCTUnwrap(storage.loadOrder(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual(order, storedOrder)
     }
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -291,6 +291,20 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual([status1, status2], storedStatuses)
     }
+
+    func test_loadOrderStatus_by_siteID_slug() throws {
+        // Given
+        let slug = "slug"
+        let status = storage.insertNewObject(ofType: OrderStatus.self)
+        status.siteID = sampleSiteID
+        status.slug = slug
+
+        // When
+        let storedStatus = try XCTUnwrap(storage.loadOrderStatus(siteID: sampleSiteID, slug: slug))
+
+        // Then
+        XCTAssertEqual(status, storedStatus)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -161,6 +161,23 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(feeLine, storedFeeLine)
     }
 
+    func test_loadOrderRefundCondensed_by_siteID_refundID() throws {
+        // Given
+        let refundID: Int64 = 123
+        let orderRefund = storage.insertNewObject(ofType: OrderRefundCondensed.self)
+        orderRefund.refundID = refundID
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.siteID = sampleSiteID
+        order.addToRefunds(orderRefund)
+
+        // When
+        let storedOrderRefund = try XCTUnwrap(storage.loadOrderRefundCondensed(siteID: sampleSiteID, refundID: refundID))
+
+        // Then
+        XCTAssertEqual(orderRefund, storedOrderRefund)
+    }
+
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -305,6 +305,53 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(status, storedStatus)
     }
+
+    func test_loadAllSiteSettings_by_siteID() throws {
+        // Given
+        let siteSetting1 = storage.insertNewObject(ofType: SiteSetting.self)
+        siteSetting1.siteID = sampleSiteID
+
+        let siteSetting2 = storage.insertNewObject(ofType: SiteSetting.self)
+        siteSetting2.siteID = sampleSiteID
+
+        // When
+        let storedSiteSettings = try XCTUnwrap(storage.loadAllSiteSettings(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual([siteSetting1, siteSetting2], storedSiteSettings)
+    }
+
+    func test_loadAllSiteSettings_by_siteID_groupKey() throws {
+        // Given
+        let groupKey = "group"
+        let siteSetting1 = storage.insertNewObject(ofType: SiteSetting.self)
+        siteSetting1.siteID = sampleSiteID
+        siteSetting1.settingGroupKey = groupKey
+
+        let siteSetting2 = storage.insertNewObject(ofType: SiteSetting.self)
+        siteSetting2.siteID = sampleSiteID
+        siteSetting2.settingGroupKey = groupKey
+
+        // When
+        let storedSiteSettings = try XCTUnwrap(storage.loadSiteSettings(siteID: sampleSiteID, settingGroupKey: groupKey))
+
+        // Then
+        XCTAssertEqual([siteSetting1, siteSetting2], storedSiteSettings)
+    }
+
+    func test_loadSiteSettings_by_siteID_settingID() throws {
+        // Given
+        let settingID = "123"
+        let siteSetting = storage.insertNewObject(ofType: SiteSetting.self)
+        siteSetting.siteID = sampleSiteID
+        siteSetting.settingID = settingID
+
+        // When
+        let storedSiteSetting = try XCTUnwrap(storage.loadSiteSetting(siteID: sampleSiteID, settingID: settingID))
+
+        // Then
+        XCTAssertEqual(siteSetting, storedSiteSetting)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -704,6 +704,35 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(Set([productTag1, productTag2]), Set(storedProductTags))
     }
+
+    func test_loadProductReviews_by_siteID() throws {
+        // Given
+        let productReview1 = storage.insertNewObject(ofType: ProductReview.self)
+        productReview1.siteID = sampleSiteID
+
+        let productReview2 = storage.insertNewObject(ofType: ProductReview.self)
+        productReview2.siteID = sampleSiteID
+
+        // When
+        let storedProductReviews = try XCTUnwrap(storage.loadProductReviews(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(Set([productReview1, productReview2]), Set(storedProductReviews))
+    }
+
+    func test_loadProductReviews_by_siteID_reviewID() throws {
+        // Given
+        let reviewID: Int64 = 123
+        let productReview = storage.insertNewObject(ofType: ProductReview.self)
+        productReview.siteID = sampleSiteID
+        productReview.reviewID = reviewID
+
+        // When
+        let storedProductReview = try XCTUnwrap(storage.loadProductReview(siteID: sampleSiteID, reviewID: reviewID))
+
+        // Then
+        XCTAssertEqual(productReview, storedProductReview)
+    }
     /*
     func test_load<#methodName#>_by_<#params#>() throws {
         // Given


### PR DESCRIPTION
part of #3465 

# Why 
In order to safely replace our stringly type predicates( p91TBi-3BJ-p2) with a type-safe version, I think it's more than required to unit test our current implementation to minimize the chance of regressions during the migration.

# How
This PR adds unit tests for all the methods on `StorageType+Extensions.swift` which are the methods where we will be replacing the old predicates.

# Testing Steps
- Take a look at the code and make sure the tests pass!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
