### PR TITLE
Fix: pull to refresh on the order status picker screen does not resets anymore the current selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,7 @@
 - [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 - [*] fix: in Settings > Switch Store, the spinner in the "Continue" button at the bottom is now visible in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/3468]
 - [*] fix: in order details, the shipping and billing address are displayed in the order of the country (in some eastern Asian countries, the address starts from the largest unit to the smallest). [https://github.com/woocommerce/woocommerce-ios/pull/3469]
-- [*] fix: pull to refresh on the order status picker screen does not resets anymore the current selection.
+- [*] fix: pull to refresh on the order status picker screen does not resets anymore the current selection. [https://github.com/woocommerce/woocommerce-ios/pull/3493]
 
 
 5.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] fix: now we don't show any more similar alert notices if an error occurred. [https://github.com/woocommerce/woocommerce-ios/pull/3474]
 - [*] fix: in Settings > Switch Store, the spinner in the "Continue" button at the bottom is now visible in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/3468]
 - [*] fix: in order details, the shipping and billing address are displayed in the order of the country (in some eastern Asian countries, the address starts from the largest unit to the smallest). [https://github.com/woocommerce/woocommerce-ios/pull/3469]
+- [*] fix: pull to refresh on the order status picker screen does not resets anymore the current selection.
 
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -75,6 +75,7 @@ final class OrderStatusListViewController: UIViewController {
         }
 
         tableView.reloadData()
+        preselectStatusIfPossible()
     }
 
     private func preselectStatusIfPossible() {


### PR DESCRIPTION
Fixes #3271 

## Description
The pull to refresh action on the order status picker screen resets the checkmark on a currently selected cell and it looks like nothing is selected, but the selection should be visible after reload.

## Testing
1. Go to Order.
2. Click on the "pencil" icon to edit order status.
3. Pull to refresh.
4. See that checkmark from the selected status is still visible.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
