### PR TITLE
Fix "Back Button" behaviour on long press.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.1
 -----
-
+- [*] Fixes a bug where long pressing the back button sometimes displayed an empty list of screens.
 
 6.0
 -----

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -15,7 +15,7 @@ extension UIViewController {
     /// Removes the text of the navigation bar back button in the next view controller of the navigation stack.
     ///
     func removeNavigationBackBarButtonText() {
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
     }
 
     /// Show the X close button or a custom close button with title on the left bar button item position

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -92,13 +92,7 @@ private extension DashboardViewController {
         rightBarButton.accessibilityIdentifier = "dashboard-settings-button"
         navigationItem.setRightBarButton(rightBarButton, animated: false)
 
-        // Don't show the Dashboard title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     func configureDashboardUIContainer() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -64,13 +64,7 @@ private extension AboutViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("About", comment: "About this app (information page title)")
-        // Don't show the About title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     /// Apply Woo styles.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -35,13 +35,7 @@ private extension LicensesViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("Licenses", comment: "Licenses (information page title)")
-        // Don't show the About title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup the main view

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -46,8 +46,7 @@ class ApplicationLogDetailViewController: UIViewController {
     func configureNavigation() {
         title = logDate
 
-        // Don't show the Application Log title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
 
         let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(showShareActivity))
         navigationItem.rightBarButtonItem = shareButton

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -55,8 +55,7 @@ class ApplicationLogViewController: UIViewController {
             comment: "Application Logs navigation bar title - this screen is where users view the list of application logs available to them."
         )
 
-        // Don't show the Help & Support title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Apply Woo styles.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -58,9 +58,7 @@ private extension HelpAndSupportViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("Help", comment: "Help and Support navigation title")
-
-        // Don't show the Settings title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
 
         // Dismiss
         navigationItem.leftBarButtonItem = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -98,13 +98,7 @@ private extension PrivacySettingsViewController {
     func configureNavigation() {
         title = NSLocalizedString("Privacy Settings", comment: "Privacy settings screen title")
 
-        // Don't show the Settings title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -76,13 +76,7 @@ private extension SettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Settings", comment: "Settings navigation title")
-        // Don't show the Settings title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -116,9 +116,7 @@ private extension OrderDetailsViewController {
     func configureNavigation() {
         let titleFormat = NSLocalizedString("Order #%1$@", comment: "Order number title. Parameters: %1$@ - order number")
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
-
-        // Don't show the Order details title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup: EntityListener

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -120,7 +120,7 @@ private extension OrderLoaderViewController {
     ///
     func configureNavigationItem() {
         title = NSLocalizedString("Loading Order", comment: "Displayed when an Order is being retrieved")
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup: Main View

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -38,8 +38,7 @@ private extension ProductListViewController {
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
         view.backgroundColor = .listBackground
 
-        // Don't show the Order details title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -85,13 +85,7 @@ private extension ManualTrackingViewController {
     }
 
     func configureBackButton() {
-        // Don't show the title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        removeNavigationBackBarButtonText()
     }
 
     func removeProgressIndicator() {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -88,8 +88,7 @@ private extension ReviewDetailsViewController {
     /// Setup: Navigation
     ///
     func configureNavigationItem() {
-        // Don't show the Notifications title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup: Main View

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -158,8 +158,7 @@ private extension ReviewsViewController {
     /// Setup: Navigation
     ///
     func configureNavigationItem() {
-        // Don't show the Settings title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        removeNavigationBackBarButtonText()
     }
 
     /// Setup: NavigationBar Buttons

--- a/WooCommerce/WooCommerceTests/ViewRelated/ManualTrackingViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ManualTrackingViewControllerTests.swift
@@ -43,7 +43,7 @@ final class ManualTrackingViewControllerTests: XCTestCase {
     func testBackButtonItemIsConfiguredAsEmpty() {
         let backBarButton = subject?.navigationItem.backBarButtonItem
 
-        XCTAssertEqual(backBarButton?.title, String())
+        XCTAssertNil(backBarButton?.title)
     }
 
     func testVCIsTableViewDataSource() {


### PR DESCRIPTION
# Why

Yesterday, I found a piece of code that hides the back button text for the next screen, and that looks and works fine until I discovered that if you long-press the back button(iOS 14+) you will get a list of all the back buttons in order to go back into a specific screen.

For screens where we hide the back button text, it looks broken.

<img width="350" alt="Screen Shot 2021-02-10 at 12 02 04 PM" src="https://user-images.githubusercontent.com/562080/107544064-d1431400-6b97-11eb-907d-336e91df2b0c.png">

This PR tries to fix that by updating the `removeNavigationBackBarButtonText()` method to use an empty image, instead of an empty text as the back button companion. Also, this PR makes sure the rest of the app uses that method instead of a custom empty back button.

# Demo
## Before
https://user-images.githubusercontent.com/562080/107544521-50384c80-6b98-11eb-9886-730eabffe8b7.MOV 

## After
https://user-images.githubusercontent.com/562080/107544440-3991f580-6b98-11eb-987d-e42c7da50688.mov

# Testing steps
- Go deep into a flow navigation wise
- Long press back button
- See that the menu list is populated with screen names.




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
