### PR TITLE
Variations: Update product variation attribute options

### DIFF
--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -297,6 +297,9 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
         try container.encode(stockStatus.rawValue, forKey: .stockStatusKey)
         try container.encode(stockQuantity, forKey: .stockQuantity)
         try container.encode(backordersKey, forKey: .backordersKey)
+
+        // Variation (Local) Attributes
+        try container.encode(attributes, forKey: .attributes)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1263,8 +1263,26 @@ private extension ProductFormViewController {
             return
         }
 
-        let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
+        let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel) { [weak self] (attributes) in
+            self?.onEditVariationAttributesCompletion(attributes: attributes)
+        }
         show(attributePickerViewController, sender: self)
+    }
+
+    func onEditVariationAttributesCompletion(attributes: [ProductVariationAttribute]) {
+        guard let productVariation = product as? EditableProductVariationModel else {
+            return
+        }
+
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+
+        let hasChangedData = attributes != productVariation.productVariation.attributes
+        guard hasChangedData else {
+            return
+        }
+        viewModel.updateVariationAttributes(attributes)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -349,11 +349,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)
             case .attributes(_, let isEditable):
-                guard isEditable, let productVariationModel = product as? EditableProductVariationModel else {
+                guard isEditable else {
                     return
                 }
-                let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
-                show(attributePickerViewController, sender: self)
+                editVariationAttributes()
             case .status, .noPriceWarning:
                 break
             }
@@ -1253,6 +1252,19 @@ private extension ProductFormViewController {
             return
         }
         viewModel.updateDownloadableFiles(downloadableFiles: data.downloadableFiles, downloadLimit: data.downloadLimit, downloadExpiry: data.downloadExpiry)
