### PR TITLE
Variations: First Variation -> Update / Create attributes remotely 

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -508,6 +508,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         // Linked Products (Upsells and Cross-sell Products)
         try container.encode(upsellIDs, forKey: .upsellIDs)
         try container.encode(crossSellIDs, forKey: .crossSellIDs)
+
+        // Attributes
+        try container.encode(attributes, forKey: .attributes)
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a ProductAttribute entity.
 ///
-public struct ProductAttribute: Decodable {
+public struct ProductAttribute: Codable {
     public let siteID: Int64
     public let attributeID: Int64
     public let name: String
@@ -67,6 +67,17 @@ public struct ProductAttribute: Decodable {
                   visible: visible,
                   variation: variation,
                   options: options)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(attributeID, forKey: .attributeID)
+        try container.encode(name, forKey: .name)
+        try container.encode(options, forKey: .options)
+        try container.encode(position, forKey: .position)
+        try container.encode(visible, forKey: .visible)
+        try container.encode(variation, forKey: .variation)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -48,7 +48,7 @@ private extension AddAttributeOptionsViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,
                                                            target: self,
-                                                           action: #selector(doneButtonPressed))
+                                                           action: #selector(nextButtonPressed))
         removeNavigationBackBarButtonText()
     }
 
@@ -294,7 +294,7 @@ extension AddAttributeOptionsViewController: KeyboardScrollable {
 //
 extension AddAttributeOptionsViewController {
 
-    @objc private func doneButtonPressed() {
+    @objc private func nextButtonPressed() {
         // TODO: to be implemented
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -45,11 +45,25 @@ final class AddAttributeOptionsViewController: UIViewController {
 private extension AddAttributeOptionsViewController {
 
     func configureNavigationBar() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
-                                                           style: .plain,
-                                                           target: self,
-                                                           action: #selector(nextButtonPressed))
         removeNavigationBackBarButtonText()
+    }
+
+    func configureRightButtonItem() {
+        // The update indicator has precedence over the next button
+        if viewModel.showUpdateIndicator {
+            let indicator = UIActivityIndicatorView(style: .medium)
+            indicator.color = .primaryButtonTitle
+            indicator.startAnimating()
+            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: indicator)
+            return
+        }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(nextButtonPressed))
+        navigationItem.rightBarButtonItem?.isEnabled = viewModel.isNextButtonEnabled
+
     }
 
     func configureMainView() {
@@ -96,7 +110,7 @@ private extension AddAttributeOptionsViewController {
 
     func renderViewModel() {
         title = viewModel.titleView
-        navigationItem.rightBarButtonItem?.isEnabled = viewModel.isNextButtonEnabled
+        configureRightButtonItem()
         tableView.reloadData()
 
         if viewModel.showGhostTableView {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -309,7 +309,7 @@ extension AddAttributeOptionsViewController: KeyboardScrollable {
 extension AddAttributeOptionsViewController {
 
     @objc private func nextButtonPressed() {
-        viewModel.updateProductAttributes()
+        viewModel.updateProductAttributes(onCompletion: { _ in })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -295,7 +295,7 @@ extension AddAttributeOptionsViewController: KeyboardScrollable {
 extension AddAttributeOptionsViewController {
 
     @objc private func nextButtonPressed() {
-        // TODO: to be implemented
+        viewModel.updateProductAttributes()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -170,6 +170,35 @@ extension AddAttributeOptionsViewModel {
 
         addNewOption(name: option.name)
     }
+
+    /// Gathers selected options and update the product's attributes
+    ///
+    func updateProductAttributes() {
+        let newOptions = state.selectedOptions.map { $0.name }
+        let newAttribute = ProductAttribute(siteID: product.siteID,
+                                            attributeID: attribute.attributeID,
+                                            name: attribute.name,
+                                            position: 0,
+                                            visible: true,
+                                            variation: true,
+                                            options: newOptions)
+
+        var currentAttributes = product.attributes
+        currentAttributes.removeAll { $0.attributeID == newAttribute.attributeID }
+        currentAttributes.append(newAttribute)
+
+        let newProduct = product.copy(attributes: currentAttributes)
+
+        let action = ProductAction.updateProduct(product: newProduct) { result in
+            switch result {
+            case let .success(newProduct):
+                print(newProduct.attributes)
+            case let .failure(error):
+                print("error: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
 }
 
 // MARK: - Synchronize Product Attribute Options
@@ -262,6 +291,30 @@ private extension AddAttributeOptionsViewModel.State.Option {
             return name
         case let .global(option):
             return option.name
+        }
+    }
+}
+
+private extension AddAttributeOptionsViewModel.Attribute {
+    /// Returns the ID associated with the attribute. `Zero` for new attributes
+    ///
+    var attributeID: Int64 {
+        switch self {
+        case .new:
+            return 0
+        case .existing(let attribute):
+            return attribute.attributeID
+        }
+    }
+
+    /// Returns the name associated with the attribute.
+    ///
+    var name: String {
+        switch self {
+        case let .new(name):
+            return name
+        case let .existing(attribute):
+            return attribute.name
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -11,7 +11,7 @@ final class AddAttributeOptionsViewModel {
 
     /// Enum to represents the original invocation source of this view model
     ///
-    enum Source {
+    enum Attribute {
         case new(name: String)
         case existing(attribute: ProductAttribute)
     }
@@ -42,7 +42,7 @@ final class AddAttributeOptionsViewModel {
     /// Title of the navigation bar
     ///
     var titleView: String? {
-        switch source {
+        switch attribute {
         case .new(let name):
             return name
         case .existing(let attribute):
@@ -64,15 +64,19 @@ final class AddAttributeOptionsViewModel {
     ///
     var onChange: (() -> (Void))?
 
+    /// Main product dependency.
+    ///
+    private let product: Product
+
     /// Main attribute dependency.
     ///
-    private let source: Source
+    private let attribute: Attribute
 
     /// When an attribute exists, returns an already configured `ResultsController`
     /// When there isn't an existing attribute, returns a dummy/un-initialized `ResultsController`
     ///
     private lazy var existingOptionsResultsController: ResultsController<StorageProductAttributeTerm> = {
-        guard case let .existing(attribute) = source, attribute.isGlobal else {
+        guard case let .existing(attribute) = attribute, attribute.isGlobal else {
             // Return a dummy ResultsController if there isn't an existing attribute. It's a workaround to not deal with an optional ResultsController.
             return ResultsController<StorageProductAttributeTerm>(storageManager: viewStorage, matching: nil, sortedBy: [])
         }
@@ -108,12 +112,16 @@ final class AddAttributeOptionsViewModel {
     ///
     private let viewStorage: StorageManagerType
 
-    init(source: Source, stores: StoresManager = ServiceLocator.stores, viewStorage: StorageManagerType = ServiceLocator.storageManager) {
-        self.source = source
+    init(product: Product,
+         attribute: Attribute,
+         stores: StoresManager = ServiceLocator.stores,
+         viewStorage: StorageManagerType = ServiceLocator.storageManager) {
+        self.product = product
+        self.attribute = attribute
         self.stores = stores
         self.viewStorage = viewStorage
 
-        switch source {
+        switch attribute {
         case .new:
             updateSections()
         case let .existing(attribute) where attribute.isGlobal:

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -37,6 +37,10 @@ final class AddAttributeOptionsViewModel {
         /// Indicates if the view model is syncing a global attribute options
         ///
         var isSyncing: Bool = false
+
+        /// Indicates if the view model is updating the product's attributes
+        ///
+        var isUpdating: Bool = false
     }
 
     /// Title of the navigation bar
@@ -56,8 +60,16 @@ final class AddAttributeOptionsViewModel {
         state.selectedOptions.isNotEmpty
     }
 
+    /// Defines ghost cells visibility
+    ///
     var showGhostTableView: Bool {
         state.isSyncing
+    }
+
+    /// Defines if the update indicator should be shown
+    ///
+    var showUpdateIndicator: Bool {
+        state.isUpdating
     }
 
     /// Closure to notify the `ViewController` when the view model properties change.
@@ -189,7 +201,11 @@ extension AddAttributeOptionsViewModel {
 
         let newProduct = product.copy(attributes: currentAttributes)
 
-        let action = ProductAction.updateProduct(product: newProduct) { result in
+        state.isUpdating = true
+        let action = ProductAction.updateProduct(product: newProduct) { [weak self] result in
+            guard let self = self else { return }
+            self.state.isUpdating = false
+
             switch result {
             case let .success(newProduct):
                 print(newProduct.attributes)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -207,9 +207,12 @@ extension AddAttributeOptionsViewModel {
                                             visible: true,
                                             variation: true,
                                             options: newOptions)
+
+        // Here we remove any possible existing attribute with the same ID and Name. For then re-adding the new updated attribute
+        // Name has to be considered, because local attributes are zero-id based.
         let updatedAttributes: [ProductAttribute] = {
             var attributes = product.attributes
-            attributes.removeAll { $0.attributeID == newAttribute.attributeID }
+            attributes.removeAll { $0.attributeID == newAttribute.attributeID && $0.name == newAttribute.name }
             attributes.append(newAttribute)
             return attributes
         }()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -273,13 +273,13 @@ extension AddAttributeViewController {
     }
 
     private func presentAddAttributeOptions(for newAttribute: String) {
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: newAttribute))
+        let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: .new(name: newAttribute))
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }
 
     private func presentAddAttributeOptions(for existingAttribute: ProductAttribute) {
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: existingAttribute))
+        let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: .existing(attribute: existingAttribute))
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
         navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -12,7 +12,7 @@ final class AddAttributeViewModel {
     ///
     private let storesManager: StoresManager
 
-    private let product: Product
+    let product: Product
     private(set) var localAndGlobalAttributes: [ProductAttribute] = []
 
     private(set) var sections: [Section] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -10,7 +10,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_new_attribute_should_have_textfield_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
 
         // Then
         let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
@@ -20,7 +20,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_when_adding_new_option_to_new_attribute_a_new_section_should_be_added() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
@@ -35,7 +35,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
     func test_when_adding_multiple_options_one_section_with_multiple_rows_is_added() throws {
         // Given
         let newOptionName = "new-option-2"
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         XCTAssertEqual(viewModel.sections.count, 1) // Option Name Section
 
         // When
@@ -51,7 +51,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_next_button_gets_enabled_after_adding_one_option() {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         XCTAssertFalse(viewModel.isNextButtonEnabled)
 
         // When
@@ -63,7 +63,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_reorder_option_reorders_the_option_within_sections() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -83,7 +83,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_reorder_option_with_same_indexes_do_not_reorders_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -102,7 +102,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_remove_option_with_correct_index_removes_it_from_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -120,7 +120,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
     func test_remove_option_with_overflown_index_does_not_alter_section() throws {
         // Given
-        let viewModel = AddAttributeOptionsViewModel(source: .new(name: sampleAttributeName))
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
         viewModel.addNewOption(name: "Option 3")
@@ -152,7 +152,10 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores, viewStorage: storage)
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(),
+                                                     attribute: .existing(attribute: sampleAttribute()),
+                                                     stores: stores,
+                                                     viewStorage: storage)
 
         waitUntil {
             return viewModel.sections.count == 2
@@ -182,7 +185,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores)
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: sampleAttribute()), stores: stores)
         XCTAssertTrue(viewModel.showGhostTableView)
 
         // Then
@@ -205,7 +208,10 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores, viewStorage: storage)
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(),
+                                                     attribute: .existing(attribute: sampleAttribute()),
+                                                     stores: stores,
+                                                     viewStorage: storage)
 
         // When
         viewModel.selectExistingOption(atIndex: 1)
@@ -241,7 +247,10 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = AddAttributeOptionsViewModel(source: .existing(attribute: sampleAttribute()), stores: stores, viewStorage: storage)
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(),
+                                                     attribute: .existing(attribute: sampleAttribute()),
+                                                     stores: stores,
+                                                     viewStorage: storage)
 
         let optionsAdded = try XCTUnwrap(viewModel.sections.last?.rows)
         XCTAssertEqual(optionsAdded, [
@@ -267,6 +276,11 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
 // MARK: Helpers
 private extension AddAttributeOptionsViewModelTests {
+
+    func sampleProduct() -> Product {
+        Product().copy(siteID: .some(123), productID: .some(12345))
+    }
+
     func sampleAttribute() -> ProductAttribute {
         ProductAttribute(siteID: 123,
                          attributeID: 1234,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -272,6 +272,31 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             .selectedOptions(name: "Option 3"),
         ])
     }
+
+    func test_update_product_should_toggle_showUpdateIndicator_property() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .updateProduct(_, onCompletion):
+                DispatchQueue.main.async {
+                    onCompletion(.success(Product()))
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: sampleAttribute()), stores: stores)
+        viewModel.updateProductAttributes()
+
+        // Then
+        XCTAssertTrue(viewModel.showUpdateIndicator)
+        waitUntil {
+            !viewModel.showUpdateIndicator
+        }
+    }
 }
 
 // MARK: Helpers


### PR DESCRIPTION
closes #3535 

# Why
Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: Update/Create attributes with their options.

**Note:** This PR does not navigate anywhere after the remote operation has been finished. That, will be handled in #3536  

# How

- Updated `Product` and `ProductAtrribute` to add `codable` conformance to it.

- On the ViewModel:
  - Add `Product` as a dependency because it's needed to update the product attributes later.
  - Rename `Source` enum to `Attribute` as it represents the intention better.
  - Added a `showUpdateIndicator` property which will be `true` while the product operation is happening.
  - Added a new `updateProductAttributes` method that will trigger the remote update by updating the existing attribute with the selected options or creating the attribute if it didn't exist before.
  
- On the ViewController:
  - Listen to the VM's `showUpdateIndicator` to decide when to show the "next" button and when to show the loading indicator.
  - Call the `ViewModel.updateProductAttributes` when pressing the next button
  - Show an error notice if the product update fails.

# Demo

## Success
App | Web
--- | ---
![demo](https://user-images.githubusercontent.com/562080/107277116-fdd51f80-6a21-11eb-8aac-64727375664b.gif) | <img width="555" alt="Screen Shot 2021-02-08 at 3 14 55 PM" src="https://user-images.githubusercontent.com/562080/107277141-04fc2d80-6a22-11eb-80e9-22e8e433c24e.png">


## Fail
![demo-error](https://user-images.githubusercontent.com/562080/107277336-38d75300-6a22-11eb-94d4-c0f6d8884f0e.gif)

# Testing Steps

- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute or write a name for a new one.
- Tap one(or more) existing options or add new ones by writing their name on the text field.
- Tap on the "Next" button
- See that a loading spinner appears instead of the next button.
- When the loading finishes, check on the web your product attribute and corroborate that it updated successfully.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
