### PR TITLE
[Variations] Add new option(to attribute) UI handling

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -231,7 +231,7 @@ private extension AddProductCategoryViewController {
                                                             self?.newCategoryTitle = newCategoryName
 
             }, onTextDidBeginEditing: {
-        }, inputFormatter: nil, keyboardType: .default)
+        }, onTextDidReturn: nil, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
@@ -146,7 +146,7 @@ private extension ProductMenuOrderViewController {
             }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
-        }, inputFormatter: IntegerInputFormatter(defaultValue: ""), keyboardType: .numbersAndPunctuation)
+        }, onTextDidReturn: nil, inputFormatter: IntegerInputFormatter(defaultValue: ""), keyboardType: .numbersAndPunctuation)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -148,7 +148,7 @@ private extension ProductSlugViewController {
             }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
-        }, inputFormatter: nil, keyboardType: .default)
+        }, onTextDidReturn: nil, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -33,6 +33,7 @@ final class AddAttributeOptionsViewController: UIViewController {
         registerTableViewCells()
         startListeningToNotifications()
         observeViewModel()
+        renderViewModel()
     }
 }
 
@@ -41,8 +42,6 @@ final class AddAttributeOptionsViewController: UIViewController {
 private extension AddAttributeOptionsViewController {
 
     func configureNavigationBar() {
-        title = viewModel.titleView
-
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,
                                                            target: self,
@@ -76,8 +75,14 @@ private extension AddAttributeOptionsViewController {
     func observeViewModel() {
         viewModel.onChange = { [weak self] in
             guard let self = self else { return }
-            self.tableView.reloadData()
+            self.renderViewModel()
         }
+    }
+
+    func renderViewModel() {
+        title = viewModel.titleView
+        navigationItem.rightBarButtonItem?.isEnabled = viewModel.isNextButtonEnabled
+        tableView.reloadData()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -69,9 +69,8 @@ private extension AddAttributeOptionsViewController {
     }
 
     func registerTableViewCells() {
-        for row in Row.allCases {
-            tableView.registerNib(for: row.type)
-        }
+        tableView.registerNib(for: BasicTableViewCell.self)
+        tableView.registerNib(for: TextFieldTableViewCell.self)
     }
 
     func observeViewModel() {
@@ -146,15 +145,15 @@ private extension AddAttributeOptionsViewController {
     /// Cells currently configured in the order they appear on screen
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
-        switch cell {
-        case let cell as TextFieldTableViewCell where row == .termTextField:
+        switch (row, cell) {
+        case (.termTextField, let cell as TextFieldTableViewCell):
             configureTextField(cell: cell)
-        case let cell as BasicTableViewCell where row == .selectedTerms:
-            configureOption(cell: cell)
-        case let cell as BasicTableViewCell where row == .existingTerms:
-            configureOption(cell: cell)
+        case (let .selectedTerms(name), let cell as BasicTableViewCell):
+            configureOption(cell: cell, text: name)
+        case (.existingTerms, let cell as BasicTableViewCell):
+            configureOption(cell: cell, text: "Work in Progress")
         default:
-            fatalError()
+            fatalError("Unsupported Cell")
             break
         }
     }
@@ -174,8 +173,8 @@ private extension AddAttributeOptionsViewController {
         cell.applyStyle(style: .body)
     }
 
-    func configureOption(cell: BasicTableViewCell) {
-        cell.textLabel?.text = "Work in progress" //TODO: to be implemented
+    func configureOption(cell: BasicTableViewCell, text: String) {
+        cell.textLabel?.text = text
     }
 }
 
@@ -213,9 +212,9 @@ extension AddAttributeOptionsViewController {
         let rows: [Row]
     }
 
-    enum Row: CaseIterable {
+    enum Row: Equatable {
         case termTextField
-        case selectedTerms
+        case selectedTerms(name: String)
         case existingTerms
 
         fileprivate var type: UITableViewCell.Type {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -32,6 +32,7 @@ final class AddAttributeOptionsViewController: UIViewController {
         registerTableViewHeaderSections()
         registerTableViewCells()
         startListeningToNotifications()
+        observeViewModel()
     }
 }
 
@@ -70,6 +71,13 @@ private extension AddAttributeOptionsViewController {
     func registerTableViewCells() {
         for row in Row.allCases {
             tableView.registerNib(for: row.type)
+        }
+    }
+
+    func observeViewModel() {
+        viewModel.onChange = { [weak self] in
+            guard let self = self else { return }
+            self.tableView.reloadData()
         }
     }
 }
@@ -156,7 +164,10 @@ private extension AddAttributeOptionsViewController {
                                                          placeholder: Localization.optionNameCellPlaceholder,
                                                          onTextChange: nil,
                                                          onTextDidBeginEditing: nil,
-                                                         onTextDidReturn: {
+                                                         onTextDidReturn: { [weak self] text in
+                                                            if let text = text {
+                                                                self?.viewModel.addNewOption(name: text)
+                                                            }
                                                          }, inputFormatter: nil,
                                                          keyboardType: .default)
         cell.configure(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -154,10 +154,11 @@ private extension AddAttributeOptionsViewController {
     func configureTextField(cell: TextFieldTableViewCell) {
         let viewModel = TextFieldTableViewCell.ViewModel(text: nil,
                                                          placeholder: Localization.optionNameCellPlaceholder,
-                                                         onTextChange: { newAttributeOption in
-
-            }, onTextDidBeginEditing: {
-        }, inputFormatter: nil, keyboardType: .default)
+                                                         onTextChange: nil,
+                                                         onTextDidBeginEditing: nil,
+                                                         onTextDidReturn: {
+                                                         }, inputFormatter: nil,
+                                                         keyboardType: .default)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -4,6 +4,8 @@ import Yosemite
 /// Provides view data for Add Attributes, and handles init/UI/navigation actions needed.
 ///
 final class AddAttributeOptionsViewModel {
+    typealias Section = AddAttributeOptionsViewController.Section
+    typealias Row = AddAttributeOptionsViewController.Row
 
     /// Defines the necessary state to produce the ViewModel's outputs.
     ///
@@ -13,12 +15,22 @@ final class AddAttributeOptionsViewModel {
         var optionsOffered: [String] = []
     }
 
-    typealias Section = AddAttributeOptionsViewController.Section
-    typealias Row = AddAttributeOptionsViewController.Row
-
+    /// Title of the navigation bar
+    ///
     var titleView: String? {
         newAttributeName ?? attribute?.name
     }
+
+    /// Defines next button visibility
+    ///
+    var isNextButtonEnabled: Bool {
+        state.optionsOffered.isNotEmpty
+    }
+
+    /// Closure to notify the `ViewController` when the view model properties change.
+    ///
+    var onChange: (() -> (Void))?
+
     private(set) var newAttributeName: String?
     private(set) var attribute: ProductAttribute?
 
@@ -30,10 +42,6 @@ final class AddAttributeOptionsViewModel {
             onChange?()
         }
     }
-
-    /// Closure to notify the `ViewController` when the view model properties change.
-    ///
-    var onChange: (() -> (Void))?
 
     private(set) var sections: [Section] = []
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -28,6 +28,13 @@ final class AddAttributeOptionsViewModel {
 
 }
 
+// MARK: - State Mutation
+extension AddAttributeOptionsViewModel {
+    func addNewOption(name: String) {
+
+    }
+}
+
 // MARK: - Synchronize Product Attribute terms
 //
 private extension AddAttributeOptionsViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -5,6 +5,14 @@ import Yosemite
 ///
 final class AddAttributeOptionsViewModel {
 
+    /// Defines the necessary state to produce the ViewModel's outputs.
+    ///
+    private struct State {
+        /// Stores the options to be offered
+        ///
+        var optionsOffered: [String] = []
+    }
+
     typealias Section = AddAttributeOptionsViewController.Section
     typealias Row = AddAttributeOptionsViewController.Row
 
@@ -13,6 +21,14 @@ final class AddAttributeOptionsViewModel {
     }
     private(set) var newAttributeName: String?
     private(set) var attribute: ProductAttribute?
+
+    /// Current `ViewModel` state.
+    ///
+    private var state: State = State() {
+        didSet {
+            updateSections()
+        }
+    }
 
     private(set) var sections: [Section] = []
 
@@ -25,13 +41,12 @@ final class AddAttributeOptionsViewModel {
         self.attribute = existingAttribute
         updateSections()
     }
-
 }
 
-// MARK: - State Mutation
+// MARK: - ViewController Inputs
 extension AddAttributeOptionsViewModel {
     func addNewOption(name: String) {
-
+        state.optionsOffered.append(name)
     }
 }
 
@@ -40,11 +55,24 @@ extension AddAttributeOptionsViewModel {
 private extension AddAttributeOptionsViewModel {
     // TODO: to be implemented - fetch of terms
 
-    /// Updates  data in sections
+    /// Updates data in sections
     ///
     func updateSections() {
         let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField])
-        sections = [textFieldSection]
+        let offeredSection = createOfferedSection()
+        sections = [textFieldSection, offeredSection].compactMap { $0 }
+    }
+
+    func createOfferedSection() -> Section? {
+        guard state.optionsOffered.isNotEmpty else {
+            return nil
+        }
+
+        let rows = state.optionsOffered.map { option in
+            AddAttributeOptionsViewModel.Row.selectedTerms
+        }
+
+        return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -27,8 +27,13 @@ final class AddAttributeOptionsViewModel {
     private var state: State = State() {
         didSet {
             updateSections()
+            onChange?()
         }
     }
+
+    /// Closure to notify the `ViewController` when the view model properties change.
+    ///
+    var onChange: (() -> (Void))?
 
     private(set) var sections: [Section] = []
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -74,7 +74,7 @@ private extension AddAttributeOptionsViewModel {
         }
 
         let rows = state.optionsOffered.map { option in
-            AddAttributeOptionsViewModel.Row.selectedTerms
+            AddAttributeOptionsViewModel.Row.selectedTerms(name: option)
         }
 
         return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -37,9 +37,7 @@ private extension AddAttributeOptionsViewModel {
     ///
     func updateSections() {
         let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField])
-        let selectedTermsSection = Section(header: Localization.headerSelectedTerms, footer: nil, rows: [.selectedTerms])
-        let existingTermsSection = Section(header: Localization.headerExistingTerms, footer: nil, rows: [.existingTerms])
-        sections = [textFieldSection, selectedTermsSection, existingTermsSection].compactMap { $0 }
+        sections = [textFieldSection]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -234,7 +234,7 @@ private extension AddAttributeViewController {
                                                             self?.enableDoneButton(self?.viewModel.newAttributeName != nil)
 
             }, onTextDidBeginEditing: {
-        }, inputFormatter: nil, keyboardType: .default)
+        }, onTextDidReturn: nil, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -8,6 +8,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         let placeholder: String?
         let onTextChange: ((_ text: String?) -> Void)?
         let onTextDidBeginEditing: (() -> Void)?
+        let onTextDidReturn: ((_ text: String?) -> Void)?
         let inputFormatter: UnitInputFormatter?
         let keyboardType: UIKeyboardType
     }
@@ -38,6 +39,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.keyboardType = viewModel.keyboardType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
+
     }
 
     @discardableResult
@@ -106,6 +108,7 @@ extension TextFieldTableViewCell: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        viewModel?.onTextDidReturn?(viewModel?.text)
         textField.resignFirstResponder()
         return true
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -108,7 +108,7 @@ extension TextFieldTableViewCell: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        viewModel?.onTextDidReturn?(viewModel?.text)
+        viewModel?.onTextDidReturn?(textField.text)
         textField.resignFirstResponder()
         return true
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -39,7 +39,6 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.keyboardType = viewModel.keyboardType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
-
     }
 
     @discardableResult

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
+		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
@@ -1486,6 +1487,7 @@
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
+		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
@@ -3117,6 +3119,15 @@
 				573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */,
 			);
 			path = TopBanner;
+			sourceTree = "<group>";
+		};
+		2619FA2A25C897720006DAFF /* Add Attributes */ = {
+			isa = PBXGroup;
+			children = (
+				2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */,
+			);
+			name = "Add Attributes";
+			path = "Variations/Add Attributes";
 			sourceTree = "<group>";
 		};
 		265BCA032430E5EA004E53EE /* Edit Categories */ = {
@@ -5003,6 +5014,7 @@
 				02F67FF325806DF000C3BAD2 /* Shipping Label */,
 				26B119BC24D0C5AB00FED5C7 /* Survey */,
 				2614EB1A24EB60DB00968D4B /* TopBanner */,
+				2619FA2A25C897720006DAFF /* Add Attributes */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
 				45C8B25A231521510002FA77 /* CustomerNoteTableViewCellTests.swift */,
@@ -6454,6 +6466,7 @@
 				02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */,
 				45E9A6EB24DAFC3E00A600E8 /* ProductReviewsViewModelTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,
+				2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */,
 				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,
 				57A5D8D92534FEBB00AA54D6 /* TotalRefundedCalculationUseCaseTests.swift in Sources */,
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -3,6 +3,16 @@ import XCTest
 
 final class AddAttributeOptionsViewModelTests: XCTestCase {
 
+    func test_new_attribute_should_have_textfield_section() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+
+        // Then
+        let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(textFieldSection, [AddAttributeOptionsViewController.Row.termTextField])
+        XCTAssertEqual(viewModel.sections.count, 1)
+    }
+
     func test_when_adding_new_option_to_new_attribute_a_new_section_should_be_added() throws {
         // Given
         let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
@@ -12,8 +22,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         viewModel.addNewOption(name: "new-option")
 
         // Then
-        XCTAssertEqual(viewModel.sections.count, 2)
         let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms])
+        XCTAssertEqual(viewModel.sections.count, 2)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -26,4 +26,20 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
+
+    func test_when_adding_multiple_options_one_section_with_multiple_rows_is_added() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+        XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
+
+        // When
+        viewModel.addNewOption(name: "new-option")
+        viewModel.addNewOption(name: "new-option-2")
+
+        // Then
+        let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms,
+                                        AddAttributeOptionsViewController.Row.selectedTerms])
+        XCTAssertEqual(viewModel.sections.count, 2)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -3,9 +3,12 @@ import XCTest
 
 final class AddAttributeOptionsViewModelTests: XCTestCase {
 
+    private let sampleAttributeName = "attr"
+    private let sampleOptionName = "new-option"
+
     func test_new_attribute_should_have_textfield_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
 
         // Then
         let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -15,31 +18,32 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_when_adding_new_option_to_new_attribute_a_new_section_should_be_added() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
-        viewModel.addNewOption(name: "new-option")
+        viewModel.addNewOption(name: sampleOptionName)
 
         // Then
         let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
-        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms])
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms(name: sampleOptionName)])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
 
     func test_when_adding_multiple_options_one_section_with_multiple_rows_is_added() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+        let newOptionName = "new-option-2"
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
-        viewModel.addNewOption(name: "new-option")
-        viewModel.addNewOption(name: "new-option-2")
+        viewModel.addNewOption(name: sampleOptionName)
+        viewModel.addNewOption(name: newOptionName)
 
         // Then
         let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
-        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms,
-                                        AddAttributeOptionsViewController.Row.selectedTerms])
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms(name: sampleOptionName),
+                                        AddAttributeOptionsViewController.Row.selectedTerms(name: newOptionName)])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -46,4 +46,16 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
                                         AddAttributeOptionsViewController.Row.selectedTerms(name: newOptionName)])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
