### PR TITLE
Shipping Labels: Apply body style when updating cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -132,6 +132,7 @@ extension ImageAndTitleAndTextTableViewCell {
     func updateUI(viewModel: ViewModel) {
         titleLabel.text = viewModel.title
         titleLabel.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
+        titleLabel.applyBodyStyle()
         titleLabel.textColor = viewModel.text?.isEmpty == false ? .text: .textSubtle
         titleLabel.numberOfLines = viewModel.numberOfLinesForTitle
         descriptionLabel.text = viewModel.text


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3576

### Description
- Fixes issue where the refunded shipping label row's title was being displayed in a footnote font style

### Notes
- This issue seems to be caused by cell reuse (https://github.com/woocommerce/woocommerce-ios/issues/3576#issuecomment-775727271)

### Testing instructions
1. Create an order
2. Create multiple shipping labels by following the shipping label testing guide (Internal ref: p91TBi-3xD-p2)
3. Refund one of the shipping labels by tapping on the ellipsis icon of a shipping label item of an order, the tapping on the Request a refund button
4. ✅ The refunded shipping label row should be displayed in a body font style

### Screenshot

Before | After 
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-10 at 11 05 08](https://user-images.githubusercontent.com/6711616/107455334-02b8e100-6b92-11eb-965c-34735cd11e9f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-10 at 11 13 00](https://user-images.githubusercontent.com/6711616/107455338-0482a480-6b92-11eb-8111-104b48f97cbb.png)






Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
