### PR TITLE
Add first screen of edit variation attributes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 final class EditableProductVariationModel {
     let productVariation: ProductVariation
 
-    private let allAttributes: [ProductAttribute]
+    let allAttributes: [ProductAttribute]
     private lazy var variationName: String = generateName(variationAttributes: productVariation.attributes, allAttributes: allAttributes)
 
     init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -223,6 +223,6 @@ extension EditableProductVariationModel: Equatable {
 extension EditableProductVariationModel {
     enum Localization {
         static let anyAttributeFormat =
-            NSLocalizedString("Any %@", comment: "Format of a product varition attribute description where the attribute is set to any value.")
+            NSLocalizedString("Any %@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -348,7 +348,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                                                                                formType: viewModel.formType,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)
-            case .status, .noPriceWarning, .attributes:
+            case .attributes:
+                if let productVariationModel = product as? EditableProductVariationModel {
+                    let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
+                    show(attributePickerViewController, sender: self)
+                }
+            case .status, .noPriceWarning:
                 break
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -348,11 +348,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                                                                                formType: viewModel.formType,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)
-            case .attributes:
-                if let productVariationModel = product as? EditableProductVariationModel {
-                    let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
-                    show(attributePickerViewController, sender: self)
+            case .attributes(_, let isEditable):
+                guard isEditable, let productVariationModel = product as? EditableProductVariationModel else {
+                    return
                 }
+                let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
+                show(attributePickerViewController, sender: self)
             case .status, .noPriceWarning:
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -1,0 +1,151 @@
+import UIKit
+import Yosemite
+
+final class AttributePickerViewController: UIViewController {
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    private let variationModel: EditableProductVariationModel
+
+    /// Init
+    ///
+    init(variationModel: EditableProductVariationModel) {
+        self.variationModel = variationModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureMainView()
+        registerTableViewHeaderSections()
+        registerTableViewCells()
+        configureTableView()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension AttributePickerViewController {
+
+    func configureNavigationBar() {
+        title = Localization.titleView
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.doneNavBarButton,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(doneButtonPressed))
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewHeaderSections() {
+        let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
+        tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
+    }
+
+    func registerTableViewCells() {
+        tableView.registerNib(for: TitleAndValueTableViewCell.self)
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension AttributePickerViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return variationModel.allAttributes.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(TitleAndValueTableViewCell.self, for: indexPath)
+        configureAttribute(cell: cell, attribute: variationModel.allAttributes[safe: indexPath.row])
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension AttributePickerViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        presentAttributeOptions(for: variationModel.allAttributes[indexPath.row])
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return 44
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
+            assertionFailure("Could not find section header view for reuseIdentifier \(headerID)")
+            return nil
+        }
+
+        headerView.leftText = Localization.headerAttributes
+        headerView.rightText = nil
+
+        return headerView
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension AttributePickerViewController {
+    func configureAttribute(cell: TitleAndValueTableViewCell, attribute: ProductAttribute?) {
+        guard let attribute = attribute else {
+            return
+        }
+
+        let optionValue = variationModel.productVariation.attributes.first(where: { $0.id == attribute.attributeID && $0.name == attribute.name })?.option ??
+            Localization.anyAttributeOption
+
+        cell.updateUI(title: attribute.name, value: optionValue)
+        cell.accessoryType = .disclosureIndicator
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+extension AttributePickerViewController {
+
+    @objc private func doneButtonPressed() {
+        // TODO-3518: Save updated attributes
+    }
+
+    private func presentAttributeOptions(for existingAttribute: ProductAttribute) {
+        // TODO-3515: Show options for attribute
+    }
+}
+
+private extension AttributePickerViewController {
+    enum Localization {
+        static let titleView = NSLocalizedString("Attributes", comment: "Edit Product Attributes screen navigation title")
+        static let doneNavBarButton = NSLocalizedString("Done", comment: "Done nav bar button title in Edit Product Attributes screen")
+        static let headerAttributes = NSLocalizedString("Options", comment: "Header of attributes section in Edit Product Attributes screen")
+        static let anyAttributeOption = NSLocalizedString("Any", comment: "Product varition attribute description where the attribute is set to any value.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -146,6 +146,6 @@ private extension AttributePickerViewController {
         static let titleView = NSLocalizedString("Attributes", comment: "Edit Product Attributes screen navigation title")
         static let doneNavBarButton = NSLocalizedString("Done", comment: "Done nav bar button title in Edit Product Attributes screen")
         static let headerAttributes = NSLocalizedString("Options", comment: "Header of attributes section in Edit Product Attributes screen")
-        static let anyAttributeOption = NSLocalizedString("Any", comment: "Product varition attribute description where the attribute is set to any value.")
+        static let anyAttributeOption = NSLocalizedString("Any", comment: "Product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AttributePickerViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="LMJ-Yc-Ynh" id="h9R-mj-s7c"/>
+                <outlet property="view" destination="iN0-l3-epB" id="qH8-bP-YVK"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="LMJ-Yc-Ynh">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="LMJ-Yc-Ynh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="M7y-IN-pPj"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="LMJ-Yc-Ynh" secondAttribute="bottom" id="TaQ-Li-YYi"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="LMJ-Yc-Ynh" secondAttribute="trailing" id="Y1H-2Q-aGh"/>
+                <constraint firstItem="LMJ-Yc-Ynh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="lej-bj-WKL"/>
+            </constraints>
+            <point key="canvasLocation" x="116" y="153"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -668,6 +668,8 @@
 		A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A650BE852578E76600C655E0 /* MockStorageManager.swift */; };
 		A6557218258B7510008AE7CA /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
 		A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */; };
+		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
+		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -1778,6 +1780,8 @@
 		A650BE852578E76600C655E0 /* MockStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockStorageManager.swift; path = ../../../Yosemite/YosemiteTests/Mocks/MockStorageManager.swift; sourceTree = "<group>"; };
 		A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModel.swift; sourceTree = "<group>"; };
 		A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModelTests.swift; sourceTree = "<group>"; };
+		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
+		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -2728,6 +2732,7 @@
 				0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */,
 				02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
+				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
 			path = Variations;
 			sourceTree = "<group>";
@@ -3869,6 +3874,15 @@
 			);
 			name = config;
 			path = ../config;
+			sourceTree = "<group>";
+		};
+		AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */ = {
+			isa = PBXGroup;
+			children = (
+				AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */,
+				AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */,
+			);
+			path = "Edit Attributes";
 			sourceTree = "<group>";
 		};
 		B53A569521123D27000776C9 /* Tools */ = {
@@ -5409,6 +5423,7 @@
 				CEE005F62076C4040079161F /* Orders.storyboard in Resources */,
 				CE85FD5C20F7A7740080B73E /* TableFooterView.xib in Resources */,
 				773077EF251E943700178696 /* ProductDownloadFileViewController.xib in Resources */,
+				AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */,
 				B57C744C20F564B400EEFC87 /* EmptyStoresTableViewCell.xib in Resources */,
 				028296ED237D28B600E84012 /* TextViewViewController.xib in Resources */,
 				451A04F52386F7C900E368C9 /* AddProductImageCollectionViewCell.xib in Resources */,
@@ -6115,6 +6130,7 @@
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
 				028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
+				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
 				4515262E2577D56C0076B03C /* AddAttributeViewController.swift in Sources */,


### PR DESCRIPTION
Part of #3515, #3516.

## Description

This PR adds first screen of variation attributes edit flow. This is the screen where you can see all attributes with options.
It doesn't allow to change any attributes yet, but it will display current values.

Navigation is connected to button that is already behind `addProductVariations` feature flag.

## Changes

- Added `AttributePickerViewController` with UITableView to display attributes + options.
- `EditableProductVariationModel` injected at VC init.
- Connected navigation from `ProductFormViewController` to `AttributePickerViewController`
- There is no additional ViewModel layer for screen now, since it simply displays data from `EditableProductVariationModel`, but maybe it'll be introduced later, together with editing and saving.

## Testing

1. Open product with existing variations
2. Open variations details
3. Tap on attributes cell (added in #3519)
4. Observe correct attributes and details on new screen

### Known limitations

- Tapping on attributes doesn't open next screen
- Done button doesn't work yet - part of #3518

## Screenshots

Any | All
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-03 at 14 12 33](https://user-images.githubusercontent.com/3132438/106739218-ef55c500-6629-11eb-8ece-d76589e98dcd.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-03 at 14 12 47](https://user-images.githubusercontent.com/3132438/106739221-f11f8880-6629-11eb-9759-6ab20734777c.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
