### PR TITLE
Variations: Delete and reorder options of a new product attribute

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -60,6 +60,7 @@ private extension AddAttributeOptionsViewController {
 
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.isEditing = true
     }
 
     func registerTableViewHeaderSections() {
@@ -104,6 +105,35 @@ extension AddAttributeOptionsViewController: UITableViewDataSource {
         configure(cell, for: row, at: indexPath)
 
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        .none // Don't show the default red delete button
+    }
+
+    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        false // Don't indent content
+    }
+
+    func tableView(_ tableView: UITableView,
+                   targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
+                   toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        // Constraint reorder destination to sections that support it.
+        let proposedSection = viewModel.sections[proposedDestinationIndexPath.section]
+        guard proposedSection.allowsReorder else {
+            return sourceIndexPath
+        }
+        return proposedDestinationIndexPath
+    }
+
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Only allow reorder if the section allows it.
+        let section = viewModel.sections[indexPath.section]
+        return section.allowsReorder
+    }
+
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        // TODO: Submit reorder on the view model
     }
 }
 
@@ -215,6 +245,7 @@ extension AddAttributeOptionsViewController {
         let header: String?
         let footer: String?
         let rows: [Row]
+        let allowsReorder: Bool
     }
 
     enum Row: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Yosemite
-import WordPressUI
 
 final class AddAttributeOptionsViewController: UIViewController {
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -133,7 +133,7 @@ extension AddAttributeOptionsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        // TODO: Submit reorder on the view model
+        viewModel.reorderOptionOffered(fromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import WordPressUI
 
 final class AddAttributeOptionsViewController: UIViewController {
 
@@ -184,7 +185,7 @@ private extension AddAttributeOptionsViewController {
         case (.termTextField, let cell as TextFieldTableViewCell):
             configureTextField(cell: cell)
         case (let .selectedTerms(name), let cell as BasicTableViewCell):
-            configureOption(cell: cell, text: name)
+            configureOptionOffered(cell: cell, text: name, index: indexPath.row)
         case (.existingTerms, let cell as BasicTableViewCell):
             configureOption(cell: cell, text: "Work in Progress")
         default:
@@ -206,6 +207,20 @@ private extension AddAttributeOptionsViewController {
                                                          keyboardType: .default)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
+    }
+
+    func configureOptionOffered(cell: BasicTableViewCell, text: String, index: Int) {
+        cell.imageView?.tintColor = .tertiaryLabel
+        cell.imageView?.image = UIImage.deleteCellImage
+        cell.textLabel?.text = text
+
+        // Listen to taps on the cell's image view
+        let tapRecognizer = UITapGestureRecognizer()
+        tapRecognizer.on { _ in
+            print("Delete at index: \(index)")
+        }
+        cell.imageView?.addGestureRecognizer(tapRecognizer)
+        cell.imageView?.isUserInteractionEnabled = true
     }
 
     func configureOption(cell: BasicTableViewCell, text: String) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -216,8 +216,8 @@ private extension AddAttributeOptionsViewController {
 
         // Listen to taps on the cell's image view
         let tapRecognizer = UITapGestureRecognizer()
-        tapRecognizer.on { _ in
-            print("Delete at index: \(index)")
+        tapRecognizer.on { [weak self] _ in
+            self?.viewModel.removeOptionOffered(atIndex: index)
         }
         cell.imageView?.addGestureRecognizer(tapRecognizer)
         cell.imageView?.isUserInteractionEnabled = true

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -67,7 +67,7 @@ extension AddAttributeOptionsViewModel {
     /// Reorder an option offered at the specified index to a desired index
     ///
     func reorderOptionOffered(fromIndex: Int, toIndex: Int) {
-        guard let option = state.optionsOffered[safe: fromIndex] else {
+        guard let option = state.optionsOffered[safe: fromIndex], fromIndex != toIndex else {
             return
         }
         state.optionsOffered.remove(at: fromIndex)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -58,8 +58,20 @@ final class AddAttributeOptionsViewModel {
 
 // MARK: - ViewController Inputs
 extension AddAttributeOptionsViewModel {
+    /// Inserts a new option with the provided name into the options offered section
+    ///
     func addNewOption(name: String) {
         state.optionsOffered.append(name)
+    }
+
+    /// Reorder an option offered at the specified index to a desired index
+    ///
+    func reorderOptionOffered(fromIndex: Int, toIndex: Int) {
+        guard let option = state.optionsOffered[safe: fromIndex] else {
+            return
+        }
+        state.optionsOffered.remove(at: fromIndex)
+        state.optionsOffered.insert(option, at: toIndex)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -73,6 +73,15 @@ extension AddAttributeOptionsViewModel {
         state.optionsOffered.remove(at: fromIndex)
         state.optionsOffered.insert(option, at: toIndex)
     }
+
+    /// Removes an option offered at a given index
+    ///
+    func removeOptionOffered(atIndex index: Int) {
+        guard index < state.optionsOffered.count else {
+            return
+        }
+        state.optionsOffered.remove(at: index)
+    }
 }
 
 // MARK: - Synchronize Product Attribute terms

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -71,7 +71,7 @@ private extension AddAttributeOptionsViewModel {
     /// Updates data in sections
     ///
     func updateSections() {
-        let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField])
+        let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField], allowsReorder: false)
         let offeredSection = createOfferedSection()
         sections = [textFieldSection, offeredSection].compactMap { $0 }
     }
@@ -85,7 +85,7 @@ private extension AddAttributeOptionsViewModel {
             AddAttributeOptionsViewModel.Row.selectedTerms(name: option)
         }
 
-        return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows)
+        return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows, allowsReorder: true)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -58,4 +58,24 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.isNextButtonEnabled)
     }
+
+    func test_reorder_option_reorders_the_option_within_sections() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        viewModel.addNewOption(name: "Option 1")
+        viewModel.addNewOption(name: "Option 2")
+        viewModel.addNewOption(name: "Option 3")
+
+        // When
+        viewModel.reorderOptionOffered(fromIndex: 0, toIndex: 2)
+
+        // Then
+        let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsOffered, [
+            .selectedTerms(name: "Option 2"),
+            .selectedTerms(name: "Option 3"),
+            .selectedTerms(name: "Option 1")
+        ])
+
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -96,6 +96,42 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             .selectedTerms(name: "Option 2"),
             .selectedTerms(name: "Option 3")
         ])
