### PR TITLE
Use rethrows for waitFor()

### DIFF
--- a/Networking/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
@@ -28,7 +28,7 @@ final class PaymentsGatewayRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "payment_gateways", filename: "payment-gateway-list")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadAllPaymentGateways(siteID: self.sampleSiteID) { result in
                 promise(result)
             }

--- a/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift
@@ -31,7 +31,7 @@ final class ProductAttributeTermRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", filename: "product-attribute-terms")
 
         // When
-        let result: Result<[ProductAttributeTerm], Error> = try waitFor { promise in
+        let result: Result<[ProductAttributeTerm], Error> = waitFor { promise in
             remote.loadProductAttributeTerms(for: self.sampleSiteID, attributeID: self.sampleAttributeID) { result in
                 promise(result)
             }
@@ -49,7 +49,7 @@ final class ProductAttributeTermRemoteTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", error: expectedError)
 
         // When
-        let result: Result<[ProductAttributeTerm], Error> = try waitFor { promise in
+        let result: Result<[ProductAttributeTerm], Error> = waitFor { promise in
             remote.loadProductAttributeTerms(for: self.sampleSiteID, attributeID: self.sampleAttributeID) { result in
                 promise(result)
             }
@@ -67,7 +67,7 @@ final class ProductAttributeTermRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", filename: "attribute-term")
 
         // When
-        let result: Result<ProductAttributeTerm, Error> = try waitFor { promise in
+        let result: Result<ProductAttributeTerm, Error> = waitFor { promise in
             remote.createProductAttributeTerm(for: self.sampleSiteID, attributeID: self.sampleAttributeID, name: "XXS") { result in
                 promise(result)
             }
@@ -85,7 +85,7 @@ final class ProductAttributeTermRemoteTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "products/attributes/\(sampleAttributeID)/terms", error: expectedError)
 
         // When
-        let result: Result<ProductAttributeTerm, Error> = try waitFor { promise in
+        let result: Result<ProductAttributeTerm, Error> = waitFor { promise in
             remote.createProductAttributeTerm(for: self.sampleSiteID, attributeID: self.sampleAttributeID, name: "XXS") { result in
                 promise(result)
             }

--- a/Networking/NetworkingTests/Remote/ProductAttributesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductAttributesRemoteTests.swift
@@ -34,7 +34,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attributes-all")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadAllProductAttributes(for: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -56,7 +56,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         let remote = ProductAttributesRemote(network: network)
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadAllProductAttributes(for: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -77,7 +77,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes", filename: "product-attribute-create")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.createProductAttribute(for: self.sampleSiteID, name: "Color") { result in
                 promise(result)
             }
@@ -96,7 +96,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         let remote = ProductAttributesRemote(network: network)
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.createProductAttribute(for: self.sampleSiteID, name: "Color") { result in
                 promise(result)
             }
@@ -118,7 +118,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes/\(defaultProductAttributeID)", filename: "product-attribute-update")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.updateProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID, name: "Color") { result in
                 promise(result)
             }
@@ -138,7 +138,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         let remote = ProductAttributesRemote(network: network)
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.updateProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID, name: "Color") { result in
                 promise(result)
             }
@@ -160,7 +160,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/attributes/\(defaultProductAttributeID)", filename: "product-attribute-delete")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.deleteProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID) { result in
                 promise(result)
             }
@@ -180,7 +180,7 @@ final class ProductAttributesRemoteTests: XCTestCase {
         let remote = ProductAttributesRemote(network: network)
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.deleteProductAttribute(for: self.sampleSiteID, productAttributeID: defaultProductAttributeID) { result in
                 promise(result)
             }

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -128,7 +128,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations/\(sampleProductVariationID)", filename: "product-variation")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadProductVariation(for: self.sampleSiteID, productID: self.sampleProductID, variationID: sampleProductVariationID) { result in
                 promise(result)
             }
@@ -150,7 +150,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         let sampleProductVariationID: Int64 = 2783
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadProductVariation(for: self.sampleSiteID, productID: self.sampleProductID, variationID: sampleProductVariationID) { result in
                 promise(result)
             }
@@ -171,7 +171,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         let sampleProductVariationID: Int64 = 1275
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variation")
 
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.createProductVariation(for: self.sampleSiteID,
                                           productID: self.sampleProductID,
                                           newVariation:
@@ -195,7 +195,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         let remote = ProductVariationsRemote(network: network)
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.createProductVariation(for: self.sampleSiteID,
                                           productID: self.sampleProductID,
                                           newVariation:

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -23,7 +23,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/\(orderID)", filename: "order-shipping-labels")
 
         // When
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             remote.loadShippingLabels(siteID: self.sampleSiteID, orderID: orderID) { result in
                 promise(result)
             }
@@ -41,7 +41,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/print", filename: "shipping-label-print")
 
         // When
-        let printData: ShippingLabelPrintData = try waitFor { promise in
+        let printData: ShippingLabelPrintData = waitFor { promise in
             remote.printShippingLabel(siteID: self.sampleSiteID, shippingLabelID: 123, paperSize: .label) { result in
                 guard let printData = try? result.get() else {
                     XCTFail("Error printing shipping label: \(String(describing: result.failure))")
@@ -64,7 +64,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/\(orderID)/\(shippingLabelID)/refund", filename: "shipping-label-refund-success")
 
         // When
-        let result: Result<ShippingLabelRefund, Error> = try waitFor { promise in
+        let result: Result<ShippingLabelRefund, Error> = waitFor { promise in
             remote.refundShippingLabel(siteID: self.sampleSiteID,
                                        orderID: orderID,
                                        shippingLabelID: shippingLabelID) { result in
@@ -85,7 +85,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/\(orderID)/\(shippingLabelID)/refund", filename: "shipping-label-refund-error")
 
         // When
-        let result: Result<ShippingLabelRefund, Error> = try waitFor { promise in
+        let result: Result<ShippingLabelRefund, Error> = waitFor { promise in
             remote.refundShippingLabel(siteID: self.sampleSiteID,
                                        orderID: orderID,
                                        shippingLabelID: shippingLabelID) { result in

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -78,7 +78,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
             }
 
             // Load the persistent container
-            let loadingError: Error? = try waitFor { promise in
+            let loadingError: Error? = waitFor { promise in
                 persistentContainer.loadPersistentStores { _, error in
                     promise(error)
                 }
@@ -329,7 +329,7 @@ private extension CoreDataIterativeMigratorTests {
     func startPersistentContainer(storeURL: URL, storeType: String, model: NSManagedObjectModel) throws -> NSPersistentContainer {
         let container = makePersistentContainer(storeURL: storeURL, storeType: storeType, model: model)
 
-        let loadingError: Error? = try waitFor { promise in
+        let loadingError: Error? = waitFor { promise in
             container.loadPersistentStores { _, error in
                 promise(error)
             }

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -540,7 +540,7 @@ private extension MigrationTests {
         let model = try XCTUnwrap(modelsInventory.model(for: .init(name: versionName)))
         let container = makePersistentContainer(storeURL: storeURL, model: model)
 
-        let loadingError: Error? = try waitFor { promise in
+        let loadingError: Error? = waitFor { promise in
             container.loadPersistentStores { _, error in
                 promise(error)
             }
@@ -579,7 +579,7 @@ private extension MigrationTests {
 
         // Load a new container
         let migratedContainer = makePersistentContainer(storeURL: storeURL, model: targetModel)
-        let loadingError: Error? = try waitFor { promise in
+        let loadingError: Error? = waitFor { promise in
             migratedContainer.loadPersistentStores { _, error in
                 promise(error)
             }

--- a/TestKit/Sources/TestKit/XCTestCase+Wait.swift
+++ b/TestKit/Sources/TestKit/XCTestCase+Wait.swift
@@ -60,7 +60,7 @@ extension XCTestCase {
     /// ## Example Usage
     ///
     /// ```
-    /// let value: String = try waitFor { promise in
+    /// let value: String = waitFor { promise in
     ///     fetchFromAPI { responseString in
     ///         promise(responseString)
     ///     }

--- a/TestKit/Sources/TestKit/XCTestCase+Wait.swift
+++ b/TestKit/Sources/TestKit/XCTestCase+Wait.swift
@@ -72,7 +72,7 @@ extension XCTestCase {
     public func waitFor<ValueType>(file: StaticString = #file,
                                    line: UInt = #line,
                                    timeout: TimeInterval = 5.0,
-                                   await: @escaping (_ promise: (@escaping (ValueType) -> Void)) throws -> Void) throws -> ValueType {
+                                   await: @escaping (_ promise: (@escaping (ValueType) -> Void)) throws -> Void) rethrows -> ValueType {
         let exp = expectation(description: "Expect promise to be called.")
 
         var receivedValue: ValueType? = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -123,7 +123,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             viewModel.submit { result in
                 promise(result)
             }
@@ -148,7 +148,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         }
 
         // When
-        let orderUpdated: Bool = try waitFor { promise in
+        let orderUpdated: Bool = waitFor { promise in
             // Capture order updated value
             dispatcher.whenReceivingAction(ofType: OrderAction.self) { action in
                 if case let .retrieveOrder(_, _, onCompletion) = action {
@@ -175,7 +175,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
-        let refund: Refund = try waitFor { promise in
+        let refund: Refund = waitFor { promise in
             dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
                 if case let .createRefund(_, _, refund, _) = action {
                     promise(refund)
@@ -199,7 +199,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
-        let refund: Refund = try waitFor { promise in
+        let refund: Refund = waitFor { promise in
             dispatcher.whenReceivingAction(ofType: RefundAction.self) { action in
                 if case let .createRefund(_, _, refund, _) = action {
                     promise(refund)
@@ -235,7 +235,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher)
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             viewModel.submit { result in
                 promise(result)
             }
@@ -315,7 +315,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
 
         // When
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher, analytics: analytics)
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             viewModel.submit { result in
                 promise(result)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
@@ -77,7 +77,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
         }
 
         let process = useCase.fulfill()
-        let retry: () -> OrderFulfillmentUseCase.FulfillmentProcess = try waitFor { promise in
+        let retry: () -> OrderFulfillmentUseCase.FulfillmentProcess = waitFor { promise in
             process.result.sink { completion in
                 guard case let .failure(error: fulfillmentError) = completion else {
                     XCTFail("Unexpected completion \(completion).")
@@ -110,7 +110,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
 
         // When
         let process = useCase.fulfill()
-        let error: OrderFulfillmentUseCase.FulfillmentError = try waitFor { promise in
+        let error: OrderFulfillmentUseCase.FulfillmentError = waitFor { promise in
             process.result.sink { completion in
                 guard case let .failure(error: fulfillmentError) = completion else {
                     XCTFail("Unexpected completion \(completion).")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
@@ -8,7 +8,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [])
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -25,7 +25,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [refundedShippingLabel])
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -43,7 +43,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -61,7 +61,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -79,7 +79,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -97,7 +97,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let factory = ShippingLabelsTopBannerFactory(shippingLabels: [shippingLabel], stores: stores)
 
         // When
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onCompletion: { topBannerView in
                                                 promise(topBannerView)
@@ -122,7 +122,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
 
         // When
         var isGiveFeedbackButtonPressed = false
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onGiveFeedbackButtonPressed: {
                                                 isGiveFeedbackButtonPressed = true
@@ -168,7 +168,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
 
         // When
         var isDismissButtonPressed = false
-        let topBannerView = try waitFor { promise in
+        let topBannerView = waitFor { promise in
             factory.createTopBannerIfNeeded(isExpanded: false,
                                             onDismissButtonPressed: {
                                                 isDismissButtonPressed = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -255,7 +255,7 @@ private extension OrderListViewModelTests {
     /// Activate the viewModel to start fetching and then return the first
     /// valid `FetchResultSnapshot` triggered.
     func activateAndRetrieveSnapshot(of viewModel: OrderListViewModel) throws -> FetchResultSnapshot {
-        return try waitFor { promise in
+        return waitFor { promise in
             // The first snapshot is dropped because it's just the default empty one.
             viewModel.snapshot.dropFirst().sink { snapshot in
                 promise(snapshot)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Add Product Variation/AddAttributeViewModelTests.swift
@@ -29,7 +29,7 @@ final class AddAttributeViewModelTests: XCTestCase {
 
         // When
         viewModel.performFetch()
-        let result: Bool = try waitFor { promise in
+        let result: Bool = waitFor { promise in
             viewModel.observeProductAttributesListStateChanges { state in
                 if state == .synced {
                     promise(true)
@@ -53,7 +53,7 @@ final class AddAttributeViewModelTests: XCTestCase {
 
         // When
         viewModel.performFetch()
-        let result: Bool = try waitFor { promise in
+        let result: Bool = waitFor { promise in
             viewModel.observeProductAttributesListStateChanges { state in
                 if state == .failed {
                     promise(true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
@@ -45,7 +45,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let defaultLimit: Int64 = -1
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadLimitChange("") { isValid in
                 promise(isValid)
             }
@@ -64,7 +64,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let expectedLimit: Int64 = 100
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadLimitChange("100") { isValid in
                 promise(isValid)
             }
@@ -83,7 +83,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let defaultLimit: Int64 = -2
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadLimitChange("-100") { isValid in
                 promise(isValid)
             }
@@ -104,7 +104,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let defaultExpiry: Int64 = -1
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadExpiryChange("") { isValid in
                 promise(isValid)
             }
@@ -123,7 +123,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let expectedExpiry: Int64 = 100
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadExpiryChange("100") { isValid in
                 promise(isValid)
             }
@@ -142,7 +142,7 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
         let defaultExpiry: Int64 = -2
 
         // Act
-        let isValidResult = try waitFor { promise in
+        let isValidResult = waitFor { promise in
             viewModel.handleDownloadExpiryChange("-100") { isValid in
                 promise(isValid)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductVariationLoadUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductVariationLoadUseCaseTests.swift
@@ -27,7 +27,7 @@ final class ProductVariationLoadUseCaseTests: XCTestCase {
         mockRetrieveProduct(result: .success(product))
 
         // Action
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             useCase.loadProductVariation(productID: 806, variationID: 725) { result in
                 promise(result)
             }
@@ -48,7 +48,7 @@ final class ProductVariationLoadUseCaseTests: XCTestCase {
         mockRetrieveProduct(result: .success(product))
 
         // Action
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             useCase.loadProductVariation(productID: 806, variationID: 725) { result in
                 promise(result)
             }
@@ -69,7 +69,7 @@ final class ProductVariationLoadUseCaseTests: XCTestCase {
         mockRetrieveProduct(result: .failure(ProductLoadError.notFoundInStorage))
 
         // Action
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             useCase.loadProductVariation(productID: 806, variationID: 725) { result in
                 promise(result)
             }
@@ -89,7 +89,7 @@ final class ProductVariationLoadUseCaseTests: XCTestCase {
         mockRetrieveProduct(result: .failure(ProductLoadError.notFoundInStorage))
 
         // Action
-        let result = try waitFor { promise in
+        let result = waitFor { promise in
             useCase.loadProductVariation(productID: 806, variationID: 725) { result in
                 promise(result)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductVariationDetailsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductVariationDetailsFactoryTests.swift
@@ -8,7 +8,7 @@ final class ProductVariationDetailsFactoryTests: XCTestCase {
         let parentProduct = MockProduct().product()
 
         // Action
-        let viewController = try waitFor { promise in
+        let viewController = waitFor { promise in
             ProductVariationDetailsFactory.productVariationDetails(productVariation: productVariation,
                                                                    parentProduct: parentProduct,
                                                                    presentationStyle: .navigationStack,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/RefundShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/RefundShippingLabelViewModelTests.swift
@@ -48,7 +48,7 @@ final class RefundShippingLabelViewModelTests: XCTestCase {
                                                      stores: stores)
 
         // When
-        let refundResult = try waitFor { promise in
+        let refundResult = waitFor { promise in
             viewModel.refundShippingLabel { result in
                 promise(result)
             }
@@ -76,7 +76,7 @@ final class RefundShippingLabelViewModelTests: XCTestCase {
                                                      stores: stores)
 
         // When
-        let refundResult = try waitFor { promise in
+        let refundResult = waitFor { promise in
             viewModel.refundShippingLabel { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/SnapshotsProvider/FetchResultSnapshotsProviderTests.swift
+++ b/Yosemite/YosemiteTests/SnapshotsProvider/FetchResultSnapshotsProviderTests.swift
@@ -68,7 +68,7 @@ final class FetchResultSnapshotsProviderTests: XCTestCase {
         let provider = FetchResultSnapshotsProvider(storageManager: storageManager, query: query)
 
         // When
-        let snapshot: FetchResultSnapshot = try waitFor { promise in
+        let snapshot: FetchResultSnapshot = waitFor { promise in
             provider.snapshot.first().sink { snapshot in
                 promise(snapshot)
             }.store(in: &self.cancellables)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
@@ -45,7 +45,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                             productTypeFilter: .simple)
 
         // When
-        let result: Result<StoredProductSettings.Setting, Error> = try waitFor { promise in
+        let result: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
             let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { (result) in
                 promise(result)
             }
@@ -65,7 +65,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
 
 
         // Then
-        let result2: Result<StoredProductSettings.Setting, Error> = try waitFor { promise in
+        let result2: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
             let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { (result) in
                 promise(result)
             }
@@ -111,7 +111,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
         subject.onAction(writeAction2)
 
         // Then
-        let result1: Result<StoredProductSettings.Setting, Error> = try waitFor { promise in
+        let result1: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
             let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID1) { (result) in
                 promise(result)
             }
@@ -120,7 +120,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
         XCTAssertTrue(result1.isSuccess)
         XCTAssertEqual(try result1.get(), productSettings1)
 
-        let result2: Result<StoredProductSettings.Setting, Error> = try waitFor { promise in
+        let result2: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
             let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID2) { (result) in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/PaymentGatewayStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/PaymentGatewayStoreTests.swift
@@ -44,7 +44,7 @@ final class PaymentGatewayStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "payment_gateways", filename: "payment-gateway-list")
 
         // When
-        let result: Result<Void, Error> = try waitFor { promise in
+        let result: Result<Void, Error> = waitFor { promise in
             let action = PaymentGatewayAction.synchronizePaymentGateways(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -69,7 +69,7 @@ final class PaymentGatewayStoreTests: XCTestCase {
         store.onAction(firstSync)
 
         // When
-        let result: Result<Void, Error> = try waitFor { promise in
+        let result: Result<Void, Error> = waitFor { promise in
             let secondSync = PaymentGatewayAction.synchronizePaymentGateways(siteID: self.sampleSiteID) { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeStoreTests.swift
@@ -64,7 +64,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+        let result: Result<[Networking.ProductAttribute], Error> = waitFor { promise in
             let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -84,7 +84,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 1)
 
         // When
-        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+        let result: Result<[Networking.ProductAttribute], Error> = waitFor { promise in
             let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -109,7 +109,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+        let result: Result<[Networking.ProductAttribute], Error> = waitFor { promise in
             let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -126,7 +126,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<[Networking.ProductAttribute], Error> = try waitFor { promise in
+        let result: Result<[Networking.ProductAttribute], Error> = waitFor { promise in
             let action = ProductAttributeAction.synchronizeProductAttributes(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -144,7 +144,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.addProductAttribute(siteID: self.sampleSiteID, name: "Color") { result in
                 promise(result)
             }
@@ -170,7 +170,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.addProductAttribute(siteID: self.sampleSiteID, name: "Color") { result in
                 promise(result)
             }
@@ -187,7 +187,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.addProductAttribute(siteID: self.sampleSiteID, name: "Color") { result in
                 promise(result)
             }
@@ -207,7 +207,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 1)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.updateProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1, name: "Color") { result in
                 promise(result)
             }
@@ -232,7 +232,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.updateProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1, name: "Color") { result in
                 promise(result)
             }
@@ -249,7 +249,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.updateProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1, name: "Color") { result in
                 promise(result)
             }
@@ -269,7 +269,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 1)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
                 promise(result)
             }
@@ -287,7 +287,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
                 promise(result)
             }
@@ -304,7 +304,7 @@ final class ProductAttributeStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributesCount, 0)
 
         // When
-        let result: Result<Networking.ProductAttribute, Error> = try waitFor { promise in
+        let result: Result<Networking.ProductAttribute, Error> = waitFor { promise in
             let action = ProductAttributeAction.deleteProductAttribute(siteID: self.sampleSiteID, productAttributeID: 1) { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductAttributeTermStoreTests.swift
@@ -74,7 +74,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributeTermsCount, 0)
 
         // When
-        let result: Result<Void, ProductAttributeTermActionError> = try waitFor { promise in
+        let result: Result<Void, ProductAttributeTermActionError> = waitFor { promise in
             let action = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: self.sampleSiteID,
                                                                                      attributeID: self.sampleAttributeID) { result in
                 promise(result)
@@ -95,7 +95,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         XCTAssertEqual(storedProductAttributeTermsCount, 0)
 
         // When
-        let result: Result<Void, ProductAttributeTermActionError> = try waitFor { promise in
+        let result: Result<Void, ProductAttributeTermActionError> = waitFor { promise in
             let action = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: self.sampleSiteID,
                                                                                      attributeID: self.sampleAttributeID) { result in
                 promise(result)
@@ -117,7 +117,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         let initialTerm = insertProductAttributeTerm(termID: sampleTermID)
 
         // When
-        let result: Result<Void, ProductAttributeTermActionError> = try waitFor { promise in
+        let result: Result<Void, ProductAttributeTermActionError> = waitFor { promise in
             let action = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: self.sampleSiteID,
                                                                                      attributeID: self.sampleAttributeID) { result in
                 promise(result)
@@ -141,7 +141,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         insertProductAttributeTerm(termID: sampleTermID)
 
         // When
-        let result: Result<Void, ProductAttributeTermActionError> = try waitFor { promise in
+        let result: Result<Void, ProductAttributeTermActionError> = waitFor { promise in
             let action = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: self.sampleSiteID,
                                                                                      attributeID: self.sampleAttributeID) { result in
                 promise(result)
@@ -161,7 +161,7 @@ final class ProductAttributeTermStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: sampleTermsPath, filename: "attribute-term")
 
         // When
-        let result: Result<Yosemite.ProductAttributeTerm, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ProductAttributeTerm, Error> = waitFor { promise in
             let action = ProductAttributeTermAction.createProductAttributeTerm(siteID: self.sampleSiteID,
                                                                                attributeID: self.sampleAttributeID,
                                                                                name: "XXS") { result in

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -537,7 +537,7 @@ final class ProductStoreTests: XCTestCase {
 
         // Action
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product")
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }
@@ -559,7 +559,7 @@ final class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // Action
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }
@@ -580,7 +580,7 @@ final class ProductStoreTests: XCTestCase {
 
         // Action
         network.simulateResponse(requestUrlSuffix: "products/295", filename: "variation-as-product")
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleVariationTypeProductID) { result in
                 promise(result)
             }
@@ -609,7 +609,7 @@ final class ProductStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/282", filename: "product")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }
@@ -638,7 +638,7 @@ final class ProductStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/295", filename: "variation-as-product")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleVariationTypeProductID) { result in
                 promise(result)
             }
@@ -670,7 +670,7 @@ final class ProductStoreTests: XCTestCase {
 
         // Action
         network.simulateResponse(requestUrlSuffix: "products/282", filename: "generic_error")
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }
@@ -688,7 +688,7 @@ final class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // Action
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }
@@ -714,7 +714,7 @@ final class ProductStoreTests: XCTestCase {
 
         // Action
         network.simulateError(requestUrlSuffix: "products/282", error: dotComError)
-        let result: Result<Yosemite.Product, Error> = try waitFor { promise in
+        let result: Result<Yosemite.Product, Error> = waitFor { promise in
             let action = ProductAction.retrieveProduct(siteID: self.sampleSiteID, productID: self.sampleProductID) { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -307,7 +307,7 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
 
         // When
-        let result: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.retrieveProductVariation(siteID: self.sampleSiteID,
                                                                          productID: self.sampleProductID,
                                                                          variationID: sampleProductVariationID) { result in
@@ -345,7 +345,7 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
 
         // When
-        let result1: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result1: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.retrieveProductVariation(siteID: self.sampleSiteID,
                                                                          productID: self.sampleProductID,
                                                                          variationID: sampleProductVariationID) { result in
@@ -354,7 +354,7 @@ final class ProductVariationStoreTests: XCTestCase {
             store.onAction(action)
         }
 
-        let result2: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result2: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.retrieveProductVariation(siteID: self.sampleSiteID,
                                                                          productID: self.sampleProductID,
                                                                          variationID: sampleProductVariationID) { result in
@@ -394,7 +394,7 @@ final class ProductVariationStoreTests: XCTestCase {
                                            thenReturn: .failure(expectedError))
 
         // When
-        let result: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.retrieveProductVariation(siteID: self.sampleSiteID,
                                                                          productID: self.sampleProductID,
                                                                          variationID: sampleProductVariationID) { result in
@@ -429,7 +429,7 @@ final class ProductVariationStoreTests: XCTestCase {
         let createdProductVariation = CreateProductVariation(regularPrice: "10", attributes: sampleProductVariationAttributes())
 
         // When
-        let result: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.createProductVariation(siteID: self.sampleSiteID,
                                                           productID: self.sampleProductID,
                                                           newVariation: createdProductVariation) { result in
@@ -467,7 +467,7 @@ final class ProductVariationStoreTests: XCTestCase {
         let createdProductVariation = CreateProductVariation(regularPrice: "10", attributes: sampleProductVariationAttributes())
 
         // When
-        let result: Result<Yosemite.ProductVariation, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
             let action = ProductVariationAction.createProductVariation(siteID: self.sampleSiteID,
                                                           productID: self.sampleProductID,
                                                           newVariation: createdProductVariation) { result in

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -90,7 +90,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         insertOrder(siteID: sampleSiteID, orderID: orderID)
 
         // When
-        let result: Result<Void, Error> = try waitFor { promise in
+        let result: Result<Void, Error> = waitFor { promise in
             let action = ShippingLabelAction.synchronizeShippingLabels(siteID: self.sampleSiteID, orderID: orderID) { result in
                 promise(result)
             }
@@ -123,7 +123,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         insertOrder(siteID: sampleSiteID, orderID: orderID)
 
         // When
-        let result: Result<Void, Error> = try waitFor { promise in
+        let result: Result<Void, Error> = waitFor { promise in
             let action = ShippingLabelAction.synchronizeShippingLabels(siteID: self.sampleSiteID, orderID: orderID) { result in
                 promise(result)
             }
@@ -152,7 +152,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<Void, Error> = try waitFor { promise in
+        let result: Result<Void, Error> = waitFor { promise in
             let action = ShippingLabelAction.synchronizeShippingLabels(siteID: self.sampleSiteID, orderID: orderID) { result in
                 promise(result)
             }
@@ -177,7 +177,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<ShippingLabelPrintData, Error> = try waitFor { promise in
+        let result: Result<ShippingLabelPrintData, Error> = waitFor { promise in
             let action = ShippingLabelAction.printShippingLabel(siteID: self.sampleSiteID,
                                                                 shippingLabelID: self.sampleShippingLabelID,
                                                                 paperSize: .label) { result in
@@ -202,7 +202,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<ShippingLabelPrintData, Error> = try waitFor { promise in
+        let result: Result<ShippingLabelPrintData, Error> = waitFor { promise in
             let action = ShippingLabelAction.printShippingLabel(siteID: self.sampleSiteID,
                                                                 shippingLabelID: self.sampleShippingLabelID,
                                                                 paperSize: .label) { result in
@@ -236,7 +236,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageShippingLabelRefund.self), 0)
 
         // When
-        let result: Result<Yosemite.ShippingLabelRefund, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ShippingLabelRefund, Error> = waitFor { promise in
             let action = ShippingLabelAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
                 promise(result)
             }
@@ -271,7 +271,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageShippingLabelRefund.self), 0)
 
         // When
-        let result: Result<Yosemite.ShippingLabelRefund, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ShippingLabelRefund, Error> = waitFor { promise in
             let action = ShippingLabelAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
                 promise(result)
             }
@@ -298,7 +298,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<Yosemite.ShippingLabelRefund, Error> = try waitFor { promise in
+        let result: Result<Yosemite.ShippingLabelRefund, Error> = waitFor { promise in
             let action = ShippingLabelAction.refundShippingLabel(shippingLabel: shippingLabel) { result in
                 promise(result)
             }
@@ -321,7 +321,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         insertShippingLabelSettings(shippingLabelSettings)
 
         // When
-        let result: Yosemite.ShippingLabelSettings? = try waitFor { promise in
+        let result: Yosemite.ShippingLabelSettings? = waitFor { promise in
             let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabel) { settings in
                 promise(settings)
             }
@@ -338,7 +338,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
-        let result: Yosemite.ShippingLabelSettings? = try waitFor { promise in
+        let result: Yosemite.ShippingLabelSettings? = waitFor { promise in
             let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabel) { settings in
                 promise(settings)
             }


### PR DESCRIPTION
I learned a while ago that `rethrows` exists. Because I didn't know that before, I used `throws` when creating `waitFor()`:

https://github.com/woocommerce/woocommerce-ios/blob/bfc2481e9177e5c07e2de88c461417ac4a7c608b/TestKit/Sources/TestKit/XCTestCase%2BWait.swift#L72-L75

🤦  Now that my eyes have been opened, it's now just `rethrows`:

https://github.com/woocommerce/woocommerce-ios/blob/31a26670f48b100292caaa5dd6209cb7ce912259/TestKit/Sources/TestKit/XCTestCase%2BWait.swift#L72-L75

Callers of `waitFor` like this: 

https://github.com/woocommerce/woocommerce-ios/blob/bfc2481e9177e5c07e2de88c461417ac4a7c608b/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift#L34-L38

No longer have to use `try` if the underlying function does not throw:

https://github.com/woocommerce/woocommerce-ios/blob/31a26670f48b100292caaa5dd6209cb7ce912259/Networking/NetworkingTests/Remote/ProductAttributeTermRemoteTests.swift#L34-L38

🤸 

## Testing

The unit tests passing should be enough. 🙂 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

