### PR TITLE
Core Data: Add MigrationStep to Encapsulate Index-Based Loops

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		454005AA24AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 454005A924AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel */; };
 		45E1862E2370450C009241F3 /* ShippingLine+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */; };
 		45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */; };
+		5707FBC425B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5707FBC325B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift */; };
 		57150E1324F462DF00E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E1224F462DF00E81611 /* TestKit */; };
 		572B40E425A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572B40E325A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift */; };
 		572C099625475208005372E1 /* SpyFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572C099525475208005372E1 /* SpyFileManager.swift */; };
@@ -243,6 +244,7 @@
 		45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		45ED6099257EB11B007B4AC6 /* Model 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 40.xcdatamodel"; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5707FBC325B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataIterativeMigrator+MigrationStep.swift"; sourceTree = "<group>"; };
 		572B40E325A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteEntityObjectsMigrationPolicy.swift; sourceTree = "<group>"; };
 		572C099525475208005372E1 /* SpyFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyFileManager.swift; sourceTree = "<group>"; };
 		5736878D24AAADAE00B528FE /* ManagedObjectModelsInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectModelsInventory.swift; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				B505F6DD20BEEA4F00BB1B69 /* CoreDataManager.swift */,
 				9302E3A5220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift */,
 				5736878D24AAADAE00B528FE /* ManagedObjectModelsInventory.swift */,
+				5707FBC325B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -992,6 +995,7 @@
 				747453A52242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift in Sources */,
 				02EAB6D72480A86D00FD873C /* CrashLogger.swift in Sources */,
 				746A9D21214078080013F6FF /* TopEarnerStats+CoreDataClass.swift in Sources */,
+				5707FBC425B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift in Sources */,
 				74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */,
 				B52B0F7920AA287C00477698 /* StorageManagerType.swift in Sources */,
 				028296F5237D404F00E84012 /* GenericAttribute+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		45E1862E2370450C009241F3 /* ShippingLine+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */; };
 		45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */; };
 		5707FBC425B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5707FBC325B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift */; };
+		5707FBC825B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5707FBC725B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift */; };
 		57150E1324F462DF00E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E1224F462DF00E81611 /* TestKit */; };
 		572B40E425A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572B40E325A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift */; };
 		572C099625475208005372E1 /* SpyFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572C099525475208005372E1 /* SpyFileManager.swift */; };
@@ -245,6 +246,7 @@
 		45ED6099257EB11B007B4AC6 /* Model 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 40.xcdatamodel"; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5707FBC325B5FE2200B7C1A6 /* CoreDataIterativeMigrator+MigrationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataIterativeMigrator+MigrationStep.swift"; sourceTree = "<group>"; };
+		5707FBC725B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataIterativeMigrator+MigrationStepTests.swift"; sourceTree = "<group>"; };
 		572B40E325A5414D00DB20E0 /* DeleteEntityObjectsMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteEntityObjectsMigrationPolicy.swift; sourceTree = "<group>"; };
 		572C099525475208005372E1 /* SpyFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyFileManager.swift; sourceTree = "<group>"; };
 		5736878D24AAADAE00B528FE /* ManagedObjectModelsInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectModelsInventory.swift; sourceTree = "<group>"; };
@@ -749,6 +751,7 @@
 				B59E11DD20A9F1FB004121A4 /* CoreDataManagerTests.swift */,
 				5736878F24AABE4D00B528FE /* ManagedObjectModelsInventoryTests.swift */,
 				57A29FB725226BDC004DEE01 /* MigrationTests.swift */,
