### PR TITLE
Variations: Update alert copy for variable product type

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -12,7 +12,7 @@ extension ProductFormViewController {
     func presentProductTypeChangeAlert(for productType: ProductType, completion: @escaping (Bool) -> ()) {
         let title = NSLocalizedString("Are you sure you want to change the product type?",
                                       comment: "Title of the alert when a user is changing the product type")
-        
+
         let body: String
         switch productType {
         case .variable:
@@ -22,7 +22,7 @@ extension ProductFormViewController {
             body = NSLocalizedString("Changing the product type will modify some of the product data",
                                      comment: "Body of the alert when a user is changing the product type")
         }
-        
+
         let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button on the alert when the user is cancelling the action on changing product type")
         let confirmButton = NSLocalizedString("Yes, change", comment: "Confirmation button on the alert when the user is changing product type")
         let alertController = UIAlertController(title: title,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -11,7 +11,7 @@ extension ProductFormViewController {
     func presentProductTypeChangeAlert(completion: @escaping (Bool) -> ()) {
         let title = NSLocalizedString("Are you sure you want to change the product type?",
                                       comment: "Title of the alert when a user is changing the product type")
-        let body = NSLocalizedString("Changing the product type will modify some of the product data",
+        let body = NSLocalizedString("Changing the product type will modify some of the product data and delete all your attributes and variations.",
                                      comment: "Body of the alert when a user is changing the product type")
         let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button on the alert when the user is cancelling the action on changing product type")
         let confirmButton = NSLocalizedString("Yes, change", comment: "Confirmation button on the alert when the user is changing product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 /// ProductFormViewController Helpers
 ///
@@ -8,11 +9,20 @@ extension ProductFormViewController {
 
     /// Product Type Change alert
     ///
-    func presentProductTypeChangeAlert(completion: @escaping (Bool) -> ()) {
+    func presentProductTypeChangeAlert(for productType: ProductType, completion: @escaping (Bool) -> ()) {
         let title = NSLocalizedString("Are you sure you want to change the product type?",
                                       comment: "Title of the alert when a user is changing the product type")
-        let body = NSLocalizedString("Changing the product type will modify some of the product data and delete all your attributes and variations.",
+        
+        let body: String
+        switch productType {
+        case .variable:
+            body = NSLocalizedString("Changing the product type will modify some of the product data and delete all your attributes and variations",
                                      comment: "Body of the alert when a user is changing the product type")
+        default:
+            body = NSLocalizedString("Changing the product type will modify some of the product data",
+                                     comment: "Body of the alert when a user is changing the product type")
+        }
+        
         let cancelButton = NSLocalizedString("Cancel", comment: "Cancel button on the alert when the user is cancelling the action on changing product type")
         let confirmButton = NSLocalizedString("Yes, change", comment: "Confirmation button on the alert when the user is changing product type")
         let alertController = UIAlertController(title: title,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -936,13 +936,16 @@ private extension ProductFormViewController {
         let command = ProductTypeBottomSheetListSelectorCommand(selected: viewModel.productModel.productType) { [weak self] (selectedProductType) in
             self?.dismiss(animated: true, completion: nil)
 
-            if let originalProductType = self?.product.productType {
-                ServiceLocator.analytics.track(.productTypeChanged, withProperties: [
-                    "from": originalProductType.rawValue,
-                    "to": selectedProductType.rawValue
-                ])
+            guard let originalProductType = self?.product.productType else {
+                return
             }
-            self?.presentProductTypeChangeAlert(completion: { (change) in
+
+            ServiceLocator.analytics.track(.productTypeChanged, withProperties: [
+                "from": originalProductType.rawValue,
+                "to": selectedProductType.rawValue
+            ])
+
+            self?.presentProductTypeChangeAlert(for: originalProductType, completion: { (change) in
                 guard change == true else {
                     return
                 }


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3541

### Testing instructions
1. Go to the Products tab
2. Tap on a variable product
3. Change product type by tapping on `Product type` and selecting a different product type
4. ✅ Confirm that the alert body reads: `Changing the product type will modify some of the product data and delete all your attributes and variations`

### Screenshot
Before | After 
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-12 at 14 53 24](https://user-images.githubusercontent.com/6711616/107736678-055c3780-6d46-11eb-880a-c7239165a187.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-12 at 15 21 48](https://user-images.githubusercontent.com/6711616/107736702-0f7e3600-6d46-11eb-9e64-3e03045d28ba.png)

### Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
