### PR TITLE
Refunded Amount Show Up as Positive Instead of Negative

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -155,8 +155,8 @@ final class OrderPaymentDetailsViewModel {
             return nil
         }
 
-        // We want the condensed refund total because it's reported as a negative value
-        return currencyFormatter.formatAmount(condensedRefund.total, with: order.currency)
+        // We can not assume the total is negative.
+        return currencyFormatter.formatAmount(condensedRefund.normalizedTotalAsNegative, with: order.currency)
     }
 
     /// Format the net amount with the correct currency
@@ -213,5 +213,18 @@ final class OrderPaymentDetailsViewModel {
 private extension OrderPaymentDetailsViewModel {
     enum Constants {
         static let decimalZero = Decimal(0)
+    }
+}
+
+
+private extension OrderRefundCondensed {
+    /// Present the refund total as a negative number,
+    /// by prefixing it with a minus symbol.
+    var normalizedTotalAsNegative: String {
+        guard total.hasPrefix("-") else {
+            return "-" + total
+        }
+
+        return total
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/TotalRefundedCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/TotalRefundedCalculationUseCase.swift
@@ -20,7 +20,12 @@ struct TotalRefundedCalculationUseCase {
     func totalRefunded() -> NSDecimalNumber {
         order.refunds.reduce(NSDecimalNumber.zero) { result, refundCondensed -> NSDecimalNumber in
             let totalAsDecimal = currencyFormatter.convertToDecimal(from: refundCondensed.total, locale: locale) ?? .zero
-            return result.adding(totalAsDecimal)
+
+            /// Even though the API returns refunds as negative, there is one case
+            /// where the refund is a positive number: right between issuing the refund
+            ///  and having the Order object updated with data from the API.
+            let total = totalAsDecimal.isNegative() ? totalAsDecimal : totalAsDecimal.multiplying(by: -1)
+            return result.adding(total)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -39,6 +39,7 @@ final class MockOrders {
     func makeOrder(status: OrderStatusEnum = .processing,
                    items: [OrderItem] = [],
                    shippingLines: [ShippingLine] = sampleShippingLines(),
+                   refunds: [OrderRefundCondensed] = [],
                    fees: [OrderFeeLine] = []) -> Order {
         return Order(siteID: siteID,
                      orderID: orderID,
@@ -64,7 +65,7 @@ final class MockOrders {
                      shippingAddress: sampleAddress(),
                      shippingLines: shippingLines,
                      coupons: [],
-                     refunds: [],
+                     refunds: refunds,
                      fees: fees)
     }
 
@@ -74,6 +75,14 @@ final class MockOrders {
 
     func orderWithFees() -> Order {
         makeOrder(fees: sampleFeeLines())
+    }
+
+    func orderWithAPIRefunds() -> Order {
+        makeOrder(refunds: refundsWithNegativeValue())
+    }
+
+    func orderWithTransientRefunds() -> Order {
+        makeOrder(refunds: refundsWithPositiveValue())
     }
 
     func sampleOrderCreatedInCurrentYear() -> Order {
@@ -241,5 +250,17 @@ final class MockOrders {
             return Date()
         }
         return date
+    }
+
+    func refundsWithNegativeValue() -> [OrderRefundCondensed] {
+        return [
+            OrderRefundCondensed(refundID: 0, reason: nil, total: "-1.2"),
+        ]
+    }
+
+    func refundsWithPositiveValue() -> [OrderRefundCondensed] {
+        return [
+            OrderRefundCondensed(refundID: 0, reason: nil, total: "1.2"),
+        ]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -11,9 +11,13 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     private var brokenOrder: Order!
     private var anotherBrokenOrder: Order!
     private var orderWithFees: Order!
+    private var orderWithAPIRefunds: Order!
+    private var orderWithTransientRefunds: Order!
     private var brokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var anotherBrokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var orderWithFeesViewModel: OrderPaymentDetailsViewModel!
+    private var orderWithAPIRefundsViewModel: OrderPaymentDetailsViewModel!
+    private var orderWithTransientRefundsViewModel: OrderPaymentDetailsViewModel!
 
     override func setUp() {
         super.setUp()
@@ -28,9 +32,19 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
 
         orderWithFees = MockOrders().orderWithFees()
         orderWithFeesViewModel = OrderPaymentDetailsViewModel(order: orderWithFees, currencySettings: CurrencySettings())
+
+        orderWithAPIRefunds = MockOrders().orderWithAPIRefunds()
+        orderWithAPIRefundsViewModel = OrderPaymentDetailsViewModel(order: orderWithAPIRefunds, refund: MockRefunds.sampleRefund())
+
+        orderWithTransientRefunds = MockOrders().orderWithTransientRefunds()
+        orderWithTransientRefundsViewModel = OrderPaymentDetailsViewModel(order: orderWithTransientRefunds, refund: MockRefunds.sampleRefund())
     }
 
     override func tearDown() {
+        orderWithAPIRefundsViewModel = nil
+        orderWithAPIRefunds = nil
+        orderWithTransientRefundsViewModel = nil
+        orderWithTransientRefunds = nil
         orderWithFeesViewModel = nil
         orderWithFees = nil
         anotherBrokenOrderViewModel = nil
@@ -150,5 +164,17 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
 
     func test_coupon_lines_matches_expectation() {
         XCTAssertEqual(viewModel.couponLines, order.coupons)
+    }
+
+    func test_order_with_API_refunds_presents_refunds_with_minus_sign() throws {
+        let refundAmount = try XCTUnwrap(orderWithAPIRefundsViewModel.refundAmount)
+
+        XCTAssertTrue(refundAmount.hasPrefix("-"))
+    }
+
+    func test_order_with_transient_refunds_presents_refunds_with_minus_sign() throws {
+        let refundAmount = try XCTUnwrap(orderWithTransientRefundsViewModel.refundAmount)
+
+        XCTAssertTrue(refundAmount.hasPrefix("-"))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/TotalRefundedCalculationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/TotalRefundedCalculationUseCaseTests.swift
@@ -38,8 +38,7 @@ final class TotalRefundedCalculationUseCaseTests: XCTestCase {
             // Values with currency are probably not possible in the API but we're
             // considering it here for resilience.
             OrderRefundCondensed(refundID: 0, reason: nil, total: "$-8.71972"),
-            // The API returns negative numbers. We're including a positive number to indicate
-            // that we don't do special handling of the sign.
+            // The API returns negative numbers. However, refunds issued but not fetched from the API are positive.
             OrderRefundCondensed(refundID: 0, reason: nil, total: "3719.8850971"),
         ]
         let order = MockOrders().empty().copy(refunds: refundItems)
@@ -50,6 +49,6 @@ final class TotalRefundedCalculationUseCaseTests: XCTestCase {
         let totalRefunded = useCase.totalRefunded()
 
         // Then
-        XCTAssertEqual(totalRefunded, NSDecimalNumber(string: "-43427.9375229"))
+        XCTAssertEqual(totalRefunded, NSDecimalNumber(string: "-50867.7077171"))
     }
 }

--- a/Yosemite/Yosemite/Stores/RefundStore.swift
+++ b/Yosemite/Yosemite/Stores/RefundStore.swift
@@ -175,7 +175,6 @@ private extension RefundStore {
 
             handleOrderItemRefunds(readOnlyRefund, storageRefund, storage)
             handleShippingLines(readOnlyRefund, storageRefund, storage)
-            handleCondensedRefundsIfNeeded(readOnlyRefund: readOnlyRefund, in: storage)
         }
     }
 
@@ -299,24 +298,6 @@ private extension RefundStore {
             storage.deleteObject(stale)
         }
         storage.saveIfNeeded()
-    }
-
-    /// Create an `Storage.OrderRefundCondensed` if they don't exist already.
-    ///
-    private func handleCondensedRefundsIfNeeded(readOnlyRefund: Refund, in storage: StorageType) {
-        // Do nothing if condensed refund already exists.
-        if storage.loadOrderRefundCondensed(siteID: readOnlyRefund.siteID, refundID: readOnlyRefund.refundID) != nil {
-            return
-        }
-
-        // Create and store the `Storage,OrderRefundCondensed` based on the `ReadOnlyRefund`.
-        let readOnlyRefundCondensed = OrderRefundCondensed(refundID: readOnlyRefund.refundID, reason: readOnlyRefund.reason, total: readOnlyRefund.amount)
-        let storageRefundCondensed = storage.insertNewObject(ofType: Storage.OrderRefundCondensed.self)
-        storageRefundCondensed.update(with: readOnlyRefundCondensed)
-
-        // Update the refunds set if the parent `Order` exists.
-        let order = storage.loadOrder(siteID: readOnlyRefund.siteID, orderID: readOnlyRefund.orderID)
-        order?.addToRefunds(storageRefundCondensed)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -465,36 +465,6 @@ class RefundStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Refund.self), 3)
         XCTAssertNil(retrieveError)
     }
-
-    func test_create_refund_updates_order_condensed_refund() throws {
-        // Given
-        storageManager.insertSampleOrder(readOnlyOrder: sampleOrder())
-        let refund = sampleRefund()
-        let refundStore = RefundStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectedCondensedRefund = OrderRefundCondensed(refundID: refund.refundID, reason: refund.reason, total: refund.amount)
-
-        // When
-        refundStore.upsertStoredRefund(readOnlyRefund: sampleRefund(), in: viewStorage)
-
-        // Then
-        let order = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderID)?.toReadOnly()
-        XCTAssertEqual(order?.refunds, [expectedCondensedRefund])
-    }
-
-    func test_create_refund_does_not_duplicate_order_condensed_refund() throws {
-        // Given
-        let refund = sampleRefund()
-        let existingCondensedRefund = OrderRefundCondensed(refundID: refund.refundID, reason: refund.reason, total: refund.amount)
-        let refundStore = RefundStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        storageManager.insertSampleOrder(readOnlyOrder: sampleOrder().copy(refunds: [existingCondensedRefund]))
-
-        // When
-        refundStore.upsertStoredRefund(readOnlyRefund: sampleRefund(), in: viewStorage)
-
-        // Then
-        let order = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderID)?.toReadOnly()
-        XCTAssertEqual(order?.refunds, [existingCondensedRefund])
-    }
 }
 
 


### PR DESCRIPTION
Closes #3467 

Fix discrepancies in order details view in between the moment a refund is issued and the moment the order is refreshed with data from the API
  
The issue is that we were always expecting refunds to have a negative value, which is not always the case. The API always seems to return funds with a negative value, but there is a case when a refund can have a positive value: in between the refund is issued in the app and the moment we update the order from the API.
  
 The fix touches the way refunds are calculated and the way they are presented. I don't love this solution, but I tried to submit a refund with a negative value and it didn't work (the API creates the refnd but sets it to zero) and forcing all refunds to be negative at the Store seemed like could be more dangerous.

https://user-images.githubusercontent.com/2722505/104858965-cb3b7980-58f0-11eb-862e-cc8ed9a423c8.mov

  
## Changes
* Make OrderPaymentDetailsViewModel and TotalRefundedCalculationUseCase check that the values of individual refunds are negative, and if they are not, make them negative.

## How to test:

1. Open an order.
2. Issue a refund (any amount).
3. Notice the issued refund amount on the order details page. It should be negative, and the Net line should be reduced by the amount refunded.
4. Repeat with more than one item, if possible.
5. Pull to refresh at any time to pull values from the API. Nothing should change, neither in the individually refunded items, nor the Net amount.
6. Repeat issuing partial refunds and pulling to refresh to see if anything breaks.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
