### PR TITLE
[UL&S] Match store address with wordpress.com account after login is completed and present error if necessary

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -40,8 +40,8 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 1.34.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-  pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/563-allow-shortcircuit-sync'
+  # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'
 

--- a/Podfile
+++ b/Podfile
@@ -38,7 +38,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.33.0'
+  pod 'WordPressAuthenticator', '~> 1.34.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile
+++ b/Podfile
@@ -38,7 +38,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.34.0-beta'
+  pod 'WordPressAuthenticator', '~> 1.33.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 1.34.0-beta'
+  pod 'WordPressAuthenticator', '~> 1.34.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/563-allow-shortcircuit-sync'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'

--- a/Podfile
+++ b/Podfile
@@ -38,10 +38,10 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.34.0-beta'
+  # pod 'WordPressAuthenticator', '~> 1.34.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-  # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+  pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.12'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.34.0-beta.1):
+  - WordPressAuthenticator (1.34.0-beta.2):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/563-allow-shortcircuit-sync`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -158,7 +158,13 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :path: "../WordPressAuthenticator-iOS"
+    :branch: issue/563-allow-shortcircuit-sync
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: cf8af893adeef7fd58e42b0dbb7db8febadacecc
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -185,7 +191,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 32b3fc31ff91c0d9e616d5f91c40f7a2294deac7
+  WordPressAuthenticator: e369a5a6ba8d92400c4672e005f6de054d3169c2
   WordPressKit: 1b61217cea9e7045ff74a9c8df391d7788776daf
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
@@ -201,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 0c10a2cb70f0c10b869dc5c9193f259186397a72
+PODFILE CHECKSUM: d042a1c1520cc733a33dc8011c97dbdccab5cde1
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.34.0-beta.2):
+  - WordPressAuthenticator (1.34.0-beta.1):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/563-allow-shortcircuit-sync`)
+  - WordPressAuthenticator (~> 1.34.0-beta)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -141,6 +141,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -155,16 +156,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: issue/563-allow-shortcircuit-sync
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: cf8af893adeef7fd58e42b0dbb7db8febadacecc
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -191,7 +182,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: e369a5a6ba8d92400c4672e005f6de054d3169c2
+  WordPressAuthenticator: 32b3fc31ff91c0d9e616d5f91c40f7a2294deac7
   WordPressKit: 1b61217cea9e7045ff74a9c8df391d7788776daf
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
@@ -207,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: d042a1c1520cc733a33dc8011c97dbdccab5cde1
+PODFILE CHECKSUM: 68967742aa99a2585d61cc4c38dcef68ca7cb36e
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.34.0-beta)
+  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -141,7 +141,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -156,6 +155,10 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :path: "../WordPressAuthenticator-iOS"
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -198,6 +201,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 68967742aa99a2585d61cc4c38dcef68ca7cb36e
+PODFILE CHECKSUM: 0c10a2cb70f0c10b869dc5c9193f259186397a72
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.34.0-beta.1):
+  - WordPressAuthenticator (1.33.0):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.34.0-beta)
+  - WordPressAuthenticator (~> 1.33.0)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -182,7 +182,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 32b3fc31ff91c0d9e616d5f91c40f7a2294deac7
+  WordPressAuthenticator: 2699e025994e127ffe2ec507fc7481f10b1df31c
   WordPressKit: 1b61217cea9e7045ff74a9c8df391d7788776daf
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 68967742aa99a2585d61cc4c38dcef68ca7cb36e
+PODFILE CHECKSUM: 1d313819231cf1538a961250f1b13313dc05f19e
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.33.0):
+  - WordPressAuthenticator (1.34.0-beta.1):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.24.0):
+  - WordPressKit (4.25.0-beta.3):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.33.0)
+  - WordPressAuthenticator (~> 1.34.0-beta)
   - WordPressShared (~> 1.12)
   - WordPressUI (~> 1.7.2)
   - Wormholy (~> 1.6.4)
@@ -182,8 +182,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 2699e025994e127ffe2ec507fc7481f10b1df31c
-  WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
+  WordPressAuthenticator: 32b3fc31ff91c0d9e616d5f91c40f7a2294deac7
+  WordPressKit: 1b61217cea9e7045ff74a9c8df391d7788776daf
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 1d313819231cf1538a961250f1b13313dc05f19e
+PODFILE CHECKSUM: 68967742aa99a2585d61cc4c38dcef68ca7cb36e
 
 COCOAPODS: 1.10.0

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -259,9 +259,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: credentials.wpcom?.siteURL))")
             let viewModel = WrongAccountErrorViewModel(siteURL: credentials.wpcom?.siteURL)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
-            navigationController.pushViewController(mismatchAccountUI, animated: true)
 
-            return
+            return navigationController.show(mismatchAccountUI, sender: nil)
         }
 
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -57,7 +57,6 @@ class AuthenticationManager: Authentication {
                                                 primaryTitleColor: .primaryButtonTitle,
                                                 secondaryTitleColor: systemLabelLightModeColor,
                                                 disabledTitleColor: .textSubtle,
-                                                disabledButtonActivityIndicatorColor: .textSubtle,
                                                 textButtonColor: .accent,
                                                 textButtonHighlightColor: .accentDark,
                                                 instructionColor: .textSubtle,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -57,6 +57,7 @@ class AuthenticationManager: Authentication {
                                                 primaryTitleColor: .primaryButtonTitle,
                                                 secondaryTitleColor: systemLabelLightModeColor,
                                                 disabledTitleColor: .textSubtle,
+                                                disabledButtonActivityIndicatorColor: .textSubtle,
                                                 textButtonColor: .accent,
                                                 textButtonHighlightColor: .accentDark,
                                                 instructionColor: .textSubtle,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -258,7 +258,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         guard let siteURL = credentials.wpcom?.siteURL, matcher.match(originalURL: siteURL) else {
             //fatalError("Self Hosted sites are not supported. Please review the Authenticator settings!")
-            print("presenting error")
+            DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: credentials.wpcom?.siteURL))")
             let viewModel = WrongAccountErrorViewModel(siteURL: credentials.wpcom?.siteURL)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
             navigationController.pushViewController(mismatchAccountUI, animated: true)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -256,7 +256,6 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let matcher = ULAccountMatcher()
 
         guard let siteURL = credentials.wpcom?.siteURL, matcher.match(originalURL: siteURL) else {
-            //fatalError("Self Hosted sites are not supported. Please review the Authenticator settings!")
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: credentials.wpcom?.siteURL))")
             let viewModel = WrongAccountErrorViewModel(siteURL: credentials.wpcom?.siteURL)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -331,9 +331,13 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         let closure: () -> Void = {
             let match = matcher.match(originalURL: wpcom.siteURL)
-            print("==== it's a match", match)
-            print("==== stop")
-            onCompletion()
+
+            if match {
+                onCompletion()
+            } else {
+                print("stopping and showing an error")
+                print("=== end . log out")
+            }
         }
 
         ServiceLocator.stores.authenticate(credentials: .init(authToken: wpcom.authToken))

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -327,15 +327,24 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
         appleUserID = nil
 
+        let matcher = ULAccountMatcher()
+
+        let closure: () -> Void = {
+            let match = matcher.match(originalURL: wpcom.siteURL)
+            print("==== it's a match", match)
+            print("==== stop")
+            onCompletion()
+        }
+
         ServiceLocator.stores.authenticate(credentials: .init(authToken: wpcom.authToken))
         let action = AccountAction.synchronizeAccount { (account, error) in
             if let account = account {
                 let credentials = Credentials(username: account.username, authToken: wpcom.authToken, siteAddress: wpcom.siteURL)
                 ServiceLocator.stores
                     .authenticate(credentials: credentials)
-                    .synchronizeEntities(onCompletion: onCompletion)
+                    .synchronizeEntities(onCompletion: closure)
             } else {
-                ServiceLocator.stores.synchronizeEntities(onCompletion: onCompletion)
+                ServiceLocator.stores.synchronizeEntities(onCompletion: closure)
             }
         }
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -38,6 +38,10 @@ enum StorePickerConfiguration {
     /// Setup the store picker for use as a basic modal in app
     ///
     case standard
+
+    /// Setup the store picker for use as list of stores
+    ///
+    case listStores
 }
 
 
