### PR TITLE
Update Products Banner for M5 Features

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -5,9 +5,9 @@ public enum FeedbackType: String, Codable {
     ///
     case general
 
-    /// identifier for the products m4 beta feedback survey
+    /// Identifier for the Products M5: Linked Products, Downloadable Files, Trashing.
     ///
-    case productsM4
+    case productsM5
 
     /// identifier for the shipping labels m1 feedback survey
     ///

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -28,11 +28,11 @@ public struct GeneralAppSettings: Codable, Equatable {
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
     ///
     public func feedbackStatus(of type: FeedbackType) -> FeedbackSettings.Status {
-        guard let feedbackSeeting = feedbacks[type] else {
+        guard let feedbackSetting = feedbacks[type] else {
             return .pending
         }
 
-        return feedbackSeeting.status
+        return feedbackSetting.status
     }
 
     /// Returns a new instance of `GeneralAppSettings` with the provided feedback seetings updated.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -43,12 +43,12 @@ struct ProductsTopBannerFactory {
 private extension ProductsTopBannerFactory {
     enum Localization {
         static let title =
-            NSLocalizedString("Create products from the app!",
-                              comment: "The title of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
+            NSLocalizedString("New features available!",
+                              comment: "The title of the top banner on the Products tab.")
         static let info =
             NSLocalizedString(
-                "It’s now possible to create simple, grouped \nand external products on the go from the Woo app. Not ready yet? Save them as draft!",
-                comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
+                "You can now add downloadable files to a product and link upsell & cross-sell products. No longer want a product? Trash it!",
+                comment: "The info of the top banner on the Products tab.")
         static let giveFeedback =
             NSLocalizedString("Give feedback",
                               comment: "The title of the button to give feedback about products beta features on the banner on the products tab")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -566,7 +566,7 @@ private extension ProductsViewController {
     ///
     func presentProductsFeedback() {
         // Present survey
-        let navigationController = SurveyCoordinatingController(survey: .productsM4Feedback)
+        let navigationController = SurveyCoordinatingController(survey: .productsM5Feedback)
         present(navigationController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -371,7 +371,7 @@ private extension ProductsViewController {
     /// Fetches products feedback visibility from AppSettingsStore and update products top banner accordingly
     ///
     func updateTopBannerView() {
-        let action = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { [weak self] result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { [weak self] result in
             switch result {
             case .success(let visible):
                 if visible {
@@ -573,7 +573,7 @@ private extension ProductsViewController {
     /// Mark feedback request as dismissed and update banner visibility
     ///
     func dismissProductsBanner() {
-        let action = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .dismissed) { [weak self] result in
+        let action = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .dismissed) { [weak self] result in
             if let error = result.failure {
                 CrashLogging.logError(error)
             }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -63,7 +63,7 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 extension SurveyViewController {
     enum Source {
         case inAppFeedback
-        case productsM4Feedback
+        case productsM5Feedback
         case shippingLabelsRelease1Feedback
 
         fileprivate var url: URL {
@@ -73,7 +73,7 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
 
-            case .productsM4Feedback:
+            case .productsM5Feedback:
                 return WooConstants.URLs.productsM4Feedback
                     .asURL()
                     .tagPlatform("ios")
@@ -90,7 +90,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsM4Feedback, .shippingLabelsRelease1Feedback:
+            case .productsM5Feedback, .shippingLabelsRelease1Feedback:
                 return Localization.giveFeedback
             }
         }
@@ -100,7 +100,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
-            case .productsM4Feedback:
+            case .productsM5Feedback:
                 return .productsM4
             case .shippingLabelsRelease1Feedback:
                 return .shippingLabelsRelease1

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -77,7 +77,7 @@ extension SurveyViewController {
                 return WooConstants.URLs.productsM4Feedback
                     .asURL()
                     .tagPlatform("ios")
-                    .tagProductMilestone("4")
+                    .tagProductMilestone("5")
             case .shippingLabelsRelease1Feedback:
                 return WooConstants.URLs.shippingLabelsRelease1Feedback
                     .asURL()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -24,7 +24,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_loads_the_correct_product_feedback_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .productsM4Feedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .productsM5Feedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -30,9 +30,9 @@ final class SurveyViewControllerTests: XCTestCase {
         _ = try XCTUnwrap(viewController.view)
         let mirror = try self.mirror(of: viewController)
 
-        //Then
+        // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback.asURL().tagPlatform("ios").tagProductMilestone("4"))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback.asURL().tagPlatform("ios").tagProductMilestone("5"))
     }
 
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .productsM4:
+        case .productsM5:
             return shouldProductsFeedbackBeVisible()
         case .shippingLabelsRelease1:
             return shouldShippingLabelsRelease1FeedbackBeVisible()

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -155,10 +155,10 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         XCTAssertEqual(error as? InferenceError, .failedToInferInstallationDate)
     }
 
-    func test_shouldBeVisible_for_productM3_is_true_if_no_settings_are_found() throws {
+    func test_shouldBeVisible_for_productM5_is_true_if_no_settings_are_found() throws {
         // Given
         let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -167,10 +167,10 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         XCTAssertTrue(shouldBeVisible)
     }
 
-    func test_shouldBeVisible_for_productM3_is_true_if_feedback_has_pending_status() throws {
+    func test_shouldBeVisible_for_productM5_is_true_if_feedback_has_pending_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -179,10 +179,10 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         XCTAssertTrue(shouldBeVisible)
     }
 
-    func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_dismissed_status() throws {
+    func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_dismissed_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .dismissed)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .dismissed)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -191,10 +191,10 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         XCTAssertFalse(shouldBeVisible)
     }
 
-    func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_given_status() throws {
+    func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_given_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .given(Date()))
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .given(Date()))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -193,7 +193,7 @@ final class AppSettingsStoreTests: XCTestCase {
         let date = Date(timeIntervalSince1970: 100)
 
         let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(installationDate: Date(timeIntervalSince1970: 4_810),
-                                                                              feedbackSatus: .given(Date(timeIntervalSince1970: 9_971_311)))
+                                                                              feedbackStatus: .given(Date(timeIntervalSince1970: 9_971_311)))
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
         // When
@@ -305,7 +305,7 @@ final class AppSettingsStoreTests: XCTestCase {
         let date = Date(timeIntervalSince1970: 300)
 
         let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(installationDate: Date(timeIntervalSince1970: 1),
-                                                                              feedbackSatus: .given(Date(timeIntervalSince1970: 999)))
+                                                                              feedbackStatus: .given(Date(timeIntervalSince1970: 999)))
 
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
@@ -421,8 +421,8 @@ private extension AppSettingsStoreTests {
         return documents!.appendingPathComponent("general-app-settings.plist")
     }
 
-    func createAppSettingAndGeneralFeedback(installationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
-        let feedback = FeedbackSettings(name: .general, status: feedbackSatus)
+    func createAppSettingAndGeneralFeedback(installationDate: Date?, feedbackStatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
+        let feedback = FeedbackSettings(name: .general, status: feedbackStatus)
         let settings = GeneralAppSettings(installationDate: installationDate, feedbacks: [feedback.name: feedback])
         return (settings, feedback)
     }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -192,7 +192,7 @@ final class AppSettingsStoreTests: XCTestCase {
         // Given
         let date = Date(timeIntervalSince1970: 100)
 
-        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(instalationDate: Date(timeIntervalSince1970: 4_810),
+        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(installationDate: Date(timeIntervalSince1970: 4_810),
                                                                               feedbackSatus: .given(Date(timeIntervalSince1970: 9_971_311)))
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
@@ -304,7 +304,7 @@ final class AppSettingsStoreTests: XCTestCase {
         // Given
         let date = Date(timeIntervalSince1970: 300)
 
-        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(instalationDate: Date(timeIntervalSince1970: 1),
+        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(installationDate: Date(timeIntervalSince1970: 1),
                                                                               feedbackSatus: .given(Date(timeIntervalSince1970: 999)))
 
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
@@ -421,9 +421,9 @@ private extension AppSettingsStoreTests {
         return documents!.appendingPathComponent("general-app-settings.plist")
     }
 
-    func createAppSettingAndGeneralFeedback(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
+    func createAppSettingAndGeneralFeedback(installationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
         let feedback = FeedbackSettings(name: .general, status: feedbackSatus)
-        let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
+        let settings = GeneralAppSettings(installationDate: installationDate, feedbacks: [feedback.name: feedback])
         return (settings, feedback)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -352,15 +352,15 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).get())
     }
 
-    func test_loadFeedbackVisibility_for_productsM4_returns_true_after_marking_it_as_pending() throws {
+    func test_loadFeedbackVisibility_for_productsM5_returns_true_after_marking_it_as_pending() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .pending) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .pending) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -372,15 +372,15 @@ final class AppSettingsStoreTests: XCTestCase {
 
     }
 
-    func test_loadFeedbackVisibility_for_productsM4_returns_false_after_marking_it_as_dismissed() throws {
+    func test_loadFeedbackVisibility_for_productsM5_returns_false_after_marking_it_as_dismissed() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .dismissed) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .dismissed) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -392,15 +392,15 @@ final class AppSettingsStoreTests: XCTestCase {
 
     }
 
-    func test_loadFeedbackVisibility_for_productsM4_returns_false_after_marking_it_as_given() throws {
+    func test_loadFeedbackVisibility_for_productsM5_returns_false_after_marking_it_as_given() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .given(Date())) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .given(Date())) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)


### PR DESCRIPTION
Closes #3481. 

## Design

This change should be the same as Android: https://github.com/woocommerce/woocommerce-android/pull/3448. 

Before | After 
--------|-------
 ![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 10 01 28](https://user-images.githubusercontent.com/198826/105216912-6eb6a500-5b10-11eb-8229-654bbf06e981.png)   |       ![Simulator Screen Shot - iPhone 11 - 2021-01-20 at 11 06 35](https://user-images.githubusercontent.com/198826/105216922-71b19580-5b10-11eb-8528-7befe78480c0.png)

## Changes

Aside from the content changes, I also fixed some typos. 

## Testing

1. Delete the app. 
2. Run using `develop` first. 
3. Log in and navigate to Products. Confirm that the old message of the banner is there. 
4. Tap Dismiss. The banner should disappear. 
5. Run using this branch. 
6. Navigate to Products. Confirm that the banner is visible again but with the updated content. 
7. Confirm that the app didn't crash. 😅 That means our plist file saving is resilient. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

