### PR TITLE
Fixed typo in enter Store Address screen

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -27,7 +27,7 @@ struct AuthenticationConstants {
     /// Login with site URL instructions.
     ///
     static let siteInstructions = NSLocalizedString(
-        "Enter the address of your WooCommerce store you'd like to connect.",
+        "Enter the address of the WooCommerce store you'd like to connect.",
         comment: "Sign in instructions for logging in with a URL."
     )
 

--- a/WooCommerce/Resources/ar.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ar.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "أدخل عنوان موقع ووردبريس الذي ترغب في الاتصال به.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "أدخل عنوان متجر WooCommerce الخاص بك الذي تود الاتصال به.";
+"Enter the address of the WooCommerce store you'd like to connect." = "أدخل عنوان متجر WooCommerce الخاص بك الذي تود الاتصال به.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "أدخل عنوان URL الخارجي إلى المنتج.";

--- a/WooCommerce/Resources/de.lproj/Localizable.strings
+++ b/WooCommerce/Resources/de.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Gib die Adresse der WordPress-Website ein, die du verbinden möchtest.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Gib die Adresse deines WooCommerce-Shops ein, den du verbinden möchtest.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Gib die Adresse deines WooCommerce-Shops ein, den du verbinden möchtest.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Gib die externe URL zum Produkt an.";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
+/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
 "#%@ %@" = "#%1$@ %2$@";
 
 /* Format for each Product attribute */
@@ -795,7 +795,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Enter the address of the WordPress site you'd like to connect.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Enter the address of your WooCommerce store you'd like to connect.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Enter the address of the WooCommerce store you'd like to connect.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Enter the external URL to the product.";

--- a/WooCommerce/Resources/es.lproj/Localizable.strings
+++ b/WooCommerce/Resources/es.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Introduce la dirección del sitio de WordPress que deseas conectar.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Introduce la dirección de la tienda de WooCommerce que quieres conectar.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Introduce la dirección de la tienda de WooCommerce que quieres conectar.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Introduce la URL externa al producto.";

--- a/WooCommerce/Resources/fr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fr.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Saisissez l’adresse du site WordPress que vous souhaitez connecter.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Entrez l’adresse de votre boutique WooCommerce que vous aimeriez connecter.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Entrez l’adresse de votre boutique WooCommerce que vous aimeriez connecter.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Saisir l’URL externe vers le produit.";

--- a/WooCommerce/Resources/he.lproj/Localizable.strings
+++ b/WooCommerce/Resources/he.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "יש להזין את כתובת האתר ב-WordPress שאליו ברצונך להתחבר.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "יש להזין את הכתובת של חנות ה-WooCommerce שלך שאליה ברצונך להתחבר.";
+"Enter the address of the WooCommerce store you'd like to connect." = "יש להזין את הכתובת של חנות ה-WooCommerce שלך שאליה ברצונך להתחבר.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "להזין את כתובת ה-URL החיצונית למוצר.";

--- a/WooCommerce/Resources/id.lproj/Localizable.strings
+++ b/WooCommerce/Resources/id.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Masukkan alamat situs WordPress yang ingin Anda hubungkan.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Masukkan alamat toko WooCommerce Anda yang ingin dihubungkan.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Masukkan alamat toko WooCommerce Anda yang ingin dihubungkan.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Masukkan URL eksternal ke produk";

--- a/WooCommerce/Resources/it.lproj/Localizable.strings
+++ b/WooCommerce/Resources/it.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Inserisci l'indirizzo del sito WordPress che desideri connettere.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Immetti l'indirizzo del negozio WooCommerce che desideri connettere.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Immetti l'indirizzo del negozio WooCommerce che desideri connettere.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Inserisci l'URL esterno al prodotto.";

--- a/WooCommerce/Resources/ja.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ja.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "連携する WordPress サイトのアドレスを入力してください。";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "連携させる WooCommerce ストアのアドレスを入力してください。";
+"Enter the address of the WooCommerce store you'd like to connect." = "連携させる WooCommerce ストアのアドレスを入力してください。";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "商品の外部 URL を入力してください。";

--- a/WooCommerce/Resources/ko.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ko.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "연결하려는 워드프레스 사이트 주소를 입력하세요.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "연결하려는 WooCommerce 스토어의 주소를 입력합니다.";
+"Enter the address of the WooCommerce store you'd like to connect." = "연결하려는 WooCommerce 스토어의 주소를 입력합니다.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "제품의 외부 URL을 입력하세요.";

--- a/WooCommerce/Resources/nl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nl.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Voer het adres van de WordPress-site in die je wilt koppelen.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Voer het adres van de WooCommerce-winkel die je wilt koppelen in.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Voer het adres van de WooCommerce-winkel die je wilt koppelen in.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Voer de externe URL naar het product in.";

--- a/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Digite o endereço do site WordPress que você deseja conectar.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Insira o endereço da loja WooCommerce que deseja vincular.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Insira o endereço da loja WooCommerce que deseja vincular.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Informe a URL externa do produto.";

--- a/WooCommerce/Resources/ru.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ru.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Введите адрес сайта WordPress, к которому требуется подключиться.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Введите адрес магазина WooCommerce, к которому требуется подключиться.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Введите адрес магазина WooCommerce, к которому требуется подключиться.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Введите внешнюю ссылку на товар.";

--- a/WooCommerce/Resources/sv.lproj/Localizable.strings
+++ b/WooCommerce/Resources/sv.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Skriv in adressen för den WordPress-webbplats du vill ansluta.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Ange adressen till den WooCommerce-butik som du vill ansluta.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Ange adressen till den WooCommerce-butik som du vill ansluta.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Ange den externa URL:en till produkten.";

--- a/WooCommerce/Resources/tr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/tr.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "Bağlanmak istediğiniz WordPress sitesinin adresini girin.";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "Bağlanmak istediğiniz WooCommerce mağazasının adresini girin.";
+"Enter the address of the WooCommerce store you'd like to connect." = "Bağlanmak istediğiniz WooCommerce mağazasının adresini girin.";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "Ürünün harici URL'sini girin.";

--- a/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "输入您要连接的 WordPress 站点的地址。";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "输入您要关联的 WooCommerce 商店的地址。";
+"Enter the address of the WooCommerce store you'd like to connect." = "输入您要关联的 WooCommerce 商店的地址。";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "输入产品的外部 URL。";

--- a/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
@@ -837,7 +837,7 @@
 "Enter the address of the WordPress site you'd like to connect." = "請輸入要連結的 WordPress 網站位址。";
 
 /* Sign in instructions for logging in with a URL. */
-"Enter the address of your WooCommerce store you'd like to connect." = "請輸入要連結的 WooCommerce 商店位址。";
+"Enter the address of the WooCommerce store you'd like to connect." = "請輸入要連結的 WooCommerce 商店位址。";
 
 /* Footer text for editing product external URL */
 "Enter the external URL to the product." = "請輸入此產品的外部 URL。";


### PR DESCRIPTION
Fixes #3551 

Did a s/'Enter the address of *your* WooCommerce store'/Enter the address of *the* WooCommerce store/

FYI - I changed the English versions of the localization strings, but didn't touch the translations.




Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
