### PR TITLE
Update autolayout constraints for header button in linked products list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -31,15 +31,14 @@
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V0q-d9-nEJ">
-                                    <rect key="frame" x="16" y="16" width="382" height="736"/>
+                                    <rect key="frame" x="16" y="16" width="382" height="786"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="ZyD-Oh-bAT"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="u7J-wB-kuj"/>
                                     </constraints>
                                     <state key="normal" title="Button"/>
                                 </button>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="km4-PZ-rGi">
-                                    <rect key="frame" x="0.0" y="768" width="414" height="0.5"/>
+                                    <rect key="frame" x="0.0" y="817.5" width="414" height="0.5"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="0.5" id="wmT-Zg-aY5"/>
@@ -51,14 +50,14 @@
                                 <constraint firstItem="V0q-d9-nEJ" firstAttribute="top" secondItem="e8L-Dl-u8g" secondAttribute="top" constant="16" id="Equ-9A-min"/>
                                 <constraint firstItem="km4-PZ-rGi" firstAttribute="leading" secondItem="e8L-Dl-u8g" secondAttribute="leading" id="LMj-Kk-evu"/>
                                 <constraint firstItem="V0q-d9-nEJ" firstAttribute="leading" secondItem="e8L-Dl-u8g" secondAttribute="leading" constant="16" id="NBG-Mk-26K"/>
+                                <constraint firstAttribute="bottom" secondItem="km4-PZ-rGi" secondAttribute="bottom" id="RGB-dQ-d11"/>
                                 <constraint firstAttribute="bottom" secondItem="V0q-d9-nEJ" secondAttribute="bottom" constant="16" id="Vnr-mH-n6u"/>
-                                <constraint firstItem="km4-PZ-rGi" firstAttribute="top" secondItem="V0q-d9-nEJ" secondAttribute="bottom" constant="16" id="noD-Kc-hNc"/>
                                 <constraint firstAttribute="trailing" secondItem="V0q-d9-nEJ" secondAttribute="trailing" constant="16" id="rmK-mm-Gkx"/>
                                 <constraint firstAttribute="trailing" secondItem="km4-PZ-rGi" secondAttribute="trailing" id="zIT-26-Ue0"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L1e-K0-Lrl">
-                            <rect key="frame" x="0.0" y="768" width="414" height="50"/>
+                            <rect key="frame" x="0.0" y="818" width="414" height="0.0"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
                     </subviews>


### PR DESCRIPTION
## Description

This PR fixes separator appearance and accessibility size handling for header button in linked products lists.

## Changes

1. Separator fix:
Separator already existed, but was pinned to a button and pushed out of a view (button bottom <-> container bottom == button bottom <-> separator top). PR updates Auto Layout constraints for separator to be pinned on container view (separator bottom == container bottom).

2. Button size fix:
Button had 2 height constraints: 1) ==50 2) >=50. PR removes first constraint, so button can expand if needed. No glitches found, since container below is always occupied with a more expanding list or empty view.

## Test

1. Open product details

if linked products already added:

2. Tap "Linked products"
3. Tap Add/Edit products

otherwise:

2. Tap "Add more details" button
3. Tap "Linked products"
4. Tap Add/Edit products

## Screenshots

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 11 49](https://user-images.githubusercontent.com/3132438/107945640-fa511380-6fa0-11eb-9b53-be07b7a737f1.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 15 29](https://user-images.githubusercontent.com/3132438/107945657-fde49a80-6fa0-11eb-8564-ae8da25e0c4e.png)

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 11 52](https://user-images.githubusercontent.com/3132438/107945670-050ba880-6fa1-11eb-939f-6e6ad6eb41a6.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 15 33](https://user-images.githubusercontent.com/3132438/107945682-0b9a2000-6fa1-11eb-9aa2-6c93ddd13708.png)

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 13 32](https://user-images.githubusercontent.com/3132438/107945582-e6a5ad00-6fa0-11eb-8824-fa6a8d13d1b5.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 14 28](https://user-images.githubusercontent.com/3132438/107945588-e86f7080-6fa0-11eb-80b8-31f88bc68352.png)

upsells h | cross-sels h
--|--
![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 16 51](https://user-images.githubusercontent.com/3132438/107945736-1e145980-6fa1-11eb-8c99-e0fd706feeb3.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 15 16 55](https://user-images.githubusercontent.com/3132438/107945747-210f4a00-6fa1-11eb-9865-d4fd738d1101.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
