### PR TITLE
Removed all the use cases of "segue" from the app

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -416,10 +416,3 @@ extension OrderDetailsViewModel {
         stores.dispatch(deleteTrackingAction)
     }
 }
-
-private extension OrderDetailsViewModel {
-
-    enum Constants {
-        static let orderStatusListSegue = "ShowOrderStatusListViewController"
-    }
-}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -236,7 +236,12 @@ extension OrderDetailsViewModel {
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .details:
             ServiceLocator.analytics.track(.orderDetailProductDetailTapped)
-            viewController.performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)
+            let identifier = ProductListViewController.classNameWithoutNamespaces
+            guard let productListVC = UIStoryboard.orders.instantiateViewController(identifier: identifier) as? ProductListViewController else {
+                return
+            }
+            productListVC.viewModel = self
+            viewController.navigationController?.pushViewController(productListVC, animated: true)
         case .refund:
             ServiceLocator.analytics.track(.orderDetailRefundDetailTapped)
             guard let refund = dataSource.refund(at: indexPath) else {
@@ -415,7 +420,6 @@ extension OrderDetailsViewModel {
 private extension OrderDetailsViewModel {
 
     enum Constants {
-        static let productDetailsSegue = "ShowProductListViewController"
         static let orderStatusListSegue = "ShowOrderStatusListViewController"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -238,6 +238,7 @@ extension OrderDetailsViewModel {
             ServiceLocator.analytics.track(.orderDetailProductDetailTapped)
             let identifier = ProductListViewController.classNameWithoutNamespaces
             guard let productListVC = UIStoryboard.orders.instantiateViewController(identifier: identifier) as? ProductListViewController else {
+                DDLogError("Error: attempted to instantiate ProductListViewController. Instantiation failed.")
                 return
             }
             productListVC.viewModel = self

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -68,7 +68,6 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="pYs-VV-dST" id="Cqx-Lg-UJh"/>
-                        <segue destination="dyy-ah-iUY" kind="show" identifier="ShowApplicationLogDetailViewController" id="Ws4-zy-SlV"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fOe-oS-ZTi" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -78,13 +77,13 @@
         <!--Application Log Detail View Controller-->
         <scene sceneID="EFa-xb-BCc">
             <objects>
-                <viewController id="dyy-ah-iUY" customClass="ApplicationLogDetailViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ApplicationLogDetailViewController" id="dyy-ah-iUY" customClass="ApplicationLogDetailViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TC5-cg-3Zt">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="VZ4-xD-33I">
-                                <rect key="frame" x="16" y="0.0" width="343" height="647"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" notEnabled="YES"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,20 +18,20 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hwi-He-cKY">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="tLZ-3e-cJY" id="uum-dx-Yau"/>
                                     <outlet property="delegate" destination="tLZ-3e-cJY" id="Ig0-wR-2Ms"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="e4p-U3-YVf"/>
                         <constraints>
                             <constraint firstAttribute="bottomMargin" secondItem="hwi-He-cKY" secondAttribute="bottom" id="UPd-Rr-5ev"/>
                             <constraint firstItem="hwi-He-cKY" firstAttribute="trailing" secondItem="e4p-U3-YVf" secondAttribute="trailing" id="mcB-Fh-FAx"/>
                             <constraint firstItem="hwi-He-cKY" firstAttribute="top" secondItem="eDL-oC-fDz" secondAttribute="topMargin" id="sVu-Pi-CPd"/>
                             <constraint firstItem="hwi-He-cKY" firstAttribute="leading" secondItem="e4p-U3-YVf" secondAttribute="leading" id="tE5-ir-eJR"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="e4p-U3-YVf"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="hwi-He-cKY" id="dz2-gV-Lqe"/>
@@ -44,27 +44,27 @@
         <!--Application Log View Controller-->
         <scene sceneID="bod-JW-RLg">
             <objects>
-                <viewController id="cZP-lH-gTc" customClass="ApplicationLogViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ApplicationLogViewController" id="cZP-lH-gTc" customClass="ApplicationLogViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kTI-Ip-3qK">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="pYs-VV-dST">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="cZP-lH-gTc" id="elE-X0-kT3"/>
                                     <outlet property="delegate" destination="cZP-lH-gTc" id="Pq1-iP-TpG"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="qMn-MK-zzV"/>
                         <constraints>
                             <constraint firstItem="qMn-MK-zzV" firstAttribute="trailing" secondItem="pYs-VV-dST" secondAttribute="trailing" id="9bn-9p-K1Z"/>
                             <constraint firstItem="pYs-VV-dST" firstAttribute="leading" secondItem="qMn-MK-zzV" secondAttribute="leading" id="OUm-VB-DJ3"/>
                             <constraint firstItem="pYs-VV-dST" firstAttribute="top" secondItem="qMn-MK-zzV" secondAttribute="top" id="nJg-fe-Omp"/>
                             <constraint firstItem="qMn-MK-zzV" firstAttribute="bottom" secondItem="pYs-VV-dST" secondAttribute="bottom" id="o10-zc-2HE"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qMn-MK-zzV"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="pYs-VV-dST" id="Cqx-Lg-UJh"/>
@@ -94,13 +94,13 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="qu3-Gh-sHY"/>
                         <constraints>
                             <constraint firstItem="VZ4-xD-33I" firstAttribute="bottom" secondItem="qu3-Gh-sHY" secondAttribute="bottom" id="4Ax-uJ-Iya"/>
                             <constraint firstItem="VZ4-xD-33I" firstAttribute="leading" secondItem="qu3-Gh-sHY" secondAttribute="leading" constant="16" id="8fn-dv-dTY"/>
                             <constraint firstItem="VZ4-xD-33I" firstAttribute="top" secondItem="qu3-Gh-sHY" secondAttribute="top" id="B4a-y2-5Qj"/>
                             <constraint firstItem="qu3-Gh-sHY" firstAttribute="trailing" secondItem="VZ4-xD-33I" secondAttribute="trailing" constant="16" id="Pft-fy-5s7"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qu3-Gh-sHY"/>
                     </view>
                     <connections>
                         <outlet property="textview" destination="VZ4-xD-33I" id="02L-PL-IgW"/>
@@ -120,13 +120,14 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="egg-mo-Y4S">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="iSl-b1-8Q7" id="D4h-Iu-gaD"/>
                                     <outlet property="delegate" destination="iSl-b1-8Q7" id="O3x-LW-ggf"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="nz7-i3-560"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="nz7-i3-560" firstAttribute="trailing" secondItem="egg-mo-Y4S" secondAttribute="trailing" id="4lT-TU-td8"/>
@@ -134,16 +135,14 @@
                             <constraint firstItem="nz7-i3-560" firstAttribute="bottom" secondItem="egg-mo-Y4S" secondAttribute="bottom" id="hoc-dS-mst"/>
                             <constraint firstItem="egg-mo-Y4S" firstAttribute="leading" secondItem="nz7-i3-560" secondAttribute="leading" id="nCX-Yb-zUk"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="nz7-i3-560"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="egg-mo-Y4S" id="Q6m-Fm-qjc"/>
-                        <segue destination="cZP-lH-gTc" kind="show" identifier="ShowApplicationLogViewController" id="C0s-Ys-0iv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FQx-lA-JpF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1342" y="1036"/>
+            <point key="canvasLocation" x="1431" y="811"/>
         </scene>
         <!--About View Controller-->
         <scene sceneID="YPr-jf-D90">
@@ -155,20 +154,20 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ibP-Y7-8cn">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="0FF-UX-4XZ" id="6jO-4P-3zY"/>
                                     <outlet property="delegate" destination="0FF-UX-4XZ" id="eUa-vM-oOL"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="BsY-oa-k6u"/>
                         <constraints>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="trailing" secondItem="BsY-oa-k6u" secondAttribute="trailing" id="2ck-f3-BSs"/>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="bottom" secondItem="BsY-oa-k6u" secondAttribute="bottom" id="69q-a2-QAu"/>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="leading" secondItem="BsY-oa-k6u" secondAttribute="leading" id="QKN-1I-cNm"/>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="top" secondItem="BsY-oa-k6u" secondAttribute="top" id="qyY-cu-ksZ"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="BsY-oa-k6u"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="ibP-Y7-8cn" id="Q44-bo-hMp"/>
@@ -195,13 +194,13 @@
                                 </wkWebViewConfiguration>
                             </wkWebView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="gcq-RR-2k7"/>
                         <constraints>
                             <constraint firstItem="3Ux-jX-kZE" firstAttribute="leading" secondItem="gcq-RR-2k7" secondAttribute="leading" id="Qmb-Md-7xS"/>
                             <constraint firstItem="gcq-RR-2k7" firstAttribute="trailing" secondItem="3Ux-jX-kZE" secondAttribute="trailing" id="hPA-YS-aD5"/>
                             <constraint firstItem="gcq-RR-2k7" firstAttribute="bottom" secondItem="3Ux-jX-kZE" secondAttribute="bottom" id="qGU-af-Ie5"/>
                             <constraint firstItem="3Ux-jX-kZE" firstAttribute="top" secondItem="gcq-RR-2k7" secondAttribute="top" id="roD-E5-KXz"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gcq-RR-2k7"/>
                     </view>
                     <connections>
                         <outlet property="webView" destination="3Ux-jX-kZE" id="Mwl-R5-9dT"/>
@@ -212,4 +211,18 @@
             <point key="canvasLocation" x="2265" y="1525"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -47,20 +47,6 @@ class ApplicationLogViewController: UIViewController {
         registerTableViewCells()
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let vc = segue.destination as? ApplicationLogDetailViewController, segue.identifier == Segues.detailSegue {
-            let logFileInfo = sender as! DDLogFileInfo
-            do {
-                let contents = try String(contentsOfFile: logFileInfo.filePath)
-                let date = dateFormatter.string(from: logFileInfo.creationDate )
-                vc.logText = contents
-                vc.logDate = date
-            } catch {
-                DDLogError("Error: attempted to get contents of logFileInfo. Contents not found.")
-            }
-        }
-    }
-
     /// Style the back button, add the title to nav bar.
     ///
     func configureNavigation() {
@@ -228,7 +214,20 @@ private extension ApplicationLogViewController {
     ///
     func logFileWasPressed(in row: Int) {
         let logFileInfo = logFiles[row]
-        performSegue(withIdentifier: Segues.detailSegue, sender: logFileInfo)
+
+        let identifier = ApplicationLogDetailViewController.classNameWithoutNamespaces
+        guard let appLogDetailVC = UIStoryboard.dashboard.instantiateViewController(identifier: identifier) as? ApplicationLogDetailViewController else {
+            return
+        }
+        do {
+            let contents = try String(contentsOfFile: logFileInfo.filePath)
+            let date = dateFormatter.string(from: logFileInfo.creationDate )
+            appLogDetailVC.logText = contents
+            appLogDetailVC.logDate = date
+        } catch {
+            DDLogError("Error: attempted to get contents of logFileInfo. Contents not found.")
+        }
+        navigationController?.pushViewController(appLogDetailVC, animated: true)
     }
 
     /// Clear old logs action
@@ -275,8 +274,4 @@ private enum Row: CaseIterable {
     var reuseIdentifier: String {
         return type.reuseIdentifier
     }
-}
-
-private struct Segues {
-    static let detailSegue = "ShowApplicationLogDetailViewController"
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -217,6 +217,7 @@ private extension ApplicationLogViewController {
 
         let identifier = ApplicationLogDetailViewController.classNameWithoutNamespaces
         guard let appLogDetailVC = UIStoryboard.dashboard.instantiateViewController(identifier: identifier) as? ApplicationLogDetailViewController else {
+            DDLogError("Error: attempted to instantiate ApplicationLogDetailViewController. Instantiation failed.")
             return
         }
         do {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -271,6 +271,7 @@ private extension HelpAndSupportViewController {
     func applicationLogWasPressed() {
         let identifier = ApplicationLogViewController.classNameWithoutNamespaces
         guard let applicationLogVC = UIStoryboard.dashboard.instantiateViewController(identifier: identifier) as? ApplicationLogViewController else {
+            DDLogError("Error: attempted to instantiate ApplicationLogViewController. Instantiation failed.")
             return
         }
         navigationController?.pushViewController(applicationLogVC, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -269,7 +269,11 @@ private extension HelpAndSupportViewController {
     /// View application log action
     ///
     func applicationLogWasPressed() {
-        performSegue(withIdentifier: Constants.appLogSegue, sender: nil)
+        let identifier = ApplicationLogViewController.classNameWithoutNamespaces
+        guard let applicationLogVC = UIStoryboard.dashboard.instantiateViewController(identifier: identifier) as? ApplicationLogViewController else {
+            return
+        }
+        navigationController?.pushViewController(applicationLogVC, animated: true)
     }
 
     @objc func dismissWasPressed() {
@@ -334,7 +338,6 @@ extension HelpAndSupportViewController: UITableViewDelegate {
 private struct Constants {
     static let rowHeight = CGFloat(44)
     static let footerHeight = 44
-    static let appLogSegue = "ShowApplicationLogViewController"
 }
 
 private struct Section {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -550,20 +550,6 @@ extension OrderDetailsViewController: UITableViewDelegate {
     }
 }
 
-
-// MARK: - Segues
-//
-extension OrderDetailsViewController {
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let productListViewController = segue.destination as? ProductListViewController {
-            productListViewController.viewModel = viewModel
-            productListViewController.products = viewModel.products
-        }
-    }
-}
-
-
 // MARK: - Trackings alert
 // Track / delete tracking alert
 private extension OrderDetailsViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,13 +18,14 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hBh-xf-Cby">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
                                     <outlet property="delegate" destination="IgL-pI-DQK" id="z2y-Op-rg4"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="wvX-aq-v2S"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="hBh-xf-Cby" firstAttribute="top" secondItem="wvX-aq-v2S" secondAttribute="top" id="336-TT-5Dd"/>
@@ -32,11 +33,10 @@
                             <constraint firstItem="wvX-aq-v2S" firstAttribute="bottom" secondItem="hBh-xf-Cby" secondAttribute="bottom" id="MGb-D6-I2u"/>
                             <constraint firstItem="hBh-xf-Cby" firstAttribute="leading" secondItem="wvX-aq-v2S" secondAttribute="leading" id="zxy-1j-4Gg"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="wvX-aq-v2S"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="hBh-xf-Cby" id="36b-Gi-HZa"/>
-                        <segue destination="gjo-lx-M5d" kind="show" identifier="ShowProductListViewController" id="wt7-3f-Jje"/>
+                        <segue destination="gjo-lx-M5d" kind="show" identifier="" id="wt7-3f-Jje"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z9o-7H-pWC" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -46,20 +46,21 @@
         <!--Product List View Controller-->
         <scene sceneID="tRI-WT-3cp">
             <objects>
-                <viewController id="gjo-lx-M5d" customClass="ProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ProductListViewController" id="gjo-lx-M5d" customClass="ProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="K91-GD-PbX">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="eY7-vI-1cr">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="gjo-lx-M5d" id="ABK-8R-DTb"/>
                                     <outlet property="delegate" destination="gjo-lx-M5d" id="wOm-50-abo"/>
                                 </connections>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="3jQ-CL-a1D"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="3jQ-CL-a1D" firstAttribute="bottom" secondItem="eY7-vI-1cr" secondAttribute="bottom" id="5eQ-Bk-PGp"/>
@@ -67,7 +68,6 @@
                             <constraint firstItem="eY7-vI-1cr" firstAttribute="leading" secondItem="3jQ-CL-a1D" secondAttribute="leading" id="ReZ-l5-UwN"/>
                             <constraint firstItem="3jQ-CL-a1D" firstAttribute="trailing" secondItem="eY7-vI-1cr" secondAttribute="trailing" id="oJy-wR-9oq"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="3jQ-CL-a1D"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="eY7-vI-1cr" id="acx-d0-6Fq"/>
@@ -78,4 +78,12 @@
             <point key="canvasLocation" x="3780" y="543"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -36,7 +36,6 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="hBh-xf-Cby" id="36b-Gi-HZa"/>
-                        <segue destination="gjo-lx-M5d" kind="show" identifier="" id="wt7-3f-Jje"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z9o-7H-pWC" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -48,11 +47,11 @@
             <objects>
                 <viewController storyboardIdentifier="ProductListViewController" id="gjo-lx-M5d" customClass="ProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="K91-GD-PbX">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="eY7-vI-1cr">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="gjo-lx-M5d" id="ABK-8R-DTb"/>


### PR DESCRIPTION
Fixes #2349 

## Description
In this PR, I removed the use of "segue" from the app, by removing the 4 segue still present within the code.
In particular, I removed these one:
- [x] ShowProductListViewController
- [x] ShowOrderStatusListViewController
- [x] ShowApplicationLogViewController
- [x] ShowApplicationLogDetailViewController

Now all the view controllers are presented via code.

## Testing
#### Case 1
1. Open an order with some products inside. 
2. Tap "Details".
3. Make sure the list of products still appears like before.

#### Case 2
1. Open Settings.
2. Tap the cell "Help & Support"
3. Select "View Application Log" -> The Application Logs list should appear.
4. Select one of the application logs. -> The application log detail VC should appear.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
