### PR TITLE
Variations: Fix a big when creating the first attribute and first variation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -251,6 +251,7 @@ private extension AddAttributeOptionsViewController {
                                                             if let text = text {
                                                                 self?.viewModel.addNewOption(name: text)
                                                             }
+
                                                          }, inputFormatter: nil,
                                                          keyboardType: .default)
         cell.configure(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -151,6 +151,9 @@ extension AddAttributeOptionsViewModel {
     /// Inserts a new option with the provided name into the options selected section
     ///
     func addNewOption(name: String) {
+        guard name.isNotEmpty else {
+            return
+        }
         state.selectedOptions.append(.local(name: name))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -91,21 +91,29 @@ final class ProductVariationsViewController: UIViewController {
     }()
 
     private var product: Product
-    private let siteID: Int64
-    private let productID: Int64
-    private let allAttributes: [ProductAttribute]
-    private let parentProductSKU: String?
-    private let formType: ProductFormType
 
+    private var siteID: Int64 {
+        product.siteID
+    }
+
+    private var productID: Int64 {
+        product.productID
+    }
+
+    private var allAttributes: [ProductAttribute] {
+        product.attributes
+    }
+
+    private var parentProductSKU: String? {
+        product.sku
+    }
+
+    private let formType: ProductFormType
     private let imageService: ImageService = ServiceLocator.imageService
     private let isAddProductVariationsEnabled: Bool
 
     init(product: Product, formType: ProductFormType, isAddProductVariationsEnabled: Bool) {
         self.product = product
-        self.siteID = product.siteID
-        self.productID = product.productID
-        self.allAttributes = product.attributes
-        self.parentProductSKU = product.sku
         self.formType = formType
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -61,6 +61,19 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isNextButtonEnabled)
     }
 
+    func test_empty_names_are_not_added_as_options() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
+
+        // When
+        viewModel.addNewOption(name: "")
+
+        // Then
+        let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(textFieldSection, [AddAttributeOptionsViewController.Row.optionTextField])
+        XCTAssertEqual(viewModel.sections.count, 1)
+    }
+
     func test_reorder_option_reorders_the_option_within_sections() throws {
         // Given
         let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))


### PR DESCRIPTION
# Why

I spotted a bug that a new variation wasn't being rendered properly after being generated when it was created using a new attribute.

<img width="392" alt="bug" src="https://user-images.githubusercontent.com/562080/108071719-0fc34d80-7034-11eb-8470-9b0c38bf4ef5.png">


This happened because the `ProductVariationsViewController` only updated its `product` property after creating a variation but did not update its `attributes` property.

# How

To fix it, I'm converting all the stored properties that derived from `product` to be computed properties, so they are always up to date.

# Demo
![create-first-attribute](https://user-images.githubusercontent.com/562080/108072150-882a0e80-7034-11eb-891a-fc402a99720b.gif)


# Testing Steps
- Create a New Variable product
- Create a Variation by creating a new attribute
- After generating the variation see that it renders properly in the variation list screen.

Note: After creating the first variation, the main product page is not updated. That will be handled In #3619

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
