### PR TITLE
Networking layer: added Shipping Labels address validation endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 4599FC5B24A6276F0056157A /* product-tags-all.json */; };
 		4599FC5E24A62AA70056157A /* ProductTagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4599FC5D24A62AA70056157A /* ProductTagsRemote.swift */; };
 		4599FC6624A633A10056157A /* ProductTagsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */; };
+		45A4B84A25D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */; };
+		45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */; };
 		45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */; };
 		45AB8B1324AA34CB00B5B36E /* product-tags-deleted.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */; };
 		45AB8B2024AB3E1F00B5B36E /* product-tags-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */; };
@@ -560,6 +562,8 @@
 		4599FC5B24A6276F0056157A /* product-tags-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-all.json"; sourceTree = "<group>"; };
 		4599FC5D24A62AA70056157A /* ProductTagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsRemote.swift; sourceTree = "<group>"; };
 		4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsRemoteTests.swift; sourceTree = "<group>"; };
+		45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationResponse.swift; sourceTree = "<group>"; };
+		45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationResponseMapper.swift; sourceTree = "<group>"; };
 		45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-created.json"; sourceTree = "<group>"; };
 		45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-deleted.json"; sourceTree = "<group>"; };
 		45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-empty.json"; sourceTree = "<group>"; };
@@ -882,6 +886,7 @@
 				02C254A7256373AB00A04423 /* ShippingLabel.swift */,
 				02C2549925636E1500A04423 /* ShippingLabelAddress.swift */,
 				457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */,
+				45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 			);
@@ -1408,6 +1413,7 @@
 				02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */,
 				029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */,
 				021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */,
+				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1916,6 +1922,7 @@
 				D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
+				45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift in Sources */,
 				45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */,
 				D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */,
 				B5C151BB217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift in Sources */,
@@ -2017,6 +2024,7 @@
 				26B2F74B24C696C00065CCC8 /* LeaderboardRow.swift in Sources */,
 				D823D90D2237784A00C90817 /* ShipmentTrackingProvider.swift in Sources */,
 				021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */,
+				45A4B84A25D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift in Sources */,
 				CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */,
 				B557DA0420975500005962F4 /* OrdersRemote.swift in Sources */,
 				CE43066C2347C5F90073CBFF /* OrderItemRefund.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		4568E2242459D3230007E478 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2232459D3230007E478 /* Post.swift */; };
 		456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456F71D324CB1E2400472EC1 /* ProductTagFromBatchCreation.swift */; };
 		457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457453E625A72C9700276508 /* CreateProductVariation.swift */; };
+		457A574025D1817E000797AD /* ShippingLabelAddressVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */; };
 		457FC68C2382B2FD00B41B02 /* product-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update.json */; };
 		458C6DE425AC72A1009B300D /* StoredProductSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458C6DE325AC72A1009B300D /* StoredProductSettings.swift */; };
 		4599FC5824A624BD0056157A /* ProductTagListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4599FC5724A624BD0056157A /* ProductTagListMapper.swift */; };
@@ -551,6 +552,7 @@
 		4568E2232459D3230007E478 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		456F71D324CB1E2400472EC1 /* ProductTagFromBatchCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagFromBatchCreation.swift; sourceTree = "<group>"; };
 		457453E625A72C9700276508 /* CreateProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProductVariation.swift; sourceTree = "<group>"; };
+		457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressVerification.swift; sourceTree = "<group>"; };
 		457FC68B2382B2FD00B41B02 /* product-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update.json"; sourceTree = "<group>"; };
 		458C6DE325AC72A1009B300D /* StoredProductSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredProductSettings.swift; sourceTree = "<group>"; };
 		4599FC5724A624BD0056157A /* ProductTagListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagListMapper.swift; sourceTree = "<group>"; };
@@ -879,6 +881,7 @@
 				029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */,
 				02C254A7256373AB00A04423 /* ShippingLabel.swift */,
 				02C2549925636E1500A04423 /* ShippingLabelAddress.swift */,
+				457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 			);
@@ -1855,6 +1858,7 @@
 				D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */,
 				B557DA1A20979D66005962F4 /* Settings.swift in Sources */,
 				CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */,
