### PR TITLE
Fix: product is now read-only when opened from the order details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,7 @@
 - [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 - [*] fix: in Settings > Switch Store, the spinner in the "Continue" button at the bottom is now visible in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/3468]
 - [*] fix: in order details, the shipping and billing address are displayed in the order of the country (in some eastern Asian countries, the address starts from the largest unit to the smallest). [https://github.com/woocommerce/woocommerce-ios/pull/3469]
-- [*] fix: product is now read-only when opened from the order details.
+- [*] fix: product is now read-only when opened from the order details. [https://github.com/woocommerce/woocommerce-ios/pull/3491]
 
 
 5.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 - [*] fix: in Settings > Switch Store, the spinner in the "Continue" button at the bottom is now visible in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/3468]
 - [*] fix: in order details, the shipping and billing address are displayed in the order of the country (in some eastern Asian countries, the address starts from the largest unit to the smallest). [https://github.com/woocommerce/woocommerce-ios/pull/3469]
+- [*] fix: product is now read-only when opened from the order details.
 
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -126,7 +126,7 @@ private extension ProductListViewController {
     func productWasPressed(orderItem: OrderItem) {
         let loaderViewController = ProductLoaderViewController(model: .init(orderItem: orderItem),
                                                                siteID: viewModel.order.siteID,
-                                                               forceReadOnly: false)
+                                                               forceReadOnly: true)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }


### PR DESCRIPTION
Fixes #3274 

## Description
Previously, when the order is in [failed, on hold, pending] state, there is a "details" row below the list of products on the order screen.
If you tap on the product on the order screen, it opens read only view.
If you tap on the product from details screen, it opens read-write view.
For creating a consistent behavior, both actions should open read-only view of the product.

## Testing
1. Go to an order.
2. Tap on a product, it opens read-only view.
3. Close product details.
4. Tap on "Details" row below the list of products.
5. Tap on a product, it opens read-only view.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