@@ -157,6 +161,8 @@ class StorePickerViewController: UIViewController {
             startListeningToNotifications()
         case .switchingStores:
             secondaryActionButton.isHidden = true
+        case .listStores:
+            hideActionButtons()
         default:
             break
         }
@@ -207,7 +213,7 @@ private extension StorePickerViewController {
             guard let self = self else {
                 return
             }
-            ServiceLocator.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin)
+            self.presentHelp()
         }
     }
 
@@ -220,6 +226,15 @@ private extension StorePickerViewController {
                                                            action: #selector(cleanupAndDismiss))
     }
 
+    func setupNavigationForListOfConnectedStores() {
+        title = NSLocalizedString("Connected Stores", comment: "Page title for the list of connected stores")
+    }
+
+    func hideActionButtons() {
+        actionButton.isHidden = true
+        secondaryActionButton.isHidden = true
+    }
+
     func setupViewForCurrentConfiguration() {
         guard isViewLoaded else {
             return
@@ -228,6 +243,9 @@ private extension StorePickerViewController {
         switch configuration {
         case .switchingStores:
             setupNavigation()
+        case .listStores:
+            hideActionButtons()
+            setupNavigationForListOfConnectedStores()
         default:
             navigationController?.setNavigationBarHidden(true, animated: true)
         }
@@ -246,6 +264,10 @@ private extension StorePickerViewController {
 
     func backgroundColor() -> UIColor {
         return WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor ?? .listBackground
+    }
+
+    func presentHelp() {
+        ServiceLocator.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin)
     }
 }
 
@@ -290,6 +312,10 @@ private extension StorePickerViewController {
     /// Sets the first available Store as the default one. If possible!
     ///
     func preselectStoreIfPossible() {
+        guard configuration != .listStores else {
+            return
+        }
+
         guard case let .available(sites) = state, let firstSite = sites.first else {
             return
         }
@@ -588,7 +614,7 @@ extension StorePickerViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        guard state.multipleStoresAvailable else {
+        guard state.multipleStoresAvailable && configuration != .listStores else {
             // If we only have a single store available, don't allow the row to be selected
             return false
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -576,6 +576,10 @@ extension StorePickerViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard configuration != .listStores else {
+            return nil
+        }
+
         return state.headerTitle?.uppercased()
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -21,6 +21,7 @@ final class ULAccountMismatchViewController: UIViewController {
     @IBOutlet private weak var userNameLabel: UILabel!
     @IBOutlet private weak var singedInAsLabel: UILabel!
     @IBOutlet private weak var wrongAccountLabel: UILabel!
+    @IBOutlet private weak var logOutButton: UIButton!
     @IBOutlet private weak var primaryButton: NUXButton!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
@@ -79,6 +80,7 @@ private extension ULAccountMismatchViewController {
         configureUserNameLabel()
         configureSignedInAsLabel()
         configureWrongAccountLabel()
+        configureLogOutButton()
     }
 
     func configureGravatar() {
@@ -98,6 +100,14 @@ private extension ULAccountMismatchViewController {
     func configureWrongAccountLabel() {
         wrongAccountLabel.applySecondaryBodyStyle()
         wrongAccountLabel.text = viewModel.logOutTitle
+    }
+
+    func configureLogOutButton() {
+        logOutButton.applyLinkButtonStyle()
+        logOutButton.setTitle(viewModel.logOutButtonTitle, for: .normal)
+        logOutButton.on(.touchUpInside) { [weak self] _ in
+            self?.didTapLogOutButton()
+        }
     }
 
     func configureImageView() {
@@ -167,6 +177,10 @@ private extension ULAccountMismatchViewController {
 
     func didTapPrimaryButton() {
         viewModel.didTapPrimaryButton(in: self)
+    }
+
+    func didTapLogOutButton() {
+        viewModel.didTapLogOutButton(in: self)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -19,6 +19,8 @@ final class ULAccountMismatchViewController: UIViewController {
 
     @IBOutlet private weak var gravatarImageView: CircularImageView!
     @IBOutlet private weak var userNameLabel: UILabel!
+    @IBOutlet private weak var singedInAsLabel: UILabel!
+    @IBOutlet private weak var wrongAccountLabel: UILabel!
     @IBOutlet private weak var primaryButton: NUXButton!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
@@ -75,8 +77,10 @@ private extension ULAccountMismatchViewController {
     func configureAccountHeader() {
 //        accountHeaderView.username = "@" + defaultAccount.username
 //        accountHeaderView.fullname = defaultAccount.displayName
-        userNameLabel.text = viewModel.userName
         gravatarImageView.downloadGravatarWithEmail(viewModel.userEmail)
+        userNameLabel.text = viewModel.userName
+        singedInAsLabel.text = viewModel.signedInText
+        wrongAccountLabel.text = viewModel.logOutTitle
     }
 
     func configureImageView() {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -75,11 +75,28 @@ final class ULAccountMismatchViewController: UIViewController {
 // MARK: - View configuration
 private extension ULAccountMismatchViewController {
     func configureAccountHeader() {
-//        accountHeaderView.username = "@" + defaultAccount.username
-//        accountHeaderView.fullname = defaultAccount.displayName
+        configureGravatar()
+        configureUserNameLabel()
+        configureSignedInAsLabel()
+        configureWrongAccountLabel()
+    }
+
+    func configureGravatar() {
         gravatarImageView.downloadGravatarWithEmail(viewModel.userEmail)
+    }
+
+    func configureUserNameLabel() {
+        userNameLabel.applyBodyStyle()
         userNameLabel.text = viewModel.userName
+    }
+
+    func configureSignedInAsLabel() {
+        singedInAsLabel.applyFootnoteStyle()
         singedInAsLabel.text = viewModel.signedInText
+    }
+
+    func configureWrongAccountLabel() {
+        wrongAccountLabel.applyFootnoteStyle()
         wrongAccountLabel.text = viewModel.logOutTitle
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -91,12 +91,12 @@ private extension ULAccountMismatchViewController {
     }
 
     func configureSignedInAsLabel() {
-        singedInAsLabel.applyFootnoteStyle()
+        singedInAsLabel.applySecondaryBodyStyle()
         singedInAsLabel.text = viewModel.signedInText
     }
 
     func configureWrongAccountLabel() {
-        wrongAccountLabel.applyFootnoteStyle()
+        wrongAccountLabel.applySecondaryBodyStyle()
         wrongAccountLabel.text = viewModel.logOutTitle
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -105,6 +105,7 @@ private extension ULAccountMismatchViewController {
     func configureLogOutButton() {
         logOutButton.applyLinkButtonStyle()
         logOutButton.setTitle(viewModel.logOutButtonTitle, for: .normal)
+        logOutButton.contentEdgeInsets = .zero
         logOutButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapLogOutButton()
         }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -18,6 +18,7 @@ final class ULAccountMismatchViewController: UIViewController {
     }()
 
     @IBOutlet private weak var gravatarImageView: CircularImageView!
+    @IBOutlet private weak var userNameLabel: UILabel!
     @IBOutlet private weak var primaryButton: NUXButton!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
@@ -74,6 +75,7 @@ private extension ULAccountMismatchViewController {
     func configureAccountHeader() {
 //        accountHeaderView.username = "@" + defaultAccount.username
 //        accountHeaderView.fullname = defaultAccount.displayName
+        userNameLabel.text = viewModel.userName
         gravatarImageView.downloadGravatarWithEmail(viewModel.userEmail)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -198,7 +198,7 @@ extension ULAccountMismatchViewController {
         return imageView
     }
 
-    func getLabel() -> UILabel {
+    func getMessage() -> UILabel {
         return errorMessage
     }
 
@@ -206,7 +206,23 @@ extension ULAccountMismatchViewController {
         return extraInfoButton
     }
 
-    func primaryActionButton() -> UIButton {
+    func getLogOutButton() -> UIButton {
+        return logOutButton
+    }
+
+    func getPrimaryActionButton() -> UIButton {
         return primaryButton
+    }
+
+    func getUserNameLabel() -> UILabel {
+        return userNameLabel
+    }
+
+    func getSingedInAsLabel() -> UILabel {
+        return singedInAsLabel
+    }
+
+    func getWrongAccountLabel() -> UILabel {
+        return wrongAccountLabel
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -9,7 +9,7 @@ import SafariServices
 final class ULAccountMismatchViewController: UIViewController {
     /// The view model providing configuration for this view controller
     /// and support for user actions
-    private let viewModel: ULErrorViewModel
+    private let viewModel: ULAccountMismatchViewModel
 
     /// Header View: Displays all of the Account Details
     ///
@@ -17,9 +17,8 @@ final class ULAccountMismatchViewController: UIViewController {
         return AccountHeaderView.instantiateFromNib()
     }()
 
-    @IBOutlet private weak var stackView: UIStackView!
+    @IBOutlet private weak var gravatarImageView: CircularImageView!
     @IBOutlet private weak var primaryButton: NUXButton!
-    @IBOutlet private weak var secondaryButton: NUXButton!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
     @IBOutlet private weak var extraInfoButton: UIButton!
@@ -36,7 +35,7 @@ final class ULAccountMismatchViewController: UIViewController {
         UIDevice.isPad() ? .all : .portrait
     }
 
-    init(viewModel: ULErrorViewModel) {
+    init(viewModel: ULAccountMismatchViewModel) {
         self.viewModel = viewModel
         super.init(nibName: Self.nibName, bundle: nil)
     }
@@ -54,7 +53,6 @@ final class ULAccountMismatchViewController: UIViewController {
         configureExtraInfoButton()
 
         configurePrimaryButton()
-        configureSecondaryButton()
 
         setUnifiedMargins(forWidth: view.frame.width)
     }
@@ -74,14 +72,9 @@ final class ULAccountMismatchViewController: UIViewController {
 // MARK: - View configuration
 private extension ULAccountMismatchViewController {
     func configureAccountHeader() {
-        guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
-            return
-        }
-
-        stackView.insertArrangedSubview(accountHeaderView, at: 0)
-        accountHeaderView.username = "@" + defaultAccount.username
-        accountHeaderView.fullname = defaultAccount.displayName
-        accountHeaderView.downloadGravatar(with: defaultAccount.email)
+//        accountHeaderView.username = "@" + defaultAccount.username
+//        accountHeaderView.fullname = defaultAccount.displayName
+        gravatarImageView.downloadGravatarWithEmail(viewModel.userEmail)
     }
 
     func configureImageView() {
@@ -94,12 +87,6 @@ private extension ULAccountMismatchViewController {
     }
 
     func configureExtraInfoButton() {
-        guard viewModel.isAuxiliaryButtonHidden == false else {
-            extraInfoButton.isHidden = true
-
-            return
-        }
-
         extraInfoButton.applyLinkButtonStyle()
         extraInfoButton.contentEdgeInsets = Constants.extraInfoCustomInsets
         extraInfoButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
@@ -113,13 +100,6 @@ private extension ULAccountMismatchViewController {
         primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapPrimaryButton()
-        }
-    }
-
-    func configureSecondaryButton() {
-        secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
-        secondaryButton.on(.touchUpInside) { [weak self] _ in
-            self?.didTapSecondaryButton()
         }
     }
 
@@ -165,10 +145,6 @@ private extension ULAccountMismatchViewController {
     func didTapPrimaryButton() {
         viewModel.didTapPrimaryButton(in: self)
     }
-
-    func didTapSecondaryButton() {
-        viewModel.didTapSecondaryButton(in: self)
-    }
 }
 
 
@@ -195,9 +171,5 @@ extension ULAccountMismatchViewController {
 
     func primaryActionButton() -> UIButton {
         return primaryButton
-    }
-
-    func secondaryActionButton() -> UIButton {
-        return secondaryButton
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -1,0 +1,203 @@
+import UIKit
+import WordPressAuthenticator
+import SafariServices
+
+
+/// UI presenting errors in the Unified Login flow.
+/// This view controller can either be presented from within WooCommerce
+/// or be injected into WordPressAuthenticator.
+final class ULAccountMismatchViewController: UIViewController {
+    /// The view model providing configuration for this view controller
+    /// and support for user actions
+    private let viewModel: ULErrorViewModel
+
+    /// Header View: Displays all of the Account Details
+    ///
+    private let accountHeaderView: AccountHeaderView = {
+        return AccountHeaderView.instantiateFromNib()
+    }()
+
+    @IBOutlet private weak var stackView: UIStackView!
+    @IBOutlet private weak var primaryButton: NUXButton!
+    @IBOutlet private weak var secondaryButton: NUXButton!
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var errorMessage: UILabel!
+    @IBOutlet private weak var extraInfoButton: UIButton!
+
+    /// Constraints on the view containing the action buttons
+    /// and the stack view containing the image and error text
+    /// Used to adjust the button width in unified views provided by WPAuthenticator
+    @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var stackViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var stackViewTrailingConstraint: NSLayoutConstraint!
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        UIDevice.isPad() ? .all : .portrait
+    }
+
+    init(viewModel: ULErrorViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: Self.nibName, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureAccountHeader()
+        configureImageView()
+        configureErrorMessage()
+        configureExtraInfoButton()
+
+        configurePrimaryButton()
+        configureSecondaryButton()
+
+        setUnifiedMargins(forWidth: view.frame.width)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setUnifiedMargins(forWidth: view.frame.width)
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        setUnifiedMargins(forWidth: size.width)
+    }
+}
+
+
+// MARK: - View configuration
+private extension ULAccountMismatchViewController {
+    func configureAccountHeader() {
+        guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
+            return
+        }
+
+        stackView.insertArrangedSubview(accountHeaderView, at: 0)
+        accountHeaderView.username = "@" + defaultAccount.username
+        accountHeaderView.fullname = defaultAccount.displayName
+        accountHeaderView.downloadGravatar(with: defaultAccount.email)
+    }
+
+    func configureImageView() {
+        imageView.image = viewModel.image
+    }
+
+    func configureErrorMessage() {
+        errorMessage.applyBodyStyle()
+        errorMessage.attributedText = viewModel.text
+    }
+
+    func configureExtraInfoButton() {
+        guard viewModel.isAuxiliaryButtonHidden == false else {
+            extraInfoButton.isHidden = true
+
+            return
+        }
+
+        extraInfoButton.applyLinkButtonStyle()
+        extraInfoButton.contentEdgeInsets = Constants.extraInfoCustomInsets
+        extraInfoButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
+        extraInfoButton.on(.touchUpInside) { [weak self] _ in
+            self?.didTapAuxiliaryButton()
+        }
+    }
+
+    func configurePrimaryButton() {
+        primaryButton.isPrimary = true
+        primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
+        primaryButton.on(.touchUpInside) { [weak self] _ in
+            self?.didTapPrimaryButton()
+        }
+    }
+
+    func configureSecondaryButton() {
+        secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
+        secondaryButton.on(.touchUpInside) { [weak self] _ in
+            self?.didTapSecondaryButton()
+        }
+    }
+
+
+    /// This logic is lifted from WPAuthenticator's LoginPrologueViewController
+    /// This View Controller will be provided to WPAuthenticator. WPAuthenticator
+    /// will insert it into its own navigation stack, where it is applying a similar logic
+    func setUnifiedMargins(forWidth viewWidth: CGFloat) {
+        guard traitCollection.horizontalSizeClass == .regular &&
+                traitCollection.verticalSizeClass == .regular else {
+            buttonViewLeadingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
+            buttonViewTrailingConstraint?.constant = ButtonViewMarginMultipliers.defaultButtonViewMargin
+            return
+        }
+
+        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
+            ButtonViewMarginMultipliers.ipadLandscape :
+            ButtonViewMarginMultipliers.ipadPortrait
+
+        let margin = viewWidth * marginMultiplier
+
+        buttonViewLeadingConstraint?.constant = margin
+        buttonViewTrailingConstraint?.constant = margin
+
+        stackViewLeadingConstraint?.constant = margin
+        stackViewTrailingConstraint?.constant = margin
+    }
+
+    private enum ButtonViewMarginMultipliers {
+        static let ipadPortrait: CGFloat = 0.1667
+        static let ipadLandscape: CGFloat = 0.25
+        static let defaultButtonViewMargin: CGFloat = 0.0
+    }
+}
+
+
+// MARK: - Actions
+private extension ULAccountMismatchViewController {
+    func didTapAuxiliaryButton() {
+        viewModel.didTapAuxiliaryButton(in: self)
+    }
+
+    func didTapPrimaryButton() {
+        viewModel.didTapPrimaryButton(in: self)
+    }
+
+    func didTapSecondaryButton() {
+        viewModel.didTapSecondaryButton(in: self)
+    }
+}
+
+
+// MARK: - Constants
+private extension ULAccountMismatchViewController {
+    enum Constants {
+        static let extraInfoCustomInsets = UIEdgeInsets(top: 12, left: 10, bottom: 12, right: 10)
+    }
+}
+
+// MARK: - Tests
+extension ULAccountMismatchViewController {
+    func getImageView() -> UIImageView {
+        return imageView
+    }
+
+    func getLabel() -> UILabel {
+        return errorMessage
+    }
+
+    func getAuxiliaryButton() -> UIButton {
+        return extraInfoButton
+    }
+
+    func primaryActionButton() -> UIButton {
+        return primaryButton
+    }
+
+    func secondaryActionButton() -> UIButton {
+        return secondaryButton
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -20,6 +20,7 @@
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
                 <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
                 <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
+                <outlet property="userNameLabel" destination="iWC-nR-Ao9" id="ooC-C0-xay"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -18,10 +18,12 @@
                 <outlet property="gravatarImageView" destination="Np4-PU-IRZ" id="WK3-f5-Ye2"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
+                <outlet property="singedInAsLabel" destination="emS-Tp-OXA" id="ajb-UO-YDy"/>
                 <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
                 <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
                 <outlet property="userNameLabel" destination="iWC-nR-Ao9" id="ooC-C0-xay"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="wrongAccountLabel" destination="gb2-Fe-8kd" id="ikk-a9-gTF"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -59,7 +61,7 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="169.5" width="346" height="527.5"/>
+                    <rect key="frame" x="34" y="143" width="346" height="580"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Np4-PU-IRZ" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="143" y="0.0" width="60" height="60"/>
@@ -80,18 +82,24 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
+                            <rect key="frame" x="152.5" y="197" width="41.5" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="197" width="281" height="150"/>
+                            <rect key="frame" x="32.5" y="249.5" width="281" height="150"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="379" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="431.5" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="497.5" width="228" height="30"/>
+                            <rect key="frame" x="59" y="550" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ULAccountMismatchViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="buttonViewLeadingConstraint" destination="r9Z-y5-j3W" id="bWb-vV-0U2"/>
+                <outlet property="buttonViewTrailingConstraint" destination="3Fe-tr-bmb" id="DjF-95-KFx"/>
+                <outlet property="errorMessage" destination="a2d-le-aKc" id="YgT-Ex-Gwh"/>
+                <outlet property="extraInfoButton" destination="GOR-hg-dbC" id="I7z-hN-FAo"/>
+                <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
+                <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
+                <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
+                <outlet property="stackView" destination="jIt-xb-rrN" id="jjG-wS-OoH"/>
+                <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
+                <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
+                    <rect key="frame" x="0.0" y="702" width="414" height="160"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
+                            <rect key="frame" x="20" y="20" width="374" height="120"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="Gcd-Af-CS9"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                    <state key="normal" title="Primary Action Button">
+                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                    </userDefinedRuntimeAttributes>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                    <rect key="frame" x="0.0" y="70" width="374" height="50"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="ju1-aE-m26"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                    <state key="normal" title="Secondary Action Button">
+                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                    </userDefinedRuntimeAttributes>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="mhI-fa-Yzw" secondAttribute="trailing" constant="20" id="8gH-vs-D9H"/>
+                        <constraint firstAttribute="bottomMargin" secondItem="mhI-fa-Yzw" secondAttribute="bottom" constant="12" id="PGb-Bi-220"/>
+                        <constraint firstItem="mhI-fa-Yzw" firstAttribute="top" secondItem="10Z-y1-ZQ6" secondAttribute="top" constant="20" id="elI-Eo-HER"/>
+                        <constraint firstItem="mhI-fa-Yzw" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" constant="20" id="vz3-FU-z4g"/>
+                    </constraints>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
+                    <rect key="frame" x="34" y="268" width="346" height="330.5"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
+                            <rect key="frame" x="32.5" y="0.0" width="281" height="150"/>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
+                            <rect key="frame" x="0.0" y="182" width="346" height="86.5"/>
+                            <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <color key="textColor" systemColor="secondaryLabelColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
+                            <rect key="frame" x="59" y="300.5" width="228" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
+                            </constraints>
+                            <state key="normal" title="Action Button"/>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="3Fe-tr-bmb"/>
+                <constraint firstItem="jIt-xb-rrN" firstAttribute="top" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="4vu-ll-3S2"/>
+                <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="34" id="Z7E-hC-lbB"/>
+                <constraint firstItem="jIt-xb-rrN" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" constant="-20" id="ZZg-jd-e4d"/>
+                <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="34" id="jMe-jj-6Bt"/>
+                <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="r9Z-y5-j3W"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="10Z-y1-ZQ6" secondAttribute="bottom" id="rPP-rT-zVR"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="86.383928571428569"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="woo-no-jetpack-error" width="281" height="150"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -61,7 +61,7 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="143" width="346" height="580"/>
+                    <rect key="frame" x="34" y="167" width="346" height="532"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Np4-PU-IRZ" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="143" y="0.0" width="60" height="60"/>
@@ -70,36 +70,41 @@
                                 <constraint firstAttribute="height" constant="60" id="hAK-uZ-REW"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iWC-nR-Ao9">
-                            <rect key="frame" x="152.5" y="92" width="41.5" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emS-Tp-OXA">
-                            <rect key="frame" x="152.5" y="144.5" width="41.5" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
-                            <rect key="frame" x="152.5" y="197" width="41.5" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hKL-EJ-A3J">
+                            <rect key="frame" x="152.5" y="92" width="41.5" height="77.5"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iWC-nR-Ao9">
+                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emS-Tp-OXA">
+                                    <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
+                                    <rect key="frame" x="0.0" y="57" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="249.5" width="281" height="150"/>
+                            <rect key="frame" x="32.5" y="201.5" width="281" height="150"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="431.5" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="383.5" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="550" width="228" height="30"/>
+                            <rect key="frame" x="59" y="502" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -17,6 +17,7 @@
                 <outlet property="extraInfoButton" destination="GOR-hg-dbC" id="I7z-hN-FAo"/>
                 <outlet property="gravatarImageView" destination="Np4-PU-IRZ" id="WK3-f5-Ye2"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
+                <outlet property="logOutButton" destination="s2i-wr-qJf" id="yxc-ia-1rX"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
                 <outlet property="singedInAsLabel" destination="emS-Tp-OXA" id="ajb-UO-YDy"/>
                 <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
@@ -61,7 +62,7 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="167" width="346" height="532"/>
+                    <rect key="frame" x="34" y="166.5" width="346" height="533"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Np4-PU-IRZ" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="143" y="0.0" width="60" height="60"/>
@@ -70,41 +71,50 @@
                                 <constraint firstAttribute="height" constant="60" id="hAK-uZ-REW"/>
                             </constraints>
                         </imageView>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hKL-EJ-A3J">
-                            <rect key="frame" x="152.5" y="92" width="41.5" height="77.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="hKL-EJ-A3J">
+                            <rect key="frame" x="129.5" y="92" width="87.5" height="78.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iWC-nR-Ao9">
-                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="23" y="0.0" width="41.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emS-Tp-OXA">
-                                    <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="23" y="26.5" width="41.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
-                                    <rect key="frame" x="0.0" y="57" width="41.5" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" alignment="firstBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="Hqt-oI-j1i">
+                                    <rect key="frame" x="0.0" y="53" width="87.5" height="25.5"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
+                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s2i-wr-qJf">
+                                            <rect key="frame" x="41.5" y="-4.5" width="46" height="30"/>
+                                            <state key="normal" title="Button"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
                             </subviews>
                         </stackView>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="201.5" width="281" height="150"/>
+                            <rect key="frame" x="32.5" y="202.5" width="281" height="150"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="383.5" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="384.5" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="502" width="228" height="30"/>
+                            <rect key="frame" x="59" y="503" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -15,10 +15,9 @@
                 <outlet property="buttonViewTrailingConstraint" destination="3Fe-tr-bmb" id="DjF-95-KFx"/>
                 <outlet property="errorMessage" destination="a2d-le-aKc" id="YgT-Ex-Gwh"/>
                 <outlet property="extraInfoButton" destination="GOR-hg-dbC" id="I7z-hN-FAo"/>
+                <outlet property="gravatarImageView" destination="Np4-PU-IRZ" id="WK3-f5-Ye2"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
-                <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
-                <outlet property="stackView" destination="jIt-xb-rrN" id="jjG-wS-OoH"/>
                 <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
                 <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -30,10 +29,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                    <rect key="frame" x="0.0" y="702" width="414" height="160"/>
+                    <rect key="frame" x="0.0" y="772" width="414" height="90"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                            <rect key="frame" x="20" y="20" width="374" height="120"/>
+                            <rect key="frame" x="20" y="20" width="374" height="50"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
                                     <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
@@ -48,19 +47,6 @@
                                         <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                                     </userDefinedRuntimeAttributes>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                    <rect key="frame" x="0.0" y="70" width="374" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="ju1-aE-m26"/>
-                                    </constraints>
-                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                                    <state key="normal" title="Secondary Action Button">
-                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                    </userDefinedRuntimeAttributes>
-                                </button>
                             </subviews>
                         </stackView>
                     </subviews>
@@ -72,20 +58,39 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="268" width="346" height="330.5"/>
+                    <rect key="frame" x="34" y="169.5" width="346" height="527.5"/>
                     <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Np4-PU-IRZ" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
+                            <rect key="frame" x="143" y="0.0" width="60" height="60"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="60" id="eVb-vV-gev"/>
+                                <constraint firstAttribute="height" constant="60" id="hAK-uZ-REW"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iWC-nR-Ao9">
+                            <rect key="frame" x="152.5" y="92" width="41.5" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emS-Tp-OXA">
+                            <rect key="frame" x="152.5" y="144.5" width="41.5" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="0.0" width="281" height="150"/>
+                            <rect key="frame" x="32.5" y="197" width="281" height="150"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="182" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="379" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="300.5" width="228" height="30"/>
+                            <rect key="frame" x="59" y="497.5" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -72,22 +72,22 @@
                             </constraints>
                         </imageView>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="hKL-EJ-A3J">
-                            <rect key="frame" x="129.5" y="92" width="87.5" height="78.5"/>
+                            <rect key="frame" x="126.5" y="92" width="93.5" height="78.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iWC-nR-Ao9">
-                                    <rect key="frame" x="23" y="0.0" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="26" y="0.0" width="41.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emS-Tp-OXA">
-                                    <rect key="frame" x="23" y="26.5" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="26" y="26.5" width="41.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" alignment="firstBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="Hqt-oI-j1i">
-                                    <rect key="frame" x="0.0" y="53" width="87.5" height="25.5"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" alignment="firstBaseline" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Hqt-oI-j1i">
+                                    <rect key="frame" x="0.0" y="53" width="93.5" height="25.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gb2-Fe-8kd">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -96,7 +96,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s2i-wr-qJf">
-                                            <rect key="frame" x="41.5" y="-4.5" width="46" height="30"/>
+                                            <rect key="frame" x="47.5" y="-4.5" width="46" height="30"/>
                                             <state key="normal" title="Button"/>
                                         </button>
                                     </subviews>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
@@ -27,6 +27,9 @@ protocol ULAccountMismatchViewModel {
     /// Provides a title for a primary action button
     var primaryButtonTitle: String { get }
 
+    /// Provides the title for the logout button
+    var logOutButtonTitle: String { get }
+
     /// Executes action associated to a tap in the view controller log out button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapLogOutButton(in viewController: UIViewController?)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// Abstracts different configurations and logic related to user interaction
+/// for error view controllers presented as part of the Unified Login flow
+protocol ULAccountMismatchViewModel {
+    /// The logged in user's email
+    var userEmail: String { get }
+
+    /// The logged in user's username
+    var userName: String { get }
+
+    /// The logged in user's display name
+    var displayName: String { get }
+    
+    /// An illustration accompanying the error
+    var image: UIImage { get }
+
+    /// Extended description of the error.
+    var text: NSAttributedString { get }
+
+    /// Provides the title for an auxiliary button
+    var auxiliaryButtonTitle: String { get }
+
+    /// Provides a title for a primary action button
+    var primaryButtonTitle: String { get }
+
+    /// Executes action associated to a tap in the view controller log out button
+    /// - Parameter viewController: usually the view controller sending the tap
+    func didTapLogOutButton(in viewController: UIViewController?)
+
+    /// Executes action associated to a tap in the view controller primary button
+    /// - Parameter viewController: usually the view controller sending the tap
+    func didTapPrimaryButton(in viewController: UIViewController?)
+
+    /// Executes action associated to a tap in the view controller auxiliary button
+    /// - Parameter viewController: usually the view controller sending the tap
+    func didTapAuxiliaryButton(in viewController: UIViewController?)
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
@@ -9,9 +9,12 @@ protocol ULAccountMismatchViewModel {
     /// The logged in user's username
     var userName: String { get }
 
-    /// The logged in user's display name
-    var displayName: String { get }
-    
+    /// Text pointing out the logged in user's username
+    var signedInText: String { get }
+
+    /// Text offering log out
+    var logOutTitle: String { get }
+
     /// An illustration accompanying the error
     var image: UIImage { get }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -35,15 +35,18 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         return account.username
     }
 
-    var displayName: String {
+    var signedInText: String {
         guard let account = defaultAccount else {
             DDLogWarn("⚠️ Present account mismatch UI for \(siteURL) without a default display account")
 
             return ""
         }
 
-        return account.displayName
+        return String.localizedStringWithFormat(Localization.signedInMessageFormat,
+                                                account.displayName)
     }
+
+    let logOutTitle: String = "Wrong account? Log Out"
 
     let image: UIImage = .errorImage
 
@@ -65,8 +68,6 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     let auxiliaryButtonTitle = Localization.findYourConnectedEmail
 
     let primaryButtonTitle = Localization.primaryButtonTitle
-
-    let secondaryButtonTitle = Localization.secondaryButtonTitle
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -97,6 +98,11 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 // MARK: - Private data structures
 private extension WrongAccountErrorViewModel {
     enum Localization {
+        static let signedInMessageFormat = NSLocalizedString("Signed in as @%1$@",
+                                                             comment: "Message describing the account a user has signed in to."
+                                                                + "Reads as: Signed is as @{username}"
+                                                                + "Parameters: %1$@ - user name")
+
         static let errorMessage = NSLocalizedString("It looks like %@ is connected to a different account.",
                                                     comment: "Message explaining that the site entered and the acount logged into do not match. "
                                                         + "Reads like 'It looks like awebsite.com is connected to a different account")
@@ -108,10 +114,6 @@ private extension WrongAccountErrorViewModel {
         static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
                                                           comment: "Action button linking to a list of connected stores."
                                                           + "Presented when logging in with a site address that does not have a valid Jetpack installation")
-
-        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
-                                                            comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
         static let yourSite = NSLocalizedString("your site",
                                                 comment: "Placeholder for site url, if the url is unknown."

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -71,13 +71,14 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        guard let url = URL(string: Strings.instructionsURLString) else {
+        guard let navigationController = viewController?.navigationController else {
             return
         }
 
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        viewController?.present(safariViewController, animated: true)
+        let storePicker = StorePickerViewController()
+        storePicker.configuration = .login
+        //storePickerCoordinator?.onDismiss = onDismiss
+        navigationController.pushViewController(storePicker, animated: true)
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -46,9 +46,9 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
                                                 account.username)
     }
 
-    let logOutTitle: String = "Wrong account?"
+    let logOutTitle: String = Localization.wrongAccountMessage
 
-    let logOutButtonTitle: String = "Log Out"
+    let logOutButtonTitle: String = Localization.logOutButtonTitle
 
     let image: UIImage = .errorImage
 
@@ -114,14 +114,21 @@ private extension WrongAccountErrorViewModel {
                                                      comment: "Button linking to webview explaining how to find your connected email"
                                                         + "Presented when logging in with a store address that does not match the account entered")
 
+        static let logOutButtonTitle = NSLocalizedString("Log Out",
+                                                          comment: "Action button triggering a Log Out."
+                                                          + "Presented when logging in with a store address that does not match the account entered")
+
         static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
                                                           comment: "Action button linking to a list of connected stores."
-                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                          + "Presented when logging in with a store address that does not match the account entered")
 
         static let yourSite = NSLocalizedString("your site",
                                                 comment: "Placeholder for site url, if the url is unknown."
-                                                    + "Presented when logging in with a site address that does not have a valid Jetpack installation."
-                                                + "The error would read: to use this app for your site you'll need...")
+                                                    + "Presented when logging in with a store address that does not match the account entered.")
+
+        static let wrongAccountMessage = NSLocalizedString("Wrong account?",
+                                                           comment: "Prompt asking users if the logged in to the wrong account."
+                                                               + "Presented when logging in with a store address that does not match the account entered.")
 
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -1,0 +1,94 @@
+import UIKit
+import SafariServices
+import WordPressAuthenticator
+import WordPressUI
+
+
+/// Configuration and actions for an ULErrorViewController, modelling
+/// an error when Jetpack is not installed or is not connected
+struct WrongAccountErrorViewModel: ULErrorViewModel {
+    private let siteURL: String
+
+    init(siteURL: String?) {
+        self.siteURL = siteURL ?? Localization.yourSite
+    }
+
+    // MARK: - Data and configuration
+    let image: UIImage = .errorImage
+
+    var text: NSAttributedString {
+        let font: UIFont = .body
+        let boldFont: UIFont = font.bold
+
+        let boldSiteAddress = NSAttributedString(string: siteURL.trimHTTPScheme(),
+                                                           attributes: [.font: boldFont])
+        let message = NSMutableAttributedString(string: Localization.errorMessage)
+
+        message.replaceFirstOccurrence(of: "%@", with: boldSiteAddress)
+
+        return message
+    }
+
+    let isAuxiliaryButtonHidden = false
+
+    let auxiliaryButtonTitle = Localization.findYourConnectedEmail
+
+    let primaryButtonTitle = Localization.primaryButtonTitle
+
+    let secondaryButtonTitle = Localization.secondaryButtonTitle
+
+    // MARK: - Actions
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        guard let url = URL(string: Strings.instructionsURLString) else {
+            return
+        }
+
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        viewController?.present(safariViewController, animated: true)
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        let refreshCommand = NavigateToRoot()
+        refreshCommand.execute(from: viewController)
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        let fancyAlert = FancyAlertViewController.makeWhatIsJetpackAlertController()
+        fancyAlert.modalPresentationStyle = .custom
+        fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
+        viewController?.present(fancyAlert, animated: true)
+    }
+}
+
+
+// MARK: - Private data structures
+private extension WrongAccountErrorViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString("It looks like %@ is connected to a different account.",
+                                                    comment: "Message explaining that the site entered and the acount logged into do not match. "
+                                                        + "Reads like 'It looks like awebsite.com is connected to a different account")
+
+        static let findYourConnectedEmail = NSLocalizedString("Find your connected email",
+                                                     comment: "Button linking to webview that explains how to find your connected email"
+                                                        + "Presented when logging in with a store address that does not belong to the account entered by the user")
+
+        static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
+                                                          comment: "Action button linking to a list of connected stores."
+                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let yourSite = NSLocalizedString("your site",
+                                                comment: "Placeholder for site url, if the url is unknown."
+                                                    + "Presented when logging in with a site address that does not have a valid Jetpack installation."
+                                                + "The error would read: to use this app for your site you'll need...")
+
+    }
+
+    enum Strings {
+        static let instructionsURLString = "https://docs.woocommerce.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app/"
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -76,7 +76,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         }
 
         let storePicker = StorePickerViewController()
-        storePicker.configuration = .login
+        storePicker.configuration = .listStores
         //storePickerCoordinator?.onDismiss = onDismiss
         navigationController.pushViewController(storePicker, animated: true)
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -54,7 +54,7 @@ struct WrongAccountErrorViewModel: ULErrorViewModel {
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
-        let fancyAlert = FancyAlertViewController.makeWhatIsJetpackAlertController()
+        let fancyAlert = FancyAlertViewController.makeNeedHelpFindingEmailAlertController()
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
         viewController?.present(fancyAlert, animated: true)
@@ -70,8 +70,8 @@ private extension WrongAccountErrorViewModel {
                                                         + "Reads like 'It looks like awebsite.com is connected to a different account")
 
         static let findYourConnectedEmail = NSLocalizedString("Find your connected email",
-                                                     comment: "Button linking to webview that explains how to find your connected email"
-                                                        + "Presented when logging in with a store address that does not belong to the account entered by the user")
+                                                     comment: "Button linking to webview explaining how to find your connected email"
+                                                        + "Presented when logging in with a store address that does not match the account entered")
 
         static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
                                                           comment: "Action button linking to a list of connected stores."

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -11,7 +11,9 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let defaultAccount: Account?
     private let storesManager: StoresManager
 
-    init(siteURL: String?, sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager, storesManager: StoresManager = ServiceLocator.stores) {
+    init(siteURL: String?,
+         sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager,
+         storesManager: StoresManager = ServiceLocator.stores) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.defaultAccount = sessionManager.defaultAccount
         self.storesManager = storesManager

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -46,7 +46,9 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
                                                 account.username)
     }
 
-    let logOutTitle: String = "Wrong account? Log Out"
+    let logOutTitle: String = "Wrong account?"
+
+    let logOutButtonTitle: String = "Log Out"
 
     let image: UIImage = .errorImage
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -79,7 +79,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
         let storePicker = StorePickerViewController()
         storePicker.configuration = .listStores
-        //storePickerCoordinator?.onDismiss = onDismiss
+
         navigationController.pushViewController(storePicker, animated: true)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -9,10 +9,12 @@ import Yosemite
 struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let siteURL: String
     private let defaultAccount: Account?
+    private let storesManager: StoresManager
 
-    init(siteURL: String?, sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager) {
+    init(siteURL: String?, sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager, storesManager: StoresManager = ServiceLocator.stores) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.defaultAccount = sessionManager.defaultAccount
+        self.storesManager = storesManager
     }
 
     // MARK: - Data and configuration
@@ -92,7 +94,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
     func didTapLogOutButton(in viewController: UIViewController?) {
         // Log out and pop
-        ServiceLocator.stores.deauthenticate()
+        storesManager.deauthenticate()
         viewController?.navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -32,7 +32,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
             return ""
         }
 
-        return account.username
+        return account.displayName
     }
 
     var signedInText: String {
@@ -43,7 +43,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         }
 
         return String.localizedStringWithFormat(Localization.signedInMessageFormat,
-                                                account.displayName)
+                                                account.username)
     }
 
     let logOutTitle: String = "Wrong account? Log Out"

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -17,16 +17,8 @@ final class ULAccountMatcher {
         resultsController.fetchedObjects
     }
 
-    init() {
-
-    }
-
-
     func match(originalURL: String) -> Bool {
         refreshResults()
-
-        print("==== sites ", sites)
-        print("==== originalURL ", originalURL)
 
         /// When loggin in with a wp.com account, WPAuthenticator will set the
         /// account's blog URL to be `https://wordpress.com`

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -2,6 +2,7 @@ import Foundation
 import Yosemite
 
 final class ULAccountMatcher {
+    private let wpComURL = "https://wordpress.com"
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
     private let resultsController: ResultsController<StorageSite> = {
@@ -27,8 +28,15 @@ final class ULAccountMatcher {
         print("==== sites ", sites)
         print("==== originalURL ", originalURL)
 
+        /// When loggin in with a wp.com account, WPAuthenticator will set the
+        /// account's blog URL to be `https://wordpress.com`
+        /// We want to move forward and allow the login for those.
+        guard originalURL != wpComURL else {
+            return true
+        }
+
         return sites
-            .map{ $0.url }
+            .map { $0.url }
             .contains(originalURL)
     }
 

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Yosemite
 
+/// Used to match a store address with a wordpress.com account, as part
+/// of the Unified Login process
 final class ULAccountMatcher {
     private let wpComURL = "https://wordpress.com"
     /// ResultsController: Loads Sites from the Storage Layer.
@@ -17,6 +19,11 @@ final class ULAccountMatcher {
         resultsController.fetchedObjects
     }
 
+
+    /// Checks if the URL passed as parameter is one of the sites
+    /// saved in Storage
+    /// - Parameter originalURL: a store address
+    /// - Returns: a boolean indicating if the url passed as parameter is already saved
     func match(originalURL: String) -> Bool {
         refreshResults()
 

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Yosemite
+
+final class ULAccountMatcher {
+    /// ResultsController: Loads Sites from the Storage Layer.
+    ///
+    private let resultsController: ResultsController<StorageSite> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "isWooCommerceActive == YES")
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+
+        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
+    private var sites: [Site] {
+        resultsController.fetchedObjects
+    }
+
+    init() {
+
+    }
+
+
+    func match(originalURL: String) -> Bool {
+        refreshResults()
+
+        print("==== sites ", sites)
+        print("==== originalURL ", originalURL)
+
+        return sites
+            .map{ $0.url }
+            .contains(originalURL)
+    }
+
+    private func refreshResults() {
+        try? resultsController.performFetch()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1007,6 +1007,7 @@
 		D8915DBF23729CFB00F63762 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8915DBE23729CFB00F63762 /* ColorPalette.xcassets */; };
 		D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC02372C8AC00F63762 /* ColorStudio.swift */; };
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
+		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -2118,6 +2119,7 @@
 		D8915DBE23729CFB00F63762 /* ColorPalette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorPalette.xcassets; sourceTree = "<group>"; };
 		D8915DC02372C8AC00F63762 /* ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStudio.swift; sourceTree = "<group>"; };
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
+		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -3954,6 +3956,7 @@
 				CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */,
 				027A2E132513124E00DA6ACB /* Keychain+Entries.swift */,
 				027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */,
+				D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -6231,6 +6234,7 @@
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */,
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
+				D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */,
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1009,6 +1009,7 @@
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
 		D89C004725B467C7000E4683 /* ULAccountMismatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */; };
 		D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */; };
+		D89C009A25B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C009925B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift */; };
 		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
 		D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */; };
 		D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */; };
@@ -2126,6 +2127,7 @@
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
 		D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewModel.swift; sourceTree = "<group>"; };
 		D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewControllerTests.swift; sourceTree = "<group>"; };
+		D89C009925B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModelTests.swift; sourceTree = "<group>"; };
 		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
 		D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModel.swift; sourceTree = "<group>"; };
 		D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewController.swift; sourceTree = "<group>"; };
@@ -3576,6 +3578,7 @@
 				D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */,
 				D85DD1E0257F376200861AA8 /* NotWPAccountViewModelTests.swift */,
 				D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */,
+				D89C009925B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -6420,6 +6423,7 @@
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
+				D89C009A25B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift in Sources */,
 				02C3FDEA251091CE009569EE /* ProductFactoryTests.swift in Sources */,
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1008,6 +1008,7 @@
 		D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC02372C8AC00F63762 /* ColorStudio.swift */; };
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
 		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
+		D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -2120,6 +2121,7 @@
 		D8915DC02372C8AC00F63762 /* ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStudio.swift; sourceTree = "<group>"; };
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
 		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
+		D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModel.swift; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -5048,6 +5050,7 @@
 				D8610BD1256F291000A5DF27 /* JetpackErrorViewModel.swift */,
 				D8610D752570AE1F00A5DF27 /* NotWPErrorViewModel.swift */,
 				D881FE052579DC78008DE6F2 /* NotWPAccountViewModel.swift */,
+				D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */,
 			);
 			path = "Navigation Exceptions";
 			sourceTree = "<group>";
@@ -5826,6 +5829,7 @@
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				0235595524496B6D004BE2B8 /* BottomSheetListSelectorCommand.swift in Sources */,
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
+				D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1008,6 +1008,7 @@
 		D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC02372C8AC00F63762 /* ColorStudio.swift */; };
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
 		D89C004725B467C7000E4683 /* ULAccountMismatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */; };
+		D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */; };
 		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
 		D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */; };
 		D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */; };
@@ -2124,6 +2125,7 @@
 		D8915DC02372C8AC00F63762 /* ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStudio.swift; sourceTree = "<group>"; };
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
 		D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewModel.swift; sourceTree = "<group>"; };
+		D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewControllerTests.swift; sourceTree = "<group>"; };
 		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
 		D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModel.swift; sourceTree = "<group>"; };
 		D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewController.swift; sourceTree = "<group>"; };
@@ -3573,6 +3575,7 @@
 				D8610BF6256F5F0900A5DF27 /* ULErrorViewControllerTests.swift */,
 				D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */,
 				D85DD1E0257F376200861AA8 /* NotWPAccountViewModelTests.swift */,
+				D89C009325B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -6315,6 +6318,7 @@
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
+				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1007,6 +1007,7 @@
 		D8915DBF23729CFB00F63762 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8915DBE23729CFB00F63762 /* ColorPalette.xcassets */; };
 		D8915DC12372C8AC00F63762 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC02372C8AC00F63762 /* ColorStudio.swift */; };
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
+		D89C004725B467C7000E4683 /* ULAccountMismatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */; };
 		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
 		D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */; };
 		D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */; };
@@ -2122,6 +2123,7 @@
 		D8915DBE23729CFB00F63762 /* ColorPalette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorPalette.xcassets; sourceTree = "<group>"; };
 		D8915DC02372C8AC00F63762 /* ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStudio.swift; sourceTree = "<group>"; };
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
+		D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewModel.swift; sourceTree = "<group>"; };
 		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
 		D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModel.swift; sourceTree = "<group>"; };
 		D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewController.swift; sourceTree = "<group>"; };
@@ -5050,6 +5052,7 @@
 			children = (
 				D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */,
 				D89CFFDC25B44468000E4683 /* ULAccountMismatchViewController.xib */,
+				D89C004625B467C7000E4683 /* ULAccountMismatchViewModel.swift */,
 				D881A319256B5CC500FE5605 /* ULErrorViewController.swift */,
 				D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */,
 				D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */,
@@ -6210,6 +6213,7 @@
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,
+				D89C004725B467C7000E4683 /* ULAccountMismatchViewModel.swift in Sources */,
 				B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */,
 				B5AA7B3D20ED5D15004DA14F /* SessionManager.swift in Sources */,
 				74C6FEA521C2F1FA009286B6 /* AboutViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1009,6 +1009,8 @@
 		D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */; };
 		D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */; };
 		D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */; };
+		D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */; };
+		D89CFFDE25B44468000E4683 /* ULAccountMismatchViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D89CFFDC25B44468000E4683 /* ULAccountMismatchViewController.xib */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -2122,6 +2124,8 @@
 		D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorStudio.swift"; sourceTree = "<group>"; };
 		D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ULAccountMatcher.swift; sourceTree = "<group>"; };
 		D89CFF3925B43BBB000E4683 /* WrongAccountErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAccountErrorViewModel.swift; sourceTree = "<group>"; };
+		D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ULAccountMismatchViewController.swift; sourceTree = "<group>"; };
+		D89CFFDC25B44468000E4683 /* ULAccountMismatchViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ULAccountMismatchViewController.xib; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -5044,6 +5048,8 @@
 		D881A318256B5C9C00FE5605 /* Navigation Exceptions */ = {
 			isa = PBXGroup;
 			children = (
+				D89CFFDB25B44468000E4683 /* ULAccountMismatchViewController.swift */,
+				D89CFFDC25B44468000E4683 /* ULAccountMismatchViewController.xib */,
 				D881A319256B5CC500FE5605 /* ULErrorViewController.swift */,
 				D881A31A256B5CC500FE5605 /* ULErrorViewController.xib */,
 				D8610BCB256F284700A5DF27 /* ULErrorViewModel.swift */,
@@ -5453,6 +5459,7 @@
 				0259D65E2582248D003B1CD6 /* ReprintShippingLabelViewController.xib in Resources */,
 				021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */,
 				57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */,
+				D89CFFDE25B44468000E4683 /* ULAccountMismatchViewController.xib in Resources */,
 				452FE64C25657EC100EB54A0 /* LinkedProductsViewController.xib in Resources */,
 				0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */,
 				025C00692550DE4700FAC222 /* BarcodeScannerViewController.xib in Resources */,
@@ -5831,6 +5838,7 @@
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
 				D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
+				D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */,
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+@testable import WooCommerce
+
+final class ULAccountMismatchViewControllerTests: XCTestCase {
+
+    func test_viewcontroller_presents_username_provided_by_viewmodel() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let userName = viewController.getUserNameLabel().text
+
+        // Then
+        XCTAssertEqual(userName, viewModel.userName)
+    }
+
+    func test_viewcontroller_presents_signedIn_provided_by_viewmodel() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let signedInAs = viewController.getSingedInAsLabel().text
+
+        // Then
+        XCTAssertEqual(signedInAs, viewModel.signedInText)
+    }
+
+    func test_viewcontroller_presents_image_provided_by_viewmodel() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let image = viewController.getImageView().image
+
+        // Then
+        XCTAssertEqual(image, viewModel.image)
+    }
+
+    func test_viewcontroller_presents_text_provided_by_viewmodel() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let message = viewController.getMessage().attributedText
+
+        // Then
+        XCTAssertEqual(message, viewModel.text)
+    }
+
+    func test_viewcontroller_assigns_title_provided_by_viewmodel_to_auxbutton() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let auxiliaryButtonTitle = viewController.getAuxiliaryButton().title(for: .normal)
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonTitle, viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_viewcontroller_assigns_visibility_provided_by_viewmodel_to_auxbutton() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let auxiliaryButtonHidden = viewController.getAuxiliaryButton().isHidden
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonHidden, viewModel.isAuxiliaryButtonHidden)
+    }
+
+    func test_viewcontroller_hits_viewmodel_when_auxbutton_is_tapped() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+
+        let auxiliaryButton = viewController.getAuxiliaryButton()
+
+        auxiliaryButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertTrue(viewModel.auxiliaryButtonTapped)
+    }
+
+    func test_viewcontroller_assigns_title_provided_by_viewmodel_to_primary_button() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let primaryButtonTitle = viewController.getPrimaryActionButton().title(for: .normal)
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, viewModel.primaryButtonTitle)
+    }
+
+    func test_viewcontroller_hits_viewmodel_when_primary_button_is_tapped() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let primaryButton = viewController.getPrimaryActionButton()
+        primaryButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertTrue(viewModel.primaryButtonTapped)
+    }
+
+    func test_viewcontroller_assigns_title_provided_by_viewmodel_to_logout_button() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let logOutButtonTitle = viewController.getLogOutButton().title(for: .normal)
+
+        // Then
+        XCTAssertEqual(logOutButtonTitle, viewModel.logOutButtonTitle)
+    }
+
+    func test_viewcontroller_hits_viewmodel_when_logout_button_is_tapped() throws {
+        // Given
+        let viewModel = MistmatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let logOutButton = viewController.getLogOutButton()
+        logOutButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertTrue(viewModel.logOutButtonTapped)
+    }
+}
+
+
+private final class MistmatchViewModel: ULAccountMismatchViewModel {
+    let userEmail: String = "email@awebsite.com"
+
+    var userName: String = "username"
+
+    var signedInText: String = "signed_in_text"
+
+    var logOutTitle: String = "log_out_title"
+
+    var logOutButtonTitle: String = "logout_button_title"
+
+    let image: UIImage = .loginNoJetpackError
+
+    let text: NSAttributedString = NSAttributedString(string: "woocommerce")
+
+    let isAuxiliaryButtonHidden: Bool = false
+
+    let auxiliaryButtonTitle: String = "Aux"
+
+    let primaryButtonTitle: String = "Primary"
+
+
+    var primaryButtonTapped: Bool = false
+    var logOutButtonTapped: Bool = false
+    var auxiliaryButtonTapped: Bool = false
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        primaryButtonTapped = true
+    }
+
+    func didTapLogOutButton(in viewController: UIViewController?) {
+        logOutButtonTapped = true
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        auxiliaryButtonTapped = true
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import WooCommerce
+
+final class WrongAccountErrorViewModelTests: XCTestCase {
+
+    func test_viewmodel_provides_expected_image() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+
+        // When
+        let image = viewModel.image
+
+        // Then
+        XCTAssertEqual(image, Expectations.image)
+    }
+
+    func test_viewmodel_provides_expected_title_for_auxiliary_button() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+
+        // When
+        let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonTitle, Expectations.findYourConnectedEmail)
+    }
+
+    func test_viewmodel_provides_expected_title_for_primary_button() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
+    }
+
+    func test_viewmodel_provides_expected_title_for_log_out_button() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+
+        // When
+        let logoutButtonTitle = viewModel.logOutButtonTitle
+
+        // Then
+        XCTAssertEqual(logoutButtonTitle, Expectations.logOutButtonTitle)
+    }
+}
+
+
+private extension WrongAccountErrorViewModelTests {
+    private enum Expectations {
+        static let url = "https://woocommerce.com"
+        static let image = UIImage.errorImage
+
+        static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
+                                                          comment: "Action button linking to a list of connected stores."
+                                                          + "Presented when logging in with a store address that does not match the account entered")
+
+        static let logOutButtonTitle = NSLocalizedString("Log Out",
+                                                          comment: "Action button triggering a Log Out."
+                                                          + "Presented when logging in with a store address that does not match the account entered")
+
+        static let findYourConnectedEmail = NSLocalizedString("Find your connected email",
+                                                     comment: "Button linking to webview explaining how to find your connected email"
+                                                        + "Presented when logging in with a store address that does not match the account entered")
+    }
+}


