### PR TITLE
Add create button on variations list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -424,7 +424,7 @@ private extension ProductVariationsViewController {
 }
 
 private extension ProductVariationsViewController {
-    @objc private func pullToRefresh(sender: UIRefreshControl) {
+    @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.productVariationListPulledToRefresh)
 
         syncingCoordinator.synchronizeFirstPage {
@@ -432,7 +432,7 @@ private extension ProductVariationsViewController {
         }
     }
 
-    @objc private func addButtonTapped() {
+    @objc func addButtonTapped() {
         // TODO-3539: Generate new variation
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -125,7 +125,8 @@ final class ProductVariationsViewController: UIViewController {
         configureTableView()
         configureSyncingCoordinator()
         registerTableViewCells()
-        configureTopBannerContainerView()
+        configureHeaderContainerView()
+        configureAddButton()
         updateTopBannerView()
 
         syncingCoordinator.synchronizeFirstPage()
@@ -220,13 +221,40 @@ private extension ProductVariationsViewController {
 }
 
 private extension ProductVariationsViewController {
-    func configureTopBannerContainerView() {
+    func configureHeaderContainerView() {
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
         headerContainer.addSubview(topStackView)
         headerContainer.pinSubviewToSafeArea(topStackView)
         topStackView.addArrangedSubview(topBannerView)
 
         tableView.tableHeaderView = headerContainer
+    }
+
+    func configureAddButton() {
+        guard isAddProductVariationsEnabled else {
+            return
+        }
+        let buttonContainer = UIView()
+        buttonContainer.backgroundColor = .listForeground
+
+        let addVariationButton = UIButton()
+        addVariationButton.translatesAutoresizingMaskIntoConstraints = false
+        addVariationButton.setTitle(Localization.addNewVariation, for: .normal)
+        addVariationButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        addVariationButton.applySecondaryButtonStyle()
+
+        buttonContainer.addSubview(addVariationButton)
+        buttonContainer.pinSubviewToSafeArea(addVariationButton, insets: .init(top: 16, left: 16, bottom: 16, right: 16))
+
+        let separator = UIView.createBorderView()
+        buttonContainer.addSubview(separator)
+        NSLayoutConstraint.activate([
+            buttonContainer.leadingAnchor.constraint(equalTo: separator.leadingAnchor),
+            buttonContainer.bottomAnchor.constraint(equalTo: separator.bottomAnchor),
+            buttonContainer.trailingAnchor.constraint(equalTo: separator.trailingAnchor)
+        ])
+
+        topStackView.addArrangedSubview(buttonContainer)
     }
 
     func updateTopBannerView() {
@@ -403,6 +431,10 @@ private extension ProductVariationsViewController {
             sender.endRefreshing()
         }
     }
+
+    @objc private func addButtonTapped() {
+        // TODO-3539: Generate new variation
+    }
 }
 
 // MARK: - Placeholders
@@ -558,5 +590,6 @@ private extension ProductVariationsViewController {
     enum Localization {
         static let emptyStateTitle = NSLocalizedString("Add your first variation", comment: "Title on the variations list screen when there are no variations")
         static let emptyStateButtonTitle = NSLocalizedString("Add Variation", comment: "Title on add variation button when there are no variations")
+        static let addNewVariation = NSLocalizedString("Add Variation", comment: "Action to add new variation on the variations list")
     }
 }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/3525.

## Description

Adds button to generate new variations on variations list. This button does nothing for now, action will be added in https://github.com/woocommerce/woocommerce-ios/issues/3539.

Button is hidden behind `isAddProductVariationsEnabled` feature flag.

## Changes

- Added container with button and line separator to UIStackView that is already used for top banner view
- Added a check for `isAddProductVariationsEnabled` feature flag

## Testing

1. Open details for variable product details with some existing variations
2. Tap on variations cell
3. Check appearance for create button on a top

## Screenshots

light v | light h
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 41 23](https://user-images.githubusercontent.com/3132438/107644934-2579f100-6c89-11eb-8157-7478a4695420.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 41 26](https://user-images.githubusercontent.com/3132438/107644938-2743b480-6c89-11eb-8165-b18860706cf8.png)

dark v | dark h
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 41 58](https://user-images.githubusercontent.com/3132438/107644954-2c086880-6c89-11eb-9c09-ed57625dd971.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 42 01](https://user-images.githubusercontent.com/3132438/107644963-2e6ac280-6c89-11eb-9cec-bb660f3dd823.png)

banner v | banner h
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 43 23](https://user-images.githubusercontent.com/3132438/107644992-3591d080-6c89-11eb-8d24-f9dcb78c8209.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-11 at 15 43 25](https://user-images.githubusercontent.com/3132438/107645023-3dea0b80-6c89-11eb-8201-457e1f7ddb1a.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
