### PR TITLE
Edit Product: disable selection state for rows that are not tappable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - [*] fix: product is now read-only when opened from the order details. [https://github.com/woocommerce/woocommerce-ios/pull/3491]
 - [*] fix: pull to refresh on the order status picker screen does not resets anymore the current selection. [https://github.com/woocommerce/woocommerce-ios/pull/3493]
 - [*] When adding or editing a link (e.g. in a product description) link settings are now presented as a popover on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3492]
+- [*] Minor enhancements: in product editing form > product reviews list, the rows don't show highlighted state on tap anymore since they are not actionable. Same for the number of upsell and cross-sell products in product editing form > linked products. [https://github.com/woocommerce/woocommerce-ios/pull/3502]
 
 
 5.8

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
@@ -140,10 +140,12 @@ private extension LinkedProductsViewController {
 
     func configureUpsellsProducts(cell: NumberOfLinkedProductsTableViewCell) {
         cell.configure(content: Localization.upsellAndCrossSellProducts(count: viewModel.upsellIDs.count))
+        cell.selectionStyle = .none
     }
 
     func configureCrossSellsProducts(cell: NumberOfLinkedProductsTableViewCell) {
         cell.configure(content: Localization.upsellAndCrossSellProducts(count: viewModel.crossSellIDs.count))
+        cell.selectionStyle = .none
     }
 
     func configureUpsellsButton(cell: ButtonTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -107,6 +107,7 @@ private extension ProductReviewsViewController {
         tableView.delegate = self
         tableView.tableFooterView = footerSpinnerView
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
+        tableView.allowsSelection = false
     }
 
     /// Setup: ResultsController


### PR DESCRIPTION
Fixes #3476 
Fixes #3479 

## Why

If a row is not tappable (not actionable), it might be less confusing if the row does not show the highlighted state which feels like it's tappable.

## Changes

- In `ProductReviewsViewController`, set the table view's `allowsSelection` to `false`. We can remove this line if we implement tapping to see review details in the future.
- In `LinkedProductsViewController`, set the `NumberOfLinkedProductsTableViewCell` rows to have `selectionStyle = .none` to disable selection state

## Testing

### Product reviews

- Go to the products tab
- Tap on a product with at least one review
- Tap on the Reviews row
- Tap on a review --> the row should not be highlighted

### Linked products (upsell/cross-sell)

- Go to the products tab
- Tap on a product whose linked products are editable
- Tap on Linked products row or from the bottom sheet
- If there are no products selected yet, tap "Add Products" to add at least one product
- After navigating back to the linked products screen, tap the "# product(s)" row --> the row should not be highlighted

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
