### PR TITLE
Adds support to Typed Predicates

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		2618707425409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */; };
 		2619F71925AF95030006DAFF /* StorageTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */; };
 		2619F72525B236E60006DAFF /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F72425B236E60006DAFF /* TypedPredicates.swift */; };
+		2619F78625B5D29B0006DAFF /* TypedPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F78525B5D29B0006DAFF /* TypedPredicateTests.swift */; };
 		261CF1C4255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */; };
 		261CF1C5255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
@@ -221,6 +222,7 @@
 		2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTypeExtensionsTests.swift; sourceTree = "<group>"; };
 		2619F72425B236E60006DAFF /* TypedPredicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedPredicates.swift; sourceTree = "<group>"; };
+		2619F78525B5D29B0006DAFF /* TypedPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedPredicateTests.swift; sourceTree = "<group>"; };
 		261CF1C1255AFDC40090D8D3 /* Model 36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 36.xcdatamodel"; sourceTree = "<group>"; };
 		261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataClass.swift"; sourceTree = "<group>"; };
 		261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -633,6 +635,7 @@
 				B54CA5C620A4BFDC00F38CD1 /* DummyStack.swift */,
 				57589E8F252275CA000F22CE /* NSManagedObjectContext+TestHelpers.swift */,
 				2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */,
+				2619F78525B5D29B0006DAFF /* TypedPredicateTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1103,6 +1106,7 @@
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,
 				B59E11DE20A9F1FB004121A4 /* CoreDataManagerTests.swift in Sources */,
 				57A29FB825226BDC004DEE01 /* MigrationTests.swift in Sources */,
+				2619F78625B5D29B0006DAFF /* TypedPredicateTests.swift in Sources */,
 				26EA01D524EC44B300176A57 /* GeneralAppSettingsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		2618707325409C65006522A1 /* ShippingLineTax+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */; };
 		2618707425409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */; };
 		2619F71925AF95030006DAFF /* StorageTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */; };
+		2619F72525B236E60006DAFF /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F72425B236E60006DAFF /* TypedPredicates.swift */; };
 		261CF1C4255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */; };
 		261CF1C5255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
@@ -219,6 +220,7 @@
 		2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataClass.swift"; sourceTree = "<group>"; };
 		2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTypeExtensionsTests.swift; sourceTree = "<group>"; };
+		2619F72425B236E60006DAFF /* TypedPredicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedPredicates.swift; sourceTree = "<group>"; };
 		261CF1C1255AFDC40090D8D3 /* Model 36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 36.xcdatamodel"; sourceTree = "<group>"; };
 		261CF1C2255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataClass.swift"; sourceTree = "<group>"; };
 		261CF1C3255B291F0090D8D3 /* PaymentGateway+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentGateway+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 			isa = PBXGroup;
 			children = (
 				B505255320EE6914008090F5 /* StorageType+Extensions.swift */,
+				2619F72425B236E60006DAFF /* TypedPredicates.swift */,
 				D87F61542265AA900031A13B /* PListFileStorage.swift */,
 				027D3E6D23A0EEA4007D91B0 /* StorageType+Deletions.swift */,
 			);
@@ -967,6 +970,7 @@
 				021EAA4725493A1600AA8CCD /* OrderItemAttribute+CoreDataClass.swift in Sources */,
 				D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */,
 				B5B914C620EFF03500F2F832 /* Site+CoreDataProperties.swift in Sources */,
+				2619F72525B236E60006DAFF /* TypedPredicates.swift in Sources */,
 				D8736B6B22F0AC9000A14A29 /* OrderCount+CoreDataProperties.swift in Sources */,
 				02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */,
 				26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */,

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -33,12 +33,6 @@ public func || (p1: TypedPredicate, p2: TypedPredicate) -> CompoundPredicate {
     CompoundPredicate(type: .or, subpredicates: [p1, p2])
 }
 
-/// Overloads the `NOT` operator for a single predicate, returns a `CompoundPredicate` that evaluates predicates with the `!` rule.
-///
-public prefix func ! (p: TypedPredicate) -> CompoundPredicate {
-    CompoundPredicate(type: .not, subpredicates: [p])
-}
-
 // MARK: - Comparison Operators Overloads
 
 /// Overloads for comparison  operators.  Each operator takes a `KeyPath` and a `Value`

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -54,6 +54,13 @@ public func == <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, R
     ComparisonPredicate(keyPath, .equalTo, value)
 }
 
