### PR TITLE
Shipping Labels M1: remove feature flag and track API error

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -85,9 +85,18 @@ extension WooAnalyticsEvent {
     }
 
     /// The result of a shipping labels API GET request.
-    public enum ShippingLabelsAPIRequestResult: String {
+    public enum ShippingLabelsAPIRequestResult {
         case success
-        case failed
+        case failed(error: Error)
+
+        fileprivate var rawValue: String {
+            switch self {
+            case .success:
+                return "success"
+            case .failed:
+                return "failed"
+            }
+        }
     }
 
     static func appFeedbackPrompt(action: AppFeedbackPromptAction) -> WooAnalyticsEvent {
@@ -107,7 +116,15 @@ extension WooAnalyticsEvent {
     }
 
     static func shippingLabelsAPIRequest(result: ShippingLabelsAPIRequestResult) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .shippingLabelsAPIRequest, properties: ["action": result.rawValue])
+        switch result {
+        case .success:
+            return WooAnalyticsEvent(statName: .shippingLabelsAPIRequest, properties: ["action": result.rawValue])
+        case .failed(let error):
+            return WooAnalyticsEvent(statName: .shippingLabelsAPIRequest, properties: [
+                "action": result.rawValue,
+                "error": error.localizedDescription
+            ])
+        }
     }
 
     static func ordersListLoaded(totalDuration: TimeInterval, pageNumber: Int, status: OrderStatus?) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,8 +9,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .shippingLabelsRelease1:
-            return true
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -22,10 +22,6 @@ enum FeatureFlag: Int {
     ///
     case reviews
 
-    /// Shipping labels - release 1
-    ///
-    case shippingLabelsRelease1
-
     /// Shipping labels - release 2
     ///
     case shippingLabelsRelease2

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -787,10 +787,6 @@ extension OrderDetailsDataSource {
         }()
 
         let shippingLabelSections: [Section] = {
-            guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease1) else {
-                return []
-            }
-
             guard shippingLabels.isNotEmpty else {
                 return []
             }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -376,7 +376,7 @@ extension OrderDetailsViewModel {
                 ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .success))
                 onCompletion?(nil)
             case .failure(let error):
-                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed))
+                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
                 DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
                 onCompletion?(error)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -70,9 +70,7 @@ final class OrderDetailsViewController: UIViewController {
         syncProducts()
         syncProductVariations()
         syncRefunds()
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease1) {
-            syncShippingLabels()
-        }
+        syncShippingLabels()
         syncTrackingsHidingAddButtonIfNecessary()
     }
 


### PR DESCRIPTION
Fixes #3434 

## Why

Now that Shipping Labels M1 has been launched publicly for a few weeks, I took a look of the data on Tracks and there is some usage (not much, but some) 😃 This PR removes the M1 feature flag from the code base, and tracks the error of a failing shipping labels API request since ~68% of the requests failed from `woocommerceios_shipping_label_api_request` event in Tracks. My guess is that most of the failure is from the site not having WooCommerce Shipping & Tax plugin installed/activated, but it'd be nice to know for sure.

## Changes

- Removed Shipping Labels M1 feature flag in https://github.com/woocommerce/woocommerce-ios/commit/257844666453328d5f5e9f79392cd8c99aa13f27
- Tracked the error of a failing shipping labels API request `woocommerceios_shipping_label_api_request` in https://github.com/woocommerce/woocommerce-ios/commit/5a87fea9cb5c57d1bc36c5ecea0512c35ed16b11

## Testing

- Switch to a store without WooCommerce Shipping & Tax plugin or deactivate the plugin on the site wp-admin if necessary
- Go to the Orders tab
- Tap on an order --> there should be an event in the console: `🔵 Tracked shipping_label_api_request` with `action: "failed"` and an `error`

## Example screenshots

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
