### PR TITLE
Added SKU back to Order Details → Product Section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix: top performers in "This Week" tab should be showing the same data as in WC Admin.
 - [*] Fix: visitor stats in Dashboard should be more consistent with web data on days when the end date for more than one tab is the same (e.g. "This Week" and "This Month" both end on January 31). [https://github.com/woocommerce/woocommerce-ios/pull/3532]
 - [internal] Refactored Core Data migrator stack to help reduce crashes [https://github.com/woocommerce/woocommerce-ios/pull/3523]
+- [**] Due to popular demand, the product SKU is displayed once again in Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3564]
 
 5.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,11 +2,11 @@
 
 6.0
 -----
+- [**] Due to popular demand, the product SKU is displayed once again in Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3564]
 - [*] Updated copyright notice to WooCommerce
 - [*] Fix: top performers in "This Week" tab should be showing the same data as in WC Admin.
 - [*] Fix: visitor stats in Dashboard should be more consistent with web data on days when the end date for more than one tab is the same (e.g. "This Week" and "This Month" both end on January 31). [https://github.com/woocommerce/woocommerce-ios/pull/3532]
 - [internal] Refactored Core Data migrator stack to help reduce crashes [https://github.com/woocommerce/woocommerce-ios/pull/3523]
-- [**] Due to popular demand, the product SKU is displayed once again in Order Details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3564]
 
 5.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -22,7 +22,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
     /// The label showing the pattern "{qty} x {item_price}".
     ///
     @IBOutlet private var subtitleLabel: UILabel!
-    
+
     /// The label showing the SKU.
     ///
     @IBOutlet private var skuLabel: UILabel!

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -22,6 +22,10 @@ final class ProductDetailsTableViewCell: UITableViewCell {
     /// The label showing the pattern "{qty} x {item_price}".
     ///
     @IBOutlet private var subtitleLabel: UILabel!
+    
+    /// The label showing the SKU.
+    ///
+    @IBOutlet private var skuLabel: UILabel!
 
     // MARK: - Overridden Methods
 
@@ -37,6 +41,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
         configureProductImageView()
         configureNameLabel()
         configurePriceLabel()
+        configureSKULabel()
         configureSubtitleLabel()
         configureSelectionStyle()
     }
@@ -75,6 +80,11 @@ private extension ProductDetailsTableViewCell {
         subtitleLabel?.text = ""
     }
 
+    func configureSKULabel() {
+        skuLabel.applySecondaryFootnoteStyle()
+        skuLabel?.text = ""
+    }
+
     func configureSelectionStyle() {
         selectionStyle = .none
     }
@@ -96,5 +106,6 @@ extension ProductDetailsTableViewCell {
         nameLabel.text = item.name
         priceLabel.text = item.total
         subtitleLabel.text = item.subtitle
+        skuLabel.text = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
@@ -28,16 +28,16 @@
                         <rect key="frame" x="76" y="19" width="228" height="85"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HX7-V5-bhX">
-                                <rect key="frame" x="0.0" y="0.0" width="228" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="228" height="45"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Title Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14R-zK-tgC">
-                                        <rect key="frame" x="0.0" y="0.0" width="188.5" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="188.5" height="45"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="893" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pPE-SE-pY7">
-                                        <rect key="frame" x="196.5" y="0.0" width="31.5" height="50"/>
+                                        <rect key="frame" x="196.5" y="0.0" width="31.5" height="45"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -56,6 +56,12 @@
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total price (item price x qty)" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBM-H2-zE2">
                                 <rect key="frame" x="0.0" y="69" width="228" height="16"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SKU" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7JH-rt-n9v">
+                                <rect key="frame" x="0.0" y="49" width="230" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -79,6 +85,7 @@
                 <outlet property="priceLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="productImageView" destination="p6h-Fq-FjW" id="bIw-1F-5GW"/>
                 <outlet property="subtitleLabel" destination="IBM-H2-zE2" id="acc-K8-vmg"/>
+                <outlet property="skuLabel" destination="7JH-rt-n9v" id="U07-2n-W3b"/>
             </connections>
             <point key="canvasLocation" x="62" y="96.5"/>
         </tableViewCell>


### PR DESCRIPTION
Fixes #3563. This PR adds the SKU back to the Products in the Order Details. 

This is my first PR in WCiOS so please bear with me if I made any mistakes 😅 

Light | Dark  
--------|-------
<img src="https://user-images.githubusercontent.com/22608780/106572084-fca57d80-655d-11eb-9439-4881c1f20b52.png" width="300"/> | <img src="https://user-images.githubusercontent.com/22608780/106572604-a7b63700-655e-11eb-9494-8705f724effb.png" width="300"/>
<img src="https://user-images.githubusercontent.com/22608780/106572611-aa189100-655e-11eb-9d91-87c8d2f5f057.png" width="300"/> | <img src="https://user-images.githubusercontent.com/22608780/106572624-adac1800-655e-11eb-9e5a-5c99622bdfb2.png" width="300"/>

## Testing

- Navigate to an order that has shipping labels and verify that the product SKU is displayed correctly.
- Navigate to an order that does NOT have any shipping labels and verify that the product SKU is displayed correctly.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

