### PR TITLE
Add Unit Test to Protect from Incorrect NSMappingModel Initializer Results

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		5772842325BF465A0092FB2C /* NSPersistentStoreCoordinator+PersistentStoreCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5772842225BF465A0092FB2C /* NSPersistentStoreCoordinator+PersistentStoreCoordinatorProtocol.swift */; };
 		5772842725BF5BFB0092FB2C /* SpyPersistentStoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5772842625BF5BFB0092FB2C /* SpyPersistentStoreCoordinator.swift */; };
 		5772842C25BF62A90092FB2C /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5772842B25BF62A90092FB2C /* Assertions.swift */; };
+		5784D65925CB52C400428B75 /* MappingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5784D65825CB52C400428B75 /* MappingModelTests.swift */; };
 		57A29FB825226BDC004DEE01 /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A29FB725226BDC004DEE01 /* MigrationTests.swift */; };
 		57A881A024CA396D00AE0943 /* GeneralAppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */; };
 		57CEB1A22525349B00D8544F /* ProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CEB1A12525349B00D8544F /* ProductVariationTests.swift */; };
@@ -274,6 +275,7 @@
 		5772842225BF465A0092FB2C /* NSPersistentStoreCoordinator+PersistentStoreCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreCoordinator+PersistentStoreCoordinatorProtocol.swift"; sourceTree = "<group>"; };
 		5772842625BF5BFB0092FB2C /* SpyPersistentStoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyPersistentStoreCoordinator.swift; sourceTree = "<group>"; };
 		5772842B25BF62A90092FB2C /* Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
+		5784D65825CB52C400428B75 /* MappingModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingModelTests.swift; sourceTree = "<group>"; };
 		57A29FB725226BDC004DEE01 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralAppSettings.swift; sourceTree = "<group>"; };
 		57CEB1A12525349B00D8544F /* ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationTests.swift; sourceTree = "<group>"; };
@@ -783,6 +785,7 @@
 				5736878F24AABE4D00B528FE /* ManagedObjectModelsInventoryTests.swift */,
 				57A29FB725226BDC004DEE01 /* MigrationTests.swift */,
 				5707FBC725B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift */,
+				5784D65825CB52C400428B75 /* MappingModelTests.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -1126,6 +1129,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5784D65925CB52C400428B75 /* MappingModelTests.swift in Sources */,
 				9302E3AC220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift in Sources */,
 				5707FBC825B610DA00B7C1A6 /* CoreDataIterativeMigrator+MigrationStepTests.swift in Sources */,
 				57CEB1A22525349B00D8544F /* ProductVariationTests.swift in Sources */,

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -49,7 +49,7 @@ final class MappingModelTests: XCTestCase {
                 return
             }
 
-            let message = """
+            let failureMessage = """
                 Failed to find a \(expectedMappingModelName).xcmappingmodel file in \
                 the bundle.
 
