### PR TITLE
Add a new Swift Package: Hardware

### DIFF
--- a/Hardware/.gitignore
+++ b/Hardware/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Hardware",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Hardware",
+            targets: ["Hardware"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Hardware",
+            dependencies: []),
+        .testTarget(
+            name: "HardwareTests",
+            dependencies: ["Hardware"]),
+    ]
+)

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Hardware",
+    platforms: [.iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Hardware/README.md
+++ b/Hardware/README.md
@@ -1,0 +1,3 @@
+# Hardware
+
+This package provides support for integrations with external hardware

--- a/Hardware/Sources/Hardware/Hardware.swift
+++ b/Hardware/Sources/Hardware/Hardware.swift
@@ -1,0 +1,10 @@
+/// We want to bootsrap this package as soon as possible, so that we can
+/// start working on it in parallel.
+/// It also helps check that the package's test have been added to the proper testing plan.
+/// This struct will be removed as soon as we start working on either
+/// https://github.com/woocommerce/woocommerce-ios/issues/3587 or
+/// https://github.com/woocommerce/woocommerce-ios/issues/3589
+/// Leaving it here for now will also help test the PR that adds the package to the project
+struct Hardware {
+    var text = "Hello, World!"
+}

--- a/Hardware/Sources/Hardware/Hardware.swift
+++ b/Hardware/Sources/Hardware/Hardware.swift
@@ -5,6 +5,10 @@
 /// https://github.com/woocommerce/woocommerce-ios/issues/3587 or
 /// https://github.com/woocommerce/woocommerce-ios/issues/3589
 /// Leaving it here for now will also help test the PR that adds the package to the project
-struct Hardware {
-    var text = "Hello, World!"
+public struct Hardware {
+    public init() {
+
+    }
+    
+    public var text = "Hello, World!"
 }

--- a/Hardware/Sources/Hardware/Hardware.swift
+++ b/Hardware/Sources/Hardware/Hardware.swift
@@ -9,6 +9,6 @@ public struct Hardware {
     public init() {
 
     }
-    
+
     public var text = "Hello, World!"
 }

--- a/Hardware/Tests/HardwareTests/HardwareTests.swift
+++ b/Hardware/Tests/HardwareTests/HardwareTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Hardware
+
+final class HardwareTests: XCTestCase {
+    func test_that_tests_run() {
+        XCTAssertEqual(Hardware().text, "Hello, World!")
+    }
+
+    static var allTests = [
+        ("testExample", test_that_tests_run),
+    ]
+}

--- a/Hardware/Tests/HardwareTests/XCTestManifests.swift
+++ b/Hardware/Tests/HardwareTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(HardwareTests.allTests),
+    ]
+}
+#endif

--- a/Hardware/Tests/LinuxMain.swift
+++ b/Hardware/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import HardwareTests
+
+var tests = [XCTestCaseEntry]()
+tests += HardwareTests.allTests()
+XCTMain(tests)

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -20,6 +20,9 @@
       location = "group:TestKit">
    </FileRef>
    <FileRef
+      location = "group:Hardware">
+   </FileRef>
+   <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
 </Workspace>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -955,6 +955,7 @@
 		D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817586322BDD81600289CFE /* OrderDetailsDataSource.swift */; };
 		D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9226222E7F0800FFA585 /* OrderStatusListViewController.swift */; };
 		D81D9229222E7F0800FFA585 /* OrderStatusListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */; };
+		D81F0A7C25D18326004F33C8 /* Hardware in Frameworks */ = {isa = PBXBuildFile; productRef = D81F0A7B25D18326004F33C8 /* Hardware */; };
 		D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D81F2D34225F0CF70084BF9C /* EmptyListMessageWithActionView.xib */; };
 		D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */; };
 		D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */; };
@@ -2202,6 +2203,7 @@
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				B5C3B5E320D189E60072CB9D /* Networking.framework in Frameworks */,
+				D81F0A7C25D18326004F33C8 /* Hardware in Frameworks */,
 				86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5223,6 +5225,9 @@
 				B55D4C1520B6131400D7A50F /* PBXTargetDependency */,
 			);
 			name = WooCommerce;
+			packageProductDependencies = (
+				D81F0A7B25D18326004F33C8 /* Hardware */,
+			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
 			productType = "com.apple.product-type.application";
@@ -7280,6 +7285,10 @@
 		57150E0E24F462C200E81611 /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		D81F0A7B25D18326004F33C8 /* Hardware */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Hardware;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -120,8 +120,8 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = ""
             isEnabled = "NO">
-            argument = "mocked-network-layer"
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-force-crash-logging 1"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -120,7 +120,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = ""
+            argument = "mocked-network-layer"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -57,6 +57,13 @@
         "identifier" : "ObservablesTests",
         "name" : "ObservablesTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Hardware",
+        "identifier" : "HardwareTests",
+        "name" : "HardwareTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
Closes #3586 
For context: p91TBi-4k7-p2 and p91TBi-4il-p2

This PR adds a new Swift Package to the project, that @allendav and myself would use as the base to start building our prototype, as mentioned in p91TBi-4k7-p2. This PR does not introduce any user-facing changes.

⚠️  There is one struct in this PR that will get removed as soon as we start actually adding code to the package. But for now, it helps check that the PR passes CI, tests can be run and code in the package can be used. The aforementioned struct is marked as disposable in the headerdocs ⚠️ 

## Changes
* Added a new swift package, named Hardware. Name might be revised later on, as we progress. 
* Made WooCommerce's main target link against Hardware.
* Edited WooCommerce's test plan to run also the unit tests corresponding to Hardware.

## How to test
* Check that CI is ✅ 
* Check out the branch, and run all the tests (i.e. pressing command+U). One way to check that the tests in the package are run might be adding a breakpoint in `HardwareTests.test_that_tests_run` and check that the breakpoint is hit.
* Build and run (i.e. command + R). Check that the project builds. For extra credit, `import Hardware` into any other class in the WooCommerce target (for example, AppDelegate), add something like the following anywhere in that class and check that "Hello World" is printed to the console:
```
        let salutation = Hardware().text
        print("salutation ", salutation)
```

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
