### PR TITLE
Variations: New Attribute -> Sync global attribute options(terms)

### DIFF
--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -70,6 +70,19 @@ public struct ProductAttribute: Decodable {
     }
 }
 
+public extension ProductAttribute {
+    /// Returns weather an attribute belongs to a product(local) or to the store(global)
+    ///
+    var isLocal: Bool {
+        attributeID == 0 // Currently the only way to know if an attribute is local is if it has a zero ID
+    }
+
+    /// Returns weather an attribute belongs to a product(local) or to the store(global)
+    ///
+    var isGlobal: Bool {
+        !isLocal
+    }
+}
 
 /// Defines all the ProductAttribute CodingKeys.
 ///

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -1,9 +1,11 @@
 import UIKit
 import Yosemite
+import WordPressUI
 
 final class AddAttributeOptionsViewController: UIViewController {
 
     @IBOutlet weak private var tableView: UITableView!
+    private let ghostTableView = UITableView()
 
     private let viewModel: AddAttributeOptionsViewModel
 
@@ -29,6 +31,7 @@ final class AddAttributeOptionsViewController: UIViewController {
         configureNavigationBar()
         configureMainView()
         configureTableView()
+        configureGhostTableView()
         registerTableViewHeaderSections()
         registerTableViewCells()
         startListeningToNotifications()
@@ -63,6 +66,15 @@ private extension AddAttributeOptionsViewController {
         tableView.isEditing = true
     }
 
+    func configureGhostTableView() {
+        view.addSubview(ghostTableView)
+        ghostTableView.isHidden = true
+        ghostTableView.translatesAutoresizingMaskIntoConstraints = false
+        ghostTableView.pinSubviewToAllEdges(view)
+        ghostTableView.backgroundColor = .listBackground
+        ghostTableView.removeLastCellSeparator()
+    }
+
     func registerTableViewHeaderSections() {
         let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
@@ -71,6 +83,7 @@ private extension AddAttributeOptionsViewController {
     func registerTableViewCells() {
         tableView.registerNib(for: BasicTableViewCell.self)
         tableView.registerNib(for: TextFieldTableViewCell.self)
+        ghostTableView.registerNib(for: WooBasicTableViewCell.self)
     }
 
     func observeViewModel() {
@@ -84,6 +97,12 @@ private extension AddAttributeOptionsViewController {
         title = viewModel.titleView
         navigationItem.rightBarButtonItem?.isEnabled = viewModel.isNextButtonEnabled
         tableView.reloadData()
+
+        if viewModel.showGhostTableView {
+            displayGhostTableView()
+        } else {
+            removeGhostTableView()
+        }
     }
 }
 
@@ -224,6 +243,27 @@ private extension AddAttributeOptionsViewController {
 
     func configureOptionAdded(cell: BasicTableViewCell, text: String) {
         cell.textLabel?.text = text
+    }
+}
+
+// MARK: - Placeholders
+//
+private extension AddAttributeOptionsViewController {
+    /// Renders ghost placeholder while terms are being synched.
+    ///
+    func displayGhostTableView() {
+        let options = GhostOptions(displaysSectionHeader: false,
+                                   reuseIdentifier: WooBasicTableViewCell.reuseIdentifier,
+                                   rowsPerSection: [3])
+        ghostTableView.displayGhostContent(options: options, style: .wooDefaultGhostStyle)
+        ghostTableView.isHidden = false
+    }
+
+    /// Removes ghost placeholder
+    ///
+    func removeGhostTableView() {
+        ghostTableView.removeGhostContent()
+        ghostTableView.isHidden = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -185,8 +185,8 @@ private extension AddAttributeOptionsViewController {
             configureTextField(cell: cell)
         case (let .selectedTerms(name), let cell as BasicTableViewCell):
             configureOptionOffered(cell: cell, text: name, index: indexPath.row)
-        case (.existingTerms, let cell as BasicTableViewCell):
-            configureOption(cell: cell, text: "Work in Progress")
+        case (let .existingTerms(name), let cell as BasicTableViewCell):
+            configureOptionAdded(cell: cell, text: name)
         default:
             fatalError("Unsupported Cell")
             break
@@ -222,7 +222,7 @@ private extension AddAttributeOptionsViewController {
         cell.imageView?.isUserInteractionEnabled = true
     }
 
-    func configureOption(cell: BasicTableViewCell, text: String) {
+    func configureOptionAdded(cell: BasicTableViewCell, text: String) {
         cell.textLabel?.text = text
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -265,7 +265,7 @@ extension AddAttributeOptionsViewController {
     enum Row: Equatable {
         case termTextField
         case selectedTerms(name: String)
-        case existingTerms
+        case existingTerms(name: String)
 
         fileprivate var type: UITableViewCell.Type {
             switch self {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -200,11 +200,11 @@ private extension AddAttributeOptionsViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch (row, cell) {
-        case (.termTextField, let cell as TextFieldTableViewCell):
+        case (.optionTextField, let cell as TextFieldTableViewCell):
             configureTextField(cell: cell)
-        case (let .selectedTerms(name), let cell as BasicTableViewCell):
+        case (let .selectedOptions(name), let cell as BasicTableViewCell):
             configureOptionOffered(cell: cell, text: name, index: indexPath.row)
-        case (let .existingTerms(name), let cell as BasicTableViewCell):
+        case (let .existingOptions(name), let cell as BasicTableViewCell):
             configureOptionAdded(cell: cell, text: name)
         default:
             fatalError("Unsupported Cell")
@@ -249,7 +249,7 @@ private extension AddAttributeOptionsViewController {
 // MARK: - Placeholders
 //
 private extension AddAttributeOptionsViewController {
-    /// Renders ghost placeholder while terms are being synched.
+    /// Renders ghost placeholder while options are being synched.
     ///
     func displayGhostTableView() {
         let options = GhostOptions(displaysSectionHeader: false,
@@ -303,15 +303,15 @@ extension AddAttributeOptionsViewController {
     }
 
     enum Row: Equatable {
-        case termTextField
-        case selectedTerms(name: String)
-        case existingTerms(name: String)
+        case optionTextField
+        case selectedOptions(name: String)
+        case existingOptions(name: String)
 
         fileprivate var type: UITableViewCell.Type {
             switch self {
-            case .termTextField:
+            case .optionTextField:
                 return TextFieldTableViewCell.self
-            case .selectedTerms, .existingTerms:
+            case .selectedOptions, .existingOptions:
                 return BasicTableViewCell.self
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -63,7 +63,8 @@ final class AddAttributeOptionsViewModel {
         }
 
         let predicate = NSPredicate(format: "siteID == %lld && attribute.attributeID == %lld", attribute.siteID, attribute.attributeID)
-        let controller = ResultsController<StorageProductAttributeTerm>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+        let controller = ResultsController<StorageProductAttributeTerm>(storageManager: viewStorage, matching: predicate, sortedBy: [descriptor])
 
         controller.onDidChangeContent = { [weak self] in
             self?.state.optionsAdded = controller.fetchedObjects
@@ -142,7 +143,8 @@ private extension AddAttributeOptionsViewModel {
     func updateSections() {
         let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField], allowsReorder: false)
         let offeredSection = createOfferedSection()
-        sections = [textFieldSection, offeredSection].compactMap { $0 }
+        let addedSection = createAddedSection()
+        sections = [textFieldSection, offeredSection, addedSection].compactMap { $0 }
     }
 
     func createOfferedSection() -> Section? {
@@ -155,6 +157,19 @@ private extension AddAttributeOptionsViewModel {
         }
 
         return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows, allowsReorder: true)
+    }
+
+    func createAddedSection() -> Section? {
+        // TODO: Handle attribute local options
+        guard state.optionsAdded.isNotEmpty else {
+            return nil
+        }
+
+        let rows = state.optionsAdded.map { term in
+            AddAttributeOptionsViewModel.Row.existingTerms(name: term.name)
+        }
+
+        return Section(header: Localization.headerExistingTerms, footer: nil, rows: rows, allowsReorder: false)
     }
 
     /// Synchronizes options(terms) for global attributes

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -93,11 +93,11 @@ final class AddAttributeOptionsViewModel {
 
     private(set) var sections: [Section] = []
 
-    /// Stores manager to dispatch sync terms(options) action.
+    /// Stores manager to dispatch sync global options action.
     ///
     private let stores: StoresManager
 
-    /// Storage manager to read fetched terms(options).
+    /// Storage manager to read fetched global options.
     ///
     private let viewStorage: StorageManagerType
 
@@ -110,7 +110,7 @@ final class AddAttributeOptionsViewModel {
         case .new:
             updateSections()
         case .existing:
-            synchronizeOptions()
+            synchronizeGlobalOptions()
         }
     }
 }
@@ -143,13 +143,13 @@ extension AddAttributeOptionsViewModel {
     }
 }
 
-// MARK: - Synchronize Product Attribute terms
+// MARK: - Synchronize Product Attribute Options
 //
 private extension AddAttributeOptionsViewModel {
     /// Updates data in sections
     ///
     func updateSections() {
-        let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.termTextField], allowsReorder: false)
+        let textFieldSection = Section(header: nil, footer: Localization.footerTextField, rows: [.optionTextField], allowsReorder: false)
         let offeredSection = createOfferedSection()
         let addedSection = createAddedSection()
         sections = [textFieldSection, offeredSection, addedSection].compactMap { $0 }
@@ -161,10 +161,10 @@ private extension AddAttributeOptionsViewModel {
         }
 
         let rows = state.optionsOffered.map { option in
-            AddAttributeOptionsViewModel.Row.selectedTerms(name: option)
+            AddAttributeOptionsViewModel.Row.selectedOptions(name: option)
         }
 
-        return Section(header: Localization.headerSelectedTerms, footer: nil, rows: rows, allowsReorder: true)
+        return Section(header: Localization.headerSelectedOptions, footer: nil, rows: rows, allowsReorder: true)
     }
 
     func createAddedSection() -> Section? {
@@ -173,28 +173,28 @@ private extension AddAttributeOptionsViewModel {
             return nil
         }
 
-        let rows = state.optionsAdded.map { term in
-            AddAttributeOptionsViewModel.Row.existingTerms(name: term.name)
+        let rows = state.optionsAdded.map { option in
+            AddAttributeOptionsViewModel.Row.existingOptions(name: option.name)
         }
 
-        return Section(header: Localization.headerExistingTerms, footer: nil, rows: rows, allowsReorder: false)
+        return Section(header: Localization.headerExistingOptions, footer: nil, rows: rows, allowsReorder: false)
     }
 
-    /// Synchronizes options(terms) for global attributes
+    /// Synchronizes options for global attributes
     ///
-    func synchronizeOptions() {
+    func synchronizeGlobalOptions() {
         guard case let .existing(attribute) = source, attribute.isGlobal else {
             return
         }
 
-        let fetchTerms = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: attribute.siteID,
-                                                                                     attributeID: attribute.attributeID) { [weak self] _ in
+        let fetchOptions = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: attribute.siteID,
+                                                                                       attributeID: attribute.attributeID) { [weak self] _ in
             guard let self = self else { return }
             self.state.optionsAdded = self.optionsOfferedResultsController.fetchedObjects
             self.state.isSyncing = false
         }
         state.isSyncing = true
-        stores.dispatch(fetchTerms)
+        stores.dispatch(fetchOptions)
     }
 }
 
@@ -202,9 +202,9 @@ private extension AddAttributeOptionsViewModel {
     enum Localization {
         static let footerTextField = NSLocalizedString("Add each option and press enter",
                                                        comment: "Footer of text field section in Add Attribute Options screen")
-        static let headerSelectedTerms = NSLocalizedString("OPTIONS OFFERED",
+        static let headerSelectedOptions = NSLocalizedString("OPTIONS OFFERED",
                                                            comment: "Header of selected attribute options section in Add Attribute Options screen")
-        static let headerExistingTerms = NSLocalizedString("ADD OPTIONS",
+        static let headerExistingOptions = NSLocalizedString("ADD OPTIONS",
                                                            comment: "Header of existing attribute options section in Add Attribute Options screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -26,6 +26,10 @@ final class AddAttributeOptionsViewModel {
         /// Stores options previously added
         ///
         var optionsAdded: [ProductAttributeTerm] = []
+
+        /// Indicates if the view model is syncing a global attribute options
+        ///
+        var isSyncing: Bool = false
     }
 
     /// Title of the navigation bar
@@ -43,6 +47,10 @@ final class AddAttributeOptionsViewModel {
     ///
     var isNextButtonEnabled: Bool {
         state.optionsOffered.isNotEmpty
+    }
+
+    var showGhostTableView: Bool {
+        state.isSyncing
     }
 
     /// Closure to notify the `ViewController` when the view model properties change.
@@ -183,7 +191,9 @@ private extension AddAttributeOptionsViewModel {
                                                                                      attributeID: attribute.attributeID) { [weak self] _ in
             guard let self = self else { return }
             self.state.optionsAdded = self.optionsOfferedResultsController.fetchedObjects
+            self.state.isSyncing = false
         }
+        state.isSyncing = true
         stores.dispatch(fetchTerms)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -96,8 +96,13 @@ final class AddAttributeOptionsViewModel {
         self.source = source
         self.stores = stores
         self.viewStorage = viewStorage
-        updateSections()
-        synchronizeOptions()
+
+        switch source {
+        case .new:
+            updateSections()
+        case .existing:
+            synchronizeOptions()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -266,17 +266,20 @@ extension AddAttributeViewController: KeyboardScrollable {
 extension AddAttributeViewController {
 
     @objc private func doneButtonPressed() {
-        presentAddAttributeOptions(for: viewModel.newAttributeName)
+        guard let name = viewModel.newAttributeName else {
+            return
+        }
+        presentAddAttributeOptions(for: name)
     }
 
-    private func presentAddAttributeOptions(for newAttribute: String?) {
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: newAttribute)
+    private func presentAddAttributeOptions(for newAttribute: String) {
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: newAttribute))
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }
 
     private func presentAddAttributeOptions(for existingAttribute: ProductAttribute) {
-        let viewModel = AddAttributeOptionsViewModel(existingAttribute: existingAttribute)
+        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: existingAttribute))
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -169,6 +169,30 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             .existingTerms(name: "Option 3")
         ])
     }
+
+    func test_sync_options_of_existing_attribute_should_display_and_hide_ghost_tableView() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: ProductAttributeTermAction.self) { action in
+            switch action {
+            case let .synchronizeProductAttributeTerms(_, _, onCompletion):
+                DispatchQueue.main.async {
+                    onCompletion(.success(()))
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores)
+        XCTAssertTrue(viewModel.showGhostTableView)
+
+        // Then
+        waitUntil {
+            !viewModel.showGhostTableView
+        }
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -8,7 +8,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_new_attribute_should_have_textfield_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
 
         // Then
         let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -18,7 +18,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_when_adding_new_option_to_new_attribute_a_new_section_should_be_added() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
@@ -33,7 +33,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
     func test_when_adding_multiple_options_one_section_with_multiple_rows_is_added() throws {
         // Given
         let newOptionName = "new-option-2"
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
@@ -49,7 +49,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_next_button_gets_enabled_after_adding_one_option() {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         XCTAssertFalse(viewModel.isNextButtonEnabled)
 
         // When
@@ -61,7 +61,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_reorder_option_reorders_the_option_within_sections() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -81,7 +81,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_reorder_option_with_same_indexes_do_not_reorders_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -100,7 +100,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_remove_option_with_correct_index_removes_it_from_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -118,7 +118,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_remove_option_with_overflown_index_does_not_alter_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(newAttribute: sampleAttributeName)
+        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -14,7 +14,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // Then
         let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
-        XCTAssertEqual(textFieldSection, [AddAttributeOptionsViewController.Row.termTextField])
+        XCTAssertEqual(textFieldSection, [AddAttributeOptionsViewController.Row.optionTextField])
         XCTAssertEqual(viewModel.sections.count, 1)
     }
 
@@ -28,7 +28,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // Then
         let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
-        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms(name: sampleOptionName)])
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedOptions(name: sampleOptionName)])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
 
@@ -44,8 +44,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // Then
         let offeredSection = try XCTUnwrap(viewModel.sections.last?.rows)
-        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedTerms(name: sampleOptionName),
-                                        AddAttributeOptionsViewController.Row.selectedTerms(name: newOptionName)])
+        XCTAssertEqual(offeredSection, [AddAttributeOptionsViewController.Row.selectedOptions(name: sampleOptionName),
+                                        AddAttributeOptionsViewController.Row.selectedOptions(name: newOptionName)])
         XCTAssertEqual(viewModel.sections.count, 2)
     }
 
@@ -74,9 +74,9 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsOffered, [
-            .selectedTerms(name: "Option 2"),
-            .selectedTerms(name: "Option 3"),
-            .selectedTerms(name: "Option 1")
+            .selectedOptions(name: "Option 2"),
+            .selectedOptions(name: "Option 3"),
+            .selectedOptions(name: "Option 1")
         ])
 
     }
@@ -94,9 +94,9 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsOffered, [
-            .selectedTerms(name: "Option 1"),
-            .selectedTerms(name: "Option 2"),
-            .selectedTerms(name: "Option 3")
+            .selectedOptions(name: "Option 1"),
+            .selectedOptions(name: "Option 2"),
+            .selectedOptions(name: "Option 3")
         ])
     }
 
@@ -113,8 +113,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsOffered, [
-            .selectedTerms(name: "Option 1"),
-            .selectedTerms(name: "Option 3")
+            .selectedOptions(name: "Option 1"),
+            .selectedOptions(name: "Option 3")
         ])
     }
 
@@ -131,9 +131,9 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsOffered, [
-            .selectedTerms(name: "Option 1"),
-            .selectedTerms(name: "Option 2"),
-            .selectedTerms(name: "Option 3")
+            .selectedOptions(name: "Option 1"),
+            .selectedOptions(name: "Option 2"),
+            .selectedOptions(name: "Option 3")
         ])
     }
 
@@ -164,9 +164,9 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         // Then
         let optionsAdded = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsAdded, [
-            .existingTerms(name: "Option 1"),
-            .existingTerms(name: "Option 2"),
-            .existingTerms(name: "Option 3")
+            .existingOptions(name: "Option 1"),
+            .existingOptions(name: "Option 2"),
+            .existingOptions(name: "Option 3")
         ])
     }
 


### PR DESCRIPTION
part of #3529 

# Why
Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Sync options(Called terms at API level) of a global attribute.

This PR does not create the attribute or option remotely yet(#3535), it only allows for the UI interaction and the ViewModel internal updates.

This PR also does not let you manage the newly synced options, that will be done in the next PR.

# How

- Updated `ProductAttribute` entity to add a couple of properties to know if it's a global or a local attribute.

- Updates `AddAttributeOptionsViewModel`: 
    - To encapsulate the two different `init` methods into a single one with a `Source` parameter, as it declares the intention better. 
    - To sync attribute options(terms) when the VM source is a global attribute.
    - To update the `updateSections()` method with the `optionsAdded` section when necessary.
    - To expose a `showGhostTableView ` property to the VC to consume.

- Updates `AddAttributeOptionsViewController`: 
    - To show a ghost table view while the terms are synched
    - To render "options added" with the correct name from the `ViewModel`.

# Demo
![sync-global-attributes](https://user-images.githubusercontent.com/562080/106955898-df121880-6703-11eb-99fb-9dccb1f50d4c.gif)



# Testing Steps
- Make sure your store has some global attributes
- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute.
- See that the gosht table view is displayed
- See that the product options are displayed

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
