### PR TITLE
Product Type: Display "Downloadable" if product is downloadable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Products: When editing variable products, you can now edit the variation attributes to select different attribute options. [https://github.com/woocommerce/woocommerce-ios/pull/3628]
 - [*] Fixes a bug where long pressing the back button sometimes displayed an empty list of screens.
+- [*] Product Type: Updated product type detail to display "Downloadable" if a product is downloadable. [https://github.com/woocommerce/woocommerce-ios/pull/3647]
 
 6.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -527,7 +527,8 @@ private extension DefaultProductFormTableViewModel {
                                                            comment: "Format of the stock quantity on the Inventory Settings row")
 
         // Product Type
-        static let downloadableProductType = NSLocalizedString("Downloadable", comment: "Display label for simple downloadable product type.")
+        static let downloadableProductType = NSLocalizedString("Downloadable",
+                                                               comment: "Display label for simple downloadable product type.")
         static let virtualProductType = NSLocalizedString("Virtual",
                                                           comment: "Display label for simple virtual product type.")
         static let physicalProductType = NSLocalizedString("Physical",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -227,10 +227,12 @@ private extension DefaultProductFormTableViewModel {
         let details: String
         switch product.productType {
         case .simple:
-            switch product.virtual {
-            case true:
+            switch (product.downloadable, product.virtual) {
+            case (true, _):
+                details = Localization.downloadableProductType
+            case (false, true):
                 details = Localization.virtualProductType
-            case false:
+            case (false, false):
                 details = Localization.physicalProductType
             }
         case .custom(let customProductType):
@@ -525,6 +527,7 @@ private extension DefaultProductFormTableViewModel {
                                                            comment: "Format of the stock quantity on the Inventory Settings row")
 
         // Product Type
+        static let downloadableProductType = NSLocalizedString("Downloadable", comment: "Display label for simple downloadable product type.")
         static let virtualProductType = NSLocalizedString("Virtual",
                                                           comment: "Display label for simple virtual product type.")
         static let physicalProductType = NSLocalizedString("Physical",


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3477

### Description
Updated product type detail to display "Downloadable" when a product's `downloadable` flag is on.

```
- If downloadable is on, show "Downloadable"
- If downloadable is off
    - If virtual is on, show "Virtual"
    - If virtual is off, show "Physical"
```

### Testing instructions
1. Add a product
2. Go to product settings and turn the `downloadable` flag on and the `virtual` flag off
3. Tap Done, then tap Publish
4. ✅ Confirm that the product type is `Downloadable`
5. Go to product settings and turn the `downloadable` flag off and the `virtual` flag on
6. Tap Done, then tap Update
7. ✅ Confirm that the product type is `Virtual`
8. Go to product settings and turn the `downloadable` flag off and the `virtual` flag off
9. Tap Done, then tap Update
10. ✅ Confirm that the product type is `Physical`


### Screenshot
Product Settings<br>(Virtual = off, <br>Downloadable = on) | Before | After
--- | --- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-12 at 16 50 18](https://user-images.githubusercontent.com/6711616/107743046-840ba180-6d53-11eb-956a-091fa1582c6e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-12 at 16 54 52](https://user-images.githubusercontent.com/6711616/107743054-8968ec00-6d53-11eb-95fa-5bb120cca07e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-12 at 16 50 11](https://user-images.githubusercontent.com/6711616/107743072-91c12700-6d53-11eb-9f18-040552cf9d23.png)




### Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
