### PR TITLE
Allow alternative types for `Product`'s `regular_price` and `sold_individually` attributes

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -274,8 +274,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
                                                       forKey: .price,
                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
             ?? ""
-
-        let regularPrice = try container.decodeIfPresent(String.self, forKey: .regularPrice)
+        let regularPrice = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                             forKey: .regularPrice,
+                                                             alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
+            ?? ""
 
         let onSale = try container.decode(Bool.self, forKey: .onSale)
 
@@ -325,7 +327,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
         let backordered = try container.decode(Bool.self, forKey: .backordered)
 
-        let soldIndividually = try container.decode(Bool.self, forKey: .soldIndividually)
+        let soldIndividually = try container.decodeIfPresent(Bool.self, forKey: .soldIndividually) ?? false
         let weight = try container.decodeIfPresent(String.self, forKey: .weight)
         let dimensions = try container.decode(ProductDimensions.self, forKey: .dimensions)
 

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -109,8 +109,10 @@ final class ProductMapperTests: XCTestCase {
         let product = try XCTUnwrap(mapLoadProductResponseWithAlternativeTypes())
 
         XCTAssertEqual(product.price, "17")
+        XCTAssertEqual(product.regularPrice, "12.89")
         XCTAssertEqual(product.salePrice, "26.73")
         XCTAssertTrue(product.manageStock)
+        XCTAssertFalse(product.soldIndividually)
     }
 
     /// Verifies that the `salePrice` field of the Product are parsed correctly when the product is on sale, and the sale price is an empty string

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -103,7 +103,7 @@ final class ProductMapperTests: XCTestCase {
     }
 
     /// Verifies that the fields of the Product with alternative types are parsed correctly when they have different types than in the struct.
-    /// Currently, `price`, `salePrice` and `manageStock` allow alternative types.
+    /// Currently, `price`, `regularPrice`, `salePrice`, `manageStock`, and `soldIndividually` allow alternative types.
     ///
     func test_that_product_alternative_types_are_properly_parsed() throws {
         let product = try XCTUnwrap(mapLoadProductResponseWithAlternativeTypes())

--- a/Networking/NetworkingTests/Responses/product-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-alternative-types.json
@@ -16,7 +16,7 @@
             "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
             "sku": "",
             "price": 17,
-            "regular_price": "",
+            "regular_price": 12.89,
             "sale_price": 26.73,
             "date_on_sale_from": null,
             "date_on_sale_from_gmt": "2019-10-15T21:30:00",
@@ -41,7 +41,7 @@
             "backorders": "no",
             "backorders_allowed": false,
             "backordered": false,
-            "sold_individually": true,
+            "sold_individually": null,
             "weight": "213",
             "dimensions": {
                 "length": "12",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fixes a bug where long pressing the back button sometimes displayed an empty list of screens.
 - [*] Product Type: Updated product type detail to display "Downloadable" if a product is downloadable. [https://github.com/woocommerce/woocommerce-ios/pull/3647]
 - [*] Fix: Update the downloadable files row to read-only, if the product is accessed from Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3669]
+- [*] Fix: Allow product's `regular_price` to be a number and `sold_individually` to be `null` as some third-party plugins could alter the type in the API. This could help with the products tab not loading due to product decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/3679]
 
 6.0
 -----


### PR DESCRIPTION
Fixes #2822 
Fixes #3511 

## Why

Third-party plugins could alter the type of certain `Product` attributes, and so far we've seen the following in #2822 and #3511:
- `regular_price`: expected a string, but received a number
- `sold_individually`: expected a boolean, but received `null`

Since we've received a few support tickets on similar decoding errors, let's support the above alternative types so that the Products tab doesn't appear blank when one of the products has a mismatched attribute type.

## Changes

In `Networking.Product`:
- Allowed decimal type for `regularPrice: String` when decoding from `regular_price` in the API response
- Allowed `null` for `soldIndividually: Bool`, and default to `false` (as in the [API doc](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties))

## Testing

I couldn't pinpoint the plugins in #3511, but was able to reproduce the `regular_price` attribute decoding error following the steps in #2822:

1. Enable the [Auctions for WooCommerce](https://woocommerce.com/products/auctions-for-woocommerce/) extension on your store
2. Create an auction product (I noticed that auction products don't appear in the products tab in mobile for some reason, they aren't included in the Products API response)
3. Create an order for the auction product (either purchased with the “buy it now” option or with a winning bid)
4. In the app, open the order details for that order
5. Tap the auction product in the Product section of the order details --> the readonly auction product should be shown

## Example screenshots

<img src="https://user-images.githubusercontent.com/1945542/108166139-b7bd4180-712e-11eb-8514-45603cd2ff99.png" width="300" />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
