### PR TITLE
Fix navbar title for cross-sells products list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Updated copyright notice to WooCommerce
 - [*] Fix: top performers in "This Week" tab should be showing the same data as in WC Admin.
 - [*] Fix: visitor stats in Dashboard should be more consistent with web data on days when the end date for more than one tab is the same (e.g. "This Week" and "This Month" both end on January 31). [https://github.com/woocommerce/woocommerce-ios/pull/3532]
+- [*] Fix: navbar title on cross-sells products list displayed title for upsells [https://github.com/woocommerce/woocommerce-ios/pull/3565]
 - [internal] Refactored Core Data migrator stack to help reduce crashes [https://github.com/woocommerce/woocommerce-ios/pull/3523]
 
 5.9

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
@@ -176,7 +176,7 @@ private extension LinkedProductsViewController {
             return
         }
 
-        let viewConfiguration = LinkedProductsListSelectorViewController.ViewConfiguration(title: Localization.titleScreenAddUpsellProducts,
+        let viewConfiguration = LinkedProductsListSelectorViewController.ViewConfiguration(title: Localization.titleScreenAddCrossSellProducts,
                                                                                            trackingContext: "cross_sells")
 
         let viewController = LinkedProductsListSelectorViewController(product: product.product,


### PR DESCRIPTION
Very simple fix, just a typo/copy-paste issue.

### Video

Observe how cross-sells edit tap opens to list with "Upsells Products":

https://user-images.githubusercontent.com/3132438/106588858-586f0700-655c-11eb-9a7e-9e1d576faa48.mp4

### Screenshots

Before | After
-------|-------
![Simulator Screen Shot - iPhone 12 - 2021-02-02 at 13 48 46](https://user-images.githubusercontent.com/3132438/106589791-7721cd80-655d-11eb-9d4f-e15e559c01f8.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-02 at 13 49 15](https://user-images.githubusercontent.com/3132438/106589804-7be68180-655d-11eb-990b-6dadf2be6586.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
