### PR TITLE
Update linked products titles (upsells and cross-sells)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
@@ -289,9 +289,8 @@ private extension LinkedProductsViewController {
             }()
         }
 
-        static let titleScreenAddUpsellProducts = NSLocalizedString("Upsells Products",
-                                                                    comment: "Navigation bar title for editing linked products for upsell products")
-        static let titleScreenAddCrossSellProducts = NSLocalizedString("Cross-sells Products",
+        static let titleScreenAddUpsellProducts = NSLocalizedString("Upsells", comment: "Navigation bar title for editing linked products for upsell products")
+        static let titleScreenAddCrossSellProducts = NSLocalizedString("Cross-sells",
                                                                        comment: "Navigation bar title for editing linked products for cross-sell products")
     }
 }


### PR DESCRIPTION
Resolves feedback from p5T066-1NH-p2#comment-7118.

## Description

This PR replaces existing "Upsells Products" and "Cross-sells Products" to simpler "Upsells" and "Cross-sells" as on previous screen.

## Screenshots

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 14 55 20](https://user-images.githubusercontent.com/3132438/107943631-0a1b2880-6f9e-11eb-996e-ac49626c1a09.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 14 56 13](https://user-images.githubusercontent.com/3132438/107943645-0e474600-6f9e-11eb-861f-f0165fce1ef6.png)

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 14 55 24](https://user-images.githubusercontent.com/3132438/107943670-169f8100-6f9e-11eb-9a9b-462acacbe34b.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 14 56 16](https://user-images.githubusercontent.com/3132438/107943685-1bfccb80-6f9e-11eb-8214-aa081b311ebe.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.