### PR TITLE
Variations: First Variation -> Navigate to EditAttributeList after creating first attribute

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+/// EditAttributesViewController: Displays the list of attributes for a product.
+///
+final class EditAttributesViewController: UIViewController {
+
+    @IBOutlet private weak var addButton: UIButton!
+    @IBOutlet private weak var addButtonSeparator: UIView!
+    @IBOutlet private var tableView: UITableView!
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -53,10 +53,7 @@ private extension EditAttributesViewController {
     }
 
     func configureRightButton() {
-        let rightBarButton = UIBarButtonItem(title: Localization.done,
-                                             style: .done,
-                                             target: self,
-                                             action: #selector(doneButtonTapped))
+        let rightBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -22,7 +22,7 @@ final class EditAttributesViewController: UIViewController {
 // MARK: - View Configuration
 private extension EditAttributesViewController {
     func registerTableViewCells() {
-//        tableView.registerNib(for: ProductCategoryTableViewCell.self)
+        tableView.registerNib(for: ImageAndTitleAndTextTableViewCell.self)
     }
 
     func configureAddButton() {
@@ -38,15 +38,14 @@ private extension EditAttributesViewController {
     func configureTableView() {
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground
-//        tableView.dataSource = self
-//        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.delegate = self
         tableView.removeLastCellSeparator()
     }
 
     func configureNavigationBar() {
         configureTitle()
         configureRightButton()
-        removeNavigationBackBarButtonText()
     }
 
     func configureTitle() {
@@ -71,9 +70,31 @@ extension EditAttributesViewController {
     @objc private func addButtonTapped() {
         // TODO: Launch add attribute flow and update product upon completion
     }
+}
 
-    override func shouldPopOnSwipeBack() -> Bool {
-        return false
+// MARK: - UITableView conformance
+//
+extension EditAttributesViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 6 // Temporary
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(ImageAndTitleAndTextTableViewCell.self, for: indexPath)
+
+        // Temporary
+        let vm = ImageAndTitleAndTextTableViewCell.ViewModel(title: "Color",
+                                                             text: "Green, Yellow, Blue",
+                                                             numberOfLinesForTitle: 0,
+                                                             numberOfLinesForText: 0)
+        cell.updateUI(viewModel: vm)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO: Navigate to edit attribute
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -7,4 +7,81 @@ final class EditAttributesViewController: UIViewController {
     @IBOutlet private weak var addButton: UIButton!
     @IBOutlet private weak var addButtonSeparator: UIView!
     @IBOutlet private var tableView: UITableView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureAddButton()
+        configureAddButtonSeparator()
+        registerTableViewCells()
+        configureTableView()
+        configureNavigationBar()
+        handleSwipeBackGesture()
+    }
+}
+
+// MARK: - View Configuration
+private extension EditAttributesViewController {
+    func registerTableViewCells() {
+//        tableView.registerNib(for: ProductCategoryTableViewCell.self)
+    }
+
+    func configureAddButton() {
+        addButton.setTitle(Localization.addNewAttribute, for: .normal)
+        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        addButton.applySecondaryButtonStyle()
+    }
+
+    func configureAddButtonSeparator() {
+        addButtonSeparator.backgroundColor = .systemColor(.separator)
+    }
+
+    func configureTableView() {
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+//        tableView.dataSource = self
+//        tableView.delegate = self
+        tableView.removeLastCellSeparator()
+    }
+
+    func configureNavigationBar() {
+        configureTitle()
+        configureRightButton()
+        removeNavigationBackBarButtonText()
+    }
+
+    func configureTitle() {
+        title = Localization.title
+    }
+
+    func configureRightButton() {
+        let rightBarButton = UIBarButtonItem(title: Localization.done,
+                                             style: .done,
+                                             target: self,
+                                             action: #selector(doneButtonTapped))
+        navigationItem.setRightBarButton(rightBarButton, animated: false)
+    }
+}
+
+// MARK: Button Actions & Navigation Handling
+extension EditAttributesViewController {
+    @objc private func doneButtonTapped() {
+        // TODO: Create variation and notify back
+    }
+
+    @objc private func addButtonTapped() {
+        // TODO: Launch add attribute flow and update product upon completion
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return false
+    }
+}
+
+// MARK: Constants
+private extension EditAttributesViewController {
+    enum Localization {
+        static let addNewAttribute = NSLocalizedString("Add New Attribute", comment: "Action to add new attribute on the Product Attributes screen")
+        static let title = NSLocalizedString("Edit Attributes", comment: "Navigation title for the Product Attributes screen")
+        static let done = NSLocalizedString("Done", comment: "Button title for the Done Action on the navigation bar")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.xib
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EditAttributesViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="addButton" destination="kdx-D1-LQl" id="XC3-ze-0Wd"/>
+                <outlet property="addButtonSeparator" destination="jcH-eR-YQX" id="TDG-g3-g0T"/>
+                <outlet property="tableView" destination="qiC-rL-M9o" id="s2s-eM-Ggv"/>
+                <outlet property="view" destination="VM8-dE-9OM" id="iaC-tH-174"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="VM8-dE-9OM">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="qiC-rL-M9o">
+                    <rect key="frame" x="0.0" y="106" width="414" height="756"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JgB-I2-Oin" userLabel="Top Container View">
+                    <rect key="frame" x="0.0" y="44" width="414" height="62"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kdx-D1-LQl">
+                            <rect key="frame" x="16" y="16" width="382" height="30"/>
+                            <state key="normal" title="Button"/>
+                        </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jcH-eR-YQX">
+                            <rect key="frame" x="0.0" y="61.5" width="414" height="0.5"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="nTR-cx-fjN"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="jcH-eR-YQX" secondAttribute="trailing" id="FeC-CZ-qha"/>
+                        <constraint firstItem="kdx-D1-LQl" firstAttribute="leading" secondItem="JgB-I2-Oin" secondAttribute="leading" constant="16" id="PHN-Mn-Ged"/>
+                        <constraint firstItem="kdx-D1-LQl" firstAttribute="top" secondItem="JgB-I2-Oin" secondAttribute="top" constant="16" id="c6H-ZR-2vv"/>
+                        <constraint firstItem="jcH-eR-YQX" firstAttribute="leading" secondItem="JgB-I2-Oin" secondAttribute="leading" id="cAM-Ml-GJf"/>
+                        <constraint firstItem="kdx-D1-LQl" firstAttribute="centerX" secondItem="JgB-I2-Oin" secondAttribute="centerX" id="iKk-Jb-vz1"/>
+                        <constraint firstItem="kdx-D1-LQl" firstAttribute="centerY" secondItem="JgB-I2-Oin" secondAttribute="centerY" id="tw5-fk-Dog"/>
+                        <constraint firstAttribute="bottom" secondItem="jcH-eR-YQX" secondAttribute="bottom" id="zkA-6B-cRQ"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="BpX-ee-mWz"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="qiC-rL-M9o" firstAttribute="top" secondItem="JgB-I2-Oin" secondAttribute="bottom" id="5ZL-hN-TvX"/>
+                <constraint firstItem="JgB-I2-Oin" firstAttribute="top" secondItem="BpX-ee-mWz" secondAttribute="top" id="OTM-FB-x7A"/>
+                <constraint firstItem="qiC-rL-M9o" firstAttribute="bottom" secondItem="BpX-ee-mWz" secondAttribute="bottom" id="WrM-dg-Cjb"/>
+                <constraint firstItem="JgB-I2-Oin" firstAttribute="leading" secondItem="BpX-ee-mWz" secondAttribute="leading" id="auf-RJ-d2u"/>
+                <constraint firstItem="JgB-I2-Oin" firstAttribute="trailing" secondItem="BpX-ee-mWz" secondAttribute="trailing" id="ccN-yL-kyf"/>
+                <constraint firstItem="qiC-rL-M9o" firstAttribute="leading" secondItem="BpX-ee-mWz" secondAttribute="leading" id="n3S-eE-wek"/>
+                <constraint firstItem="BpX-ee-mWz" firstAttribute="trailing" secondItem="qiC-rL-M9o" secondAttribute="trailing" id="pi6-3T-cyB"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="128.57142857142856"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.xib
@@ -23,7 +23,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="qiC-rL-M9o">
-                    <rect key="frame" x="0.0" y="106" width="414" height="756"/>
+                    <rect key="frame" x="0.0" y="106" width="414" height="790"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JgB-I2-Oin" userLabel="Top Container View">
@@ -44,7 +44,7 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="jcH-eR-YQX" secondAttribute="trailing" id="FeC-CZ-qha"/>
-                        <constraint firstItem="kdx-D1-LQl" firstAttribute="leading" secondItem="JgB-I2-Oin" secondAttribute="leading" constant="16" id="PHN-Mn-Ged"/>
+                        <constraint firstItem="kdx-D1-LQl" firstAttribute="leading" secondItem="JgB-I2-Oin" secondAttribute="leadingMargin" constant="8" id="PHN-Mn-Ged"/>
                         <constraint firstItem="kdx-D1-LQl" firstAttribute="top" secondItem="JgB-I2-Oin" secondAttribute="top" constant="16" id="c6H-ZR-2vv"/>
                         <constraint firstItem="jcH-eR-YQX" firstAttribute="leading" secondItem="JgB-I2-Oin" secondAttribute="leading" id="cAM-Ml-GJf"/>
                         <constraint firstItem="kdx-D1-LQl" firstAttribute="centerX" secondItem="JgB-I2-Oin" secondAttribute="centerX" id="iKk-Jb-vz1"/>
@@ -58,11 +58,11 @@
             <constraints>
                 <constraint firstItem="qiC-rL-M9o" firstAttribute="top" secondItem="JgB-I2-Oin" secondAttribute="bottom" id="5ZL-hN-TvX"/>
                 <constraint firstItem="JgB-I2-Oin" firstAttribute="top" secondItem="BpX-ee-mWz" secondAttribute="top" id="OTM-FB-x7A"/>
-                <constraint firstItem="qiC-rL-M9o" firstAttribute="bottom" secondItem="BpX-ee-mWz" secondAttribute="bottom" id="WrM-dg-Cjb"/>
-                <constraint firstItem="JgB-I2-Oin" firstAttribute="leading" secondItem="BpX-ee-mWz" secondAttribute="leading" id="auf-RJ-d2u"/>
-                <constraint firstItem="JgB-I2-Oin" firstAttribute="trailing" secondItem="BpX-ee-mWz" secondAttribute="trailing" id="ccN-yL-kyf"/>
-                <constraint firstItem="qiC-rL-M9o" firstAttribute="leading" secondItem="BpX-ee-mWz" secondAttribute="leading" id="n3S-eE-wek"/>
-                <constraint firstItem="BpX-ee-mWz" firstAttribute="trailing" secondItem="qiC-rL-M9o" secondAttribute="trailing" id="pi6-3T-cyB"/>
+                <constraint firstItem="qiC-rL-M9o" firstAttribute="bottom" secondItem="VM8-dE-9OM" secondAttribute="bottom" id="WrM-dg-Cjb"/>
+                <constraint firstItem="JgB-I2-Oin" firstAttribute="leading" secondItem="VM8-dE-9OM" secondAttribute="leading" id="auf-RJ-d2u"/>
+                <constraint firstItem="JgB-I2-Oin" firstAttribute="trailing" secondItem="qiC-rL-M9o" secondAttribute="trailing" id="ccN-yL-kyf"/>
+                <constraint firstItem="qiC-rL-M9o" firstAttribute="leading" secondItem="VM8-dE-9OM" secondAttribute="leading" id="n3S-eE-wek"/>
+                <constraint firstAttribute="trailing" secondItem="qiC-rL-M9o" secondAttribute="trailing" id="pi6-3T-cyB"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="128.57142857142856"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -150,6 +150,7 @@ private extension ProductVariationsViewController {
     /// Set the title.
     ///
     func configureNavigationBar() {
+        removeNavigationBackBarButtonText()
         title = NSLocalizedString(
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -372,11 +372,25 @@ private extension ProductVariationsViewController {
         let addAttributeViewController = AddAttributeViewController(viewModel: viewModel) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.product = updatedProduct
-
-            // TODO: Replace stack with AttributeList UI in #3536
-            self.navigationController?.popToViewController(self, animated: true)
+            self.navigateToEditAttributeViewController()
         }
         show(addAttributeViewController, sender: self)
+    }
+
+    /// Cleans the navigation stack until `self` and navigates to `EditAttributesViewController`
+    ///
+    func navigateToEditAttributeViewController() {
+        guard let navigationController = navigationController else {
+            return
+        }
+
+        let editAttributeViewController = EditAttributesViewController()
+        guard let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) else {
+            return show(editAttributeViewController, sender: nil)
+        }
+
+        let viewControllersUntilSelf = navigationController.viewControllers[0...indexOfSelf]
+        navigationController.setViewControllers(viewControllersUntilSelf + [editAttributeViewController], animated: true)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -410,6 +410,8 @@
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
+		2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */; };
+		2688642125D323C600821BA5 /* EditAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2688642025D323C600821BA5 /* EditAttributesViewController.xib */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1525,6 +1527,8 @@
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
+		2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewController.swift; sourceTree = "<group>"; };
+		2688642025D323C600821BA5 /* EditAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditAttributesViewController.xib; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -3945,6 +3949,8 @@
 				AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */,
 				AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */,
 				AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */,
+				2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */,
+				2688642025D323C600821BA5 /* EditAttributesViewController.xib */,
 			);
 			path = "Edit Attributes";
 			sourceTree = "<group>";
@@ -5442,6 +5448,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2688642125D323C600821BA5 /* EditAttributesViewController.xib in Resources */,
 				B56DB3D72049BFAA00D4AA8E /* LaunchScreen.storyboard in Resources */,
 				CE583A0C2107937F00D73C1C /* TextViewTableViewCell.xib in Resources */,
 				D843D5CC22437E59001BFA55 /* TitleAndEditableValueTableViewCell.xib in Resources */,
@@ -6098,6 +6105,7 @@
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
+				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,


### PR DESCRIPTION
closes #3536  

# Why

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: **Navigate to "Edit Attribute List" after creating the first attribute**, this will allow merchants to add more attributes before generating the first variation.

Note: This PR, does not implement any functionality inside the `EditAttribute` screen, this is only the UI, real content will be handled in #3537 


# How

- Adds `EditAttributesViewController` with dummy content.

- Update `ProductVariationsViewController` to present `EditAttributesViewController` after finishing creating/updating the first attribute. A note here, is that the view controllers used to create the attribute(`AddAttributeVC` and `AddAttributeOptionVC`) are being removed before presenting the `EditAttributesVC`.

# Screenshots

Light | Dark
--- | ---
<img width="407" alt="normal" src="https://user-images.githubusercontent.com/562080/107466043-7a0a5880-6b31-11eb-87bb-20f5f773b745.png"> | <img width="411" alt="dark-mode" src="https://user-images.githubusercontent.com/562080/107466046-7b3b8580-6b31-11eb-9e43-43a31048e5eb.png">


Landscape | Big Font
--- | ---
<img width="819" alt="landscape" src="https://user-images.githubusercontent.com/562080/107466079-8b536500-6b31-11eb-87e8-7a8c7b570f54.png"> | <img width="395" alt="big-font" src="https://user-images.githubusercontent.com/562080/107466081-8bebfb80-6b31-11eb-8b27-e97016986bee.png">


# Demo

![demo](https://user-images.githubusercontent.com/562080/107466274-a45c1600-6b31-11eb-9b63-e4c1134329d8.gif)


# Testing Steps
- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute or write a name for a new one.
- Tap one(or more) existing options or add new ones by writing their name on the text field.
- Tap on the "Next" button
- When the loading finishes, see that you are redirected to a dummy attribute list screen.
- When tapping back, you should be redirected back to the empty state screen(not the Add Attribute Option Screen)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
