### PR TITLE
Update user.env.example with additional *_API_KEY_PATH

### DIFF
--- a/fastlane/env/user.env.example
+++ b/fastlane/env/user.env.example
@@ -1,4 +1,6 @@
-PILOT_API_KEY_PATH=".configure-files/app_store_connect_fastlane_api_key.json"
+PILOT_API_KEY_PATH=".configure-files/app_store_connect_fastlane_api_key.json" # fastlane testlight
+DELIVER_API_KEY_PATH=$PILOT_API_KEY_PATH # fastlane deliver
+SIGH_API_KEY_PATH=$PILOT_API_KEY_PATH # fastlane match
 
 GHHELPER_ACCESS=<GitHub access token>
 SENTRY_AUTH_TOKEN=<Sentry auth token>


### PR DESCRIPTION
## Why?

This is a continuation of #3603 because obviously I was too quick to merge it and forgot to update the example file (Fridays, right?)

## How?

Updated the `user.env.example` file to reflect the useful env vars you might want to declare to be able to use the API_KEY with various fastlane actions. In particular, this adds a declaration for `DELIVER_API_KEY_PATH` (used by `fastlane deliver` and the `upload_app_store_data` lane) and `SIGH_API_KEY_PATH` (used by `fastlane match`) to be the same values as the one for `PILOT_API_KEY_PATH` (used by the `testflight` action).

Note that I don't think we need to declare those additional env vars in CircleCI because I don't think we ever run fastlane match or fastlane deliver from CI? Though I could be wrong there, didn't explicitly check.