### PR TITLE
UL&S: Remove shadows from buttons on the "Pick store to connect" screen in the WordPress.com login flow

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -84,7 +84,7 @@ class StorePickerViewController: UIViewController {
         didSet {
             secondaryActionButton.backgroundColor = .clear
             secondaryActionButton.titleFont = StyleManager.actionButtonTitleFont
-            secondaryActionButton.setTitle(NSLocalizedString("Try another account",
+            secondaryActionButton.setTitle(NSLocalizedString("Try With Another Account",
                                                              comment: "Button to trigger connection to another account in store picker"),
                                            for: .normal)
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -59,15 +59,6 @@ class StorePickerViewController: UIViewController {
 
     // MARK: - Private Properties
 
-    /// White-Background View, to be placed surrounding the bottom area.
-    ///
-    @IBOutlet private var actionBackgroundView: UIView! {
-        didSet {
-            actionBackgroundView.layer.masksToBounds = false
-            actionBackgroundView.layer.shadowOpacity = StorePickerConstants.backgroundShadowOpacity
-        }
-    }
-
     /// Default Action Button.
     ///
     @IBOutlet private var actionButton: FancyAnimatedButton! {
@@ -654,7 +645,6 @@ extension StorePickerViewController: UITableViewDelegate {
 // MARK: - StorePickerConstants: Contains all of the constants required by the Picker.
 //
 private enum StorePickerConstants {
-    static let backgroundShadowOpacity = Float(0.2)
     static let numberOfSections = 1
     static let emptyStateRowCount = 1
     static let estimatedRowHeight = CGFloat(50)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.xib
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="StorePickerViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
-                <outlet property="actionBackgroundView" destination="H5J-Qa-DXp" id="aj6-RY-z7g"/>
                 <outlet property="actionButton" destination="0KD-hY-YaS" id="mJR-Pi-S0z"/>
                 <outlet property="secondaryActionButton" destination="Slo-h4-7qY" id="YFU-eL-sGS"/>
                 <outlet property="tableView" destination="oVs-XS-592" id="tgt-K5-nCu"/>
@@ -30,7 +29,7 @@
                         <outlet property="delegate" destination="-1" id="srI-Ru-BMi"/>
                     </connections>
                 </tableView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H5J-Qa-DXp" userLabel="Action Background View">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H5J-Qa-DXp">
                     <rect key="frame" x="0.0" y="702" width="414" height="194"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0a6-Ee-KF8">
@@ -78,6 +77,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="t7O-Ph-IKW"/>
             <constraints>
                 <constraint firstItem="oVs-XS-592" firstAttribute="top" secondItem="t7O-Ph-IKW" secondAttribute="top" id="2Y8-wP-jSa"/>
                 <constraint firstItem="t7O-Ph-IKW" firstAttribute="trailing" secondItem="oVs-XS-592" secondAttribute="trailing" id="Mr3-k9-GG9"/>
@@ -87,7 +87,6 @@
                 <constraint firstItem="t7O-Ph-IKW" firstAttribute="trailing" secondItem="H5J-Qa-DXp" secondAttribute="trailing" id="iDf-P9-Du1"/>
                 <constraint firstAttribute="bottom" secondItem="H5J-Qa-DXp" secondAttribute="bottom" id="vIo-fJ-O96"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="t7O-Ph-IKW"/>
             <point key="canvasLocation" x="-476" y="19.211822660098523"/>
         </view>
     </objects>


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3572

### Description
- Removed shadows from CTA buttons
- Updated `Try another account` to `Try With Another Account`

### How to test
1. My Store > Settings icon > Log Out
2. Login
3. Land on `Pick store to connect` screen
4. ✅ Check that there are no shadows on the CTA buttons and that the buttons read `Try With Another Account` and `Continue`

### Screenshot

Before | After
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-15 at 15 33 59](https://user-images.githubusercontent.com/6711616/107913328-8e23df00-6fa3-11eb-9a9b-54b96c453575.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-15 at 15 27 04](https://user-images.githubusercontent.com/6711616/107913352-9c71fb00-6fa3-11eb-892f-ed6246cec198.png)

### Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
