### PR TITLE
Variations: First Variation -> Add local attribute options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -153,7 +153,7 @@ extension AddAttributeOptionsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        viewModel.reorderOptionOffered(fromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
+        viewModel.reorderSelectedOptions(fromIndex: sourceIndexPath.row, toIndex: destinationIndexPath.row)
     }
 }
 
@@ -239,7 +239,7 @@ private extension AddAttributeOptionsViewController {
         // Listen to taps on the cell's image view
         let tapRecognizer = UITapGestureRecognizer()
         tapRecognizer.on { [weak self] _ in
-            self?.viewModel.removeOptionOffered(atIndex: index)
+            self?.viewModel.removeSelectedOption(atIndex: index)
         }
         cell.imageView?.addGestureRecognizer(tapRecognizer)
         cell.imageView?.isUserInteractionEnabled = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -69,7 +69,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         viewModel.addNewOption(name: "Option 3")
 
         // When
-        viewModel.reorderOptionOffered(fromIndex: 0, toIndex: 2)
+        viewModel.reorderSelectedOptions(fromIndex: 0, toIndex: 2)
 
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -89,7 +89,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         viewModel.addNewOption(name: "Option 3")
 
         // When
-        viewModel.reorderOptionOffered(fromIndex: 1, toIndex: 1)
+        viewModel.reorderSelectedOptions(fromIndex: 1, toIndex: 1)
 
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -108,7 +108,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         viewModel.addNewOption(name: "Option 3")
 
         // When
-        viewModel.removeOptionOffered(atIndex: 1)
+        viewModel.removeSelectedOption(atIndex: 1)
 
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -126,7 +126,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         viewModel.addNewOption(name: "Option 3")
 
         // When
-        viewModel.removeOptionOffered(atIndex: 3)
+        viewModel.removeSelectedOption(atIndex: 3)
 
         // Then
         let optionsOffered = try XCTUnwrap(viewModel.sections.last?.rows)


### PR DESCRIPTION
closes #3529 

# Why

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Support local attributes and options when creating the first variation.

This PR does not create the attribute or option remotely yet(#3535), it only allows for the UI interaction and the ViewModel internal updates.

# How

- Add a new `Option` enum inside our `State` struct to properly differentiate what kind of option are we dealing with, either `.local` or `.global`

- Update the `VM` `init` to populate the `state.optionsAdded` from `attribute.options` when the attribute is local.

- Update the `VM` to work with the new `Option` enum described before.

# Demo
![option-existing-local-attribute](https://user-images.githubusercontent.com/562080/107086254-c10dec00-67c7-11eb-9e4f-8f6e81ed562d.gif)


# Testing Steps

- On web, go to a variable product without any variation and add one(or more) local attributes.
- On the app, navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on the local attribute you just created
- Tap one(or more) existing option and see that it moves to the selected options
- Add a new option by writing the name on the text field
- Remove the existing option and see that it moves back to the existing options section
- Remove the new option and see that it disappears.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
