### PR TITLE
Product Settings > Visibility: hide the separator between password visibility and password text field row

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
@@ -22,7 +22,9 @@ extension UITableViewCell {
     /// Be careful applying this to a reusable cell where the separator is expected to be shown in some cases.
     ///
     func hideSeparator() {
-        separatorInset = UIEdgeInsets(top: 0, left: separatorInset.left, bottom: 0, right: .greatestFiniteMagnitude)
+        // Using `CGFloat.greatestFiniteMagnitude` for the right separator inset would not work if the cell is initially configured with `hideSeparator()` then
+        // updated with `showSeparator()` later after the table view is rendered - the separator would not be shown again.
+        separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 999999)
     }
 
     /// Shows the separator for a cell.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -57,6 +57,11 @@ final class ProductVisibilityViewController: UIViewController {
         }
     }
 
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        reloadSections()
+    }
+
     private func reloadSections() {
         if visibility == .passwordProtected {
             sections = [Section(rows: [.publicVisibility, .passwordVisibility, .passwordField, .privateVisibility])]
@@ -212,7 +217,7 @@ private extension ProductVisibilityViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = row.description
         cell.accessoryType = row.visibility == visibility ? .checkmark : .none
-        cell.showSeparator()
+        cell.showSeparator(inset: .init(top: 0, left: tableView.layoutMargins.left, bottom: 0, right: 0))
     }
 
     func configurePasswordVisibilityCell(cell: BasicTableViewCell, indexPath: IndexPath) {
@@ -225,7 +230,7 @@ private extension ProductVisibilityViewController {
         if isSelected {
             cell.hideSeparator()
         } else {
-            cell.showSeparator()
+            cell.showSeparator(inset: .init(top: 0, left: tableView.layoutMargins.left, bottom: 0, right: 0))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -216,13 +216,12 @@ private extension ProductVisibilityViewController {
     }
 
     func configurePasswordVisibilityCell(cell: BasicTableViewCell, indexPath: IndexPath) {
-        let row = sections[indexPath.section].rows[indexPath.row]
-        cell.selectionStyle = .default
-        cell.textLabel?.text = row.description
+        configureVisibilityCell(cell: cell, indexPath: indexPath)
 
-        let isSelected = row.visibility == visibility
-        cell.accessoryType = isSelected ? .checkmark : .none
-
+        let isSelected: Bool = {
+            let row = sections[indexPath.section].rows[indexPath.row]
+            return row.visibility == visibility
+        }()
         if isSelected {
             cell.hideSeparator()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -196,6 +196,8 @@ private extension ProductVisibilityViewController {
     ///
    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
+        case let cell as BasicTableViewCell where row == .passwordVisibility:
+            configurePasswordVisibilityCell(cell: cell, indexPath: indexPath)
         case let cell as BasicTableViewCell:
             configureVisibilityCell(cell: cell, indexPath: indexPath)
         case let cell as TitleAndTextFieldWithImageTableViewCell:
@@ -210,6 +212,22 @@ private extension ProductVisibilityViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = row.description
         cell.accessoryType = row.visibility == visibility ? .checkmark : .none
+        cell.showSeparator()
+    }
+
+    func configurePasswordVisibilityCell(cell: BasicTableViewCell, indexPath: IndexPath) {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        cell.selectionStyle = .default
+        cell.textLabel?.text = row.description
+
+        let isSelected = row.visibility == visibility
+        cell.accessoryType = isSelected ? .checkmark : .none
+
+        if isSelected {
+            cell.hideSeparator()
+        } else {
+            cell.showSeparator()
+        }
     }
 
     func configurePasswordFieldCell(cell: TitleAndTextFieldWithImageTableViewCell, indexPath: IndexPath) {


### PR DESCRIPTION
Fixes #2274 

## Why

The goal is to hide the password visibility cell separator when it is selected since the password text field is shown below. @rachelmcr noticed a challenging issue if a cell is first configured with `hideSeparator()` and then later changed to `showSeparator()` (ref https://github.com/woocommerce/woocommerce-ios/issues/2274#issuecomment-760948136) - a few of us looking into this and the usage of [`CGFloat.greatestFiniteMagnitude`](https://developer.apple.com/documentation/coregraphics/cgfloat/1845207-greatestfinitemagnitude) in the separator inset is causing this issue. This PR addresses this unexpected issue by replacing `.greatestFiniteMagnitude` with a large number. Feel free to suggest any other ideas!

## Changes

- In `ProductVisibilityViewController`, separated cell configuration for `Row.passwordVisibility` so that we show/hide the cell separator when it is deselected/selected, respectively.
- In `UITableViewCell.hideSeparator()`, replaced `.greatestFiniteMagnitude` right inset with a large number - I've tried `.greatestFiniteMagnitude - 1` but it did not work 😐 

## Testing

### Scenario 1: product is originally not password protected

- Go to the products tab
- Tap on a product with public or private visibility
- Tap the ellipsis menu, then tap "Product Settings"
- Tap "Visibility" row when it becomes tappable --> the "Password Protected" row should have a separator
- Tap "Password Protected" row --> the password text field should appear, and "Password Protected" row should not have a separator
- Feel free to tap around to verify that the separator is hidden when "Password Protected" is selected

### Scenario 2: product is originally password protected

- Go to the products tab
- Tap on a product that is password protected
- Tap the ellipsis menu, then tap "Product Settings"
- Tap "Visibility" row when it becomes tappable --> the "Password Protected" row should not have a separator and the password text field is shown below
- Tap "Public" or "Private" row --> the password text field should be hidden, and "Password Protected" row should now have a separator
- Feel free to tap around to verify that the separator is hidden when "Password Protected" is selected

## Example screenshots

product is not password protected | product is password protected
-- | --
![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 11 16 43](https://user-images.githubusercontent.com/1945542/105122389-1502aa80-5b11-11eb-931d-c738798d60da.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 11 16 52](https://user-images.githubusercontent.com/1945542/105122392-1633d780-5b11-11eb-9276-f2b79cd30ade.png)
![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 11 15 22](https://user-images.githubusercontent.com/1945542/105122382-10d68d00-5b11-11eb-8626-73c37a84352b.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 11 15 27](https://user-images.githubusercontent.com/1945542/105122387-1338e700-5b11-11eb-8d84-48c9917393f5.png)
 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
