### PR TITLE
Replace NSPredicates with TypedPredicates

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -8,21 +8,21 @@ public extension StorageType {
     /// Retrieves the Stored Account.
     ///
     func loadAccount(userID: Int64) -> Account? {
-        let predicate = NSPredicate(format: "userID = %ld", userID)
+        let predicate = \Account.userID == userID
         return firstObject(ofType: Account.self, matching: predicate)
     }
 
     /// Retrieves the Stores AccountSettings.
     ///
     func loadAccountSettings(userID: Int64) -> AccountSettings? {
-        let predicate = NSPredicate(format: "userID = %ld", userID)
+        let predicate = \AccountSettings.userID == userID
         return firstObject(ofType: AccountSettings.self, matching: predicate)
     }
 
     /// Retrieves the Stored Site.
     ///
     func loadSite(siteID: Int64) -> Site? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \Site.siteID == siteID
         return firstObject(ofType: Site.self, matching: predicate)
     }
 
@@ -31,70 +31,70 @@ public extension StorageType {
     /// Retrieves the Stored Order.
     ///
     func loadOrder(siteID: Int64, orderID: Int64) -> Order? {
-        let predicate = NSPredicate(format: "orderID = %ld AND siteID = %ld", orderID, siteID)
+        let predicate = \Order.orderID == orderID && \Order.siteID == siteID
         return firstObject(ofType: Order.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Lookup.
     ///
     func loadOrderSearchResults(keyword: String) -> OrderSearchResults? {
-        let predicate = NSPredicate(format: "keyword = %@", keyword)
+        let predicate = \OrderSearchResults.keyword == keyword
         return firstObject(ofType: OrderSearchResults.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Item.
     ///
     func loadOrderItem(siteID: Int64, orderID: Int64, itemID: Int64) -> OrderItem? {
-        let predicate = NSPredicate(format: "order.siteID = %ld AND order.orderID = %ld AND itemID = %ld", siteID, orderID, itemID)
+        let predicate = \OrderItem.order.siteID == siteID && \OrderItem.order.orderID == orderID && \OrderItem.itemID == itemID
         return firstObject(ofType: OrderItem.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Item Tax.
     ///
     func loadOrderItemTax(itemID: Int64, taxID: Int64) -> OrderItemTax? {
-        let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", itemID, taxID)
+        let predicate = \OrderItemTax.item?.itemID == itemID && \OrderItemTax.taxID == taxID
         return firstObject(ofType: OrderItemTax.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Coupon.
     ///
     func loadOrderCoupon(siteID: Int64, couponID: Int64) -> OrderCoupon? {
-        let predicate = NSPredicate(format: "order.siteID = %ld AND couponID = %ld", siteID, couponID)
+        let predicate = \OrderCoupon.order.siteID == siteID && \OrderCoupon.couponID == couponID
         return firstObject(ofType: OrderCoupon.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Fee.
     ///
     func loadOrderFeeLine(siteID: Int64, feeID: Int64) -> OrderFeeLine? {
-        let predicate = NSPredicate(format: "order.siteID = %ld AND feeID = %ld", siteID, feeID)
+        let predicate = \OrderFeeLine.order.siteID == siteID && \OrderFeeLine.feeID == feeID
         return firstObject(ofType: OrderFeeLine.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Refund Condensed.
     ///
     func loadOrderRefundCondensed(siteID: Int64, refundID: Int64) -> OrderRefundCondensed? {
-        let predicate = NSPredicate(format: "order.siteID = %ld AND refundID = %ld", siteID, refundID)
+        let predicate = \OrderRefundCondensed.order?.siteID == siteID && \OrderRefundCondensed.refundID == refundID
         return firstObject(ofType: OrderRefundCondensed.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Shipping Line.
     ///
     func loadOrderShippingLine(siteID: Int64, shippingID: Int64) -> ShippingLine? {
-        let predicate = NSPredicate(format: "order.siteID = %ld AND shippingID = %ld", siteID, shippingID)
+        let predicate = \ShippingLine.order?.siteID == siteID && \ShippingLine.shippingID == shippingID
         return firstObject(ofType: ShippingLine.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Shipping Line Tax.
     ///
     func loadShippingLineTax(shippingID: Int64, taxID: Int64) -> ShippingLineTax? {
-        let predicate = NSPredicate(format: "shipping.shippingID = %ld AND taxID = %ld", shippingID, taxID)
+        let predicate = \ShippingLineTax.shipping?.shippingID == shippingID && \ShippingLineTax.taxID == taxID
         return firstObject(ofType: ShippingLineTax.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Note.
     ///
     func loadOrderNote(noteID: Int64) -> OrderNote? {
-        let predicate = NSPredicate(format: "noteID = %ld", noteID)
+        let predicate = \OrderNote.noteID == noteID
         return firstObject(ofType: OrderNote.self, matching: predicate)
     }
 
@@ -103,42 +103,42 @@ public extension StorageType {
     /// Retrieves the Stored OrderCount.
     ///
     func loadOrderCount(siteID: Int64) -> OrderCount? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \OrderCount.siteID == siteID
         return firstObject(ofType: OrderCount.self, matching: predicate)
     }
 
     /// Retrieves the Stored TopEarnerStats.
     ///
     func loadTopEarnerStats(date: String, granularity: String) -> TopEarnerStats? {
-        let predicate = NSPredicate(format: "date ==[c] %@ AND granularity ==[c] %@", date, granularity)
+        let predicate = \TopEarnerStats.date == date && \TopEarnerStats.granularity == granularity
         return firstObject(ofType: TopEarnerStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored SiteVisitStats.
     ///
     func loadSiteVisitStats(granularity: String) -> SiteVisitStats? {
-        let predicate = NSPredicate(format: "granularity ==[c] %@", granularity)
+        let predicate = \SiteVisitStats.granularity == granularity
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored SiteVisitStats for stats v4.
     ///
     func loadSiteVisitStats(granularity: String, date: String) -> SiteVisitStats? {
-        let predicate = NSPredicate(format: "granularity ==[c] %@ AND date = %@", granularity, date)
+        let predicate = \SiteVisitStats.granularity == granularity && \SiteVisitStats.date == date
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStats for V4 API.
     ///
     func loadOrderStatsV4(siteID: Int64, timeRange: String) -> OrderStatsV4? {
-        let predicate = NSPredicate(format: "siteID = %ld AND timeRange ==[c] %@", siteID, timeRange)
+        let predicate = \OrderStatsV4.siteID == siteID && \OrderStatsV4.timeRange == timeRange
         return firstObject(ofType: OrderStatsV4.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStatsV4interval.
     ///
     func loadOrderStatsInterval(interval: String, orderStats: OrderStatsV4) -> OrderStatsV4Interval? {
-        let predicate = NSPredicate(format: "interval ==[c] %@ AND stats = %@", interval, orderStats)
+        let predicate = \OrderStatsV4Interval.interval == interval && \OrderStatsV4Interval.stats == orderStats
         return firstObject(ofType: OrderStatsV4Interval.self, matching: predicate)
     }
 
@@ -147,7 +147,7 @@ public extension StorageType {
     /// Retrieves all of the Stores OrderStatuses for the provided siteID.
     ///
     func loadOrderStatuses(siteID: Int64) -> [OrderStatus]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \OrderStatus.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \OrderStatus.name, ascending: false)
         return allObjects(ofType: OrderStatus.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -155,7 +155,7 @@ public extension StorageType {
     /// Retrieves the Stored OrderStatus
     ///
     func loadOrderStatus(siteID: Int64, slug: String) -> OrderStatus? {
-        let predicate = NSPredicate(format: "siteID = %ld AND slug ==[c] %@", siteID, slug)
+        let predicate = \OrderStatus.siteID == siteID && \OrderStatus.slug == slug
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
 
@@ -164,7 +164,7 @@ public extension StorageType {
     /// Retrieves **all** of the stored SiteSettings for the provided siteID.
     ///
     func loadAllSiteSettings(siteID: Int64) -> [SiteSetting]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \SiteSetting.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -172,7 +172,7 @@ public extension StorageType {
     /// Retrieves stored SiteSettings for the provided siteID and settingGroupKey.
     ///
     func loadSiteSettings(siteID: Int64, settingGroupKey: String) -> [SiteSetting]? {
-        let predicate = NSPredicate(format: "siteID = %ld AND settingGroupKey ==[c] %@", siteID, settingGroupKey)
+        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingGroupKey == settingGroupKey
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -180,7 +180,7 @@ public extension StorageType {
     /// Retrieves the Stored SiteSetting.
     ///
     func loadSiteSetting(siteID: Int64, settingID: String) -> SiteSetting? {
-        let predicate = NSPredicate(format: "siteID = %ld AND settingID ==[c] %@", siteID, settingID)
+        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingID == settingID
         return firstObject(ofType: SiteSetting.self, matching: predicate)
     }
 
@@ -189,14 +189,14 @@ public extension StorageType {
     /// Retrieves the Notification.
     ///
     func loadNotification(noteID: Int64) -> Note? {
-        let predicate = NSPredicate(format: "noteID = %ld", noteID)
+        let predicate = \Note.noteID == noteID
         return firstObject(ofType: Note.self, matching: predicate)
     }
 
     /// Retrieves the Notification.
     ///
     func loadNotification(noteID: Int64, noteHash: Int) -> Note? {
-        let predicate = NSPredicate(format: "noteID = %ld AND noteHash = %ld", noteID, noteHash)
+        let predicate = \Note.noteID == noteID && \Note.noteHash == (Int64)(noteHash)
         return firstObject(ofType: Note.self, matching: predicate)
     }
 
@@ -205,14 +205,14 @@ public extension StorageType {
     /// Retrieves a specific stored ShipmentTracking entity.
     ///
     func loadShipmentTracking(siteID: Int64, orderID: Int64, trackingID: String) -> ShipmentTracking? {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND trackingID ==[c] %@", siteID, orderID, trackingID)
+        let predicate = \ShipmentTracking.siteID == siteID && \ShipmentTracking.orderID == orderID && \ShipmentTracking.trackingID == trackingID
         return firstObject(ofType: ShipmentTracking.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTracking entities for the provided siteID and orderID.
     ///
     func loadShipmentTrackingList(siteID: Int64, orderID: Int64) -> [ShipmentTracking]? {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
+        let predicate = \ShipmentTracking.siteID == siteID && \ShipmentTracking.orderID == orderID
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTracking.orderID, ascending: false)
         return allObjects(ofType: ShipmentTracking.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -220,14 +220,14 @@ public extension StorageType {
     /// Retrieves a specific stored ShipmentTrackingProviderGroup
     ///
     func loadShipmentTrackingProviderGroup(siteID: Int64, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
-        let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, providerGroupName)
+        let predicate = \ShipmentTrackingProviderGroup.siteID == siteID && \ShipmentTrackingProviderGroup.name == providerGroupName
         return firstObject(ofType: ShipmentTrackingProviderGroup.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTrackingProviderGroup entities for the provided siteID.
     ///
     func loadShipmentTrackingProviderGroupList(siteID: Int64) -> [ShipmentTrackingProviderGroup]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ShipmentTrackingProviderGroup.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProviderGroup.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProviderGroup.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -235,7 +235,7 @@ public extension StorageType {
     /// Retrieves all of the stored ShipmentTrackingProvider entities for the provided siteID.
     ///
     func loadShipmentTrackingProviderList(siteID: Int64) -> [ShipmentTrackingProvider]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ShipmentTrackingProvider.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProvider.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProvider.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -243,7 +243,7 @@ public extension StorageType {
     /// Retrieves a stored ShipmentTrackingProvider for the provided siteID.
     ///
     func loadShipmentTrackingProvider(siteID: Int64, name: String) -> ShipmentTrackingProvider? {
-        let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, name)
+        let predicate = \ShipmentTrackingProvider.siteID == siteID && \ShipmentTrackingProvider.name == name
         return firstObject(ofType: ShipmentTrackingProvider.self, matching: predicate)
     }
 
@@ -252,7 +252,7 @@ public extension StorageType {
     /// Retrieves all of the stored Products for the provided siteID.
     ///
     func loadProducts(siteID: Int64) -> [Product]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \Product.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \Product.productID, ascending: false)
         return allObjects(ofType: Product.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -260,14 +260,14 @@ public extension StorageType {
     /// Retrieves all of the stored Products matching the provided array products ids from the provided SiteID
     ///
     func loadProducts(siteID: Int64, productsIDs: [Int64]) -> [Product] {
-        let predicate = NSPredicate(format: "siteID = %ld AND productID IN %@", siteID, productsIDs)
+        let predicate = \Product.siteID == siteID && \Product.productID === productsIDs
         return allObjects(ofType: Product.self, matching: predicate, sortedBy: nil)
     }
 
     /// Retrieves a stored Product for the provided siteID.
     ///
     func loadProduct(siteID: Int64, productID: Int64) -> Product? {
-        let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld", siteID, productID)
+        let predicate = \Product.siteID == siteID && \Product.productID == productID
         return firstObject(ofType: Product.self, matching: predicate)
     }
 
@@ -276,8 +276,8 @@ public extension StorageType {
     /// Note: WC attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
     func loadProductAttribute(siteID: Int64, productID: Int64, attributeID: Int64, name: String) -> ProductAttribute? {
-        let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
-                                    siteID, productID, attributeID, name)
+        let predicate = \ProductAttribute.product?.siteID == siteID && \ProductAttribute.product?.productID == productID
+            && \ProductAttribute.attributeID == attributeID && \ProductAttribute.name == name
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
     }
 
@@ -286,21 +286,22 @@ public extension StorageType {
     /// Note: this method is useful to fetch global attributes, which always have a non-zero ID.
     ///
     func loadProductAttribute(siteID: Int64, attributeID: Int64) -> ProductAttribute? {
-        let predicate = NSPredicate(format: "siteID = %ld AND attributeID = %ld", siteID, attributeID)
+        let predicate = \ProductAttribute.siteID == siteID && \ProductAttribute.attributeID == attributeID
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Attribute Term by, attribute and term ID.
     ///
     func loadProductAttributeTerm(siteID: Int64, termID: Int64, attributeID: Int64) -> ProductAttributeTerm? {
-        let predicate = NSPredicate(format: "siteID = %ld AND termID = %ld AND attribute.attributeID = %ld", siteID, termID, attributeID)
+        let predicate = \ProductAttributeTerm.siteID == siteID && \ProductAttributeTerm.termID == termID
+            && \ProductAttributeTerm.attribute?.attributeID == attributeID
         return firstObject(ofType: ProductAttributeTerm.self, matching: predicate)
     }
 
     /// Retrieves the all of the stored Product Attributes for a `siteID`.
     ///
     func loadProductAttributes(siteID: Int64) -> [ProductAttribute] {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ProductAttribute.siteID == siteID
         return allObjects(ofType: ProductAttribute.self, matching: predicate, sortedBy: nil)
     }
 
@@ -309,57 +310,57 @@ public extension StorageType {
     /// Note: WC default attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
     func loadProductDefaultAttribute(siteID: Int64, productID: Int64, defaultAttributeID: Int64, name: String) -> ProductDefaultAttribute? {
-        let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
-                                    siteID, productID, defaultAttributeID, name)
+        let predicate = \ProductDefaultAttribute.product?.siteID == siteID && \ProductDefaultAttribute.product?.productID == productID
+            && \ProductDefaultAttribute.attributeID == defaultAttributeID && \ProductDefaultAttribute.name == name
         return firstObject(ofType: ProductDefaultAttribute.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Image.
     ///
     func loadProductImage(siteID: Int64, productID: Int64, imageID: Int64) -> ProductImage? {
-        let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND imageID = %ld", siteID, productID, imageID)
+        let predicate = \ProductImage.product?.siteID == siteID && \ProductImage.product?.productID == productID && \ProductImage.imageID == imageID
         return firstObject(ofType: ProductImage.self, matching: predicate)
     }
 
     /// Retrieves the all of the stored Product Categories for a `siteID`.
     ///
     func loadProductCategories(siteID: Int64) -> [ProductCategory] {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ProductCategory.siteID == siteID
         return allObjects(ofType: ProductCategory.self, matching: predicate, sortedBy: nil)
     }
 
     /// Retrieves the Stored Product Category.
     ///
     func loadProductCategory(siteID: Int64, categoryID: Int64) -> ProductCategory? {
-        let predicate = NSPredicate(format: "siteID = %ld AND categoryID = %ld", siteID, categoryID)
+        let predicate = \ProductCategory.siteID == siteID && \ProductCategory.categoryID == categoryID
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
 
     /// Retrieves the Stored ProductSearchResults Lookup.
     ///
     func loadProductSearchResults(keyword: String) -> ProductSearchResults? {
-        let predicate = NSPredicate(format: "keyword = %@", keyword)
+        let predicate = \ProductSearchResults.keyword == keyword
         return firstObject(ofType: ProductSearchResults.self, matching: predicate)
     }
 
     /// Retrieves the all of the stored Product Tags for a `siteID`.
     ///
     func loadProductTags(siteID: Int64) -> [ProductTag] {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ProductTag.siteID == siteID
         return allObjects(ofType: ProductTag.self, matching: predicate, sortedBy: nil)
     }
 
     /// Retrieves the Stored Product Tag.
     ///
     func loadProductTag(siteID: Int64, tagID: Int64) -> ProductTag? {
-        let predicate = NSPredicate(format: "siteID = %ld AND tagID = %ld", siteID, tagID)
+        let predicate = \ProductTag.siteID == siteID && \ProductTag.tagID == tagID
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ProductReviews for the provided siteID. Sorted by dateCreated, descending
     ///
     func loadProductReviews(siteID: Int64) -> [ProductReview]? {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \ProductReview.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \ProductReview.dateCreated, ascending: false)
         return allObjects(ofType: ProductReview.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -367,7 +368,7 @@ public extension StorageType {
     /// Retrieves a stored ProductReview for the provided siteID and reviewID.
     ///
     func loadProductReview(siteID: Int64, reviewID: Int64) -> ProductReview? {
-        let predicate = NSPredicate(format: "siteID = %ld AND reviewID = %ld", siteID, reviewID)
+        let predicate = \ProductReview.siteID == siteID && \ProductReview.reviewID == reviewID
         return firstObject(ofType: ProductReview.self, matching: predicate)
     }
 
@@ -375,7 +376,7 @@ public extension StorageType {
     /// Sorted by name, ascending
     ///
     func loadProductShippingClasses(siteID: Int64) -> [ProductShippingClass]? {
-        let predicate = NSPredicate(format: "siteID = %lld", siteID)
+        let predicate = \ProductShippingClass.siteID == siteID
         let descriptor = NSSortDescriptor(keyPath: \ProductShippingClass.name, ascending: true)
         return allObjects(ofType: ProductShippingClass.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -384,7 +385,7 @@ public extension StorageType {
     /// Sorted by name, ascending
     ///
     func loadProductShippingClass(siteID: Int64, remoteID: Int64) -> ProductShippingClass? {
-        let predicate = NSPredicate(format: "siteID = %lld AND shippingClassID = %lld", siteID, remoteID)
+        let predicate = \ProductShippingClass.siteID == siteID && \ProductShippingClass.shippingClassID == remoteID
         return firstObject(ofType: ProductShippingClass.self, matching: predicate)
     }
 
@@ -392,7 +393,7 @@ public extension StorageType {
     /// Sorted by dateCreated, descending
     ///
     func loadProductVariations(siteID: Int64, productID: Int64) -> [ProductVariation]? {
-        let predicate = NSPredicate(format: "siteID = %lld AND productID = %lld", siteID, productID)
+        let predicate = \ProductVariation.siteID == siteID && \ProductVariation.productID == productID
         let descriptor = NSSortDescriptor(keyPath: \ProductVariation.dateCreated, ascending: false)
         return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -400,7 +401,7 @@ public extension StorageType {
     /// Retrieves a stored ProductVariation for the provided siteID and productVariationID.
     ///
     func loadProductVariation(siteID: Int64, productVariationID: Int64) -> ProductVariation? {
-        let predicate = NSPredicate(format: "siteID = %lld AND productVariationID = %lld", siteID, productVariationID)
+        let predicate = \ProductVariation.siteID == siteID && \ProductVariation.productVariationID == productVariationID
         return firstObject(ofType: ProductVariation.self, matching: predicate)
     }
 
@@ -411,7 +412,7 @@ public extension StorageType {
             return nil
         }
 
-        let predicate = NSPredicate(format: "slug = %@", slug)
+        let predicate = \TaxClass.slug == slug
         return firstObject(ofType: TaxClass.self, matching: predicate)
     }
 
@@ -427,7 +428,7 @@ public extension StorageType {
     /// Retrieves all of the stored Refund entities for the provided siteID and orderID.
     ///
     func loadRefunds(siteID: Int64, orderID: Int64) -> [Refund] {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
+        let predicate = \Refund.siteID == siteID && \Refund.orderID == orderID
         let descriptor = NSSortDescriptor(keyPath: \Refund.dateCreated, ascending: false)
         return allObjects(ofType: Refund.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -435,28 +436,28 @@ public extension StorageType {
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.
     ///
     func loadRefund(siteID: Int64, orderID: Int64, refundID: Int64) -> Refund? {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND refundID = %ld", siteID, orderID, refundID)
+        let predicate = \Refund.siteID == siteID && \Refund.orderID == orderID && \Refund.refundID == refundID
         return firstObject(ofType: Refund.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderItemRefund.
     ///
     func loadRefundItem(siteID: Int64, refundID: Int64, itemID: Int64) -> OrderItemRefund? {
-    let predicate = NSPredicate(format: "refund.siteID = %ld AND refund.refundID = %ld AND itemID = %ld", siteID, refundID, itemID)
+        let predicate = \OrderItemRefund.refund?.siteID == siteID && \OrderItemRefund.refund?.refundID == refundID && \OrderItemRefund.itemID == itemID
         return firstObject(ofType: OrderItemRefund.self, matching: predicate)
     }
 
     /// Retrieves the Stored Refund Shipping Line.
     ///
     func loadRefundShippingLine(siteID: Int64, shippingID: Int64) -> ShippingLine? {
-        let predicate = NSPredicate(format: "refund.siteID = %ld AND shippingID = %ld", siteID, shippingID)
+        let predicate = \ShippingLine.refund?.siteID == siteID && \ShippingLine.shippingID == shippingID
         return firstObject(ofType: ShippingLine.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderItemTaxRefund.
     ///
     func loadRefundItemTax(itemID: Int64, taxID: Int64) -> OrderItemTaxRefund? {
-        let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", itemID, taxID)
+        let predicate = \OrderItemTaxRefund.item?.itemID == itemID && \OrderItemTaxRefund.taxID == taxID
         return firstObject(ofType: OrderItemTaxRefund.self, matching: predicate)
     }
 
@@ -465,14 +466,14 @@ public extension StorageType {
     /// Returns all stored payment gateways for a site.
     ///
     func loadAllPaymentGateways(siteID: Int64) -> [PaymentGateway] {
-        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let predicate = \PaymentGateway.siteID == siteID
         return allObjects(ofType: PaymentGateway.self, matching: predicate, sortedBy: nil)
     }
 
     /// Returns a single payment gateway given a `siteID` and a `gatewayID`
     ///
     func loadPaymentGateway(siteID: Int64, gatewayID: String) -> PaymentGateway? {
-        let predicate = NSPredicate(format: "siteID = %ld AND gatewayID = %@", siteID, gatewayID)
+        let predicate = \PaymentGateway.siteID == siteID && \PaymentGateway.gatewayID == gatewayID
         return firstObject(ofType: PaymentGateway.self, matching: predicate)
     }
 
@@ -481,21 +482,21 @@ public extension StorageType {
     /// Returns all stored shipping labels for a site and order.
     ///
     func loadAllShippingLabels(siteID: Int64, orderID: Int64) -> [ShippingLabel] {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
+        let predicate = \ShippingLabel.siteID == siteID && \ShippingLabel.orderID == orderID
         return allObjects(ofType: ShippingLabel.self, matching: predicate, sortedBy: nil)
     }
 
     /// Returns a single shipping label given a `siteID`, `orderID`, and `shippingLabelID`
     ///
     func loadShippingLabel(siteID: Int64, orderID: Int64, shippingLabelID: Int64) -> ShippingLabel? {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND shippingLabelID = %ld", siteID, orderID, shippingLabelID)
+        let predicate = \ShippingLabel.siteID == siteID && \ShippingLabel.orderID == orderID && \ShippingLabel.shippingLabelID == shippingLabelID
         return firstObject(ofType: ShippingLabel.self, matching: predicate)
     }
 
     /// Returns a single shipping label settings given a `siteID` and `orderID`
     ///
     func loadShippingLabelSettings(siteID: Int64, orderID: Int64) -> ShippingLabelSettings? {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
+        let predicate = \ShippingLabelSettings.siteID == siteID && \ShippingLabelSettings.orderID == orderID
         return firstObject(ofType: ShippingLabelSettings.self, matching: predicate)
     }
 }

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -110,35 +110,35 @@ public extension StorageType {
     /// Retrieves the Stored TopEarnerStats.
     ///
     func loadTopEarnerStats(date: String, granularity: String) -> TopEarnerStats? {
-        let predicate = \TopEarnerStats.date == date && \TopEarnerStats.granularity == granularity
+        let predicate = \TopEarnerStats.date =~ date && \TopEarnerStats.granularity =~ granularity
         return firstObject(ofType: TopEarnerStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored SiteVisitStats.
     ///
     func loadSiteVisitStats(granularity: String) -> SiteVisitStats? {
-        let predicate = \SiteVisitStats.granularity == granularity
+        let predicate = \SiteVisitStats.granularity =~ granularity
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored SiteVisitStats for stats v4.
     ///
     func loadSiteVisitStats(granularity: String, date: String) -> SiteVisitStats? {
-        let predicate = \SiteVisitStats.granularity == granularity && \SiteVisitStats.date == date
+        let predicate = \SiteVisitStats.granularity =~ granularity && \SiteVisitStats.date =~ date
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStats for V4 API.
     ///
     func loadOrderStatsV4(siteID: Int64, timeRange: String) -> OrderStatsV4? {
-        let predicate = \OrderStatsV4.siteID == siteID && \OrderStatsV4.timeRange == timeRange
+        let predicate = \OrderStatsV4.siteID == siteID && \OrderStatsV4.timeRange =~ timeRange
         return firstObject(ofType: OrderStatsV4.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStatsV4interval.
     ///
     func loadOrderStatsInterval(interval: String, orderStats: OrderStatsV4) -> OrderStatsV4Interval? {
-        let predicate = \OrderStatsV4Interval.interval == interval && \OrderStatsV4Interval.stats == orderStats
+        let predicate = \OrderStatsV4Interval.interval =~ interval && \OrderStatsV4Interval.stats == orderStats
         return firstObject(ofType: OrderStatsV4Interval.self, matching: predicate)
     }
 
@@ -155,7 +155,7 @@ public extension StorageType {
     /// Retrieves the Stored OrderStatus
     ///
     func loadOrderStatus(siteID: Int64, slug: String) -> OrderStatus? {
-        let predicate = \OrderStatus.siteID == siteID && \OrderStatus.slug == slug
+        let predicate = \OrderStatus.siteID == siteID && \OrderStatus.slug =~ slug
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
 
@@ -172,7 +172,7 @@ public extension StorageType {
     /// Retrieves stored SiteSettings for the provided siteID and settingGroupKey.
     ///
     func loadSiteSettings(siteID: Int64, settingGroupKey: String) -> [SiteSetting]? {
-        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingGroupKey == settingGroupKey
+        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingGroupKey =~ settingGroupKey
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
     }
@@ -180,7 +180,7 @@ public extension StorageType {
     /// Retrieves the Stored SiteSetting.
     ///
     func loadSiteSetting(siteID: Int64, settingID: String) -> SiteSetting? {
-        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingID == settingID
+        let predicate = \SiteSetting.siteID == siteID && \SiteSetting.settingID =~ settingID
         return firstObject(ofType: SiteSetting.self, matching: predicate)
     }
 
@@ -205,7 +205,7 @@ public extension StorageType {
     /// Retrieves a specific stored ShipmentTracking entity.
     ///
     func loadShipmentTracking(siteID: Int64, orderID: Int64, trackingID: String) -> ShipmentTracking? {
-        let predicate = \ShipmentTracking.siteID == siteID && \ShipmentTracking.orderID == orderID && \ShipmentTracking.trackingID == trackingID
+        let predicate = \ShipmentTracking.siteID == siteID && \ShipmentTracking.orderID == orderID && \ShipmentTracking.trackingID =~ trackingID
         return firstObject(ofType: ShipmentTracking.self, matching: predicate)
     }
 
@@ -220,7 +220,7 @@ public extension StorageType {
     /// Retrieves a specific stored ShipmentTrackingProviderGroup
     ///
     func loadShipmentTrackingProviderGroup(siteID: Int64, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
-        let predicate = \ShipmentTrackingProviderGroup.siteID == siteID && \ShipmentTrackingProviderGroup.name == providerGroupName
+        let predicate = \ShipmentTrackingProviderGroup.siteID == siteID && \ShipmentTrackingProviderGroup.name =~ providerGroupName
         return firstObject(ofType: ShipmentTrackingProviderGroup.self, matching: predicate)
     }
 
@@ -243,7 +243,7 @@ public extension StorageType {
     /// Retrieves a stored ShipmentTrackingProvider for the provided siteID.
     ///
     func loadShipmentTrackingProvider(siteID: Int64, name: String) -> ShipmentTrackingProvider? {
-        let predicate = \ShipmentTrackingProvider.siteID == siteID && \ShipmentTrackingProvider.name == name
+        let predicate = \ShipmentTrackingProvider.siteID == siteID && \ShipmentTrackingProvider.name =~ name
         return firstObject(ofType: ShipmentTrackingProvider.self, matching: predicate)
     }
 
@@ -276,7 +276,7 @@ public extension StorageType {
     /// Note: WC attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
     func loadProductAttribute(siteID: Int64, productID: Int64, attributeID: Int64, name: String) -> ProductAttribute? {
-        let predicate = \ProductAttribute.product?.siteID == siteID && \ProductAttribute.product?.productID == productID
+        let predicate = \ProductAttribute.product?.siteID == siteID && \ProductAttribute.product?.productID =~ productID
             && \ProductAttribute.attributeID == attributeID && \ProductAttribute.name == name
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
     }
@@ -310,7 +310,7 @@ public extension StorageType {
     /// Note: WC default attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
     func loadProductDefaultAttribute(siteID: Int64, productID: Int64, defaultAttributeID: Int64, name: String) -> ProductDefaultAttribute? {
-        let predicate = \ProductDefaultAttribute.product?.siteID == siteID && \ProductDefaultAttribute.product?.productID == productID
+        let predicate = \ProductDefaultAttribute.product?.siteID == siteID && \ProductDefaultAttribute.product?.productID =~ productID
             && \ProductDefaultAttribute.attributeID == defaultAttributeID && \ProductDefaultAttribute.name == name
         return firstObject(ofType: ProductDefaultAttribute.self, matching: predicate)
     }


### PR DESCRIPTION
closes #3465 

# Why

After https://github.com/woocommerce/woocommerce-ios/pull/3485 we can now replace the existing stringly-typed `NSPredicates` with the new safer version that uses Swift's keypaths.

# How
<img width="300" alt="Screen Shot 2021-01-18 at 3 54 36 PM" src="https://user-images.githubusercontent.com/562080/104961991-7dcd1400-59a5-11eb-883f-a5dc6afc9f8c.png">


# Testing Steps
We should not have any regressions as these methods are unit tested but a smoke test checking that the app works as expected does not hurt 😇 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
### 