### PR TITLE
Variations: Add Attribute screen updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -323,7 +323,7 @@ private extension AddAttributeViewController {
     enum Localization {
         static let titleView = NSLocalizedString("Add attribute", comment: "Add Product Attribute screen navigation title")
         static let nextNavBarButton = NSLocalizedString("Next", comment: "Next nav bar button title in Add Product Attribute screen")
-        static let titleCellPlaceholder = NSLocalizedString("Attribute name",
+        static let titleCellPlaceholder = NSLocalizedString("New Attribute Name",
                                                             comment: "Add Product Attribute. Placeholder of cell presenting the title of the new attribute.")
         static let syncErrorMessage = NSLocalizedString("Unable to load product attributes", comment: "Load Product Attributes Action Failed")
         static let retryAction = NSLocalizedString("Retry", comment: "Retry Action")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -240,9 +240,12 @@ private extension AddAttributeViewController {
                                                          onTextChange: { [weak self] newAttributeName in
                                                             self?.viewModel.handleNewAttributeNameChange(newAttributeName)
                                                             self?.enableDoneButton(self?.viewModel.newAttributeName != nil)
-
-            }, onTextDidBeginEditing: {
-        }, onTextDidReturn: nil, inputFormatter: nil, keyboardType: .default)
+                                                         }, onTextDidBeginEditing: {
+                                                         }, onTextDidReturn: { [weak self] _ in
+                                                            self?.doneButtonPressed()
+                                                         }, inputFormatter: nil,
+                                                         keyboardType: .default,
+                                                         returnKeyType: .next)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -117,7 +117,8 @@ extension AddAttributeViewModel {
 
 private extension AddAttributeViewModel {
     enum Localization {
-        static let footerTextField = NSLocalizedString("Variation type (ie Color, Size)", comment: "Footer of text field section in Add Attribute screen")
+        static let footerTextField = NSLocalizedString("To create a variation, you'll need to set its attributes (i.e. \"Color,\" \"Size\") first",
+                                                       comment: "Footer of text field section in Add Attribute screen")
         static let headerAttributes = NSLocalizedString("Or tap to select existing attribute", comment: "Header of attributes section in Add Attribute screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -11,6 +11,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         let onTextDidReturn: ((_ text: String?) -> Void)?
         let inputFormatter: UnitInputFormatter?
         let keyboardType: UIKeyboardType
+        var returnKeyType: UIReturnKeyType = .default
     }
 
     @IBOutlet private weak var textField: UITextField!
@@ -37,6 +38,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.placeholder = viewModel.placeholder
         textField.borderStyle = .none
         textField.keyboardType = viewModel.keyboardType
+        textField.returnKeyType = viewModel.returnKeyType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
     }


### PR DESCRIPTION
Fixes: #3526 

## Description

Updates the Add Attribute screen placeholder text. Also updates the keyboard so it displays a "next" button (instead of "return") that navigates to the next screen when tapped.

## Changes

* Text field placeholder updated to `New Attribute Name`.
* Text field footer text updated to `To create a variation, you’ll need to set its attributes (i.e. “Color,” “Size”) first`.
* `TextFieldTableViewCell` now supports an optional `returnKeyType` to change the keyboard "return" button.
* `TextFieldTableViewCell.ViewModel` in `AddAttributeViewController` sets the `returnKeyType` and `onTextDidReturn` to support navigating to the next screen when the "next" button is tapped.

<img src="https://user-images.githubusercontent.com/8658164/107978185-448fc000-6fb4-11eb-96bc-85859ada6bdd.gif" width="300px">


## Testing

1. Before you start, make sure you have a variable product on your store with no variations.
2. In the app, go to the Products tab.
3. Select your variable product.
4. Select "Add variations."
5. Select "Add Variation."
6. Confirm the placeholder text updates appear as expected on the Add Attribute screen.
7. Tap into the new attribute name field and confirm that tapping "next" on the keyboard does nothing (except dismiss the keyboard) if there is no text in the text field.
8. Enter a new attribute name, tap "next" on the keyboard, and confirm it proceeds to the next screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
