### PR TITLE
Dashboard: fix visitor stats data on days when the end date is the same for more than one tab

### DIFF
--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -8,41 +8,4 @@ public enum StatGranularity: String, Decodable {
     case week
     case month
     case year
-
-    public var pluralizedString: String {
-        switch self {
-        case .day:
-            return NSLocalizedString("Days", comment: "Plural of 'day' — a statistical unit")
-        case .week:
-            return NSLocalizedString("Weeks", comment: "Plural of 'week' — a statistical unit")
-        case .month:
-            return NSLocalizedString("Months", comment: "Plural of 'month' — a statistical unit")
-        case .year:
-            return NSLocalizedString("Years", comment: "Plural of 'year' — a statistical unit")
-        }
-    }
-
-    public var accessibilityIdentifier: String {
-        return "granularity-\(self.rawValue)"
-    }
-}
-
-// MARK: - StringConvertible Conformance
-//
-extension StatGranularity: CustomStringConvertible {
-
-    /// Returns a user-freindly, localized string describing the stat granularity
-    ///
-    public var description: String {
-        switch self {
-        case .day:
-            return NSLocalizedString("Day", comment: "Statistical unit - a single day")
-        case .week:
-            return NSLocalizedString("Week", comment: "Statistical unit - a single week")
-        case .month:
-            return NSLocalizedString("Month", comment: "Statistical unit - a single week")
-        case .year:
-            return NSLocalizedString("Year", comment: "Statistical unit - a single year")
-        }
-    }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Updated copyright notice to WooCommerce
 - [*] Fix: top performers in "This Week" tab should be showing the same data as in WC Admin.
+- [*] Fix: visitor stats in Dashboard should be more consistent with web data on days when the end date for more than one tab is the same (e.g. "This Week" and "This Month" both end on January 31). [https://github.com/woocommerce/woocommerce-ios/pull/3532]
 - [internal] Refactored Core Data migrator stack to help reduce crashes [https://github.com/woocommerce/woocommerce-ios/pull/3523]
 
 5.9

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -123,8 +123,8 @@ public extension StorageType {
 
     /// Retrieves the Stored SiteVisitStats for stats v4.
     ///
-    func loadSiteVisitStats(granularity: String, date: String) -> SiteVisitStats? {
-        let predicate = \SiteVisitStats.granularity =~ granularity && \SiteVisitStats.date =~ date
+    func loadSiteVisitStats(granularity: String, timeRange: String) -> SiteVisitStats? {
+        let predicate = \SiteVisitStats.granularity =~ granularity && \SiteVisitStats.timeRange == timeRange
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -114,13 +114,6 @@ public extension StorageType {
         return firstObject(ofType: TopEarnerStats.self, matching: predicate)
     }
 
-    /// Retrieves the Stored SiteVisitStats.
-    ///
-    func loadSiteVisitStats(granularity: String) -> SiteVisitStats? {
-        let predicate = \SiteVisitStats.granularity =~ granularity
-        return firstObject(ofType: SiteVisitStats.self, matching: predicate)
-    }
-
     /// Retrieves the Stored SiteVisitStats for stats v4.
     ///
     func loadSiteVisitStats(granularity: String, timeRange: String) -> SiteVisitStats? {

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -235,29 +235,15 @@ class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(topEarnerStat, storedTopEarnerStat)
     }
 
-    func test_loadSiteVisitStats_by_granularity() throws {
+    func test_loadSiteVisitStats_by_granularity_and_timeRange() throws {
         // Given
         let granularity = "daily"
         let siteVisitStat = storage.insertNewObject(ofType: SiteVisitStats.self)
         siteVisitStat.granularity = granularity
+        siteVisitStat.timeRange = "today"
 
         // When
-        let storedSiteVisitStat = try XCTUnwrap(storage.loadSiteVisitStats(granularity: granularity))
-
-        // Then
-        XCTAssertEqual(siteVisitStat, storedSiteVisitStat)
-    }
-
-    func test_loadSiteVisitStats_by_granularity_date() throws {
-        // Given
-        let date = Date().description
-        let granularity = "daily"
-        let siteVisitStat = storage.insertNewObject(ofType: SiteVisitStats.self)
-        siteVisitStat.date = date
-        siteVisitStat.granularity = granularity
-
-        // When
-        let storedSiteVisitStat = try XCTUnwrap(storage.loadSiteVisitStats(granularity: granularity, date: date))
+        let storedSiteVisitStat = try XCTUnwrap(storage.loadSiteVisitStats(granularity: granularity, timeRange: "today"))
 
         // Then
         XCTAssertEqual(siteVisitStat, storedSiteVisitStat)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -373,9 +373,9 @@ private extension StoreStatsV4PeriodViewController {
         let storageManager = ServiceLocator.storageManager
         let dateFormatter = DateFormatter.Stats.statsDayFormatter
         dateFormatter.timeZone = siteTimezone
-        let predicate = NSPredicate(format: "granularity ==[c] %@ AND date == %@",
+        let predicate = NSPredicate(format: "granularity ==[c] %@ AND timeRange == %@",
                                     timeRange.siteVisitStatsGranularity.rawValue,
-                                    dateFormatter.string(from: currentDate))
+                                    timeRange.rawValue)
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -47,7 +47,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
             case .thisMonth:
                 success(onCompletion)
             case .thisYear:
-                store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats)
+                store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats, timeRange: timeRange)
                 onCompletion(nil)
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -136,7 +136,7 @@ public extension StatsStoreV4 {
                                             return
                                         }
 
-                                        self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats)
+                                        self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats, timeRange: timeRange)
                                         onCompletion(nil)
         }
     }
@@ -237,13 +237,14 @@ extension StatsStoreV4 {
 extension StatsStoreV4 {
     /// Updates (OR Inserts) the specified ReadOnly SiteVisitStats Entity into the Storage Layer.
     ///
-    func upsertStoredSiteVisitStats(readOnlyStats: Networking.SiteVisitStats) {
+    func upsertStoredSiteVisitStats(readOnlyStats: Networking.SiteVisitStats, timeRange: StatsTimeRangeV4) {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
         let storageSiteVisitStats = storage.loadSiteVisitStats(
-            granularity: readOnlyStats.granularity.rawValue, date: readOnlyStats.date) ?? storage.insertNewObject(ofType: Storage.SiteVisitStats.self)
+            granularity: readOnlyStats.granularity.rawValue, timeRange: timeRange.rawValue) ?? storage.insertNewObject(ofType: Storage.SiteVisitStats.self)
         storageSiteVisitStats.update(with: readOnlyStats)
+        storageSiteVisitStats.timeRange = timeRange.rawValue
         handleSiteVisitStatsItems(readOnlyStats, storageSiteVisitStats, storage)
         storage.saveIfNeeded()
     }

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -142,9 +142,9 @@ final class StatsStoreV4Tests: XCTestCase {
         let statsStore = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 0)
-        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStats())
+        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStats(), timeRange: .thisYear)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 1)
-        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "site-visits-alt")
         let action = StatsActionV4
@@ -207,11 +207,12 @@ final class StatsStoreV4Tests: XCTestCase {
     func testUpsertStoredSiteVisitStatsEffectivelyPersistsNewSiteVisitStats() {
         let statsStore = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let remoteSiteVisitStats = sampleSiteVisitStats()
+        let timeRange = StatsTimeRangeV4.thisYear
 
-        XCTAssertNil(viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue))
-        statsStore.upsertStoredSiteVisitStats(readOnlyStats: remoteSiteVisitStats)
+        XCTAssertNil(viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue, timeRange: timeRange.rawValue))
+        statsStore.upsertStoredSiteVisitStats(readOnlyStats: remoteSiteVisitStats, timeRange: timeRange)
 
-        let storageSiteVisitStats = viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue)
+        let storageSiteVisitStats = viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue, timeRange: timeRange.rawValue)
         XCTAssertEqual(storageSiteVisitStats?.toReadOnly(), remoteSiteVisitStats)
     }
 