### PR DESCRIPTION
Closes #3482 

This is a PR against the 5.8 release branch, to fix an omission picked up during testing:

pbMoDN-1KW#comment-3684-p2
pbMoDN-1KW#comment-3687-p2

In action:

https://user-images.githubusercontent.com/2722505/104858404-cb397a80-58ec-11eb-9d8c-d3c1ad65c3bb.mov


Screenshots:

| Light Appearance | Dark Appearance |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/104858339-4b131500-58ec-11eb-8327-7c2768886491.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/104858338-4b131500-58ec-11eb-95da-44ef3314f210.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/104858336-4a7a7e80-58ec-11eb-9f72-9c9fd8f1ffe6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/104858335-4a7a7e80-58ec-11eb-921e-6cefe110e304.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/104858390-ae04ac00-58ec-11eb-8aed-e7b24b03bc53.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/104858389-ae04ac00-58ec-11eb-904e-daf9a79c0edf.png" width="350"/> |



## Rationale

When logging with Store Address, the flow is:
1. enter the store address
2. enter the email associated to the wp.com account
3. enter password
4. pick store

We missed checking if the email/password entered in steps 2 and 3 and the store address entered in step 1 correspond to the same account.

There is a serious limitation to do so. At the end of the login process, WooCommerce is notified by WordPressAuthenticator of the userId corresponding to the email/password entered in steps 2+3. However, there is no way for neither WPAuthenticator, nor WooCommerce, to know at that point the userID that corresponds to the store address entered in step 1.

