### PR TITLE
Yosemite layer: added Shipping Labels address validation

### DIFF
--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -20,4 +20,10 @@ public enum ShippingLabelAction: Action {
     /// Loads the settings for a shipping label.
     ///
     case loadShippingLabelSettings(shippingLabel: ShippingLabel, completion: (ShippingLabelSettings?) -> Void)
+
+    /// Validate a shipping address.
+    ///
+    case validateAddress(siteID: Int64,
+                         address: ShippingLabelAddressVerification,
+                         completion: (Result<ShippingLabelAddressValidationResponse, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -45,6 +45,8 @@ public final class ShippingLabelStore: Store {
                                 completion: completion)
         case .loadShippingLabelSettings(let shippingLabel, let completion):
             loadShippingLabelSettings(shippingLabel: shippingLabel, completion: completion)
+        case .validateAddress(let siteID, let address, let completion):
+            validateAddress(siteID: siteID, address: address, completion: completion)
         }
     }
 }
@@ -95,6 +97,12 @@ private extension ShippingLabelStore {
 
     func loadShippingLabelSettings(shippingLabel: ShippingLabel, completion: (ShippingLabelSettings?) -> Void) {
         completion(storageManager.viewStorage.loadShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID)?.toReadOnly())
+    }
+
+    func validateAddress(siteID: Int64,
+                         address: ShippingLabelAddressVerification,
+                         completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void) {
+        remote.addressValidation(siteID: siteID, address: address, completion: completion)
     }
 }
 


### PR DESCRIPTION
Fixes #2969

## Description
As part of Shipping Labels Milestone 2 we need to validate the address (origin and destination) for the Shipping Labels.
In the previous PR, I implemented the [networking layer](https://github.com/woocommerce/woocommerce-ios/pull/3623) with the normalize-address endpoint.
In this PR, I implemented the Yosemite layer to verify an address. The Yosemite layer, in this specific case, don't do anything on the storage level since we don't need to store the information.

## Testing
- Just CI, for the moment this code is not used and will be useful later.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
