### PR TITLE
Add check for addProductVariations feature flag

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -339,12 +339,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 ServiceLocator.analytics.track(.productDetailViewGroupedProductsTapped)
                 editGroupedProducts()
                 break
-            case .variations:
+            case .variations(let row):
                 ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
-                guard let product = product as? EditableProductModel else {
-                    return
-                }
-                guard product.product.variations.isNotEmpty || isAddProductVariationsEnabled else {
+                guard let product = product as? EditableProductModel, row.isActionable else {
                     return
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -344,6 +344,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard let product = product as? EditableProductModel else {
                     return
                 }
+                guard product.product.variations.isNotEmpty || isAddProductVariationsEnabled else {
+                    return
+                }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
                                                                                formType: viewModel.formType,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)


### PR DESCRIPTION
## Description

This PR adds back accidentally removed check for `addProductVariations` feature flag.

In test build variations cell looks inactive but still opens to Create Variations flow which is unfinished yet. Check is used for viewmodel (cell appearance) setup, but not for actual tap action.

## Changes

Since creation flow starts only from empty state - prevent opening of `ProductVariationsViewController` if there are no existing variations (and no active `addProductVariations` flag). Therefore empty state can't be reached and creation flow can't be triggered. 

## Testing

0. Disable `addProductVariations` feature flag/run in release mode.
1. Open details for variable product with no variations yet created.
2. Tap on "Variations" cell.

## Screenshot

<img src="https://user-images.githubusercontent.com/3132438/107641446-b00c2180-6c84-11eb-98a2-ecf95f15081a.png" width="350">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