+				457A574025D1817E000797AD /* ShippingLabelAddressVerification.swift in Sources */,
 				74ABA1D1213F22CA00FFAD30 /* TopEarnersStatsRemote.swift in Sources */,
 				025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */,
 				02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		4599FC6624A633A10056157A /* ProductTagsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */; };
 		45A4B84A25D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */; };
 		45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */; };
+		45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */; };
+		45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */; };
 		45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */; };
 		45AB8B1324AA34CB00B5B36E /* product-tags-deleted.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */; };
 		45AB8B2024AB3E1F00B5B36E /* product-tags-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */; };
@@ -564,6 +566,8 @@
 		4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsRemoteTests.swift; sourceTree = "<group>"; };
 		45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationResponse.swift; sourceTree = "<group>"; };
 		45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationResponseMapper.swift; sourceTree = "<group>"; };
+		45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-validation-success.json"; sourceTree = "<group>"; };
+		45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-validation-error.json"; sourceTree = "<group>"; };
 		45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-created.json"; sourceTree = "<group>"; };
 		45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-deleted.json"; sourceTree = "<group>"; };
 		45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-empty.json"; sourceTree = "<group>"; };
@@ -1335,6 +1339,8 @@
 				D823D91322377EE600C90817 /* shipment_tracking_providers.json */,
 				028FA471257E110700F88A48 /* shipping-label-refund-error.json */,
 				028FA472257E110700F88A48 /* shipping-label-refund-success.json */,
+				45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */,
+				45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */,
 				B56C1EB920EA7D2C00D749F9 /* sites.json */,
 				7426CA1221AF34A3004E9FFC /* site-api.json */,
 				74AB5B4E21AF3F0D00859C12 /* site-api-no-woo.json */,
@@ -1681,6 +1687,7 @@
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
+				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
 				740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */,
 				B5147876211B9227007562E5 /* broken-orders-mark-2.json in Resources */,
 				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,
@@ -1777,6 +1784,7 @@
 				743E84F622172D3E00FAC9D7 /* shipment_tracking_single.json in Resources */,
 				4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */,
 				020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */,
+				45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */,
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
 				02F096C22406691100C0C1D5 /* media-library.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */; };
 		45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */; };
 		45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */; };
+		45A4B86225D3086600776FB4 /* ShippingLabelAddressValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */; };
 		45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */; };
 		45AB8B1324AA34CB00B5B36E /* product-tags-deleted.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */; };
 		45AB8B2024AB3E1F00B5B36E /* product-tags-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */; };
@@ -568,6 +569,7 @@
 		45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationResponseMapper.swift; sourceTree = "<group>"; };
 		45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-validation-success.json"; sourceTree = "<group>"; };
 		45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-validation-error.json"; sourceTree = "<group>"; };
+		45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationError.swift; sourceTree = "<group>"; };
 		45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-created.json"; sourceTree = "<group>"; };
 		45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-deleted.json"; sourceTree = "<group>"; };
 		45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-tags-empty.json"; sourceTree = "<group>"; };
@@ -891,6 +893,7 @@
 				02C2549925636E1500A04423 /* ShippingLabelAddress.swift */,
 				457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */,
 				45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */,
+				45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 			);
@@ -2030,6 +2033,7 @@
 				B524194121AC60A700D6FC0A /* DotcomDevice.swift in Sources */,
 				4599FC5824A624BD0056157A /* ProductTagListMapper.swift in Sources */,
 				26B2F74B24C696C00065CCC8 /* LeaderboardRow.swift in Sources */,
+				45A4B86225D3086600776FB4 /* ShippingLabelAddressValidationError.swift in Sources */,
 				D823D90D2237784A00C90817 /* ShipmentTrackingProvider.swift in Sources */,
 				021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */,
 				45A4B84A25D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelAddressValidationResponseMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAddressValidationResponseMapper.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+