@@ -219,17 +220,18 @@ final class StatsStoreV4Tests: XCTestCase {
     ///
     func testUpdateStoredSiteVisitStatsEffectivelyUpdatesPreexistantSiteVisitStats() {
         let statsStore = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let timeRange = StatsTimeRangeV4.thisYear
 
-        XCTAssertNil(viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue))
-        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStats())
+        XCTAssertNil(viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue, timeRange: timeRange.rawValue))
+        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStats(), timeRange: timeRange)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
-        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStatsMutated())
+        statsStore.upsertStoredSiteVisitStats(readOnlyStats: sampleSiteVisitStatsMutated(), timeRange: timeRange)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
 
         let expectedSiteVisitStats = sampleSiteVisitStatsMutated()
-        let storageSiteVisitStats = viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue)
+        let storageSiteVisitStats = viewStorage.loadSiteVisitStats(granularity: StatGranularity.year.rawValue, timeRange: timeRange.rawValue)
         XCTAssertEqual(storageSiteVisitStats?.toReadOnly(), expectedSiteVisitStats)
     }
 


### PR DESCRIPTION
Attempted fix for #1795 
Based on https://github.com/woocommerce/woocommerce-ios/pull/3531

## Why

I wanted to work on this fix because I can reproduce the issue this week of the year 😆 Right now, we save `SiteVisitStats`'s `granularity` to the period unit like `day`/`day`/`day`/`month` for `Today`/`This Week`/`This Month`/`This Year` respectively. In `StoreStatsV4PeriodViewController` where we show the visitor stats, we query `SiteVisitStats` with `granularity` (each time range's period unit) and `date` (the end date of the time range). This is usually fine, but for certain days of the year the `granularity` and `date` could be the same for two time ranges. For example, "This Week"'s end date for 1/25-31 is 1/31 (for regions that start the week on Mondays) and "This Month"'s end date is also 1/31. In the database, we also only see 3 entries for `SiteVisitStats` in this case.

