### PR TITLE
Variations: Resolve accessibility issues for edit variation attribute options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
@@ -37,6 +37,7 @@ final class AttributeOptionListSelectorCommand: ListSelectorCommand {
         case .option(let optionName):
             cell.textLabel?.text = optionName
         }
+        cell.textLabel?.numberOfLines = 0
     }
 
     func handleSelectedChange(selected: Row, viewController: ViewController) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.xib
@@ -30,8 +30,8 @@
             <constraints>
                 <constraint firstItem="LMJ-Yc-Ynh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="M7y-IN-pPj"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="LMJ-Yc-Ynh" secondAttribute="bottom" id="TaQ-Li-YYi"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="LMJ-Yc-Ynh" secondAttribute="trailing" id="Y1H-2Q-aGh"/>
-                <constraint firstItem="LMJ-Yc-Ynh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="lej-bj-WKL"/>
+                <constraint firstAttribute="trailing" secondItem="LMJ-Yc-Ynh" secondAttribute="trailing" id="Y1H-2Q-aGh"/>
+                <constraint firstItem="LMJ-Yc-Ynh" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="lej-bj-WKL"/>
             </constraints>
             <point key="canvasLocation" x="116" y="153"/>
         </view>


### PR DESCRIPTION
Fixes: #3600 

## Description

This PR fixes issues found in an accessibility review of "edit attributes" for product variations. Two main issues were found:

* Large Fonts: When editing a variation attribute, long attribute options can be cut off, especially with larger font sizes.
* Landscape: Margins are inconsistent on devices with notches. Some screens have edge-to-edge table cell backgrounds, while other screens have a left/right margin.

## Changes

* Large Fonts: In `AttributeOptionListSelectorCommand`, the attribute option label is set with `numberOfLines = 0` to allow multi-line text wrapping.
* Landscape: The constraints in `AttributePickerViewController.xib` are now set relative to the view edge and not the safe area. The content is still within the safe area but the table cell background now extends edge-to-edge (same as in `ListSelectorViewController`).

Note: I didn't change the landscape in other product/variations screens (such as `ProductVariationsViewController`). I'll follow up about this in a p2 post for discussion/clarification about landscape design throughout the rest of the app.

### Screenshots

Large Fonts - Before|Large Fonts - After
-|-
<img src="https://user-images.githubusercontent.com/8658164/107245745-67a3f800-6a27-11eb-97a2-36e2ee43f6a3.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/107400130-735fef00-6af9-11eb-8fa0-f193c34adec9.gif" width="300px">

/|Landscape
-|-
Before|![Attribute options - before](https://user-images.githubusercontent.com/8658164/107246951-b1d9a900-6a28-11eb-8bc2-656c387b4091.png)
After|![Attribute options - after](https://user-images.githubusercontent.com/8658164/107400338-a0ac9d00-6af9-11eb-93cd-f51d1dc2cb9d.png)




## Testing

Setup: You may need to add a new, longer attribute option to one of your variable products (on the web) before starting this testing.

1. Rotate your device to landscape orientation.
2. Go to the Products tab.
3. Select a variable product.
4. Select **Variations**.
5. Select a product variation.
6. Select **Attributes**.
7. Notice the Attributes table background extends edge-to-edge, while the table contents are within the safe area (not behind the device notch).
8. Select an attribute.
9. Notice the attribute options table background extends edge-to-edge, while the table contents are within the safe area (not behind the device notch), matching the Attributes screen.
10. Rotate your device to portrait orientation.
11. Increase the font size on your device (Settings app > Accessibility > Display & Text Size > Larger Text).
12. Confirm that no matter what font size is selected, you can view the full text of each attribute option in the list.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
