### PR TITLE
Pull the Stripe Terminal SDK as a dependency of the Hardware Package

### DIFF
--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -30,6 +30,6 @@ let package = Package(
             dependencies: ["StripeTerminal"]),
         .testTarget(
             name: "HardwareTests",
-            dependencies: ["Hardware", "StripeTerminal"]),
+            dependencies: ["Hardware"]),
     ]
 )

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // This should be fine wile we continue development, but if the Stripe SDK
         // does not provide official support for SPM whenever we start getting close
         // to release, we might need to migrate to CocoaPods.
-        .package(name: "StripeTerminal", url: "https://github.com/stripe/stripe-terminal-ios", .branch("spm_beta")),
+        .package(name: "StripeTerminal", url: "https://github.com/stripe/stripe-terminal-ios", .exact("1.4.0-spmbeta")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // Notice we are pulling a branch instead of a tag.
+        // Notice we are pulling a beta tag.
         // See https://github.com/stripe/stripe-terminal-ios/issues/61 for
         // a discussion and the rationale behind this decission.
         // This should be fine wile we continue development, but if the Stripe SDK

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -30,6 +30,6 @@ let package = Package(
             dependencies: ["StripeTerminal"]),
         .testTarget(
             name: "HardwareTests",
-            dependencies: ["Hardware"]),
+            dependencies: ["Hardware", "StripeTerminal"]),
     ]
 )

--- a/Hardware/Package.swift
+++ b/Hardware/Package.swift
@@ -14,14 +14,20 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        // Notice we are pulling a branch instead of a tag.
+        // See https://github.com/stripe/stripe-terminal-ios/issues/61 for
+        // a discussion and the rationale behind this decission.
+        // This should be fine wile we continue development, but if the Stripe SDK
+        // does not provide official support for SPM whenever we start getting close
+        // to release, we might need to migrate to CocoaPods.
+        .package(name: "StripeTerminal", url: "https://github.com/stripe/stripe-terminal-ios", .branch("spm_beta")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Hardware",
-            dependencies: []),
+            dependencies: ["StripeTerminal"]),
         .testTarget(
             name: "HardwareTests",
             dependencies: ["Hardware"]),

--- a/Hardware/Sources/Hardware/Hardware.swift
+++ b/Hardware/Sources/Hardware/Hardware.swift
@@ -1,3 +1,9 @@
+/// This import is here just to prove that the Stripe Terminal SDK has been
+/// imported correctly. Like the rest of the file, it will be removed as soon as we start working on either
+/// https://github.com/woocommerce/woocommerce-ios/issues/3587 or
+/// https://github.com/woocommerce/woocommerce-ios/issues/3589
+import StripeTerminal
+
 /// We want to bootsrap this package as soon as possible, so that we can
 /// start working on it in parallel.
 /// It also helps check that the package's test have been added to the proper testing plan.

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "StripeTerminal",
         "repositoryURL": "https://github.com/stripe/stripe-terminal-ios",
         "state": {
-          "branch": "spm_beta",
+          "branch": null,
           "revision": "48e6c75c74b0fe52c16dff54da53944c5d001008",
-          "version": "4.1.2"
+          "version": "1.4.0-spmbeta"
         }
       }
     ]

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
         "state": {
           "branch": "spm_beta",
           "revision": "48e6c75c74b0fe52c16dff54da53944c5d001008",
-          "version": null
+          "version": "4.1.2"
         }
       }
     ]

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "1f1fe7eeebeb06037c23a2a89d6f8f1271d625be",
           "version": "4.1.2"
         }
+      },
+      {
+        "package": "StripeTerminal",
+        "repositoryURL": "https://github.com/stripe/stripe-terminal-ios",
+        "state": {
+          "branch": "spm_beta",
+          "revision": "48e6c75c74b0fe52c16dff54da53944c5d001008",
+          "version": null
+        }
       }
     ]
   },


### PR DESCRIPTION
Closes #3595 
For context: p91TBi-4k7-p2 and p91TBi-4il-p2

This PR pulls the Stripe Terminal SDK specifically [the tag that supports SPM](https://github.com/stripe/stripe-terminal-ios/issues/61) as a dependency of Hardware. 

Hardware is a new (yet empty) Package introduced in #3615 

The dependency tree would be:

WooCommerce
    |
    | -> Hardware
            |
            | -> Stripe Terminal SDK


## Changes
* Added the Stripe Terminal SDK as a dependency to Hardware
* Import the Stripe Terminal into a struct declared in Hardware, just to prove that the build passes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
