### PR TITLE
Variations: First Variation -> Render attribute list + create multiple attributes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -52,7 +52,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         }
     }
 
-    struct ViewModel {
+    struct ViewModel: Equatable {
         let title: String?
         let text: String?
         let textTintColor: UIColor?

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -54,7 +54,7 @@ private extension AddAttributeViewController {
 
     func configureNavigationBar() {
         title = Localization.titleView
-
+        removeNavigationBackBarButtonText()
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,
                                                            target: self,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -46,6 +46,7 @@ private extension EditAttributesViewController {
     func configureNavigationBar() {
         configureTitle()
         configureRightButton()
+        removeNavigationBackBarButtonText()
     }
 
     func configureTitle() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -80,7 +80,18 @@ extension EditAttributesViewController {
     }
 
     @objc private func addButtonTapped() {
-        // TODO: Launch add attribute flow and update product upon completion
+        navigateToAddAttributeViewController()
+    }
+
+    /// Navigates to `AddAttributeViewController` and upon completion, update the product and clean the navigation stack
+    ///
+    private func navigateToAddAttributeViewController() {
+        let addAttributeVM = AddAttributeViewModel(product: viewModel.product)
+        let addAttributeViewController = AddAttributeViewController(viewModel: addAttributeVM) { [weak self] updatedProduct in
+            guard let self = self else { return }
+            self.viewModel.updateProduct(updatedProduct)
+        }
+        show(addAttributeViewController, sender: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -89,19 +89,13 @@ extension EditAttributesViewController {
 extension EditAttributesViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 6 // Temporary
+        return viewModel.attributes.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(ImageAndTitleAndTextTableViewCell.self, for: indexPath)
-
-        // Temporary
-        let vm = ImageAndTitleAndTextTableViewCell.ViewModel(title: "Color",
-                                                             text: "Green, Yellow, Blue",
-                                                             numberOfLinesForTitle: 0,
-                                                             numberOfLinesForText: 0)
-        cell.updateUI(viewModel: vm)
-
+        let cellViewModel = viewModel.attributes[indexPath.row]
+        cell.updateUI(viewModel: cellViewModel)
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -90,6 +90,8 @@ extension EditAttributesViewController {
         let addAttributeViewController = AddAttributeViewController(viewModel: addAttributeVM) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.viewModel.updateProduct(updatedProduct)
+            self.tableView.reloadData()
+            self.navigationController?.popToViewController(self, animated: true)
         }
         show(addAttributeViewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -8,6 +8,17 @@ final class EditAttributesViewController: UIViewController {
     @IBOutlet private weak var addButtonSeparator: UIView!
     @IBOutlet private var tableView: UITableView!
 
+    private let viewModel: EditAttributesViewModel
+
+    init(viewModel: EditAttributesViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configureAddButton()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -65,6 +65,9 @@ private extension EditAttributesViewController {
     }
 
     func configureRightButton() {
+        guard viewModel.showDoneButton else {
+            return
+        }
         let rightBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -5,24 +5,30 @@ final class EditAttributesViewModel {
 
     /// Main product dependency
     ///
-    private var product: Product
+    private var product: Product {
+        didSet {
+            self.attributes = createAttributeViewModels()
+        }
+    }
 
     /// If true, a done button will appear that allows the merchant to generate a variation
     ///
     private let allowVariationCreation: Bool
 
-    init(product: Product, allowVariationCreation: Bool) {
-        self.product = product
-        self.allowVariationCreation = allowVariationCreation
-    }
-}
+    /// Datasource for the product attributes table view
+    ///
+    var attributes: [ImageAndTitleAndTextTableViewCell.ViewModel] = []
 
-// MARK: View Controller Outputs
-extension EditAttributesViewModel {
     /// Defines done button visibility
     ///
     var showDoneButton: Bool {
         allowVariationCreation
+    }
+
+    init(product: Product, allowVariationCreation: Bool) {
+        self.product = product
+        self.allowVariationCreation = allowVariationCreation
+        self.attributes = createAttributeViewModels()
     }
 }
 
@@ -33,5 +39,19 @@ extension EditAttributesViewModel {
     ///
     func updateProduct(_ product: Product) {
         self.product = product
+    }
+}
+
+// MARK: Helpers
+private extension EditAttributesViewModel {
+
+    /// Creates an array of `ImageAndTitleAndTextTableViewCell.ViewModel` based on the `product.attributes`
+    func createAttributeViewModels() -> [ImageAndTitleAndTextTableViewCell.ViewModel] {
+        product.attributes.map { attribute in
+            ImageAndTitleAndTextTableViewCell.ViewModel(title: attribute.name,
+                                                        text: attribute.options.joined(separator: ", "),
+                                                        numberOfLinesForTitle: 0,
+                                                        numberOfLinesForText: 0)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -17,6 +17,15 @@ final class EditAttributesViewModel {
     }
 }
 
+// MARK: View Controller Outputs
+extension EditAttributesViewModel {
+    /// Defines done button visibility
+    ///
+    var showDoneButton: Bool {
+        allowVariationCreation
+    }
+}
+
 // MARK: View Controller inputs
 extension EditAttributesViewModel {
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class EditAttributesViewModel {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -1,5 +1,28 @@
 import Foundation
+import Yosemite
 
 final class EditAttributesViewModel {
 
+    /// Main product dependency
+    ///
+    private var product: Product
+
+    /// If true, a done button will appear that allows the merchant to generate a variation
+    ///
+    private let allowVariationCreation: Bool
+
+    init(product: Product, allowVariationCreation: Bool) {
+        self.product = product
+        self.allowVariationCreation = allowVariationCreation
+    }
+}
+
+// MARK: View Controller inputs
+extension EditAttributesViewModel {
+
+    /// Updates the view model output properties based on the provided `product`.
+    ///
+    func updateProduct(_ product: Product) {
+        self.product = product
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -5,7 +5,7 @@ final class EditAttributesViewModel {
 
     /// Main product dependency
     ///
-    private var product: Product {
+    private(set) var product: Product {
         didSet {
             self.attributes = createAttributeViewModels()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -384,7 +384,8 @@ private extension ProductVariationsViewController {
             return
         }
 
-        let editAttributeViewController = EditAttributesViewController()
+        let editAttributesViewModel = EditAttributesViewModel(product: product, allowVariationCreation: true)
+        let editAttributeViewController = EditAttributesViewController(viewModel: editAttributesViewModel)
         guard let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) else {
             return show(editAttributeViewController, sender: nil)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -412,6 +412,8 @@
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
 		2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */; };
 		2688642125D323C600821BA5 /* EditAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2688642025D323C600821BA5 /* EditAttributesViewController.xib */; };
+		2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */; };
+		2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1529,6 +1531,8 @@
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
 		2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewController.swift; sourceTree = "<group>"; };
 		2688642025D323C600821BA5 /* EditAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditAttributesViewController.xib; sourceTree = "<group>"; };
+		2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModel.swift; sourceTree = "<group>"; };
+		2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -2322,6 +2326,7 @@
 				0271E1632509C66200633F7A /* DefaultProductFormTableViewModelTests.swift */,
 				0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */,
 				0215C6FB2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift */,
+				2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -3950,6 +3955,7 @@
 				AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */,
 				AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */,
 				2688641A25D3202B00821BA5 /* EditAttributesViewController.swift */,
+				2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */,
 				2688642025D323C600821BA5 /* EditAttributesViewController.xib */,
 			);
 			path = "Edit Attributes";
@@ -5847,6 +5853,7 @@
 				5778E00624DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift in Sources */,
 				456396A725C81C9A001F1A26 /* ShippingLabelFormViewController.swift in Sources */,
 				02DD81FA242CAA400060E50B /* Media+WPMediaAsset.swift in Sources */,
+				2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */,
 				024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */,
 				029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
@@ -6544,6 +6551,7 @@
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
 				02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */,
+				2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */,
 				02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+@testable import Yosemite
 
 final class EditAttributesViewModelTests: XCTestCase {
 
@@ -17,5 +18,56 @@ final class EditAttributesViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.showDoneButton)
+    }
+
+    func test_product_attributes_are_correctly_converted_into_view_models() {
+        // Given
+        let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
+        let product = Product().copy(attributes: [attribute])
+
+        // When
+        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
+
+        // Then
+        let expectedVM = ImageAndTitleAndTextTableViewCell.ViewModel(title: "attr",
+                                                                     text: "Option 1, Option 2",
+                                                                     numberOfLinesForTitle: 0,
+                                                                     numberOfLinesForText: 0)
+        XCTAssertEqual(viewModel.attributes, [expectedVM])
+    }
+
+    func test_product_attributes_are_recreated_after_updating_the_product() {
+        // Given
+        let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
+        let attribute2 = sampleAttribute(name: "attr-2", options: ["Option 3", "Option 4"])
+        let product = Product().copy(attributes: [attribute])
+        let product2 = product.copy(attributes: [attribute, attribute2])
+
+        // When
+        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
+        viewModel.updateProduct(product2)
+
+        // Then
+        let expectedVM = ImageAndTitleAndTextTableViewCell.ViewModel(title: "attr",
+                                                                     text: "Option 1, Option 2",
+                                                                     numberOfLinesForTitle: 0,
+                                                                     numberOfLinesForText: 0)
+        let expectedVM2 = ImageAndTitleAndTextTableViewCell.ViewModel(title: "attr-2",
+                                                                      text: "Option 3, Option 4",
+                                                                      numberOfLinesForTitle: 0,
+                                                                      numberOfLinesForText: 0)
+        XCTAssertEqual(viewModel.attributes, [expectedVM, expectedVM2])
+    }
+}
+
+private extension EditAttributesViewModelTests {
+    func sampleAttribute(attributeID: Int64 = 1234, name: String, options: [String] = []) -> ProductAttribute {
+        ProductAttribute(siteID: 123,
+                         attributeID: attributeID,
+                         name: name ,
+                         position: 0,
+                         visible: true,
+                         variation: true,
+                         options: options)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -1,0 +1,5 @@
+import XCTest
+
+final class EditAttributesViewModelTests: XCTestCase {
+    
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -1,5 +1,21 @@
 import XCTest
+@testable import WooCommerce
 
 final class EditAttributesViewModelTests: XCTestCase {
-    
+
+    func test_done_button_is_visible_when_allowing_variation_creation() {
+        // Given, Then
+        let viewModel = EditAttributesViewModel(product: .init(), allowVariationCreation: true)
+
+        // Then
+        XCTAssertTrue(viewModel.showDoneButton)
+    }
+
+    func test_done_button_is_not_visible_when_not_allowing_variation_creation() {
+        // Given, Then
+        let viewModel = EditAttributesViewModel(product: .init(), allowVariationCreation: false)
+
+        // Then
+        XCTAssertFalse(viewModel.showDoneButton)
+    }
 }

--- a/Yosemite/Yosemite/Stores/ProductAttributeStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductAttributeStore.swift
@@ -147,7 +147,12 @@ private extension ProductAttributeStore {
                 }
                 return storage.insertNewObject(ofType: Storage.ProductAttribute.self)
             }()
+
+            // Workaround: API does not return options when fetching global product attributes.
+            // Here, we persist them manually from previous sessions, in order to keep the product data up to date.
+            let storedOptions = readOnlyProductAttribute.options.isEmpty ? storageProductAttribute.options : readOnlyProductAttribute.options
             storageProductAttribute.update(with: readOnlyProductAttribute)
+            storageProductAttribute.options = storedOptions ?? []
         }
     }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -2,7 +2,6 @@ import Foundation
 import Networking
 import Storage
 
-
 // MARK: - ProductStore
 //
 public class ProductStore: Store {
@@ -287,9 +286,7 @@ private extension ProductStore {
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let product):
                 self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
-                    // For some reason, using `storageManager.viewStorage.loadProduct` does not fetches the options of some product attributes.
-                    // Using `sharedDerivedStorage.loadProduct` does fetches that latest state.
-                    guard let storageProduct = self?.sharedDerivedStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
+                    guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
                         onCompletion(.failure(.notFoundInStorage))
                         return
                     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -287,7 +287,9 @@ private extension ProductStore {
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let product):
                 self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
-                    guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
+                    // For some reason, using `storageManager.viewStorage.loadProduct` does not fetches the options of some product attributes.
+                    // Using `sharedDerivedStorage.loadProduct` does fetches that latest state.
+                    guard let storageProduct = self?.sharedDerivedStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
                         onCompletion(.failure(.notFoundInStorage))
                         return
                     }


### PR DESCRIPTION
closes #3537 

# Why
Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: **Render attribute list content + allow the merchants to keep adding more attributes before creating the first variation** 

Note: This PR, does not implement any functionality inside the EditAttribute screen, this is only the UI, real content will be handled in #3537

# How

- Add `EditAttributesViewModel` to store product info and generate attributes view models for the VC to render, as well as control the done button visibility, which only should be shown when creating the first variation.

- Update `EditAttributesViewController` to render content based on it's View Model.

- Update `EditAttributesViewController` to allow users to keep adding attributes by navigating to the `AddAttributeViewController` when tapping the `Add New Attribute` button.

- Update `AddAttributeViewController` to make sure it deletes the back button text when navigating away from it.

- Update `ProductAttributeStore` to add a workaround when fetching options and terms from a global attribute. This happens on the `AddAttributeViewController` and I'm still working on finding a definitive solution 😇 

# Demo
![add-flow-demo](https://user-images.githubusercontent.com/562080/107696890-84873800-6c80-11eb-8c05-9c54fd5fddaa.gif)


# Testing Steps

- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute or write a name for a new one.
- Tap one(or more) existing options or add new ones by writing their name on the text field.
- Tap on the "Next" button
- When the loading finishes, see that you are redirected to the attribute list screen.
- Make sure that you can tap the "Add New Attribute" method and add more attributes correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
