### PR TITLE
Aztec: Show link settings as a popover

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 - [*] fix: in Settings > Switch Store, the spinner in the "Continue" button at the bottom is now visible in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/3468]
 - [*] fix: in order details, the shipping and billing address are displayed in the order of the country (in some eastern Asian countries, the address starts from the largest unit to the smallest). [https://github.com/woocommerce/woocommerce-ios/pull/3469]
+- [*] When adding or editing a link (e.g. in a product description) link settings are now presented as a popover on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3492]
 
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
@@ -66,8 +66,17 @@ private extension AztecLinkFormatBarCommand {
             }
         })
 
-        // TODO-1496: show the Link Settings as a popover.
         let navigationController = UINavigationController(rootViewController: linkController)
+        navigationController.modalPresentationStyle = .popover
+        navigationController.popoverPresentationController?.sourceView = richTextView
+        if richTextView.selectedRange.length > 0,
+           let textRange = richTextView.selectedTextRange,
+           let selectionRect = richTextView.selectionRects(for: textRange).first {
+            navigationController.popoverPresentationController?.sourceRect = selectionRect.rect
+        } else if let textRange = richTextView.selectedTextRange {
+            let caretRect = richTextView.caretRect(for: textRange.start)
+            navigationController.popoverPresentationController?.sourceRect = caretRect
+        }
         presenter?.present(navigationController, animated: true)
         richTextView.resignFirstResponder()
     }


### PR DESCRIPTION
Fixes: #1496 

## Description

This PR displays Link Settings in Aztec (when adding/editing a link in the editor) as a popover on iPad instead of a modal. This matches the current Aztec behavior in WPiOS.

## Changes

Link Settings is now displayed with a popover `modalPresentationStyle` using the same approach as in [WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/28aeee291bfc558b17c195faf78e9b581098a7d6/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift#L1732). The popover arrow will point to the selected link text or (if no text was selected when the link button was tapped) to the current cursor position.

This doesn't change the modal style on iPhones.

Before|After
-|-
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-01-19 at 12 49 35](https://user-images.githubusercontent.com/8658164/105041374-d3172d00-5a5a-11eb-91c9-2e9cdc0d7c04.png)|![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-01-19 at 12 37 33](https://user-images.githubusercontent.com/8658164/105041480-f346ec00-5a5a-11eb-88be-85e3e6d4f8bc.png)

## Testing

On iPad:

1. Add a new product or edit an existing product.
2. Select Description.
3. Add some text in the editor.
4. With or without selecting some text first, tap the link button to add a link.
5. Confirm the link settings open as a popover, with the popover arrow pointed toward your text selection or (if no text is selected when you tap the link button) toward the current cursor position.
6. Rotate your device and confirm the popover behaves as expected.
7. Confirm you can insert the link or cancel adding the link as expected.

On iPhone:

1. Add a new product or edit an existing product.
2. Select Description.
3. Add some text in the editor.
4. With or without selecting some text first, tap the link button to add a link.
5. Confirm the link settings open with a full screen style (no change from before).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
