### PR TITLE
Revert unwanted bump to WordPressAuthenticator

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.25.0-beta.3):
+  - WordPressKit (4.24.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -183,7 +183,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 2699e025994e127ffe2ec507fc7481f10b1df31c
-  WordPressKit: 1b61217cea9e7045ff74a9c8df391d7788776daf
+  WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: cb5d0c58f92778b6dffcdcb8234ed8d7a930ce90
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471


### PR DESCRIPTION
Revert a bump to WordPressKit introduced, by mistake, in #3483

## Changes
Reverted the pinned version of WPKit in Podfile.lock

## How to test
Check out the branch, run `bundle exec pod install` and check that the build passes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
