### PR TITLE
Variations: “Edit Attributes” Button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -148,7 +148,7 @@ final class ProductVariationsViewController: UIViewController {
 //
 private extension ProductVariationsViewController {
 
-    /// Set the title.
+    /// Set the title and navigation buttons.
     ///
     func configureNavigationBar() {
         removeNavigationBackBarButtonText()
@@ -156,6 +156,20 @@ private extension ProductVariationsViewController {
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."
         )
+        if product.variations.isNotEmpty {
+            configureMoreOptionsButton()
+        }
+    }
+
+    /// Configure More Options button.
+    ///
+    func configureMoreOptionsButton() {
+        let moreButton = UIBarButtonItem(image: .moreImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(presentMoreOptionsActionSheet(_:)))
+        moreButton.accessibilityLabel = Localization.moreButtonLabel
+        navigationItem.setRightBarButton(moreButton, animated: false)
     }
 
     /// Apply Woo styles.
@@ -443,6 +457,28 @@ private extension ProductVariationsViewController {
     }
 }
 
+// MARK: Action Sheet
+//
+private extension ProductVariationsViewController {
+    @objc private func presentMoreOptionsActionSheet(_ sender: UIBarButtonItem) {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        let editAttributesAction = UIAlertAction(title: Localization.editAttributesAction, style: .default) { [weak self] _ in
+            self?.navigateToEditAttributeViewController()
+        }
+        actionSheet.addAction(editAttributesAction)
+
+        let cancelAction = UIAlertAction(title: Localization.cancelAction, style: .cancel)
+        actionSheet.addAction(cancelAction)
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = sender
+
+        present(actionSheet, animated: true)
+    }
+}
+
 // MARK: - Placeholders
 //
 private extension ProductVariationsViewController {
@@ -597,5 +633,8 @@ private extension ProductVariationsViewController {
         static let emptyStateTitle = NSLocalizedString("Add your first variation", comment: "Title on the variations list screen when there are no variations")
         static let emptyStateButtonTitle = NSLocalizedString("Add Variation", comment: "Title on add variation button when there are no variations")
         static let addNewVariation = NSLocalizedString("Add Variation", comment: "Action to add new variation on the variations list")
+        static let moreButtonLabel = NSLocalizedString("More options", comment: "Accessibility label to show the More Options action sheet")
+        static let editAttributesAction = NSLocalizedString("Edit Attributes", comment: "Action to edit the attributes and options used for variations")
+        static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel button in the More Options action sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -156,7 +156,7 @@ private extension ProductVariationsViewController {
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."
         )
-        if product.variations.isNotEmpty {
+        if product.variations.isNotEmpty && isAddProductVariationsEnabled {
             configureMoreOptionsButton()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -415,19 +415,19 @@ private extension ProductVariationsViewController {
         let addAttributeViewController = AddAttributeViewController(viewModel: viewModel) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.product = updatedProduct
-            self.navigateToEditAttributeViewController()
+            self.navigateToEditAttributeViewController(allowVariationCreation: true)
         }
         show(addAttributeViewController, sender: self)
     }
 
     /// Cleans the navigation stack until `self` and navigates to `EditAttributesViewController`
     ///
-    func navigateToEditAttributeViewController() {
+    func navigateToEditAttributeViewController(allowVariationCreation: Bool) {
         guard let navigationController = navigationController else {
             return
         }
 
-        let editAttributesViewModel = EditAttributesViewModel(product: product, allowVariationCreation: true)
+        let editAttributesViewModel = EditAttributesViewModel(product: product, allowVariationCreation: allowVariationCreation)
         let editAttributeViewController = EditAttributesViewController(viewModel: editAttributesViewModel)
         editAttributeViewController.onVariationCreation = { [weak self] _ in
             self?.removeEmptyViewController()
@@ -465,7 +465,7 @@ private extension ProductVariationsViewController {
         actionSheet.view.tintColor = .text
 
         let editAttributesAction = UIAlertAction(title: Localization.editAttributesAction, style: .default) { [weak self] _ in
-            self?.navigateToEditAttributeViewController()
+            self?.navigateToEditAttributeViewController(allowVariationCreation: false)
         }
         actionSheet.addAction(editAttributesAction)
 


### PR DESCRIPTION
Closes: #3194 

## Description

If a variable product has existing variations, a `...` menu is shown with an "Edit Attributes" button (currently behind the `addProductVariations` feature flag). The button navigates to the Edit Attributes screen, allowing the user to edit the attributes and options and generate new variations again. 

## Changes

In `ProductVariationsViewController`:

* The `...` menu ("more options" button) is configured and added to the navigation bar on the condition that the product has variations and the `addProductVariations` feature flag is enabled.
* The "more options" action sheet is configured and presented with an "Edit Attributes" button and a "Cancel" button.

<img src="https://user-images.githubusercontent.com/8658164/108072485-dbb15200-705e-11eb-8566-7cb8338176cf.gif" width="300px">


## Testing

**Setup:** Make sure you have at least two variable products on your store, one with variations and one without any variations.

Without variations:
1. Go to the Products tab.
2. Select the variable product with no variations.
3. Select "Add variations."
4. Confirm no `...` appears in the navigation bar.

With variations:
1. Go to the Products tab.
2. Select the variable product with variations.
3. Select "Variations."
4. Tap the `...` menu in the top right.
5. Confirm you can tap "Cancel" to close the action sheet.
6. Tap the `...` menu again.
7. Select "Edit Attributes" and confirm it opens the "Edit Attributes" screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