+/// Defines a new  operator `equal insensitive`  between a `KeyPath` and a `Value`. Returns a `ComparisonPredicate` that evaluates the parameters using the `==[c]` rule.
+///
+infix operator =~ : ComparisonPrecedence
+public func =~ <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, ResultingType>, value: ResultingType) -> ComparisonPredicate {
+    ComparisonPredicate(keyPath, .equalTo, value, .caseInsensitive)
+}
+
 /// Overloads the `not equal` operator between a `KeyPath` and a `Value`. Returns a `ComparisonPredicate` that evaluates the parameters using the `!=` rule.
 ///
 public func != <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, ResultingType>, value: ResultingType) -> ComparisonPredicate {
@@ -71,10 +78,12 @@ public func === <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, 
 internal extension ComparisonPredicate {
     /// Returns a `ComparisonPredicate` by converting the parameters into `NSExpression` instances using the provided `Operator` as a modifier.
     ///
-    convenience init<RootType, ResultingType>(_ keyPath: KeyPath<RootType, ResultingType>, _ operator: NSComparisonPredicate.Operator, _ value: Any?) {
+    convenience init<RootType, ResultingType>(_ keyPath: KeyPath<RootType, ResultingType>,
+                                              _ operator: NSComparisonPredicate.Operator,
+                                              _ value: Any?,
+                                              _ options: NSComparisonPredicate.Options = []) {
         let keyPathExpression = NSExpression(forKeyPath: keyPath)
         let valueExpression = NSExpression(forConstantValue: value)
-        let options = ResultingType.self == String.self ? NSComparisonPredicate.Options.caseInsensitive : []
         self.init(leftExpression: keyPathExpression, rightExpression: valueExpression, modifier: .direct, type: `operator`, options: options)
     }
 }

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -74,6 +74,7 @@ internal extension ComparisonPredicate {
     convenience init<RootType, ResultingType>(_ keyPath: KeyPath<RootType, ResultingType>, _ operator: NSComparisonPredicate.Operator, _ value: Any?) {
         let keyPathExpression = NSExpression(forKeyPath: keyPath)
         let valueExpression = NSExpression(forConstantValue: value)
-        self.init(leftExpression: keyPathExpression, rightExpression: valueExpression, modifier: .direct, type: `operator`)
+        let options = ResultingType.self == String.self ? NSComparisonPredicate.Options.caseInsensitive : []
+        self.init(leftExpression: keyPathExpression, rightExpression: valueExpression, modifier: .direct, type: `operator`, options: options)
     }
 }

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+///
+/// The goal of these utilities is to be able to provide a type-safe API when creating `NSPredicates`.
+/// This is achieved by overloading logical operators between a `Swift.KeyPath` which is type-safe and a `Value`.
+/// `KeyPaths` and `Values` can be transformed into `NSExpression` via a native `APIs`
+/// Which then can be converted to a `NSComparisonPredicate` using the `init(leftExpression, rightExpression, operator)`method.
+///
+
+
 // MARK: - Types
 
-/// Protocol that `CompoundPredicate` and `ComparisonPredicate` to be able perform operations between them
+/// Protocol to enclose `CompoundPredicate` and `ComparisonPredicate` instances  to be able perform operations between them.
 ///
 public protocol TypedPredicate: NSPredicate {}
 
@@ -18,7 +26,7 @@ public final class ComparisonPredicate: NSComparisonPredicate, TypedPredicate {}
 // MARK: - Compound Operators Overloads
 
 /// Overloads for compound operators.
-/// Each operator takes  `TypedPredicate` instances and returns a `CompoundPredicate` that evaluate the predicates using their respective logical rule.
+/// Each operator takes `TypedPredicate` instances and returns a `CompoundPredicate` that evaluate the predicates using their respective logical rule.
 ///
 
 /// Overloads the `AND` operator between two predicates, returns a `CompoundPredicate` that evaluates the two predicates with the `&&` rule.

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -54,7 +54,7 @@ public func == <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, R
     ComparisonPredicate(keyPath, .equalTo, value)
 }
 
-/// Defines a new  operator `equal insensitive`  between a `KeyPath` and a `Value`. Returns a `ComparisonPredicate` that evaluates the parameters using the `==[c]` rule.
+/// Defines a new  operator `=~` between a `KeyPath` and a `Value`. Returns a `ComparisonPredicate` that evaluates the parameters using the `==[c]` rule.
 ///
 infix operator =~ : ComparisonPrecedence
 public func =~ <RootType, ResultingType: Equatable>(keyPath: KeyPath<RootType, ResultingType>, value: ResultingType) -> ComparisonPredicate {

--- a/Storage/Storage/Tools/TypedPredicates.swift
+++ b/Storage/Storage/Tools/TypedPredicates.swift
@@ -35,7 +35,7 @@ public func && (p1: TypedPredicate, p2: TypedPredicate) -> CompoundPredicate {
     CompoundPredicate(type: .and, subpredicates: [p1, p2])
 }
 
-/// Overloads the `OR` operator between two predicates, returns a `CompoundPredicate` that evaluates the two predicates with the `!!` rule.
+/// Overloads the `OR` operator between two predicates, returns a `CompoundPredicate` that evaluates the two predicates with the `||` rule.
 ///
 public func || (p1: TypedPredicate, p2: TypedPredicate) -> CompoundPredicate {
     CompoundPredicate(type: .or, subpredicates: [p1, p2])

--- a/Storage/StorageTests/Tools/TypedPredicateTests.swift
+++ b/Storage/StorageTests/Tools/TypedPredicateTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Storage
+
+final class TypedPredicateTests: XCTestCase {
+
+    func test_EQUAL_operator_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID == 20
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20")
+    }
+
+    func test_NOT_EQUAL_operator_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID != 20
+        XCTAssertEqual(predicate.predicateFormat, "dummyID != 20")
+    }
+
+    func test_IN_operator_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID === [20, 21, 22]
+        XCTAssertEqual(predicate.predicateFormat, "dummyID IN {20, 21, 22}")
+    }
+
+    func test_AND_operator_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID == 20 && \Dummy.name == "name"
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 AND name == \"name\"")
+    }
+
+    func test_OR_operator_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name"
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR name == \"name\"")
+    }
+
+    func test_multiple_operators_produces_correct_predicate() {
+        let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name" && \Dummy.slug === ["slug", "name"]
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR (name == \"name\" AND slug IN {\"slug\", \"name\"})")
+    }
+}
+
+/// Dummy class that is key path accessible
+///
+private class Dummy {
+    @objc let dummyID: Int = 20
+    @objc let name: String = "name"
+    @objc let slug: String = "slug"
+}