+/// Mapper: Shipping Label Address Validation Response
+///
+struct ShippingLabelAddressValidationResponseMapper: Mapper {
+    /// (Attempts) to convert a dictionary into ShippingLabelAddress.
+    ///
+    func map(response: Data) throws -> ShippingLabelAddress {
+        let decoder = JSONDecoder()
+        return try decoder.decode(ShippingLabelAddressValidationResponseEnvelope.self, from: response).data.address
+    }
+}
+
+/// ShippingLabelAddressValidationResponseEnvelope Disposable Entity:
+/// `Normalize Address` endpoint returns the shipping label address document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ShippingLabelAddressValidationResponseEnvelope: Decodable {
+    let data: ShippingLabelAddressValidationResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ShippingLabelAddressValidationResponseMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAddressValidationResponseMapper.swift
@@ -4,11 +4,11 @@ import Foundation
 /// Mapper: Shipping Label Address Validation Response
 ///
 struct ShippingLabelAddressValidationResponseMapper: Mapper {
-    /// (Attempts) to convert a dictionary into ShippingLabelAddress.
+    /// (Attempts) to convert a dictionary into ShippingLabelAddressValidationResponse.
     ///
-    func map(response: Data) throws -> ShippingLabelAddress {
+    func map(response: Data) throws -> ShippingLabelAddressValidationResponse {
         let decoder = JSONDecoder()
-        return try decoder.decode(ShippingLabelAddressValidationResponseEnvelope.self, from: response).data.address
+        return try decoder.decode(ShippingLabelAddressValidationResponseEnvelope.self, from: response).data
     }
 }
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -51,8 +51,22 @@ public struct ShippingLabelAddress: Equatable {
     }
 }
 
-// MARK: Decodable
-extension ShippingLabelAddress: Decodable {
+// MARK: Codable
+extension ShippingLabelAddress: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(company, forKey: .company)
+        try container.encode(name, forKey: .name)
+        try container.encode(phone, forKey: .phone)
+        try container.encode(country, forKey: .country)
+        try container.encode(state, forKey: .state)
+        try container.encode(address1, forKey: .address1)
+        try container.encode(address2, forKey: .address2)
+        try container.encode(city, forKey: .city)
+        try container.encode(postcode, forKey: .postcode)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case company
         case name

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Represents Shipping Label Address Validation Error.
+///
+public struct ShippingLabelAddressValidationError: Equatable {
+    public let address: String?
+    public let general: String?
+
+    public init(address: String?, general: String?) {
+        self.address = address
+        self.general = general
+    }
+}
+
+extension ShippingLabelAddressValidationError: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let address = try container.decodeIfPresent(String.self, forKey: .address)
+        let general = try container.decodeIfPresent(String.self, forKey: .address)
+        self.init(address: address, general: general)
+    }
+}
+
+/// Defines all of the ShippingLabelAddressValidationError CodingKeys
+///
+private extension ShippingLabelAddressValidationError {
+    enum CodingKeys: String, CodingKey {
+        case address
+        case general
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
@@ -16,7 +16,7 @@ extension ShippingLabelAddressValidationError: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let address = try container.decodeIfPresent(String.self, forKey: .address)
-        let general = try container.decodeIfPresent(String.self, forKey: .address)
+        let general = try container.decodeIfPresent(String.self, forKey: .general)
         self.init(address: address, general: general)
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
@@ -3,21 +3,21 @@ import Foundation
 /// Represents Shipping Label Address Validation Error.
 ///
 public struct ShippingLabelAddressValidationError: Equatable {
-    public let address: String?
-    public let general: String?
+    public let addressError: String?
+    public let generalError: String?
 
-    public init(address: String?, general: String?) {
-        self.address = address
-        self.general = general
+    public init(addressError: String?, generalError: String?) {
+        self.addressError = addressError
+        self.generalError = generalError
     }
 }
 
 extension ShippingLabelAddressValidationError: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let address = try container.decodeIfPresent(String.self, forKey: .address)
-        let general = try container.decodeIfPresent(String.self, forKey: .general)
-        self.init(address: address, general: general)
+        let addressError = try container.decodeIfPresent(String.self, forKey: .address)
+        let generalError = try container.decodeIfPresent(String.self, forKey: .general)
+        self.init(addressError: addressError, generalError: generalError)
     }
 }
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Represents Shipping Label Address that has been validated.
+///
+public struct ShippingLabelAddressValidationResponse: Equatable {
+    public let address: ShippingLabelAddress
+
+    public init(address: ShippingLabelAddress) {
+        self.address = address
+    }
+}
+
+extension ShippingLabelAddressValidationResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let address = try container.decode(ShippingLabelAddress.self, forKey: .address)
+        self.init(address: address)
+    }
+}
+
+/// Defines all of the ShippingLabelAddressValidationResponse CodingKeys
+///
+private extension ShippingLabelAddressValidationResponse {
+    enum CodingKeys: String, CodingKey {
+        case address = "normalized"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
@@ -1,20 +1,23 @@
 import Foundation
 
-/// Represents Shipping Label Address that has been validated.
+/// Represents Shipping Label Address that has been validated or that generated an error.
 ///
 public struct ShippingLabelAddressValidationResponse: Equatable {
-    public let address: ShippingLabelAddress
+    public let address: ShippingLabelAddress?
+    public let errors: ShippingLabelAddressValidationError?
 
-    public init(address: ShippingLabelAddress) {
+    public init(address: ShippingLabelAddress?, errors: ShippingLabelAddressValidationError?) {
         self.address = address
+        self.errors = errors
     }
 }
 
 extension ShippingLabelAddressValidationResponse: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let address = try container.decode(ShippingLabelAddress.self, forKey: .address)
-        self.init(address: address)
+        let address = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .address)
+        let errors = try container.decodeIfPresent(ShippingLabelAddressValidationError.self, forKey: .errors)
+        self.init(address: address, errors: errors)
     }
 }
 