+    }
 
+    func test_remove_option_with_correct_index_removes_it_from_section() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        viewModel.addNewOption(name: "Option 1")
+        viewModel.addNewOption(name: "Option 2")
+        viewModel.addNewOption(name: "Option 3")
+
+        // When
+        viewModel.removeOptionOffered(atIndex: 1)
+
+        // Then
+        let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsOffered, [
+            .selectedTerms(name: "Option 1"),
+            .selectedTerms(name: "Option 3")
+        ])
+    }
+
+    func test_remove_option_with_overflown_index_does_not_alter_section() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        viewModel.addNewOption(name: "Option 1")
+        viewModel.addNewOption(name: "Option 2")
+        viewModel.addNewOption(name: "Option 3")
+
+        // When
+        viewModel.removeOptionOffered(atIndex: 3)
+
+        // Then
+        let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsOffered, [
+            .selectedTerms(name: "Option 1"),
+            .selectedTerms(name: "Option 2"),
+            .selectedTerms(name: "Option 3")
+        ])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -78,4 +78,24 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         ])
 
     }
+
+    func test_reorder_option_with_same_indexes_do_not_reorders_section() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        viewModel.addNewOption(name: "Option 1")
+        viewModel.addNewOption(name: "Option 2")
+        viewModel.addNewOption(name: "Option 3")
+
+        // When
+        viewModel.reorderOptionOffered(fromIndex: 1, toIndex: 1)
+
+        // Then
+        let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsOffered, [
+            .selectedTerms(name: "Option 1"),
+            .selectedTerms(name: "Option 2"),
+            .selectedTerms(name: "Option 3")
+        ])
+
+    }
 }


### PR DESCRIPTION
closes #3528 

# Why
Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Reorder and delete options offered to a new product attribute.

This PR does not create the attribute or option remotely yet(#3535), it only allows for the UI interaction and the ViewModel internal updates.

# How

- Update `AddAttributeOptionsViewController` to support reordering by implementing the `moveRowAt` and `canMoveRowAt` methods.

- Update `AddAttributeOptionsViewController` to show an `X` button in the "Options Offered" cell and attack a gesture recognizer to it.

- Update `Section` struct to include an `allowsReorder` property so that the `ViewModel` can dictate which section can be reordered.

- Update `AddAttributeOptionsViewModel` to support `reorder` and `delete` functions by modifying it's internal state.

# Demo
![reorder-delete](https://user-images.githubusercontent.com/562080/106777458-0210cf80-6613-11eb-9e08-a2b10dd528dc.gif)

# Testing Steps

- Navigate to a variable product that does not have any variation yet
- Initiate the "Add Variation" Flow by: Tap on the Add variations button(There are two) and create a new attribute(By adding a new attribute name)
- Add a couple of new options
- Try to reorder and delete some options
- See that everything works correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