@@ -61,7 +61,7 @@ final class MappingModelTests: XCTestCase {
                 If not that, the mapping model is probably not following the standard naming \
                 pattern that we use for mapping model files.
                 """
-            XCTAssertTrue(mappingModelNames.contains(expectedMappingModelName), message)
+            XCTAssertTrue(mappingModelNames.contains(expectedMappingModelName), failureMessage)
         }
     }
 

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -71,7 +71,7 @@ final class MappingModelTests: XCTestCase {
                     the bundle.
 
                     This can mean that NSMappingModel() returned an incorrect \
-                    mapping model to use for migrating from \(step.sourceVersion.name) to
+                    mapping model to use for migrating from \(step.sourceVersion.name) to \
                     \(step.targetVersion.name). There's probably something wrong with how we \
                     configured the mapping or the model.
 
@@ -85,8 +85,8 @@ final class MappingModelTests: XCTestCase {
                     Unexpectedly found a \(expectedMappingModelName).xcmappingmodel file in \
                     the bundle.
 
-                    This can mean that we defined a mapping model file for migrating from
-                    \(step.sourceVersion.name) to \(step.targetVersion.name) but NSMappingModel()
+                    This can mean that we defined a mapping model file for migrating from \
+                    \(step.sourceVersion.name) to \(step.targetVersion.name) but NSMappingModel() \
                     did not return that model. There's probably something wrong with how we \
                     configured the mapping or the model.
                     """

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -6,8 +6,13 @@ import CoreData
 
 private typealias MigrationStep = CoreDataIterativeMigrator.MigrationStep
 
+/// Test cases that protect us from incorrectly configuring mapping models.
+///
+/// This is an assisting unit test for the functionality of `CoreDataIterativeMigrator`.
+///
 final class MappingModelTests: XCTestCase {
 
+    /// The standard mapping model naming pattern that we follow.
     private let mappingModelNamePattern = #"^WooCommerceModelV(?<source>\d+)toV(?<target>\d+)$"#
 
     private var modelsInventory: ManagedObjectModelsInventory!
@@ -82,6 +87,8 @@ final class MappingModelTests: XCTestCase {
 private extension MappingModelTests {
 
     /// Returns all the mapping model file names (excluding extensions) from the bundle.
+    ///
+    /// - Returns: File names like `["WooCommerceModelV40toV41", "WooCommerceModelV21toV22"]`.
     func mappingModelNames() -> [String] {
         // The mapping models (.xcmappingmodel) have the "cdm" file extension when they are compiled.
         (mainBundle.urls(forResourcesWithExtension: "cdm", subdirectory: nil) ?? []).map {

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -8,7 +8,7 @@ private typealias MigrationStep = CoreDataIterativeMigrator.MigrationStep
 
 final class MappingModelTests: XCTestCase {
 
-    private let mappingModelNamePattern = #"^WooCommerceModelV(\d+)toV(\d+)$"#
+    private let mappingModelNamePattern = #"^WooCommerceModelV(?<source>\d+)toV(?<target>\d+)$"#
 
     private var modelsInventory: ManagedObjectModelsInventory!
     private var mainBundle: Bundle!
@@ -65,7 +65,7 @@ final class MappingModelTests: XCTestCase {
         }
     }
 
-    func test_all_mapping_model_files_follow_the_standard_naming_pattern() throws {
+    func test_all_mapping_model_files_follow_the_standard_naming_pattern() {
         // Given
         let mappingModelNames = self.mappingModelNames()
 

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import TestKit
+import CoreData
+
+@testable import Storage
+
+private typealias MigrationStep = CoreDataIterativeMigrator.MigrationStep
+
+final class MappingModelTests: XCTestCase {
+    private var modelsInventory: ManagedObjectModelsInventory!
+    private var mainBundle: Bundle!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mainBundle = Bundle(for: CoreDataManager.self)
+        modelsInventory = try .from(packageName: "WooCommerce", bundle: mainBundle)
+    }
+
+    override func tearDown() {
+        modelsInventory = nil
+        mainBundle = nil
+        super.tearDown()
+    }
+
+    func test_NSMappingModel_returns_the_appropriate_custom_mapping_models() throws {
+        // Given
+        let customMappingModelNames = (mainBundle.urls(forResourcesWithExtension: "cdm", subdirectory: nil) ?? []).map {
+            $0.deletingPathExtension().lastPathComponent
+        }
+        // Confidence-check. We have custom mapping models so this should not be empty.
+        assertNotEmpty(customMappingModelNames)
+
+        let steps: [MigrationStep] = try {
+            let firstModel = try XCTUnwrap(modelsInventory.model(for: try XCTUnwrap(modelsInventory.versions.first)))
+            return try MigrationStep.steps(using: modelsInventory,
+                                           source: firstModel,
+                                           target: modelsInventory.currentModel)
+        }()
+        assertNotEmpty(steps)
+
+        // When and Then
+        steps.forEach { step in
+            let expectedMappingModelName = self.expectedMappingModelName(step: step)
+
+            guard NSMappingModel(from: [mainBundle],
+                                 forSourceModel: step.sourceModel,
+                                 destinationModel: step.targetModel) != nil else {
+                return
+            }
+
+            let message = """
+                Failed to find a \(expectedMappingModelName).xcmappingmodel file in \
+                the bundle.
+
+                This can mean that NSMappingModel() returned an incorrect \
+                mapping model to use for migrating from \(step.sourceVersion.name) to
+                \(step.targetVersion.name). There's probably something wrong with how we \
+                configured the mapping or the model.
+
+                If not that, the mapping model is probably not following the standard naming \
+                pattern that we use for mapping model files.
+                """
+            XCTAssertTrue(customMappingModelNames.contains(expectedMappingModelName), message)
+        }
+    }
+}
+
+private extension MappingModelTests {
+    /// Return the expected file name of the mapping model for the given migration step.
+    ///
+    /// If the step is for migrating from "Model 40" to "Model 41", we expected the mapping model
+    /// to be named "WooCommerceModelV40to41".
+    ///
+    func expectedMappingModelName(step: MigrationStep) -> String {
+        "WooCommerceModelV\(step.sourceVersion.versionNumber)toV\(step.targetVersion.versionNumber)"
+    }
+}
+
+private extension ManagedObjectModelsInventory.ModelVersion {
+    /// Return the number part of the models name. For example, if the name is "Model 41", this
+    /// will return "41".
+    var versionNumber: String {
+        name.dropFirst("Model ".count).description
+    }
+}

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -25,7 +25,7 @@ final class MappingModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_NSMappingModel_returns_the_appropriate_custom_mapping_models() throws {
+    func test_NSMappingModel_returns_the_appropriate_mapping_models() throws {
         // Given
         let mappingModelNames = self.mappingModelNames()
         // Confidence-check. We have custom mapping models so this should not be empty.

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -7,6 +7,9 @@ import CoreData
 private typealias MigrationStep = CoreDataIterativeMigrator.MigrationStep
 
 final class MappingModelTests: XCTestCase {
+
+    private let mappingModelNamePattern = #"^WooCommerceModelV(\d+)toV(\d+)$"#
+
     private var modelsInventory: ManagedObjectModelsInventory!
     private var mainBundle: Bundle!
 
@@ -61,11 +64,26 @@ final class MappingModelTests: XCTestCase {
             XCTAssertTrue(mappingModelNames.contains(expectedMappingModelName), message)
         }
     }
+
+    func test_all_mapping_model_files_follow_the_standard_naming_pattern() throws {
+        // Given
+        let mappingModelNames = self.mappingModelNames()
+
+        mappingModelNames.forEach { name in
+            // When
+            let range = name.range(of: mappingModelNamePattern, options: .regularExpression)
+
+            // Then
+            XCTAssertNotNil(range)
+        }
+    }
 }
 
 private extension MappingModelTests {
 
+    /// Returns all the mapping model file names (excluding extensions) from the bundle.
     func mappingModelNames() -> [String] {
+        // The mapping models (.xcmappingmodel) have the "cdm" file extension when they are compiled.
         (mainBundle.urls(forResourcesWithExtension: "cdm", subdirectory: nil) ?? []).map {
             $0.deletingPathExtension().lastPathComponent
         }

--- a/Storage/StorageTests/CoreData/MappingModelTests.swift
+++ b/Storage/StorageTests/CoreData/MappingModelTests.swift
@@ -24,11 +24,9 @@ final class MappingModelTests: XCTestCase {
 
     func test_NSMappingModel_returns_the_appropriate_custom_mapping_models() throws {
         // Given
-        let customMappingModelNames = (mainBundle.urls(forResourcesWithExtension: "cdm", subdirectory: nil) ?? []).map {
-            $0.deletingPathExtension().lastPathComponent
-        }
+        let mappingModelNames = self.mappingModelNames()
         // Confidence-check. We have custom mapping models so this should not be empty.
-        assertNotEmpty(customMappingModelNames)
+        assertNotEmpty(mappingModelNames)
 
         let steps: [MigrationStep] = try {
             let firstModel = try XCTUnwrap(modelsInventory.model(for: try XCTUnwrap(modelsInventory.versions.first)))
@@ -60,12 +58,19 @@ final class MappingModelTests: XCTestCase {
                 If not that, the mapping model is probably not following the standard naming \
                 pattern that we use for mapping model files.
                 """
-            XCTAssertTrue(customMappingModelNames.contains(expectedMappingModelName), message)
+            XCTAssertTrue(mappingModelNames.contains(expectedMappingModelName), message)
         }
     }
 }
 
 private extension MappingModelTests {
+
+    func mappingModelNames() -> [String] {
+        (mainBundle.urls(forResourcesWithExtension: "cdm", subdirectory: nil) ?? []).map {
+            $0.deletingPathExtension().lastPathComponent
+        }
+    }
+
     /// Return the expected file name of the mapping model for the given migration step.
     ///
     /// If the step is for migrating from "Model 40" to "Model 41", we expected the mapping model

--- a/TestKit/Sources/TestKit/Assertions.swift
+++ b/TestKit/Sources/TestKit/Assertions.swift
@@ -6,6 +6,12 @@ public func assertEmpty<T: Collection>(_ collection: T, file: StaticString = #fi
     XCTAssertTrue(collection.isEmpty, "Expected collection \(collection) to be empty.", file: file, line: line)
 }
 
+/// Asserts that a collection is not empty.
+///
+public func assertNotEmpty<T: Collection>(_ collection: T, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(collection.isEmpty, "Expected collection \(collection) to not be empty.", file: file, line: line)
+}
+
 /// Asserts that `lhs` has the same pointer address as `rhs`.
 ///
 public func assertThat(_ lhs: AnyObject?, isIdenticalTo rhs: AnyObject?, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
We found out a while ago that the `NSMappingModel()` initializer can lie and return the incorrect mapping model (p91TBi-463-p2). 

If you follow the following steps, migrating from 40 to 41 will return the mapping model that should be used for migrating from 39 to 40. 🤦 

1. In `WooCommerceModelV39toV40`:
    a. Delete the `ProductAttributeToProductAttribute` entity mapping.
     b. In the `ProductToProduct` entity mapping, delete the `attributes` relationship mapping.

We're still not sure why this happens. We fixed this issue in https://github.com/woocommerce/woocommerce-ios/pull/3431 by changing the mapping model configuration. But this doesn't change the fact that `NSMappingModel()` can still lie. Who knows if, at some point, this was the cause of our migration issues. 🤷 

## Changes

This PR adds a unit test, [`MappingModelTests`](https://github.com/woocommerce/woocommerce-ios/blob/add/mapping-model-protection/Storage/StorageTests/CoreData/MappingModelTests.swift), that will fail if the `NSMappingModel()` initializer returns the incorrect mapping model. 

## Testing


1. In `WooCommerceModelV39toV40`:
    a. Delete the `ProductAttributeToProductAttribute` entity mapping.
     b. In the `ProductToProduct` entity mapping, delete the `attributes` relationship mapping.
2. Run the `MappingModelTests` unit tests. 

The test will fail because migrating from 40 to 41 will return the (incorrect) **39 to 40** mapping model.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

