### PR TITLE
Variations: First Variation -> Allow existing options to be selected as offered options.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -64,6 +64,7 @@ private extension AddAttributeOptionsViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.isEditing = true
+        tableView.allowsSelectionDuringEditing = true
     }
 
     func configureGhostTableView() {
@@ -160,7 +161,10 @@ extension AddAttributeOptionsViewController: UITableViewDataSource {
 //
 extension AddAttributeOptionsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
+        guard viewModel.sections[indexPath.section].allowsSelection else {
+            return
+        }
+        viewModel.selectExistingOption(atIndex: indexPath.row)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -300,6 +304,7 @@ extension AddAttributeOptionsViewController {
         let footer: String?
         let rows: [Row]
         let allowsReorder: Bool
+        let allowsSelection: Bool
     }
 
     enum Row: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -247,6 +247,8 @@ private extension AddAttributeOptionsViewController {
 
     func configureOptionAdded(cell: BasicTableViewCell, text: String) {
         cell.textLabel?.text = text
+        cell.imageView?.image = nil
+        cell.imageView?.isUserInteractionEnabled = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -141,6 +141,15 @@ extension AddAttributeOptionsViewModel {
         }
         state.optionsOffered.remove(at: index)
     }
+
+    /// Moves an option from at the specified index to the "Options Offered" section.
+    ///
+    func selectExistingOption(atIndex index: Int) {
+        guard let option = state.optionsAdded[safe: index] else {
+            return
+        }
+        addNewOption(name: option.name)
+    }
 }
 
 // MARK: - Synchronize Product Attribute Options
@@ -173,9 +182,14 @@ private extension AddAttributeOptionsViewModel {
             return nil
         }
 
-        let rows = state.optionsAdded.map { option in
-            AddAttributeOptionsViewModel.Row.existingOptions(name: option.name)
-        }
+        // Filter options that exists in `optionsOffered` for then converting them to `Row` types.
+        let rows = state.optionsAdded
+            .filter { option in
+                !state.optionsOffered.contains(option.name)
+            }
+            .map { option in
+                AddAttributeOptionsViewModel.Row.existingOptions(name: option.name)
+            }
 
         return Section(header: Localization.headerExistingOptions, footer: nil, rows: rows, allowsReorder: false)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -220,6 +220,37 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             .existingOptions(name: "Option 1"),
         ])
     }
+
+    func test_selecting_all_added_options_removes_its_section() throws {
+        // Given
+        let storage = MockStorageManager()
+        insertSampleAttributeWithTerms(on: storage)
+
+        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), viewStorage: storage)
+        waitUntil {
+            viewModel.sections.count == 2
+        }
+
+        let optionsAdded = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsAdded, [
+            .existingOptions(name: "Option 1"),
+            .existingOptions(name: "Option 2"),
+            .existingOptions(name: "Option 3"),
+        ])
+
+        // When
+        viewModel.selectExistingOption(atIndex: 0)
+        viewModel.selectExistingOption(atIndex: 0)
+        viewModel.selectExistingOption(atIndex: 0)
+
+        // Then
+        let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(optionsOffered, [
+            .selectedOptions(name: "Option 1"),
+            .selectedOptions(name: "Option 2"),
+            .selectedOptions(name: "Option 3"),
+        ])
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -194,12 +194,18 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
     func test_select_addedOption_moves_it_to_offeredSection_and_removes_it_from_addedSection() throws {
         // Given
         let storage = MockStorageManager()
-        insertSampleAttributeWithTerms(on: storage)
-
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), viewStorage: storage)
-        waitUntil {
-            viewModel.sections.count == 2
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: ProductAttributeTermAction.self) { action in
+            switch action {
+            case let .synchronizeProductAttributeTerms(_, _, onCompletion):
+                self.insertSampleAttributeWithTerms(on: storage)
+                onCompletion(.success(()))
+            default:
+                break
+            }
         }
+
+        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores, viewStorage: storage)
 
         // When
         viewModel.selectExistingOption(atIndex: 1)
@@ -224,12 +230,18 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
     func test_selecting_all_added_options_removes_its_section() throws {
         // Given
         let storage = MockStorageManager()
-        insertSampleAttributeWithTerms(on: storage)
-
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), viewStorage: storage)
-        waitUntil {
-            viewModel.sections.count == 2
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: ProductAttributeTermAction.self) { action in
+            switch action {
+            case let .synchronizeProductAttributeTerms(_, _, onCompletion):
+                self.insertSampleAttributeWithTerms(on: storage)
+                onCompletion(.success(()))
+            default:
+                break
+            }
         }
+
+        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores, viewStorage: storage)
 
         let optionsAdded = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsAdded, [

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -203,6 +203,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // When
         viewModel.selectExistingOption(atIndex: 1)
+        viewModel.selectExistingOption(atIndex: 1)
         waitUntil {
             viewModel.sections.count == 3
         }
@@ -213,10 +214,10 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         XCTAssertEqual(optionsOffered, [
             .selectedOptions(name: "Option 2"),
+            .selectedOptions(name: "Option 3"),
         ])
         XCTAssertEqual(optionsAdded, [
             .existingOptions(name: "Option 1"),
-            .existingOptions(name: "Option 3"),
         ])
     }
 }


### PR DESCRIPTION
Part of #3529

# Why

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Allow existing options to be selected as offered options.

This PR does not create the attribute or option remotely yet(#3535), it only allows for the UI interaction and the ViewModel internal updates.

This PR only handles global attributes, local attributes will be handled on a following PR.

# How

- Update ViewModel to:
  - Add a new `selectExistingOption(at Index: Int)` method for allowing moving existing options into offered options.
  - Add a new `filterOptionsAdded() -> [ProductAttributeTerms]` method that will give us an array of existing options but filtering the ones that have already been selected.
  
- Update ViewController to:
  - Update the `Section` struct so the VM can determine which section is selectable
  - Wire `didSelectRowAtIndexPath` with the new VM interface
  - Clean the `X` image on the cell when rendering an existing option, to fix a small cell reuse issue.

# Demo
![existing-global-attribute-management](https://user-images.githubusercontent.com/562080/107066827-7337ba80-67ac-11eb-90d5-e2e80e6c5df1.gif)

# Testing Steps
- Make sure your store has some global attributes
- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute.
- Tap one(or more) existing option and see that it moves to the selected options
- Add a new option by writing the name on the text field
- Remove the existing option and see that it moves back to the existing options section
- Remove the new option and see that it disappears.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