+				5707FBC725B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -1089,6 +1092,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9302E3AC220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift in Sources */,
+				5707FBC825B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift in Sources */,
 				57CEB1A22525349B00D8544F /* ProductVariationTests.swift in Sources */,
 				B59E11E020A9F5E6004121A4 /* Constants.swift in Sources */,
 				B54CA5C320A4BF6900F38CD1 /* NSManagedObjectContextStorageTests.swift in Sources */,

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
@@ -5,5 +5,66 @@ extension CoreDataIterativeMigrator {
     struct MigrationStep {
         let sourceModel: NSManagedObjectModel
         let targetModel: NSManagedObjectModel
+
+        /// Returns an inclusive list of models between the source and target models.
+        ///
+        /// For example, if `sourceModel` is `"Model 13"` and `targetModel` is `"Model 16"`, then this
+        /// will return this list of `NSManagedObjectModels` in order:
+        ///
+        /// - Model 13
+        /// - Model 14
+        /// - Model 15
+        /// - Model 16
+        ///
+        /// This also works if the `targetModel` is lower than the `sourceModel`. For example, if the
+        /// `sourceModel` is `"Model 16"` and `targetModel` is `"Model 13"`, then this list will
+        /// be returned:
+        ///
+        /// - Model 16
+        /// - Model 15
+        /// - Model 14
+        /// - Model 13
+        ///
+        /// We don't really use the descending list at the moment. I'm just keeping this logic
+        /// as is for now so I don't accidentally introduce regressions. Someday, one brave soul
+        /// will refactor this and remove the descending logic.
+        ///
+        /// - Returns: The list of models to be used for migration, including the `sourceModel` and
+        ///            the `targetModel`.
+        private static func modelsToMigrate(using allModels: [NSManagedObjectModel],
+                                            source sourceModel: NSManagedObjectModel,
+                                            target targetModel: NSManagedObjectModel) throws -> [NSManagedObjectModel] {
+            var modelsToMigrate = [NSManagedObjectModel]()
+            var firstFound = false, lastFound = false, reverse = false
+
+            for model in allModels {
+                if model.isEqual(sourceModel) || model.isEqual(targetModel) {
+                    if firstFound {
+                        lastFound = true
+                        // In case a reverse migration is being performed (descending through the
+                        // ordered array of models), check whether the source model is found
+                        // after the final model.
+                        reverse = model.isEqual(sourceModel)
+                    } else {
+                        firstFound = true
+                    }
+                }
+
+                if firstFound {
+                    modelsToMigrate.append(model)
+                }
+
+                if lastFound {
+                    break
+                }
+            }
+
+            // Ensure that the source model is at the start of the list.
+            if reverse {
+                modelsToMigrate = modelsToMigrate.reversed()
+            }
+
+            return modelsToMigrate
+        }
     }
 }

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
@@ -1,0 +1,9 @@
+import CoreData
+
+extension CoreDataIterativeMigrator {
+    /// A step in the iterative migration loop executed by `CoreDataIterativeMigrator.iterativeMigrate`.
+    struct MigrationStep {
+        let sourceModel: NSManagedObjectModel
+        let targetModel: NSManagedObjectModel
+    }
+}

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator+MigrationStep.swift
@@ -4,7 +4,7 @@ private typealias ModelVersion = ManagedObjectModelsInventory.ModelVersion
 
 extension CoreDataIterativeMigrator {
     /// A step in the iterative migration loop executed by `CoreDataIterativeMigrator.iterativeMigrate`.
-    struct MigrationStep {
+    struct MigrationStep: Equatable {
         let sourceVersion: ManagedObjectModelsInventory.ModelVersion
         let sourceModel: NSManagedObjectModel
 

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -219,67 +219,6 @@ private extension CoreDataIterativeMigrator {
         return sourceModel
     }
 
-    /// Returns an inclusive list of models between the source and target models.
-    ///
-    /// For example, if `sourceModel` is `"Model 13"` and `targetModel` is `"Model 16"`, then this
-    /// will return this list of `NSManagedObjectModels` in order:
-    ///
-    /// - Model 13
-    /// - Model 14
-    /// - Model 15
-    /// - Model 16
-    ///
-    /// This also works if the `targetModel` is lower than the `sourceModel`. For example, if the
-    /// `sourceModel` is `"Model 16"` and `targetModel` is `"Model 13"`, then this list will
-    /// be returned:
-    ///
-    /// - Model 16
-    /// - Model 15
-    /// - Model 14
-    /// - Model 13
-    ///
-    /// We don't really use the descending list at the moment. I'm just keeping this logic
-    /// as is for now so I don't accidentally introduce regressions. Someday, one brave soul
-    /// will refactor this and remove the descending logic.
-    ///
-    /// - Returns: The list of models to be used for migration, including the `sourceModel` and
-    ///            the `targetModel`.
-    func modelsToMigrate(using allModels: [NSManagedObjectModel],
-                         source sourceModel: NSManagedObjectModel,
-                         target targetModel: NSManagedObjectModel) throws -> [NSManagedObjectModel] {
-        var modelsToMigrate = [NSManagedObjectModel]()
-        var firstFound = false, lastFound = false, reverse = false
-
-        for model in allModels {
-            if model.isEqual(sourceModel) || model.isEqual(targetModel) {
-                if firstFound {
-                    lastFound = true
-                    // In case a reverse migration is being performed (descending through the
-                    // ordered array of models), check whether the source model is found
-                    // after the final model.
-                    reverse = model.isEqual(sourceModel)
-                } else {
-                    firstFound = true
-                }
-            }
-
-            if firstFound {
-                modelsToMigrate.append(model)
-            }
-
-            if lastFound {
-                break
-            }
-        }
-
-        // Ensure that the source model is at the start of the list.
-        if reverse {
-            modelsToMigrate = modelsToMigrate.reversed()
-        }
-
-        return modelsToMigrate
-    }
-
     /// Load a developer-defined `NSMappingModel` (`*.xcmappingmodel` file) or infer it.
     func mappingModel(from sourceModel: NSManagedObjectModel,
                       to targetModel: NSManagedObjectModel) throws -> NSMappingModel {

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -165,30 +165,8 @@ private extension CoreDataIterativeMigrator {
         }
     }
 
-    func makeMigrationAttemptLogMessage(models: [NSManagedObjectModel],
-                                        from fromModel: NSManagedObjectModel,
-                                        to toModel: NSManagedObjectModel) -> String {
-        // This logic is a bit nasty. I'm just trying to keep the existing logic intact for now.
-
-        let versions = modelsInventory.versions
-
-        let fromName: String? = {
-            if let index = models.firstIndex(of: fromModel) {
-                return versions[safe: index]?.name
-            } else {
-                return nil
-            }
-        }()
-
-        let toName: String? = {
-            if let index = models.firstIndex(of: toModel) {
-                return versions[safe: index]?.name
-            } else {
-                return nil
-            }
-        }()
-
-        return "⚠️ Attempting migration from \(fromName ?? "unknown") to \(toName ?? "unknown")"
+    func makeMigrationAttemptLogMessage(step: MigrationStep) -> String {
+        "⚠️ Attempting migration from \(step.sourceVersion.name) to \(step.targetVersion.name)"
     }
 }
 

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -179,34 +179,24 @@ private extension CoreDataIterativeMigrator {
                              storeType: String,
                              fromModel: NSManagedObjectModel,
                              toModel: NSManagedObjectModel,
-                             with mappingModel: NSMappingModel) -> (success: Bool, error: Error?) {
+                             with mappingModel: NSMappingModel) throws {
         let tempDestinationURL = createTemporaryFolder(at: url)
 
         // Migrate from the source model to the target model using the mapping,
         // and store the resulting data at the temporary path.
         let migrator = NSMigrationManager(sourceModel: fromModel, destinationModel: toModel)
-        do {
-            try migrator.migrateStore(from: url,
-                                      sourceType: storeType,
-                                      options: nil,
-                                      with: mappingModel,
-                                      toDestinationURL: tempDestinationURL,
-                                      destinationType: storeType,
-                                      destinationOptions: nil)
-        } catch {
-            return (false, error)
-        }
+        try migrator.migrateStore(from: url,
+                                  sourceType: storeType,
+                                  options: nil,
+                                  with: mappingModel,
+                                  toDestinationURL: tempDestinationURL,
+                                  destinationType: storeType,
+                                  destinationOptions: nil)
 
-        do {
-            // Delete the original store files.
-            try deleteStoreFiles(storeURL: url)
-            // Replace the (deleted) original store files with the migrated store files.
-            try copyMigratedOverOriginal(from: tempDestinationURL, to: url)
-        } catch {
-            return (false, error)
-        }
-
-        return (true, nil)
+        // Delete the original store files.
+        try deleteStoreFiles(storeURL: url)
+        // Replace the (deleted) original store files with the migrated store files.
+        try copyMigratedOverOriginal(from: tempDestinationURL, to: url)
     }
 
     func model(for metadata: [String: Any]) throws -> NSManagedObjectModel {

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -219,17 +219,6 @@ private extension CoreDataIterativeMigrator {
         return sourceModel
     }
 
-    func models(for modelVersions: [ManagedObjectModelsInventory.ModelVersion]) throws -> [NSManagedObjectModel] {
-        try modelVersions.map { version -> NSManagedObjectModel in
-            guard let model = self.modelsInventory.model(for: version) else {
-                let description = "No model found for \(version.name)"
-                throw NSError(domain: "IterativeMigrator", code: 110, userInfo: [NSLocalizedDescriptionKey: description])
-            }
-
-            return model
-        }
-    }
-
     /// Returns an inclusive list of models between the source and target models.
     ///
     /// For example, if `sourceModel` is `"Model 13"` and `targetModel` is `"Model 16"`, then this

--- a/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
+++ b/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
@@ -91,6 +91,9 @@ struct ManagedObjectModelsInventory {
         return NSManagedObjectModel(contentsOf: expectedMomURL)
     }
 
+    /// Loads the corresponding `NSManagedObjectModel` for the given `versions`.
+    ///
+    /// - Throws: If one of the `NSManagedObjectModels` is not found or cannot be loaded.
     func models(for versions: [ModelVersion]) throws -> [NSManagedObjectModel] {
         try versions.map { version in
             guard let model = self.model(for: version) else {

--- a/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
+++ b/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
@@ -90,6 +90,19 @@ struct ManagedObjectModelsInventory {
         let expectedMomURL = packageURL.appendingPathComponent(version.name).appendingPathExtension("mom")
         return NSManagedObjectModel(contentsOf: expectedMomURL)
     }
+
+    func models(for versions: [ModelVersion]) throws -> [NSManagedObjectModel] {
+        try versions.map { version in
+            guard let model = self.model(for: version) else {
+                let description = "No model found for \(version.name)"
+                throw NSError(domain: "ManagedObjectModelsInventory",
+                              code: 110,
+                              userInfo: [NSLocalizedDescriptionKey: description])
+            }
+
+            return model
+        }
+    }
 }
 
 // MARK: - Utils

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TestKit
+import CoreData
 
 @testable import Storage
 
@@ -110,8 +111,17 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
         XCTAssertEqual(actualStep, expectedStep)
     }
 
-    func test_steps_returns_empty_if_the_source_is_an_unknown_model() {
+    func test_steps_returns_empty_if_the_source_is_an_unknown_model() throws {
+        // Given
+        let unknownModel = NSManagedObjectModel()
 
+        // When
+        let steps = try MigrationStep.steps(using: modelsInventory,
+                                            source: unknownModel,
+                                            target: modelsInventory.currentModel)
+
+        // Then
+        assertEmpty(steps)
     }
 
     /// If the `source` and `target` are the same models, `steps()` will return steps from **that**

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
@@ -113,4 +113,22 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
     func test_steps_returns_empty_if_the_source_is_an_unknown_model() {
 
     }
+
+    /// If the `source` and `target` are the same models, `steps()` will return steps from **that**
+    /// model version up to the latest version in the inventory.
+    ///
+    /// This seems like a bug in the `steps()` loop that has existed for a long time. I would have
+    /// expected that 0 steps are returned. I'm just keeping it as is for now. We don't
+    /// reach this condition because of the precondition checks in `CoreDataIterativeMigrator`.
+    func test_steps_returns_source_to_latest_version_MigrationSteps_if_the_source_and_target_are_the_same() throws {
+        // Given
+        let modelVersion37 = ModelVersion(name: "Model 37")
+        let sourceModel = try XCTUnwrap(modelsInventory.model(for: modelVersion37))
+
+        // When
+        let steps = try MigrationStep.steps(using: modelsInventory, source: sourceModel, target: sourceModel)
+
+        // Then
+        XCTAssertEqual(steps.count, modelsInventory.versions.count - 37)
+    }
 }

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
@@ -124,6 +124,20 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
         assertEmpty(steps)
     }
 
+    func test_steps_returns_empty_if_the_source_is_the_current_model() throws {
+        // Given
+        let sourceModel = modelsInventory.currentModel
+        let targetModel = modelsInventory.currentModel
+
+        // When
+        let steps = try MigrationStep.steps(using: modelsInventory,
+                                            source: sourceModel,
+                                            target: targetModel)
+
+        // Then
+        assertEmpty(steps)
+    }
+
     /// If the `source` and `target` are the same models, `steps()` will return steps from **that**
     /// model version up to the latest version in the inventory.
     ///

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import Storage
+
+private typealias MigrationStep = CoreDataIterativeMigrator.MigrationStep
+private typealias ModelVersion = ManagedObjectModelsInventory.ModelVersion
+
+/// Test cases for `MigrationStep` functions.
+final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
+
+    private var modelsInventory: ManagedObjectModelsInventory!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        modelsInventory = try .from(packageName: "WooCommerce", bundle: Bundle(for: CoreDataManager.self))
+    }
+
+    override func tearDown() {
+        modelsInventory = nil
+        super.tearDown()
+    }
+
+    func test_steps_returns_MigrationSteps_from_source_to_the_target_model() throws {
+        // Given
+        let modelVersion23 = ModelVersion(name: "Model 23")
+        let modelVersion31 = ModelVersion(name: "Model 31")
+        let sourceModel = try XCTUnwrap(modelsInventory.model(for: modelVersion23))
+        let targetModel = try XCTUnwrap(modelsInventory.model(for: modelVersion31))
+
+        // When
+        let steps = try MigrationStep.steps(using: modelsInventory, source: sourceModel, target: targetModel)
+
+        // Then
+
+        // There should be 8 steps:
+        //   - 23 to 24
+        //   - 24 to 25
+        //   - 25 to 26
+        //   - 26 to 27
+        //   - 27 to 28
+        //   - 28 to 29
+        //   - 29 to 30
+        //   - 30 to 31
+        XCTAssertEqual(steps.count, 8)
+
+        // Assert the values of first and last steps.
+        let modelVersion24 = ModelVersion(name: "Model 24")
+
+        let expectedFirstStep = MigrationStep(sourceVersion: modelVersion23,
+                                              sourceModel: try XCTUnwrap(modelsInventory.model(for: modelVersion23)),
+                                              targetVersion: modelVersion24,
+                                              targetModel: try XCTUnwrap(modelsInventory.model(for: modelVersion24)))
+        let actualFirstStep = try XCTUnwrap(steps.first)
+        XCTAssertEqual(actualFirstStep, expectedFirstStep)
+
+        let modelVersion30 = ModelVersion(name: "Model 30")
+
+        let expectedLastStep = MigrationStep(sourceVersion: modelVersion30,
+                                              sourceModel: try XCTUnwrap(modelsInventory.model(for: modelVersion30)),
+                                              targetVersion: modelVersion31,
+                                              targetModel: try XCTUnwrap(modelsInventory.model(for: modelVersion31)))
+        let actualLastStep = try XCTUnwrap(steps.last)
+        XCTAssertEqual(actualLastStep, expectedLastStep)
+    }
+
+    func test_steps_returns_empty_if_the_source_and_target_are_the_same() {
+
+    }
+
+    func test_steps_returns_empty_if_the_source_is_an_unknown_model() {
+
+    }
+}

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigrator+MigrationStepTests.swift
@@ -30,9 +30,7 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
         let targetModel = try XCTUnwrap(modelsInventory.model(for: modelVersion31))
 
         // When
-        let steps = try MigrationStep.steps(using: modelsInventory,
-                                            source: sourceModel,
-                                            target: targetModel)
+        let steps = try MigrationStep.steps(using: modelsInventory, source: sourceModel, target: targetModel)
 
         // Then
         // There should be 8 steps:
@@ -75,9 +73,7 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
         let targetModel = try XCTUnwrap(modelsInventory.model(for: targetVersion))
 
         // When
-        let steps = try MigrationStep.steps(using: modelsInventory,
-                                            source: sourceModel,
-                                            target: targetModel)
+        let steps = try MigrationStep.steps(using: modelsInventory, source: sourceModel, target: targetModel)
 
         // Then
         XCTAssertEqual(steps.count, 1)
@@ -130,9 +126,7 @@ final class CoreDataIterativeMigrator_MigrationStepTests: XCTestCase {
         let targetModel = modelsInventory.currentModel
 
         // When
-        let steps = try MigrationStep.steps(using: modelsInventory,
-                                            source: sourceModel,
-                                            target: targetModel)
+        let steps = try MigrationStep.steps(using: modelsInventory, source: sourceModel, target: targetModel)
 
         // Then
         assertEmpty(steps)


### PR DESCRIPTION
Part of fixing #2667. Continuation of #3267.

Like #3267, this is another digestible chunk of the [WIP branch](https://github.com/woocommerce/woocommerce-ios/compare/issue/2667-reduce-file-operations-in-core-data) which reduces the `FileManager` operations in our Core Data stack. I've been trying to simplify the stack and add more unit tests to reduce the chances of regressions. 

I think the next PR will be the last one, which removes the `FileManager` operations. 

## Changes

This PR removes this index-based operation from the `CoreDataIterativeMigrator`: 

https://github.com/woocommerce/woocommerce-ios/blob/c3d5ad8d0ee956652cc57002d8ba4a27b17d0688/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift#L63-L68

These variables and their functions have also been removed from the `CoreDataIterativeMigrator`:

https://github.com/woocommerce/woocommerce-ios/blob/c3d5ad8d0ee956652cc57002d8ba4a27b17d0688/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift#L53-L56

These are now encapsulated inside a new `struct`, [`MigrationStep`](https://github.com/woocommerce/woocommerce-ios/blob/8fa4773ee1dca0019084efa1b0d177e289126533/Storage/Storage/CoreData/CoreDataIterativeMigrator%2BMigrationStep.swift#L6-L27). 

As a result, there is now a logical split: 

- `MigrationStep`: The **what**. Answers what `NSManagedObjectModels` are involved to upgrade a store to the latest version. 
- `CoreDataIterativeMigrator`:  The **how**. Blindly follows the steps given by [`MigrationStep.steps()`](https://github.com/woocommerce/woocommerce-ios/blob/8fa4773ee1dca0019084efa1b0d177e289126533/Storage/Storage/CoreData/CoreDataIterativeMigrator%2BMigrationStep.swift#L21-L27) and focuses on File and `NSMigrationManager` operations. 

## Testing

Please do a regression test that migrations still happen.

1. Delete the app on the device. 
2. Using this branch, delete models 41 and 42. 
3. Set the current model version to 40. 
4. Run the app and log in. But probably don't open Orders and Products because we're missing some Core Data properties. 😅 
5. Stop the app. 
6. Restore the deleted model versions and reset the current model version to 42. 
7. Add a breakpoint on this line:

    https://github.com/woocommerce/woocommerce-ios/blob/8fa4773ee1dca0019084efa1b0d177e289126533/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift#L68

8. Run the app again. Migrations should happen. Confirm that the breakpoint above was hit twice. And the `migrationAttemptMessage` variable contain these values:
    - `⚠️ Attempting migration from Model 40 to Model 41`
    - `⚠️ Attempting migration from Model 41 to Model 42`
9. Confirm that you can load the Orders and Products. 


## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

