### PR TITLE
Variations: First Variation -> Notify when an attribute is updated

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -21,8 +21,10 @@ final class AddAttributeOptionsViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    /// Init
+    /// Initializer for `AddAttributeViewController`
     ///
+    /// - Parameters:
+    ///   - onCompletion: Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
     init(viewModel: AddAttributeOptionsViewModel,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          onCompletion: @escaping (Product) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -21,7 +21,7 @@ final class AddAttributeOptionsViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    /// Initializer for `AddAttributeViewController`
+    /// Initializer for `AddAttributeOptionsViewController`
     ///
     /// - Parameters:
     ///   - onCompletion: Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -11,6 +11,10 @@ final class AddAttributeOptionsViewController: UIViewController {
 
     private let noticePresenter: NoticePresenter
 
+    /// Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
+    ///
+    private let onCompletion: (Product) -> Void
+
     /// Keyboard management
     ///
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
@@ -19,9 +23,12 @@ final class AddAttributeOptionsViewController: UIViewController {
 
     /// Init
     ///
-    init(viewModel: AddAttributeOptionsViewModel, noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+    init(viewModel: AddAttributeOptionsViewModel,
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+         onCompletion: @escaping (Product) -> Void) {
         self.viewModel = viewModel
         self.noticePresenter = noticePresenter
+        self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -316,8 +323,7 @@ extension AddAttributeOptionsViewController {
             guard let self = self else { return }
             switch result {
             case let .success(product):
-                // TODO: Navigate to attributes screen, maybe clean the stack? #3536
-                print(product.attributes)
+                self.onCompletion(product)
             case let .failure(error):
                 self.noticePresenter.enqueue(notice: .init(title: Localization.updateAttributeError, feedbackType: .error))
                 DDLogError(error.localizedDescription)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -184,7 +184,7 @@ extension AddAttributeViewController: UITableViewDelegate {
             return
         }
         let attribute = viewModel.localAndGlobalAttributes[indexPath.row]
-        presentAddAttributeOptions(attribute: .existing(attribute: attribute))
+        presentAddAttributeOptions(for: .existing(attribute: attribute))
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -277,12 +277,12 @@ extension AddAttributeViewController {
         guard let name = viewModel.newAttributeName else {
             return
         }
-        presentAddAttributeOptions(attribute: .new(name: name))
+        presentAddAttributeOptions(for: .new(name: name))
     }
 
     /// Presents `AddAttributeOptionsViewController` and passes the same `onCompletion` closure, for our presenterVC  to handle.
     ///
-    private func presentAddAttributeOptions(attribute: AddAttributeOptionsViewModel.Attribute) {
+    private func presentAddAttributeOptions(for attribute: AddAttributeOptionsViewModel.Attribute) {
         let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: attribute)
         let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel, onCompletion: onCompletion)
         show(addAttributeOptionsVC, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -19,8 +19,10 @@ final class AddAttributeViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    /// Init
+    /// Initializer for `AddAttributeViewController`
     ///
+    /// - Parameters:
+    ///   - onCompletion: Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
     init(viewModel: AddAttributeViewModel, onCompletion: @escaping (Product) -> Void) {
         self.viewModel = viewModel
         self.onCompletion = onCompletion

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -9,6 +9,10 @@ final class AddAttributeViewController: UIViewController {
 
     private let viewModel: AddAttributeViewModel
 
+    /// Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
+    ///
+    private let onCompletion: (Product) -> Void
+
     /// Keyboard management
     ///
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
@@ -17,8 +21,9 @@ final class AddAttributeViewController: UIViewController {
 
     /// Init
     ///
-    init(viewModel: AddAttributeViewModel) {
+    init(viewModel: AddAttributeViewModel, onCompletion: @escaping (Product) -> Void) {
         self.viewModel = viewModel
+        self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -273,11 +278,11 @@ extension AddAttributeViewController {
         presentAddAttributeOptions(attribute: .new(name: name))
     }
 
+    /// Presents `AddAttributeOptionsViewController` and passes the same `onCompletion` closure, for our presenterVC  to handle.
+    ///
     private func presentAddAttributeOptions(attribute: AddAttributeOptionsViewModel.Attribute) {
         let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: attribute)
-        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel) { product in
-            print(product.attributes)
-        }
+        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel, onCompletion: onCompletion)
         show(addAttributeOptionsVC, sender: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -176,7 +176,8 @@ extension AddAttributeViewController: UITableViewDelegate {
         guard row == .existingAttribute else {
             return
         }
-        presentAddAttributeOptions(for: viewModel.localAndGlobalAttributes[indexPath.row])
+        let attribute = viewModel.localAndGlobalAttributes[indexPath.row]
+        presentAddAttributeOptions(attribute: .existing(attribute: attribute))
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -269,19 +270,15 @@ extension AddAttributeViewController {
         guard let name = viewModel.newAttributeName else {
             return
         }
-        presentAddAttributeOptions(for: name)
+        presentAddAttributeOptions(attribute: .new(name: name))
     }
 
-    private func presentAddAttributeOptions(for newAttribute: String) {
-        let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: .new(name: newAttribute))
-        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
-        navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
-    }
-
-    private func presentAddAttributeOptions(for existingAttribute: ProductAttribute) {
-        let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: .existing(attribute: existingAttribute))
-        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel)
-        navigationController?.pushViewController(addAttributeOptionsVC, animated: true)
+    private func presentAddAttributeOptions(attribute: AddAttributeOptionsViewModel.Attribute) {
+        let viewModel = AddAttributeOptionsViewModel(product: self.viewModel.product, attribute: attribute)
+        let addAttributeOptionsVC = AddAttributeOptionsViewController(viewModel: viewModel) { product in
+            print(product.attributes)
+        }
+        show(addAttributeOptionsVC, sender: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -90,7 +90,7 @@ final class ProductVariationsViewController: UIViewController {
         return stateCoordinator
     }()
 
-    private let product: Product
+    private var product: Product
     private let siteID: Int64
     private let productID: Int64
     private let allAttributes: [ProductAttribute]
@@ -368,7 +368,13 @@ extension ProductVariationsViewController: UITableViewDelegate {
 private extension ProductVariationsViewController {
     func navigateToAddAttributeViewController() {
         let viewModel = AddAttributeViewModel(product: product)
-        let addAttributeViewController = AddAttributeViewController(viewModel: viewModel)
+        let addAttributeViewController = AddAttributeViewController(viewModel: viewModel) { [weak self] updatedProduct in
+            guard let self = self else { return }
+            self.product = updatedProduct
+
+            // TODO: Replace stack with AttributeList UI in #3536
+            self.navigationController?.popToViewController(self, animated: true)
+        }
         show(addAttributeViewController, sender: self)
     }
 }


### PR DESCRIPTION
closes #3618  

# Why

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: **Add completion blogs to notify when a product attribute is updated/created**

Note: This PR, temporarily drives you back to the empty state screen, #3536 will be in charge of displaying the correct screen later.

# How

- Add `onCompletion` closures to `AddAttributeViewController` and `AddAttributeOptionsViewController`
- Set that `onCompletion` closure on  `ProductVariationsViewController` and update the `product` property when the flow is finished.


# Demo
![demo](https://user-images.githubusercontent.com/562080/107404233-11d95980-6ad4-11eb-9c5a-65de937fe76b.gif)

# Testing Steps
- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute or write a name for a new one.
- Tap one(or more) existing options or add new ones by writing their name on the text field.
- Tap on the "Next" button
- See that a loading spinner appears instead of the next button.
- When the loading finishes, see that you are redirected back to the empty state screen.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
