### PR TITLE
Variations: Create First Variation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -147,7 +147,6 @@ private extension EditAttributesViewController {
     enum Localization {
         static let addNewAttribute = NSLocalizedString("Add New Attribute", comment: "Action to add new attribute on the Product Attributes screen")
         static let title = NSLocalizedString("Edit Attributes", comment: "Navigation title for the Product Attributes screen")
-        static let done = NSLocalizedString("Done", comment: "Button title for the Done Action on the navigation bar")
 
         static let generatingVariation = NSLocalizedString("Generating Variation", comment: "Title for the progress screen while generating a variation")
         static let waitInstructions = NSLocalizedString("Please wait while we create the new variation",

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -77,6 +77,9 @@ private extension EditAttributesViewController {
 extension EditAttributesViewController {
     @objc private func doneButtonTapped() {
         // TODO: Create variation and notify back
+        viewModel.generateVariation { result in
+
+        }
     }
 
     @objc private func addButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -52,7 +52,6 @@ extension EditAttributesViewModel {
         let action = ProductVariationAction.createProductVariation(siteID: product.siteID,
                                                                    productID: product.productID,
                                                                    newVariation: createVariationParameter()) { result in
-            print(result)
             onCompletion(result)
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -15,6 +15,10 @@ final class EditAttributesViewModel {
     ///
     private let allowVariationCreation: Bool
 
+    /// Stores dependency. Needed to generate variations
+    ///
+    private let stores: StoresManager
+
     /// Datasource for the product attributes table view
     ///
     var attributes: [ImageAndTitleAndTextTableViewCell.ViewModel] = []
@@ -25,9 +29,10 @@ final class EditAttributesViewModel {
         allowVariationCreation
     }
 
-    init(product: Product, allowVariationCreation: Bool) {
+    init(product: Product, allowVariationCreation: Bool, stores: StoresManager = ServiceLocator.stores) {
         self.product = product
         self.allowVariationCreation = allowVariationCreation
+        self.stores = stores
         self.attributes = createAttributeViewModels()
     }
 }
@@ -39,6 +44,18 @@ extension EditAttributesViewModel {
     ///
     func updateProduct(_ product: Product) {
         self.product = product
+    }
+
+    /// Generates a variation in the host site using the product attributes
+    ///
+    func generateVariation(onCompletion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        let action = ProductVariationAction.createProductVariation(siteID: product.siteID,
+                                                                   productID: product.productID,
+                                                                   newVariation: createVariationParameter()) { result in
+            print(result)
+            onCompletion(result)
+        }
+        stores.dispatch(action)
     }
 }
 
@@ -53,5 +70,12 @@ private extension EditAttributesViewModel {
                                                         numberOfLinesForTitle: 0,
                                                         numberOfLinesForText: 0)
         }
+    }
+
+    /// Returns a `CreateProductVariation` type with no price and no options selected for any of it's attributes.
+    ///
+    func createVariationParameter() -> CreateProductVariation {
+        let attributes = product.attributes.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: "") }
+        return CreateProductVariation(regularPrice: "", attributes: attributes)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -415,6 +415,11 @@ private extension ProductVariationsViewController {
 
         let editAttributesViewModel = EditAttributesViewModel(product: product, allowVariationCreation: true)
         let editAttributeViewController = EditAttributesViewController(viewModel: editAttributesViewModel)
+        editAttributeViewController.onVariationCreation = { [weak self] _ in
+            self?.removeEmptyViewController()
+            self?.navigationController?.popViewController(animated: true)
+        }
+
         guard let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) else {
             return show(editAttributeViewController, sender: nil)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -58,6 +58,38 @@ final class EditAttributesViewModelTests: XCTestCase {
                                                                       numberOfLinesForText: 0)
         XCTAssertEqual(viewModel.attributes, [expectedVM, expectedVM2])
     }
+
+    func test_create_variations_is_invoked_with_correct_parameters() {
+        // Given
+        let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
+        let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
+        let product = Product().copy(attributes: [attribute, attribute2])
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: true, stores: mockStores)
+
+        // When
+        let variationSubmitted: CreateProductVariation = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+               switch action {
+               case let .createProductVariation(_, _, newVariation, _):
+                promise(newVariation)
+               default:
+                   break
+               }
+            }
+
+            viewModel.generateVariation { _ in }
+        }
+
+        // Then
+        let expectedAttributes = [
+            ProductVariationAttribute(id: 0, name: "attr", option: ""),
+            ProductVariationAttribute(id: 1, name: "attr-2", option: ""),
+        ]
+        let expectedVariation = CreateProductVariation(regularPrice: "", attributes: expectedAttributes)
+        XCTAssertEqual(expectedVariation, variationSubmitted)
+    }
 }
 
 private extension EditAttributesViewModelTests {

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -12,6 +12,7 @@ public typealias Address = Networking.Address
 public typealias APNSDevice = Networking.APNSDevice
 public typealias CommentStatus = Networking.CommentStatus
 public typealias Credentials = Networking.Credentials
+public typealias CreateProductVariation = Networking.CreateProductVariation
 public typealias DotcomDevice = Networking.DotcomDevice
 public typealias Leaderboard = Networking.Leaderboard
 public typealias LeaderboardRow = Networking.LeaderboardRow


### PR DESCRIPTION
closes #3538 

# Why 

Creating the first variation is a big and complex flow, for that reason, I'm splitting it into several smaller flows.
Today's turn will be to: **Actually create the first variation** and navigate back to the variations list after it.

Note: After creating the first variation, the main product page is not updated. That will be handled In #3619 

# How

- Update `EditAttributesViewModel` to expose a `generateVariation()` method.

- Update `EditAttributesViewController` to:
  - Call the VM `generateVariation` method, when the "Done" button is pressed.
  - Show a loading screen while the variation is being generated
  - Show an error notice if the variation generation fails
  - Expose an `onVariationCreation` closure, to notify back after the variation is generated.


- Update `ProductVariationsViewController` to pop the previously pushed `EditAttributesViewController` after the variation is created.


# Demo

![create-variation](https://user-images.githubusercontent.com/562080/107889619-ec888900-6ee1-11eb-9300-2f6c508a10e9.gif)


# Testing Steps
- Navigate to a variable product with no variations added
- Tap both of the "Add variations" buttons
- Tap on an existing attribute or write a name for a new one.
- Tap one(or more) existing options or add new ones by writing their name on the text field.
- Tap on the "Next" button
- When the loading finishes, see that you are redirected to the attribute list screen.
- Tap on the "Done" button to generate the first variation.
- See a loading screen
- See that the user is redirected to the variations list screen and the new variation is visible


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