--- a/Storage/StorageTests/Tools/TypedPredicateTests.swift
+++ b/Storage/StorageTests/Tools/TypedPredicateTests.swift
@@ -20,17 +20,17 @@ final class TypedPredicateTests: XCTestCase {
 
     func test_AND_operator_produces_correct_predicate() {
         let predicate = \Dummy.dummyID == 20 && \Dummy.name == "name"
-        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 AND name == \"name\"")
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 AND name ==[c] \"name\"")
     }
 
     func test_OR_operator_produces_correct_predicate() {
         let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name"
-        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR name == \"name\"")
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR name ==[c] \"name\"")
     }
 
     func test_multiple_operators_produces_correct_predicate() {
         let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name" && \Dummy.slug === ["slug", "name"]
-        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR (name == \"name\" AND slug IN {\"slug\", \"name\"})")
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR (name ==[c] \"name\" AND slug IN[c] {\"slug\", \"name\"})")
     }
 }
 

--- a/Storage/StorageTests/Tools/TypedPredicateTests.swift
+++ b/Storage/StorageTests/Tools/TypedPredicateTests.swift
@@ -19,18 +19,18 @@ final class TypedPredicateTests: XCTestCase {
     }
 
     func test_AND_operator_produces_correct_predicate() {
-        let predicate = \Dummy.dummyID == 20 && \Dummy.name == "name"
+        let predicate = \Dummy.dummyID == 20 && \Dummy.name =~ "name"
         XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 AND name ==[c] \"name\"")
     }
 
     func test_OR_operator_produces_correct_predicate() {
-        let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name"
+        let predicate = \Dummy.dummyID == 20 || \Dummy.name =~ "name"
         XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR name ==[c] \"name\"")
     }
 
     func test_multiple_operators_produces_correct_predicate() {
-        let predicate = \Dummy.dummyID == 20 || \Dummy.name == "name" && \Dummy.slug === ["slug", "name"]
-        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR (name ==[c] \"name\" AND slug IN[c] {\"slug\", \"name\"})")
+        let predicate = \Dummy.dummyID == 20 || \Dummy.name =~ "name" && \Dummy.slug === ["slug", "name"]
+        XCTAssertEqual(predicate.predicateFormat, "dummyID == 20 OR (name ==[c] \"name\" AND slug IN {\"slug\", \"name\"})")
     }
 }
 


### PR DESCRIPTION
part of #3465 

# Why
After [adding unit tests on our predicate methods](https://github.com/woocommerce/woocommerce-ios/pull/3480) we can proceed to add the necessary tools that will allow us to create type-safe predicates. 

The next PR will replace our current predicates with safe-predicates using the tools added here.

# How
This PR adds a set of protocols, classes, and operator overloads in order to provide a type-safe API to create `NSPredicates`. 

This is achieved by overloading logical operators between a `Swift.KeyPath` which is type-safe and a `Value`. 
`KeyPaths` and `Values` can be transformed into `NSExpression` via a native `APIs` which then can be converted to an `NSComparisonPredicate` using the `init(leftExpression, rightExpression, operator)` method. This will allow us to support the `EQUAL`, `NOT EQUAL`, and `IN` predicates.

Additionally, we can group multiple `NSComparisonPredicate` into `NSCompoundPredicates` that will add support to `AND` and `OR` predicates.

# Testing Steps
- 👀 to the code and tests

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
