### PR TITLE
Order Details: Fix product image not loading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fixes a bug where long pressing the back button sometimes displayed an empty list of screens.
 - [*] Product Type: Updated product type detail to display "Downloadable" if a product is downloadable. [https://github.com/woocommerce/woocommerce-ios/pull/3647]
 - [*] Fix: Update the downloadable files row to read-only, if the product is accessed from Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3669]
+- [*] Fix: Thumbnail image of a product wasn't being loaded correctly in Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3678]
 
 6.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -92,7 +92,12 @@ extension PickListTableViewCell {
                                                        with: item.imageURL?.absoluteString,
                                                        placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),
                                                        progressBlock: nil,
-                                                       completion: nil)
+                                                       completion: { [weak productImageView] (image, error) in
+                                                           guard image != nil else {
+                                                               return
+                                                           }
+                                                           productImageView?.contentMode = .scaleAspectFill
+                                                       })
         name = item.name
         quantity = item.quantity
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -92,12 +92,7 @@ extension PickListTableViewCell {
                                                        with: item.imageURL?.absoluteString,
                                                        placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),
                                                        progressBlock: nil,
-                                                       completion: { [weak productImageView] (image, error) in
-                                                           guard image != nil else {
-                                                               return
-                                                           }
-                                                           productImageView?.contentMode = .scaleAspectFill
-                                                       })
+                                                       completion: nil)
         name = item.name
         quantity = item.quantity
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -21,6 +21,7 @@ final class ProductListViewController: UIViewController {
         super.viewDidLoad()
 
         self.items = viewModel.order.items
+        self.products = viewModel.products
         configureMainView()
         configureTableView()
     }


### PR DESCRIPTION
Resolves #3550 

### Description
- Fixed a bug in Order Details where the thumbnail image of a product wasn't being loaded correctly.

### Error
- We were getting a `Kingfisher.KingfisherError.ImageSettingErrorReason.emptySource` for this method:
https://github.com/woocommerce/woocommerce-ios/blob/3632d0a0dd6f594e5bb3cdf78701c97dd69db106/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Product%20List%20Section/Product%20Details/PickListTableViewCell.swift#L91-L95

### Actual source of error
- The `products` property wasn't being set in `ProductListViewController`. As a result, the `imageURL` we pass in `downloadAndCacheImageForImageView` was nil, which is why we were getting the error above.

### How to test
1. Go to the Orders tab and tap on a order with an order status of failed / on hold / pending 
2. Tap “Details” below the product list inside the order
3. ✅ Confirm that the thumbnail images are loaded correctly

### Screenshot
Before | After
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-17 at 14 35 28](https://user-images.githubusercontent.com/6711616/108160984-72e4db00-712d-11eb-910f-fa8204cef842.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-17 at 14 31 58](https://user-images.githubusercontent.com/6711616/108160983-724c4480-712d-11eb-9d68-45e0fd2b5a3c.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
