### PR TITLE
[Tooling] Update release-toolkit to 0.14.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a932bd25320f2b82be0774b66e550c6862cd8765
-  tag: 0.12.0
+  revision: 0ad59f8ad1644b68f8dbe3ebc3e16bb331a24117
+  tag: 0.14.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.12.0)
+    fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -225,7 +225,7 @@ GEM
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.18)
+    oj (3.11.2)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.12.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.14.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
Update our tooling to [release-toolkit v0.14.0](https://github.com/wordpress-mobile/release-toolkit/releases/tag/0.14.0), which includes improvements about release notes automation.