+
+    func test_next_button_gets_enabled_after_adding_one_option() {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+
+        // When
+        viewModel.addNewOption(name: sampleOptionName)
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonEnabled)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import WooCommerce
+
+final class AddAttributeOptionsViewModelTests: XCTestCase {
+
+    func test_when_adding_new_option_to_new_attribute_a_new_section_should_be_added() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: "attr")
+        XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
+
+        // When
+        viewModel.addNewOption(name: "new-option")
+
+        // Then
+        XCTAssertEqual(viewModel.sections.count, 2)
+        let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms])
+    }
+}


### PR DESCRIPTION
closes #3527 

# Why

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Add a new option, to a new attribute. All of these are prerequisites for creating our first variation!

This PR does not create the attribute or option remotely yet(#3535), it only allows to create it visually.

# How
- Update `TextFieldTableViewCell` to provide a callback when the return key is pressed

- Update `AddAttributeOptionsViewController.Row` so that the `.selectedTerms` case has now an associated value to transport the option name

- Update `AddAttributeOptionsViewModel` to add a method so consumer can add new options. This is powered by a new `State` struct that is in charge of holding the view model state. This `state` has an observation that regenerates the `sections` property everytime it changes. This helps us to maintain the view in sync.

- Update `AddAttributeOptionsViewController` to render the options offered section and the next button visibility based on the view model content.

# Demo
![add-new-option](https://user-images.githubusercontent.com/562080/106648775-b7ce1680-655e-11eb-8737-e2a0e858561f.gif)

# Testing Steps
- Navigate to a variable product that does not have variations yet
- Tap on "Add Variation" cell
- Tap on "Add Variation" Button
- Write an attribute name and tap next
- Write an option name and hit enter/return
- See that the option is moved to the "options offered" section
- See that the next button is enabled

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
