### PR TITLE
Variations: Show current variation options in Attributes cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -105,7 +105,7 @@ private extension DefaultProductFormTableViewModel {
             case .priceSettings(let editable):
                 return .price(viewModel: variationPriceSettingsRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .attributes(let editable):
-                return .attributes(viewModel: variationAttributesRow(isEditable: editable), isEditable: editable)
+                return .attributes(viewModel: variationAttributesRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .shippingSettings(let editable):
                 return .shipping(viewModel: shippingSettingsRow(product: productVariation, isEditable: editable), isEditable: editable)
             case .inventorySettings(let editable):
@@ -418,10 +418,10 @@ private extension DefaultProductFormTableViewModel {
         return ProductFormSection.SettingsRow.WarningViewModel(icon: icon, title: title)
     }
 
-    func variationAttributesRow(isEditable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
+    func variationAttributesRow(productVariation: EditableProductVariationModel, isEditable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.customizeImage
         let title = Localization.variationAttributesTitle
-        let details = "Any Color - Any Material"
+        let details = productVariation.name
 
         return .init(icon: icon, title: title, details: details, isActionable: isEditable)
     }


### PR DESCRIPTION
Closes: #3520 

## Description

This PR updates the Attributes cell (in the Product Variation detail screen), so it renders the variation's current attribute options. If no option is selected for an attribute, the cell will display `Any [attribute]`.

For example, a variable product can have the attributes `Color` and `Size`:

* For a variation with the `Color` set to `Blue` and the `Size` set to `Large`, the Attributes cell will display `Blue - Large`.
* For a variation with the `Color` set to `Red` and no `Size` option selected, the Attributes cell will display `Red - Any Size`.

## Changes

In `EditableProductVariationModel` we already generate the variation's name based on the variation's attributes, in the same format we need for the Attributes cell. Here we use that name (`productVariation.name`) 

### Screenshots

Variation with all options selected|Variation with some options selected|Variation with no options selected
-|-|-
![Simulator Screen Shot - iPhone 12 mini - 2021-02-02 at 12 52 34](https://user-images.githubusercontent.com/8658164/106611342-c36e0d00-655f-11eb-9607-2012ecb76c0f.png)|![Simulator Screen Shot - iPhone 12 mini - 2021-02-02 at 12 52 40](https://user-images.githubusercontent.com/8658164/106611408-da146400-655f-11eb-9e7d-0c107d2d7808.png)|![Simulator Screen Shot - iPhone 12 mini - 2021-02-02 at 12 55 49](https://user-images.githubusercontent.com/8658164/106611429-e00a4500-655f-11eb-96cd-d682c5359af0.png)


## Testing

1. Open a variable product that has existing variations.
2. Tap on Variations.
3. Select a variation.
4. Notice the **Attributes** cell includes details about the selected options for the current variation.

Try with a variety of product variations:

* A variation where all the attributes have selected options (e.g. `Blue - Large`)
* A variation where some or all the attributes do **not** have selected options (e.g. `Red - Any Size` or `Any Color - Any Size`)
* A variation with many attributes, or attributes with long option names (the options should all be displayed, wrapping to multiple lines if needed)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