## Changes
* After the login process is completed, and before presenting the store picker, we will check if the store address entered in step 1 is one of the stores associated to the wordpress.com account entered in steps 2+3. To do so, we use `ULAccountMatcher`
* Add a new error screen specific to this use case: `ULAccountMismatchViewController`. Notice there is an issue with the spacing of the "Wrong Account?" label and "LogOut" button. I can not figure out for the life of me why how to solve that gap. Any help or suggestions are more than welcome.
* Add a new view model specific for this case.
* Add tests
* Add a new configuration to StorePickerViewController to support displaying only the list of sites. StorePickerViewController had already three responsibilities at this point, and I am adding a fourth now, but I am afraid to break it down this close to a release. We should probably think of ways to simplifying it, by breaking it down into its four responsibilities.

## How to test
Prepare two different accounts with at least one store each. Let's call them Account A and Account B

First testing flow:
1. In the login prologue, tap Login With Store Address. 
2. Enter the address of a store associated to account A
3. In the next step, enter the email and password associated to account B
4. Notice if there is an error screen. 
5. In the error screen, tap the Log Out button.
6. The app should navigate to the login prologue again

Second testing flow:
1. In the login prologue, tap Login With Store Address. 
2. Enter the address of a store associated to account A
3. In the next step, enter the email and password associated to account B
4. Notice if there is an error screen. 
5. In the error screen, tap See Connected Stores.
6. The app should navigate to a list of stores associated with account B
7. Tap back, tap Log Out

Third testing flow:
1. In the login prologue, tap Login With Store Address. 
2. Enter the address of a store associated to account A
3. In the next step, enter the email and password associated to account A
4. The app should navigate to the store picker
5. Select a store, everything should work as expected.

cc: @designsimply 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
