### PR TITLE
Replace all Automattic copyrights, where appropriate, with WooCommerce.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+6.0
+-----
+- [*] Updated copyright notice to WooCommerce
+
 5.9
 -----
 - [**] Product List: if a user applies custom sort orders and filters in the Product List, now when they reopen the app will be able to see the previous settings applied. [https://github.com/woocommerce/woocommerce-ios/pull/3454]

--- a/WooCommerce/Classes/System/WooCommerce-Bridging-Header.h
+++ b/WooCommerce/Classes/System/WooCommerce-Bridging-Header.h
@@ -3,7 +3,6 @@
 //  WooCommerce
 //
 //  Created by Thuy Copeland on 6/19/18.
-//  Copyright © 2018 Automattic. All rights reserved.
 //
 
 #ifndef WooCommerce_Bridging_Header_h

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -22,7 +22,7 @@ class AboutViewController: UIViewController {
             Bundle.main.detailedVersionNumber()
         )
         let localizedTitleTextLine2 = String.localizedStringWithFormat(
-            NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year"),
+            NSLocalizedString("© %@ WooCommerce, Inc and WooCommerce Ireland Ltd.", comment: "About View's Footer Text. The variable is the current year"),
             year
         )
         return String(format: localizedTitleTextLine1, year) + "\n" + localizedTitleTextLine2

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -22,7 +22,7 @@ class AboutViewController: UIViewController {
             Bundle.main.detailedVersionNumber()
         )
         let localizedTitleTextLine2 = String.localizedStringWithFormat(
-            NSLocalizedString("© %@ WooCommerce, Inc and WooCommerce Ireland Ltd.", comment: "About View's Footer Text. The variable is the current year"),
+            NSLocalizedString("© %@ WooCommerce, Inc. and WooCommerce Ireland Ltd.", comment: "About View's Footer Text. The variable is the current year"),
             year
         )
         return String(format: localizedTitleTextLine1, year) + "\n" + localizedTitleTextLine2


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-ios/issues/3514

## Description

We are updating copyright notices to say WooCommerce instead of Automattic. The guidelines:

* If they just generically say, “Automattic,” then we can update them to generically say, “WooCommerce.”
* If they list the full entity name of “Automattic Inc” we should update the new notice to say “WooCommerce, Inc and WooCommerce Ireland Ltd.”
* The hiring prompt ("Made with love by Automattic. We're hiring!") is an exception and should be left as-is.

## Changes

I only found two copyright references:

* I removed one copyright reference in the code, since it seemed unnecessary.
* I updated the About screen footer from "Automattic, Inc" to "WooCommerce, Inc and WooCommerce Ireland Ltd."

<img src="https://user-images.githubusercontent.com/8658164/105703468-2ed33180-5f05-11eb-87e4-6aff918831db.png" width="300px">


## Testing

1. Go to Settings > WooCommerce and confirm the About screen shows the updated copyright notice.
2. Confirm there are no other copyright notices (user-facing or in the code) that still refer to Automattic.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
