### PR TITLE
Products: Fix dynamic type support for details text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
@@ -22,7 +22,7 @@ private extension EditableProductVariationModel {
         let detailsAttributedString = NSMutableAttributedString(attributedString: stockStatusAttributedString)
         detailsAttributedString.append(NSAttributedString(string: " • ", attributes: [
             .foregroundColor: UIColor.textSubtle,
-            .font: Style.detailsFont
+            .font: StyleManager.footerLabelFont
         ]))
         detailsAttributedString.append(variationStatusOrPriceAttributedString)
         return NSAttributedString(attributedString: detailsAttributedString)
@@ -33,7 +33,7 @@ private extension EditableProductVariationModel {
         return NSAttributedString(string: stockText,
                                   attributes: [
                                     .foregroundColor: UIColor.textSubtle,
-                                    .font: Style.detailsFont
+                                    .font: StyleManager.footerLabelFont
         ])
     }
 
@@ -58,7 +58,7 @@ private extension EditableProductVariationModel {
         let attributedString = NSMutableAttributedString(string: detailsText,
                                                          attributes: [
                                                             .foregroundColor: textColor,
-                                                            .font: Style.detailsFont
+                                                            .font: StyleManager.footerLabelFont
         ])
         return attributedString
     }
@@ -66,12 +66,6 @@ private extension EditableProductVariationModel {
     func createPriceText(currency: String, currencySettings: CurrencySettings) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         return currencyFormatter.formatAmount(productVariation.price, with: currency) ?? ""
-    }
-}
-
-private extension EditableProductVariationModel {
-    enum Style {
-        static let detailsFont = StyleManager.footerLabelFont
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3614

### Notes

> The details text should adjust size automatically; it probably just needs adjustsFontForContentSizeCategory set to true. (We have this for all label styles in UILabel+Helpers but this label has extra/conditional attributes so it isn't using those helpers.)

I followed this suggestion and set`adjustsFontForContentSizeCategory` to true, but unfortunately this didn't resolve the issue.
 
I'm not totally sure why directly calling `StyleManager.footerLabelFont` instead of `Style.detailsFont` fixes the issue.


### Testing instructions
1. Go to the Products tab.
2. Select a variable product.
3. Select Variations and notice you see a list of the product variations.
4. In the device's Settings app, go to Accessibility > Display & Text Size > Larger Text and use the slider to increase the font size.
5. Go back to the app.
6. ✅ Notice that the details text (stock status and price) for each variation has changed to a larger size.

### Demo
https://user-images.githubusercontent.com/6711616/107309347-9b395d80-6acd-11eb-8c57-6d767d7e5290.mov


