### PR TITLE
[Tooling] Update 'upload_app_store_data' lane for APIKey use

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -600,15 +600,12 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   end
 
   desc "Upload App Store Data"
-  lane :upload_app_store_data do | options |
-    
+  lane :upload_app_store_data do | options |    
     deliver(
-      app_identifier: 'com.automattic.woocommerce',
-      copyright: '2019 WooCommerce',
       skip_binary_upload: true,
-      team_id: '299112',
       skip_screenshots: true,
-      ignore_language_directory_validation: true
+      ignore_language_directory_validation: true,
+      precheck_include_in_app_purchases: false # Not supported yet when using ADC APIKey
     )
   end
 


### PR DESCRIPTION
## Why?

Now that we've migrated to using an APIKey to authenticate to ADC API (see #3599), we need to disable the precheck for In-App Purchases when invoking `deliver`, because this precheck does not support the use of APIKey yet.

```
$ fl upload_app_store_data
…
[17:04:37]: Creating phased release on App Store Connect
[17:04:39]: Uploading app review information to App Store Connect
[17:04:41]: Running precheck before submitting to review, if you'd like to disable this check you can set run_precheck_before_submit to false
[17:04:41]: Running precheck 👮‍♀️ 👮
+------------------+---------------------------+
|                 Lane Context                 |
+------------------+---------------------------+
| DEFAULT_PLATFORM | ios                       |
| PLATFORM_NAME    | ios                       |
| LANE_NAME        | ios upload_app_store_data |
+------------------+---------------------------+
[17:04:41]: Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck or use Apple ID login

+------+------------------+-------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 2    | is_ci            | 0           |
| 3    | setup_circle_ci  | 0           |
| 💥   | deliver          | 112         |
+------+------------------+-------------+

[17:04:41]: fastlane finished with errors

[!] Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck or use Apple ID login
```

## How?

* Previously, I was always using `fastlane deliver --skip_binary_upload --skip_screenshots` directly from the command line instead of the `upload_app_store_data` lane, because that's what our Release Scenarios were telling me to do (PR comming soon in our mobile-toolbox to fix that). But using `deliver` command directly means that this doesn't load the `~/.wcios-env.default` file which contains my env vars like `DELIVER_API_KEY_PATH`, which means it were always asking me to type my username and password manually to log in
* Now that we've migrated to using the API Key to interact with everything ADC, I will now use the `upload_app_store_data` lane instead during release, which takes care of calling `deliver` with the right parameters but also take those env vars into account, so in our case uses the `DELIVER_API_KEY_PATH` env var to authenticate with the API Key
* But to be able to do that, I had to update that lane to:
  * Get rid of obsolete parameters which where are either provided by the `Deliverfile` (`app_identifier` and `team_id`) or are stored in the metadata`.txt` file (`copyright`)
  * Add a parameter to skip precheck for in-app purchases, as it's not yet supported for use with API Key, which honestly is unlikely to fail as we change those very infrequently.

## To Test

I've used the `upload_app_store_data` lane when releasing 5.9 a couple of minutes ago and confirmed that those changes worked.

This won't really need a review as I've tested it live already, so I'll merge it right away myself, but I still wanted to open an explicit PR to keep track of that change and its rationale, also so that we can reference it when discussing it and applying similar changes to other repos.