### PR TITLE
Order Details: Update downloadable files row to read-only

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [**] Products: When editing variable products, you can now edit the variation attributes to select different attribute options. [https://github.com/woocommerce/woocommerce-ios/pull/3628]
 - [*] Fixes a bug where long pressing the back button sometimes displayed an empty list of screens.
 - [*] Product Type: Updated product type detail to display "Downloadable" if a product is downloadable. [https://github.com/woocommerce/woocommerce-ios/pull/3647]
+- [*] Fix: Update the downloadable files row to read-only, if the product is accessed from Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3669]
 
 6.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -88,8 +88,8 @@ private extension DefaultProductFormTableViewModel {
                 return .groupedProducts(viewModel: groupedProductsRow(product: product.product, isEditable: editable), isEditable: editable)
             case .variations:
                 return .variations(viewModel: variationsRow(product: product.product))
-            case .downloadableFiles:
-                return .downloadableFiles(viewModel: downloadsRow(product: product))
+            case .downloadableFiles(let editable):
+                return .downloadableFiles(viewModel: downloadsRow(product: product, isEditable: editable), isEditable: editable)
             case .linkedProducts(let editable):
                 return .linkedProducts(viewModel: linkedProductsRow(product: product, isEditable: editable), isEditable: editable)
             default:
@@ -430,7 +430,7 @@ private extension DefaultProductFormTableViewModel {
 
     // MARK: Product downloads only
 
-    func downloadsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
+    func downloadsRow(product: ProductFormDataModel, isEditable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.cloudImage
         let title = Localization.downloadsTitle
         var details = Localization.emptyDownloads
@@ -446,7 +446,8 @@ private extension DefaultProductFormTableViewModel {
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
-                                                        details: details)
+                                                        details: details,
+                                                        isActionable: isEditable)
     }
 
     // MARK: Linked products only

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -27,7 +27,7 @@ enum ProductFormEditAction: Equatable {
     case status(editable: Bool)
     case attributes(editable: Bool)
     // Downloadable products only
-    case downloadableFiles
+    case downloadableFiles(editable: Bool)
 }
 
 /// Creates actions for different sections/UI on the product form.
@@ -99,7 +99,7 @@ private extension ProductFormActionsFactory {
             .inventorySettings(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
-            shouldShowDownloadableProduct ? .downloadableFiles: nil,
+            shouldShowDownloadableProduct ? .downloadableFiles(editable: editable): nil,
             .shortDescription(editable: editable),
             .linkedProducts(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -210,7 +210,7 @@ private extension ProductFormTableViewDataSource {
              .externalURL(let viewModel, _),
              .sku(let viewModel, _),
              .groupedProducts(let viewModel, _),
-             .downloadableFiles(let viewModel),
+             .downloadableFiles(let viewModel, _),
              .linkedProducts(let viewModel, _),
              .variations(let viewModel),
              .attributes(let viewModel, _):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -34,7 +34,7 @@ enum ProductFormSection: Equatable {
         case sku(viewModel: ViewModel, isEditable: Bool)
         case groupedProducts(viewModel: ViewModel, isEditable: Bool)
         case variations(viewModel: ViewModel)
-        case downloadableFiles(viewModel: ViewModel)
+        case downloadableFiles(viewModel: ViewModel, isEditable: Bool)
         case noPriceWarning(viewModel: WarningViewModel)
         case status(viewModel: SwitchableViewModel, isEditable: Bool)
         case linkedProducts(viewModel: ViewModel, isEditable: Bool)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -272,7 +272,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             case .reviews:
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
-            case .downloadableFiles:
+            case .downloadableFiles(_, let isEditable):
+                guard isEditable else {
+                    return
+                }
                 ServiceLocator.analytics.track(.productDetailViewDownloadableFilesTapped)
                 showDownloadableFiles()
             case .linkedProducts(_, let isEditable):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
@@ -163,7 +163,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
                                                 formType: .edit)
 
         // Assert
-        XCTAssertTrue(factory.settingsSectionActions().contains(.downloadableFiles))
+        XCTAssertTrue(factory.settingsSectionActions().contains(.downloadableFiles(editable: true)))
     }
 
     func test_downloadableFiles_row_is_invisible_for_non_downloadable_product_without_downloadableFiles() {
@@ -176,7 +176,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
                                                 formType: .edit)
 
         // Assert
-        XCTAssertFalse(factory.settingsSectionActions().contains(.downloadableFiles))
+        XCTAssertFalse(factory.settingsSectionActions().contains(.downloadableFiles(editable: true)))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -159,7 +159,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
                                                                        .tags(editable: true),
-                                                                       .downloadableFiles,
+                                                                       .downloadableFiles(editable: true),
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -59,7 +59,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
                                                                        .reviews,
-                                                                       .downloadableFiles,
+                                                                       .downloadableFiles(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)


### PR DESCRIPTION
Resolves #3577 

### Description
- Fixed a bug where the downloadable files row was editable when accessed from Order Details

### How to test
1. Create and publish a product with downloadable files.
2. Create an order containing the product from step 1.
3. Go to Orders > tap on the product.
4. ✅ The downloadable files row should be read-only.

### Screenshots
_Notice that there's no chevron on the downloadable file row in the After screenshot_
Before | After 
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-16 at 16 48 45](https://user-images.githubusercontent.com/6711616/108033127-e37cf080-7076-11eb-99b1-961cf58ca8a4.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-16 at 16 43 02](https://user-images.githubusercontent.com/6711616/108033121-e24bc380-7076-11eb-9b03-41e895ff7e82.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