@@ -23,5 +26,6 @@ extension ShippingLabelAddressValidationResponse: Decodable {
 private extension ShippingLabelAddressValidationResponse {
     enum CodingKeys: String, CodingKey {
         case address = "normalized"
+        case errors = "field_errors"
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressVerification.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressVerification.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Represents Shipping Label Address that should be verified.
+///
+public struct ShippingLabelAddressVerification: Equatable {
+    public let address: ShippingLabelAddress
+    public let type: ShipType
+
+    public init(address: ShippingLabelAddress, type: ShipType) {
+        self.address = address
+        self.type = type
+    }
+
+    /// Represents all of the possible Type Statuses in enum form.
+    /// It can be either be destination for the `Ship TO` address OR `origin` for the `Ship FROM` address.
+    ///
+    public enum ShipType: String, Encodable, Hashable {
+        case origin
+        case destination
+    }
+}
+
+extension ShippingLabelAddressVerification: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(address, forKey: .address)
+        try container.encode(type, forKey: .type)
+    }
+}
+
+/// Defines all of the ShippingLabelAddressVerification CodingKeys
+///
+private extension ShippingLabelAddressVerification {
+    enum CodingKeys: String, CodingKey {
+        case address
+        case type
+    }
+}

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -11,6 +11,9 @@ public protocol ShippingLabelRemoteProtocol {
                              orderID: Int64,
                              shippingLabelID: Int64,
                              completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void)
+    func addressValidation(siteID: Int64,
+                           address: ShippingLabelAddressVerification,
+                           completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -62,12 +65,32 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
         let mapper = ShippingLabelRefundMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Address validation for a shipping address.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the shipping label.
+    ///   - address: The address that should be verified.
+    ///   - completion: Closure to be executed upon completion.
+    public func addressValidation(siteID: Int64,
+                                  address: ShippingLabelAddressVerification,
+                                  completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void) {
+        do {
+            let parameters = try address.toDictionary()
+            let path = "\(Path.normalizeAddress)"
+            let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let mapper = ShippingLabelAddressValidationResponseMapper()
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constant
 private extension ShippingLabelRemote {
     enum Path {
         static let shippingLabels = "label"
+        static let normalizeAddress = "normalize-address"
     }
 
     enum ParameterKey {

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -13,7 +13,7 @@ public protocol ShippingLabelRemoteProtocol {
                              completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void)
     func addressValidation(siteID: Int64,
                            address: ShippingLabelAddressVerification,
-                           completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void)
+                           completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -73,7 +73,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     ///   - completion: Closure to be executed upon completion.
     public func addressValidation(siteID: Int64,
                                   address: ShippingLabelAddressVerification,
-                                  completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void) {
+                                  completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void) {
         do {
             let parameters = try address.toDictionary()
             let path = "\(Path.normalizeAddress)"

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -11,9 +11,6 @@ public protocol ShippingLabelRemoteProtocol {
                              orderID: Int64,
                              shippingLabelID: Int64,
                              completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void)
-    func addressValidation(siteID: Int64,
-                           address: ShippingLabelAddressVerification,
-                           completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -11,6 +11,9 @@ public protocol ShippingLabelRemoteProtocol {
                              orderID: Int64,
                              shippingLabelID: Int64,
                              completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void)
+    func addressValidation(siteID: Int64,
+                           address: ShippingLabelAddressVerification,
+                           completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -100,4 +100,62 @@ final class ShippingLabelRemoteTests: XCTestCase {
                         "The parcel has been shipped. ( 400 )")
         XCTAssertEqual(result.failure as? DotcomError, expectedError)
     }
+
+    func test_shippingAddressValidation_returns_address_on_success() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "normalize-address", filename: "shipping-label-address-validation-success")
+
+        // When
+        let result: Result<ShippingLabelAddressValidationResponse, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID, address: self.sampleShippingLabelAddressVerification()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let address = try XCTUnwrap(result.get().address)
+        let errors = try result.get().errors
+        XCTAssertEqual(address, sampleShippingLabelAddress())
+        XCTAssertNil(errors)
+    }
+
+    func test_shippingAddressValidation_returns_errors_on_failure() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "normalize-address", filename: "shipping-label-address-validation-error")
+
+        // When
+        let result: Result<ShippingLabelAddressValidationResponse, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID, address: self.sampleShippingLabelAddressVerification()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let address = try result.get().address
+        let errors = try XCTUnwrap(result.get().errors)
+        XCTAssertNil(address)
+        XCTAssertEqual(errors.address, "House number is missing")
+        XCTAssertEqual(errors.general, "Address not found")
+    }
+}
+
+private extension ShippingLabelRemoteTests {
+    func sampleShippingLabelAddressVerification() -> ShippingLabelAddressVerification {
+        let type: ShippingLabelAddressVerification.ShipType = .destination
+        return ShippingLabelAddressVerification(address: sampleShippingLabelAddress(), type: type)
+    }
+
+    func sampleShippingLabelAddress() -> ShippingLabelAddress {
+        return ShippingLabelAddress(company: "",
+                                    name: "Anitaa",
+                                    phone: "41535032",
+                                    country: "US",
+                                    state: "CA",
+                                    address1: "60 29TH ST # 343",
+                                    address2: "",
+                                    city: "SAN FRANCISCO",
+                                    postcode: "94110-4929")
+    }
 }

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -136,8 +136,8 @@ final class ShippingLabelRemoteTests: XCTestCase {
         let address = try result.get().address
         let errors = try XCTUnwrap(result.get().errors)
         XCTAssertNil(address)
-        XCTAssertEqual(errors.address, "House number is missing")
-        XCTAssertEqual(errors.general, "Address not found")
+        XCTAssertEqual(errors.addressError, "House number is missing")
+        XCTAssertEqual(errors.generalError, "Address not found")
     }
 }
 

--- a/Networking/NetworkingTests/Responses/shipping-label-address-validation-error.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-address-validation-error.json
@@ -1,0 +1,6 @@
+{
+    "success": true,
+    "field_errors": {
+        "general": "Address not found"
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-address-validation-error.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-address-validation-error.json
@@ -1,6 +1,9 @@
 {
-    "success": true,
-    "field_errors": {
-        "general": "Address not found"
+    "data" : {
+        "success" : true,
+        "field_errors" : {
+            "address" : "House number is missing",
+            "general" : "Address not found"
+        }
     }
 }

--- a/Networking/NetworkingTests/Responses/shipping-label-address-validation-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-address-validation-success.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "success": true,
+        "normalized": {
+            "address_2": "",
+            "city": "SAN FRANCISCO",
+            "state": "CA",
+            "postcode": "94110-4929",
+            "country": "US",
+            "address": "60 29TH ST # 343",
+            "name": "Anitaa",
+            "company": "",
+            "phone": "41535032"
+        },
+        "is_trivial_normalization": false
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -23,6 +23,10 @@ final class MockShippingLabelRemote {
         let shippingLabelID: Int64
     }
 
+    private struct AddressValidationResultKey: Hashable {
+        let siteID: Int64
+    }
+
     /// The results to return based on the given arguments in `loadShippingLabels`
     private var loadAllResults = [LoadAllResultKey: Result<OrderShippingLabelListResponse, Error>]()
 
@@ -31,6 +35,9 @@ final class MockShippingLabelRemote {
 
     /// The results to return based on the given arguments in `refundShippingLabel`
     private var refundResults = [RefundResultKey: Result<ShippingLabelRefund, Error>]()
+
+    /// The results to return based on the given arguments in `addressValidation`
+    private var addressValidationResults = [AddressValidationResultKey: Result<ShippingLabelAddress, Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -56,6 +63,13 @@ final class MockShippingLabelRemote {
                                     thenReturn result: Result<ShippingLabelRefund, Error>) {
         let key = RefundResultKey(siteID: siteID, orderID: orderID, shippingLabelID: shippingLabelID)
         refundResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `addressValidation` is called.
+    func whenValidatingAddress(siteID: Int64,
+                               thenReturn result: Result<ShippingLabelAddress, Error>) {
+        let key = AddressValidationResultKey(siteID: siteID)
+        addressValidationResults[key] = result
     }
 }
 
@@ -96,6 +110,19 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = RefundResultKey(siteID: siteID, orderID: orderID, shippingLabelID: shippingLabelID)
             if let result = self.refundResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func addressValidation(siteID: Int64, address: ShippingLabelAddressVerification, completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = AddressValidationResultKey(siteID: siteID)
+            if let result = self.addressValidationResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -37,7 +37,7 @@ final class MockShippingLabelRemote {
     private var refundResults = [RefundResultKey: Result<ShippingLabelRefund, Error>]()
 
     /// The results to return based on the given arguments in `addressValidation`
-    private var addressValidationResults = [AddressValidationResultKey: Result<ShippingLabelAddress, Error>]()
+    private var addressValidationResults = [AddressValidationResultKey: Result<ShippingLabelAddressValidationResponse, Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -67,7 +67,7 @@ final class MockShippingLabelRemote {
 
     /// Set the value passed to the `completion` block if `addressValidation` is called.
     func whenValidatingAddress(siteID: Int64,
-                               thenReturn result: Result<ShippingLabelAddress, Error>) {
+                               thenReturn result: Result<ShippingLabelAddressValidationResponse, Error>) {
         let key = AddressValidationResultKey(siteID: siteID)
         addressValidationResults[key] = result
     }
@@ -117,7 +117,8 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
         }
     }
 
-    func addressValidation(siteID: Int64, address: ShippingLabelAddressVerification, completion: @escaping (Result<ShippingLabelAddress, Error>) -> Void) {
+    func addressValidation(siteID: Int64, address: ShippingLabelAddressVerification,
+                           completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 


### PR DESCRIPTION
Part of #2969

## Description
As part of Shipping Labels Milestone 2 we need to validate the address (origin and destination) for the Shipping Labels.
In this PR, I implemented the networking layer to verify an address. Unlike the other endpoints in the app, the response can contain the verified address or a list of errors.

## Changes
- `ShippingLabelAddress` now conform to `Codable`.
- Implemented the new model `ShippingLabelAddressVerification` that contains the parameters that should be passed to the validation endpoint.
- Implemented the new model `ShippingLabelAddressValidationResponse` that parses the response of the validation endpoint, that can return the `address` or a list of `errors` (two for the moments).
- Implemented the new model `ShippingLabelAddressValidationError` that parses the `field_errors` under the validation response in case of error during the validation.
- Implemented `ShippingLabelAddressValidationResponseMapper` that convert a dictionary into `ShippingLabelAddressValidationResponse`.
- Implemented the method `addressValidation` under `ShippingLabelRemote` + tests.
- Added two JSON sample responses `shipping-label-address-validation-error.json` and `shipping-label-address-validation-success.json`.
- implemented the address validation result under `MockShippingLabelRemote`.
 
## Testing
- Just CI, for the moment this code is not used and will be useful later.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
