### PR TITLE
Fix cells separator on variations list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -180,6 +180,7 @@ private extension ProductVariationsViewController {
         tableView.backgroundColor = .listBackground
         tableView.refreshControl = refreshControl
         tableView.tableFooterView = footerSpinnerView
+        tableView.separatorStyle = .none
     }
 
     /// Setup: Sync'ing Coordinator


### PR DESCRIPTION
## Description

1-line change. Variations list had 2 sets separators, one is custom view from the cell, another is system from UITableView.
System separator is longer in length, so you can spot a color change in "before" screenshot.
Updated separator style is same as in design assets and main products list.

## Testing

1. Select product with existing variations on products tab
2. Tap on "variations" cell
3. Check separators in variations list

## Screenshots

before | after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/107633350-eb085800-6c78-11eb-9300-8801610bb76a.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/107633383-fb203780-6c78-11eb-975f-60a91ca82ad7.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
