### PR TITLE
Restore ProductAttributeTermStore on DefaultStoresManager

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -41,6 +41,7 @@ class AuthenticatedState: StoresManagerState {
             OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             PaymentGatewayStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductAttributeStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            ProductAttributeTermStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductReviewStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductCategoryStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network),


### PR DESCRIPTION
By mistake, the `ProductAttributeTermStore` was removed from the `AuthenticatedState` in [this commit](https://github.com/woocommerce/woocommerce-ios/commit/58359f5b205c3c7d6bc4e6c0dc39e1b1d8167c67#diff-3be003826afcdd22aa5f28dce37b56ed1ab7f9d3a80b26ea96ca78a3deb5c3e2L44)

This PR just restores that.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
