### PR TITLE
Fix: notice presenter presented by the tab bar controller inside the AppCoordinator

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -263,7 +263,7 @@ private extension AppDelegate {
     ///
     func setupNoticePresenter() {
         var noticePresenter = ServiceLocator.noticePresenter
-        noticePresenter.presentingViewController = window?.rootViewController
+        noticePresenter.presentingViewController = appCoordinator?.tabBarController
     }
 
     /// Push Notifications: Authorization + Registration!


### PR DESCRIPTION
This is a hotfix for resolving a regression introduced in this PR https://github.com/woocommerce/woocommerce-ios/pull/3498, where the Notice Presenter was no longer working because the `presentingViewController` was not correctly set to the tab bar controller under `AppCoordinator`.
This PR will be merged inside the `release/5.9` branch.

[Slack discussion](https://a8c.slack.com/archives/C6H8C3G23/p1611336604025200).

## Testing
Make sure that the notice presenter inside the app works like before everywhere.
One of the tests can be this one:
1. Open a product
2. Click on 'Price'
3. Set 'sale' price higher than 'regular' price
4. Press 'Done' button multiple times
5. Notice the error message
6. Leave the screen
7. Notice that the message disappears, and no other similar messages are shown.

<img src="https://user-images.githubusercontent.com/495617/104602186-6a573b80-567b-11eb-92ce-432ffc799a38.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
