### PR TITLE
In-App Feedback: Add app version

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -72,7 +72,7 @@ extension SurveyViewController {
                 return WooConstants.URLs.inAppFeedback
                     .asURL()
                     .tagPlatform("ios")
-                    .tagAppVersion()
+                    .tagAppVersion(Bundle.main.bundleVersion())
 
             case .productsM5Feedback:
                 return WooConstants.URLs.productsM4Feedback
@@ -146,8 +146,8 @@ extension URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestPlatformTag, value: platformName))
     }
 
-    func tagAppVersion() -> URL {
-        appendingQueryItem(URLQueryItem(name: Tags.surveyRequestAppVersionTag, value: Bundle.main.bundleVersion()))
+    func tagAppVersion(_ version: String) -> URL {
+        appendingQueryItem(URLQueryItem(name: Tags.surveyRequestAppVersionTag, value: version))
     }
 
     func tagProductMilestone(_ milestone: String) -> URL {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -72,6 +72,7 @@ extension SurveyViewController {
                 return WooConstants.URLs.inAppFeedback
                     .asURL()
                     .tagPlatform("ios")
+                    .tagAppVersion()
 
             case .productsM5Feedback:
                 return WooConstants.URLs.productsM4Feedback
@@ -145,6 +146,10 @@ extension URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestPlatformTag, value: platformName))
     }
 
+    func tagAppVersion() -> URL {
+        appendingQueryItem(URLQueryItem(name: Tags.surveyRequestAppVersionTag, value: Bundle.main.bundleVersion()))
+    }
+
     func tagProductMilestone(_ milestone: String) -> URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestProductMilestoneTag, value: milestone))
     }
@@ -169,6 +174,7 @@ extension URL {
 
     private enum Tags {
         static let surveyRequestPlatformTag = "woo-mobile-platform"
+        static let surveyRequestAppVersionTag = "app-version"
         static let surveyRequestProductMilestoneTag = "product-milestone"
         static let surveyRequestShippingLabelsMilestoneTag = "shipping_label_milestone"
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -19,7 +19,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL().tagPlatform("ios"))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL().tagPlatform("ios").tagAppVersion(Bundle.main.bundleVersion()))
     }
 
     func test_it_loads_the_correct_product_feedback_survey() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
@@ -15,6 +15,14 @@ final class URL_SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(expectedURL, actualURL)
     }
 
+    func test_tagging_app_version_appends_the_correct_tag_data() throws {
+        let expectedURL = "https://testurl.com?app-version=1.2.3"
+
+        let actualURL = URL(string: "https://testurl.com")?.tagAppVersion("1.2.3").absoluteString
+
+        XCTAssertEqual(expectedURL, actualURL)
+    }
+
     func test_tagging_product_milestone_appends_the_correct_tag_data() throws {
         let expectedURL = "https://testurl.com?product-milestone=test"
 


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3644

### Description
- Added app version to the in-app survey metadata

### Testing instructions
1. Go to the My Store section
2. Click on the Settings icon on the upper right corner of the toolbar
3. Once the settings view is presented, click on the `Send feedback` option
4. Wait for the survey loading and make sure everything is working the same way as before
5. Complete the Survey Form
6. Go to the CrowdSignal dashboard with a valid A8C account (tap the A8C icon and select `Switch to: A8C`), then go to the respective Survey overview page you just answered
7. Click at the far right corner of the Overview page and click on the export button to download the Survey report, you can export in both CSV or Excel, it's up to your choice.
8. Go to the right end of the report file and verify if the custom tags are presented according to the Survey you just answered

### Example report
```
248663318,"2021-02-14 23:44:46","2021-02-14 23:45:03","IP Omitted",JP,Japan,Unknown,,Test,Test,,"Mobile Device, Direct","iOS 14.2",iPhone,,woo-mobile-platform,ios,app-version,6.0.0.1
````


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
