### PR TITLE
Shipping Labels M2: add feature flag, and a creation CTA behind the feature flag in order details

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,6 +11,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease1:
             return true
+        case .shippingLabelsRelease2:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -25,4 +25,8 @@ enum FeatureFlag: Int {
     /// Shipping labels - release 1
     ///
     case shippingLabelsRelease1
+
+    /// Shipping labels - release 2
+    ///
+    case shippingLabelsRelease2
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -282,6 +282,8 @@ private extension OrderDetailsDataSource {
             configureShippingLabelProduct(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
             configureAggregateOrderItem(cell: cell, at: indexPath)
+        case let cell as ButtonTableViewCell where row == .shippingLabelCreateButton:
+            configureCreateShippingLabelButton(cell: cell, at: indexPath)
         case let cell as ButtonTableViewCell where row == .markCompleteButton:
             configureMarkCompleteButton(cell: cell)
         case let cell as ButtonTableViewCell where row == .shippingLabelReprintButton:
@@ -442,6 +444,15 @@ private extension OrderDetailsDataSource {
         cell.leftText = Titles.netAmount
         cell.rightText = paymentViewModel.netAmount
         cell.hideFootnote()
+    }
+
+    private func configureCreateShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
+        cell.configure(style: .primary,
+                       title: Titles.createShippingLabel,
+                       bottomSpacing: 0) {
+            // TODO-2972: present shipping label creation form
+        }
+        cell.hideSeparator()
     }
 
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
@@ -747,6 +758,10 @@ extension OrderDetailsDataSource {
 
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2) {
+                rows.append(.shippingLabelCreateButton)
+            }
+
             if isProcessingPayment {
                 rows.append(.markCompleteButton)
             } else if isRefundedStatus == false {
@@ -1049,6 +1064,7 @@ extension OrderDetailsDataSource {
         static let refunded = NSLocalizedString("Refunded",
                                                 comment: "The title for the refunded amount cell")
         static let netAmount = NSLocalizedString("Net Payment", comment: "The title for the net amount paid cell")
+        static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
         static let reprintShippingLabel = NSLocalizedString("Reprint Shipping Label", comment: "Text on the button that reprints a shipping label")
     }
 
@@ -1188,6 +1204,7 @@ extension OrderDetailsDataSource {
         case netAmount
         case tracking
         case trackingAdd
+        case shippingLabelCreateButton
         case shippingLabelDetail
         case shippingLabelPrintingInfo
         case shippingLabelProduct
@@ -1233,6 +1250,8 @@ extension OrderDetailsDataSource {
                 return OrderTrackingTableViewCell.reuseIdentifier
             case .trackingAdd:
                 return LeftImageTableViewCell.reuseIdentifier
+            case .shippingLabelCreateButton:
+                return ButtonTableViewCell.reuseIdentifier
             case .shippingLabelDetail:
                 return WooBasicTableViewCell.reuseIdentifier
             case .shippingLabelPrintingInfo:


### PR DESCRIPTION
Fixes #3533 

## Why

To make UI integration easier during development, this PR added a CTA to create a shipping label in order details behind a new feature flag for Shipping Labels M2.

## Changes

- Added a new feature flag `FeatureFlag.shippingLabelsRelease2` that is only enabled in installable builds and debug mode
- In Order Details, added a CTA (`Row.shippingLabelCreateButton`) which we can integrate with the creation form later (the actual eligibility check will be implemented in https://github.com/woocommerce/woocommerce-ios/issues/2971)

## Testing

### Feature flag on - debug mode

- Go to the orders tab
- Tap on any order --> there should be a "Create Shipping Label" CTA in the Products section

### Feature flag off

- Turn off feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the orders tab
- Tap on any order --> there should not be a "Create Shipping Label" CTA in the Products section

## Example screenshots

@woocommerce/mobile-designers we might want to update the style for "Mark Order Complete" CTA to secondary button style, so that we don't have two primary CTAs in a row? Also, the "Mark Order Complete" CTA is called "Mark as Fulfilled" - I'm guessing this is the same button and we can update the copy?

<img width="200" alt="Screen Shot 2021-02-08 at 4 35 46 PM" src="https://user-images.githubusercontent.com/1945542/107195967-fb2bf780-6a2c-11eb-8106-a4e85240b0ab.png">


\ | dark | light
-- | -- | --
one CTA only (order status is not processing) | ![Simulator Screen Shot - iPhone 11 - 2021-02-08 at 16 23 52](https://user-images.githubusercontent.com/1945542/107194852-8e642d80-6a2b-11eb-8133-ca6e9d0627a1.png) | ![Simulator Screen Shot - iPhone 11 - 2021-02-08 at 16 24 56](https://user-images.githubusercontent.com/1945542/107194762-72608c00-6a2b-11eb-95bf-5e70219e172d.png)
two CTAs (order status is processing) | ![Simulator Screen Shot - iPhone 11 - 2021-02-08 at 16 23 57](https://user-images.githubusercontent.com/1945542/107195635-8d7fcb80-6a2c-11eb-9f17-3c3f485541a6.png) | ![Simulator Screen Shot - iPhone 11 - 2021-02-08 at 16 25 01](https://user-images.githubusercontent.com/1945542/107195172-f74ba580-6a2b-11eb-859d-5fcfeb973a46.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
