### PR TITLE
Cast "Update Sourcery" spell to revive "rake generate" from the graveyard!

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 
 
 extension Order {

--- a/Podfile
+++ b/Podfile
@@ -112,7 +112,7 @@ def networking_pods
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 
-  pod 'Sourcery', '~> 0.18', :configuration => 'Debug'
+  pod 'Sourcery', '~> 1.0.3', :configuration => 'Debug'
 
   # Used for HTML parsing
   aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
     - Sentry/Core (= 4.5.0)
   - Sentry/Core (4.5.0)
   - Sodium-Fork (0.8.2)
-  - Sourcery (0.18.0)
+  - Sourcery (1.0.3)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.5.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.0)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
-  - Sourcery (~> 0.18)
+  - Sourcery (~> 1.0.3)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.35.0-beta.1)
   - WordPressKit (~> 4.25.0)
@@ -178,7 +178,7 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
-  Sourcery: e0e8658a1ce6d9f475156ad3ffce4c68f1261b3e
+  Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -199,6 +199,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: d3993531d5dd5b231a0dee9f4ddd23fa1cc78f0d
+PODFILE CHECKSUM: f987bc8d4f4c4aa53bf53cbec676385ecfe675d5
 
 COCOAPODS: 1.10.0

--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 import Networking
 
 


### PR DESCRIPTION
fixes: #2864

# Why 
Our `rake generate` script failed because we used a version of `Sourcery` that could not cope with SPM. Thankfully, it [has been updated](https://github.com/krzysztofzablocki/Sourcery/pull/896) to fix that issue.

# How
- Update `Sourcery` version to `1.0.3`(the latest one)
- Ran "rake generate" and make sure that the script works

# Testing Steps
- Checkout branch and run `bundle exec pod install`
- Ran `rake generate`
- Make sure the scripts finish successfully and that no files have changed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
