### PR TITLE
BaseScreen: revert to use a waiter to fix tablet UI tests

### DIFF
--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -21,7 +21,7 @@ class BaseScreen {
     func waitForPage() throws -> BaseScreen {
         XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (activity) in
             /// Don't use a waiter if it's already enabled – this will make the test run faster
-            guard !expectedElement.isEnabled else {
+            guard let expectedElement = expectedElement, !expectedElement.isEnabled else {
                 return
             }
             let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)

--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -20,10 +20,6 @@ class BaseScreen {
     @discardableResult
     func waitForPage() throws -> BaseScreen {
         XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (activity) in
-            /// Don't use a waiter if it's already enabled – this will make the test run faster
-            guard let expectedElement = expectedElement, !expectedElement.isEnabled else {
-                return
-            }
             let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
             XCTAssert(result, "Page \(self) is not loaded.")
 //            Logger.log(message: "Page \(self) is loaded", event: .i)


### PR DESCRIPTION
Fixes UI tests in `develop`

Tablet UI tests started failing in https://github.com/woocommerce/woocommerce-ios/pull/3337, and I was able to reproduce the test failure with the same simulator (iPad Air - 4th generation) iOS 14.1. The reason for the failure is because after entering site address, the email text field element cannot be found right away and it fails on this line:

https://github.com/woocommerce/woocommerce-ios/blob/6f444f1c47b5e37aa309b55d03622eaaf06b4979/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift#L24

I first tried with a nil-check on `expectedElement` https://github.com/woocommerce/woocommerce-ios/commit/6ecc146f606b88c02adfd32da95b6b1c08d9a288, that worked locally but not in CI. So I ended up reverting the changes to early return if `expectedElement.isEnabled` is true. I'm not an expert on `XCTContext` though, please feel free to fix the test failure while keeping the speed optimization!

## Changes

Removed the speed optimization in `BaseScreen.waitForPage` to fix the tablet UI tests.

## Testing

Just CI - I ran the optional UI tests, and both iPhone and iPad UI tests passed in the latest commit!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
