### PR TITLE
Variations: Update "Any Attribute" option in AttributeOptionListSelectorCommand

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -223,6 +223,6 @@ extension EditableProductVariationModel: Equatable {
 extension EditableProductVariationModel {
     enum Localization {
         static let anyAttributeFormat =
-            NSLocalizedString("Any %@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
+            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
@@ -52,7 +52,7 @@ final class AttributeOptionListSelectorCommand: ListSelectorCommand {
 private extension AttributeOptionListSelectorCommand {
     enum Localization {
         static let anyOption = NSLocalizedString(
-            "Any %@",
+            "Any %1$@",
             comment: "Product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
@@ -6,7 +6,7 @@ import Yosemite
 final class AttributeOptionListSelectorCommand: ListSelectorCommand {
 
     enum Row: Equatable {
-        case anyOption
+        case anyOption(String)
         case option(String)
     }
 
@@ -21,19 +21,19 @@ final class AttributeOptionListSelectorCommand: ListSelectorCommand {
 
     init(attribute: ProductAttribute, selectedOption: ProductVariationAttribute?) {
         self.navigationBarTitle = attribute.name
-        self.data = [Row.anyOption] + attribute.options.map { Row.option($0) }
+        self.data = [Row.anyOption(attribute.name)] + attribute.options.map { Row.option($0) }
 
         if let selectedOption = selectedOption {
             self.selected = .option(selectedOption.option)
         } else {
-            self.selected = .anyOption
+            self.selected = .anyOption(attribute.name)
         }
     }
 
     func configureCell(cell: BasicTableViewCell, model: Row) {
         switch model {
-        case .anyOption:
-            cell.textLabel?.text = Localization.anyOption
+        case .anyOption(let attributeName):
+            cell.textLabel?.text = String.localizedStringWithFormat(Localization.anyOption, attributeName)
         case .option(let optionName):
             cell.textLabel?.text = optionName
         }
@@ -52,7 +52,7 @@ final class AttributeOptionListSelectorCommand: ListSelectorCommand {
 private extension AttributeOptionListSelectorCommand {
     enum Localization {
         static let anyOption = NSLocalizedString(
-            "Any Attribute",
+            "Any %@",
             comment: "Product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Product Variation/AttributeOptionListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Product Variation/AttributeOptionListSelectorCommandTests.swift
@@ -24,7 +24,7 @@ final class AttributeOptionListSelectorCommandTests: XCTestCase {
         let command = AttributeOptionListSelectorCommand(attribute: attribute, selectedOption: selectedAttribute)
 
         // Then
-        XCTAssertEqual(command.data, [.anyOption, .option("Blue"), .option("Red")])
+        XCTAssertEqual(command.data, [.anyOption("Color"), .option("Blue"), .option("Red")])
     }
 
     func test_command_selects_initial_option_correctly() {
@@ -59,7 +59,7 @@ final class AttributeOptionListSelectorCommandTests: XCTestCase {
         let command = AttributeOptionListSelectorCommand(attribute: attribute, selectedOption: nil)
 
         // Then
-        XCTAssertEqual(command.selected, .anyOption)
+        XCTAssertEqual(command.selected, .anyOption("Color"))
     }
 
 


### PR DESCRIPTION
Fixes: #3637 

## Description

When editing the attributes in a product variation, after selecting an attribute (e.g. Color) you're taken to a list of all the attribute options. Previously this included a generic "Any Attribute" option; now the generic option is "Any [attribute name]". For example, for the Color attribute the generic option is "Any Color."

## Changes

* In `AttributeOptionListSelectorCommand`, `anyOption` now takes the attribute name as a string to use in the localized `"Any %@"` string.

Before|After
-|-
![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 12 27 31](https://user-images.githubusercontent.com/8658164/107636595-c6a28080-6c64-11eb-835e-0c5e45588889.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 12 25 26](https://user-images.githubusercontent.com/8658164/107636603-c86c4400-6c64-11eb-8334-936c272dddf2.png)


## Testing

1. Make sure you have at least one variable product with variations on your store.
2. Go to the Products tab in the app.
3. Select a variable product.
4. Select Variations.
5. Select a product variation.
6. Select Attributes.
7. Select one of the attributes.
8. Confirm you see a list of all the available options for that attribute, including an "Any [attribute name]" (e.g. "Any Color") option at the top of the list.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