<img width="735" alt="Screen Shot 2021-01-25 at 2 20 11 PM" src="https://user-images.githubusercontent.com/1945542/105671681-128fbe80-5f1e-11eb-877e-61cdd5ffee50.png">

To prevent from conflicting data models, the previous PR https://github.com/woocommerce/woocommerce-ios/pull/3531 added `timeRange` attribute to `SiteVisitStats` entity so that we can later store `SiteVisitStats` with a unique time range and query with the time range for each tab in Dashboard. This PR set the `timeRange` attribute when saving to storage and query with `timeRange` for UI display.

This PR doesn't close the issue #1795 because there could be other reasons for incorrect visitor data like from the API, which I've seen before but cannot reproduce.

## Changes

- In `Yosemite.StatsStoreV4`, set `timeRange` to `Storage.SiteVisitStats` when upserting
  - It also loads existing object with the same `timeRange` instead `date` since `date` might not be unique for each tab
- In `StoreStatsV4PeriodViewController`, replaced `date` with `timeRange` in `SiteVisitStats` FRC predicate
- Updated unit tests

## Testing

Prerequisites:
1. The store has non-zero visitor stats on various days this month
2. The region of the simulator/device has Monday as the start of the week (e.g. UK)

- Launch the app --> check the visitor stats in `Today`/`This Week`/`This Month`/`This Year` tabs, they should not conflict with each other (e.g. `This Week` is 3 while `This Month` is 0) and are consistent with `wp-admin > Stats`

## Example screenshots

### `SiteVisitStats` in the database

before | after
-- | --
<img width="735" alt="Screen Shot 2021-01-25 at 2 20 11 PM" src="https://user-images.githubusercontent.com/1945542/105950918-34b64780-60aa-11eb-8091-b3ba5f772b67.png"> | <img width="886" alt="Screen Shot 2021-01-27 at 1 27 46 PM" src="https://user-images.githubusercontent.com/1945542/105951423-f66d5800-60aa-11eb-9e1a-169f2faf68d5.png">

### Dashboard tabs

\ | This Week | This Month | This Year
-- | -- | -- | --
before | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 18 58](https://user-images.githubusercontent.com/1945542/105951520-23216f80-60ab-11eb-9d9e-fb61364b2d58.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 19 00](https://user-images.githubusercontent.com/1945542/105951525-26b4f680-60ab-11eb-9aa4-ea2500b67d1e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 19 01](https://user-images.githubusercontent.com/1945542/105951528-27e62380-60ab-11eb-9ce2-1e45e8dc3c9a.png)
after | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 52 53](https://user-images.githubusercontent.com/1945542/105951529-287eba00-60ab-11eb-9fdb-695c930e0732.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 52 55](https://user-images.githubusercontent.com/1945542/105951533-29afe700-60ab-11eb-886d-a89013d2ed37.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 13 52 57](https://user-images.githubusercontent.com/1945542/105951537-2a487d80-60ab-11eb-9a7f-648b5b6d71d9.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