+    }
+}
+
+// MARK: Action - Edit Product Variation Attributes
+//
+private extension ProductFormViewController {
+    func editVariationAttributes() {
+        guard let productVariationModel = product as? EditableProductVariationModel else {
+            return
+        }
+
+        let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel)
+        show(attributePickerViewController, sender: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -247,6 +247,10 @@ extension ProductFormViewModel {
         product = EditableProductModel(product: product.product.copy(upsellIDs: upsellIDs,
                                                                      crossSellIDs: crossSellIDs))
     }
+
+    func updateVariationAttributes(_ attributes: [ProductVariationAttribute]) {
+        // no-op
+    }
 }
 
 // MARK: Remote actions

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -96,6 +96,8 @@ protocol ProductFormViewModelProtocol {
 
     func updateLinkedProducts(upsellIDs: [Int64], crossSellIDs: [Int64])
 
+    func updateVariationAttributes(_ attributes: [ProductVariationAttribute])
+
     // Remote action
 
     /// Creates/updates a product remotely given an optional product status to override.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -229,6 +229,12 @@ extension ProductVariationFormViewModel {
     func updateLinkedProducts(upsellIDs: [Int64], crossSellIDs: [Int64]) {
         // no-op
     }
+
+    func updateVariationAttributes(_ attributes: [ProductVariationAttribute]) {
+        productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(attributes: attributes),
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
+    }
 }
 
 // MARK: Remote actions

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -7,10 +7,14 @@ final class AttributePickerViewController: UIViewController {
 
     private let variationModel: EditableProductVariationModel
 
+    typealias Completion = (_ attributes: [ProductVariationAttribute]) -> Void
+    private let onCompletion: Completion
+
     /// Init
     ///
-    init(variationModel: EditableProductVariationModel) {
+    init(variationModel: EditableProductVariationModel, onCompletion: @escaping Completion) {
         self.variationModel = variationModel
+        self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -132,7 +136,7 @@ private extension AttributePickerViewController {
 extension AttributePickerViewController {
 
     @objc private func doneButtonPressed() {
-        // TODO-3518: Save updated attributes
+        onCompletion(variationModel.productVariation.attributes)
     }
 
     private func presentAttributeOptions(for existingAttribute: ProductAttribute) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -36,8 +36,7 @@ private extension AttributePickerViewController {
     func configureNavigationBar() {
         title = Localization.titleView
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.doneNavBarButton,
-                                                           style: .plain,
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
                                                            target: self,
                                                            action: #selector(doneButtonPressed))
     }
@@ -144,7 +143,6 @@ extension AttributePickerViewController {
 private extension AttributePickerViewController {
     enum Localization {
         static let titleView = NSLocalizedString("Attributes", comment: "Edit Product Attributes screen navigation title")
-        static let doneNavBarButton = NSLocalizedString("Done", comment: "Done nav bar button title in Edit Product Attributes screen")
         static let headerAttributes = NSLocalizedString("Options", comment: "Header of attributes section in Edit Product Attributes screen")
         static let anyAttributeOption = NSLocalizedString("Any", comment: "Product variation attribute description where the attribute is set to any value.")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -132,6 +132,21 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
+
+    func test_product_variation_has_unsaved_changes_from_editing_attributes() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
+        let viewModel = ProductVariationFormViewModel(productVariation: model, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let attributes = [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]
+        viewModel.updateVariationAttributes(attributes)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
 }
 
 // Helper in unit tests

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -129,6 +129,22 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.images, newImages)
     }
 
+    func test_updating_attributes() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let model = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
+        let viewModel = ProductVariationFormViewModel(productVariation: model, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newAttribute = ProductVariationAttribute(id: 1, name: "Color", option: "Blue")
+        let newAttributes = [newAttribute]
+        viewModel.updateVariationAttributes(newAttributes)
+
+        //Assert
+        XCTAssertEqual(viewModel.productModel.productVariation.attributes, newAttributes)
+    }
+
     func testDisablingAVariationUpdatesItsStatusFromPublishToPrivate() {
         // Arrange
         let productVariation = MockProductVariation().productVariation().copy(status: .publish)


### PR DESCRIPTION
Closes: #3518 

## Description

This PR updates a product variation when its attributes are changed.

Note: The ability to actually edit a variation's attributes (choose new options for each attribute in the UI) is still in progress (#3515, #3516), so for now it isn't possible to actually change the variation attributes in the app. To test that the update works as expected, you can hardcode new values (with the testing steps described below).

## Changes

* At the networking layer, `ProductVariation` now encodes the variation attributes so they can be updated.
* `ProductFormViewController` was refactored to move the edit attributes action into an `editVariationAttributes` method. `onEditVariationAttributesCompletion` (called when the "done" button is pressed in `AttributePickerViewController`) handles checking for unsaved changes (which enables the "update" button on the variation) and updating the variation when editing attributes is completed.
* `ProductVariationFormViewModel` performs the variation update with the new attributes.
* Two tests are added for checking for unsaved attributes changes and for updating attributes.

## Testing

No changes to variation attributes:
1. Go to Products and select a variable product.
2. Select "Variations."
3. Select a product variation to edit it.
4. Select "Attributes."
5. Tap the back button or Done button and confirm there are no changes and no Update button appears.

Changes to variation attributes:
1. **Initial setup:** In [the doneButtonPressed method in AttributePickerViewController](https://github.com/woocommerce/woocommerce-ios/blob/a903c99142bcd4af07295a087a6230b3e3eb119a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit%20Attributes/AttributePickerViewController.swift#L138-L140), replace `onCompletion(variationModel.productVariation.attributes)` with a hardcoded change to the variation attributes, as shown below (replacing each attribute's `id`, `name`, and `option` with values that correspond with your product variation, changing one or more of the options from your variation's saved values):
```swift
let attributes = [ProductVariationAttribute(id: 1, name: "color", option: "Blue"), ProductVariationAttribute(id: 0, name: "Logo", option: "No")]
onCompletion(attributes)
```
2. Build and run the app.
3. Go to Products and select a variable product.
4. Select "Variations."
5. Select a product variation to edit it.
6. Select "Attributes."
7. Tap the Done button.
8. Notice the Attributes cell is updated with the changes from step 1, and the variation shows the Update button in the top right.
9. Update the variation and confirm the changes are saved remotely and display in the variations list and when you reopen/refresh the variation details.

### Screencast

Note: This screencast shows a change from the variation "Blue - Yes" to "Blue - No", using the testing steps described above.

<img src="https://user-images.githubusercontent.com/8658164/106933240-990f8180-6710-11eb-92ad-297040fd6c70.gif" width="300px">



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
