### PR TITLE
Shipping Labels: populated fields in the address form screen

### DIFF
--- a/WooCommerce/Classes/Tools/SiteAddress.swift
+++ b/WooCommerce/Classes/Tools/SiteAddress.swift
@@ -52,8 +52,8 @@ final class SiteAddress {
 
     private func getValueFromSiteSettings(_ settingID: String) -> String? {
         return siteSettings.first { (setting) -> Bool in
-                    return setting.settingID.contains(settingID)
-                }?.value
+            return setting.settingID.isEqual(to: settingID)
+        }?.value
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -286,7 +286,7 @@ private extension ShippingLabelAddressFormViewController {
         static let nameFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
         static let companyField = NSLocalizedString("Company", comment: "Text field company in Shipping Label Address Validation")
         static let companyFieldPlaceholder = NSLocalizedString("Optional", comment: "Text field placeholder in Shipping Label Address Validation")
-        static let phoneField = NSLocalizedString("Phones", comment: "Text field phone in Shipping Label Address Validation")
+        static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Shipping Label Address Validation")
         static let phoneFieldPlaceholder = NSLocalizedString("Optional", comment: "Text field placeholder in Shipping Label Address Validation")
         static let addressField = NSLocalizedString("Address", comment: "Text field address in Shipping Label Address Validation")
         static let addressFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -126,111 +126,111 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func configureName(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.nameField,
-                                                                 text: "",
-                                                                 placeholder: Localization.nameFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.nameField,
+                                                                     text: viewModel.address?.name,
+                                                                     placeholder: Localization.nameFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureCompany(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.companyField,
-                                                                 text: "",
-                                                                 placeholder: Localization.companyFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.companyField,
+                                                                     text: viewModel.address?.company,
+                                                                     placeholder: Localization.companyFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configurePhone(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.phoneField,
-                                                                 text: "",
-                                                                 placeholder: Localization.phoneFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.phoneField,
+                                                                     text: viewModel.address?.phone,
+                                                                     placeholder: Localization.phoneFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureAddress(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.addressField,
-                                                                 text: "",
-                                                                 placeholder: Localization.addressFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.addressField,
+                                                                     text: viewModel.address?.address1,
+                                                                     placeholder: Localization.addressFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureAddress2(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.address2Field,
-                                                                 text: "",
-                                                                 placeholder: Localization.address2FieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.address2Field,
+                                                                     text: viewModel.address?.address2,
+                                                                     placeholder: Localization.address2FieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureCity(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.cityField,
-                                                                 text: "",
-                                                                 placeholder: Localization.cityFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.cityField,
+                                                                     text: viewModel.address?.city,
+                                                                     placeholder: Localization.cityFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configurePostcode(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.postcodeField,
-                                                                 text: "",
-                                                                 placeholder: Localization.postcodeFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.postcodeField,
+                                                                     text: viewModel.address?.postcode,
+                                                                     placeholder: Localization.postcodeFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureState(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.stateField,
-                                                                 text: "",
-                                                                 placeholder: Localization.stateFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.stateField,
+                                                                     text: viewModel.address?.state,
+                                                                     placeholder: Localization.stateFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureCountry(cell: TitleAndTextFieldTableViewCell, row: Row) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.countryField,
-                                                                 text: "",
-                                                                 placeholder: Localization.countryFieldPlaceholder,
-                                                                 state: .normal,
-                                                                 keyboardType: .default,
-                                                                 textFieldAlignment: .leading) { (newText) in
+        let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.countryField,
+                                                                     text: viewModel.address?.country,
+                                                                     placeholder: Localization.countryFieldPlaceholder,
+                                                                     state: .normal,
+                                                                     keyboardType: .default,
+                                                                     textFieldAlignment: .leading) { (newText) in
 
         }
-        cell.configure(viewModel: viewModel)
+        cell.configure(viewModel: cellViewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -10,8 +10,7 @@ final class ShippingLabelFormViewController: UIViewController {
     /// Init
     ///
     init(order: Order) {
-        // TODO: pass the real origin address. It will be implemented in a next PR that fetch the store address.
-        viewModel = ShippingLabelFormViewModel(originAddress: order.billingAddress, destinationAddress: order.shippingAddress)
+        viewModel = ShippingLabelFormViewModel(originAddress: nil, destinationAddress: order.shippingAddress)
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -13,13 +13,13 @@ final class ShippingLabelFormViewModel {
 
     init(originAddress: Address?, destinationAddress: Address?) {
         self.originAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: originAddress) ??
-            ShippingLabelFormViewModel.generateDefaultOriginAddress()
+            ShippingLabelFormViewModel.getDefaultOriginAddress()
         self.destinationAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: destinationAddress)
     }
 
     var sections: [Section] {
-        let shipFrom = Row(type: .shipFrom, dataState: .validated, displayMode: .editable)
-        let shipTo = Row(type: .shipTo, dataState: .pending, displayMode: .editable)
+        let shipFrom = Row(type: .shipFrom, dataState: .pending, displayMode: .editable)
+        let shipTo = Row(type: .shipTo, dataState: .pending, displayMode: .disabled)
         let packageDetails = Row(type: .packageDetails, dataState: .pending, displayMode: .disabled)
         let shippingCarrierAndRates = Row(type: .shippingCarrierAndRates, dataState: .pending, displayMode: .disabled)
         let paymentMethod = Row(type: .paymentMethod, dataState: .pending, displayMode: .disabled)
@@ -30,7 +30,9 @@ final class ShippingLabelFormViewModel {
 
 // MARK: - Utils
 extension ShippingLabelFormViewModel {
-    private static func generateDefaultOriginAddress() -> ShippingLabelAddress? {
+    // We generate the default origin address using the information
+    // of the logged Account and of the website.
+    private static func getDefaultOriginAddress() -> ShippingLabelAddress? {
         let address = Address(firstName: ServiceLocator.stores.sessionManager.defaultAccount?.displayName ?? "",
                 lastName: "", company: ServiceLocator.stores.sessionManager.defaultSite?.name ?? "",
                 address1: SiteAddress().address,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -12,7 +12,8 @@ final class ShippingLabelFormViewModel {
     let destinationAddress: ShippingLabelAddress?
 
     init(originAddress: Address?, destinationAddress: Address?) {
-        self.originAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: originAddress)
+        self.originAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: originAddress) ??
+            ShippingLabelFormViewModel.generateDefaultOriginAddress()
         self.destinationAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: destinationAddress)
     }
 
@@ -29,6 +30,20 @@ final class ShippingLabelFormViewModel {
 
 // MARK: - Utils
 extension ShippingLabelFormViewModel {
+    private static func generateDefaultOriginAddress() -> ShippingLabelAddress? {
+        let address = Address(firstName: ServiceLocator.stores.sessionManager.defaultAccount?.displayName ?? "",
+                lastName: "", company: ServiceLocator.stores.sessionManager.defaultSite?.name ?? "",
+                address1: SiteAddress().address,
+                address2: SiteAddress().address2,
+                city: SiteAddress().city,
+                state: SiteAddress().state,
+                postcode: SiteAddress().postalCode,
+                country: SiteAddress().countryName ?? "",
+                phone: "",
+                email: ServiceLocator.stores.sessionManager.defaultAccount?.email)
+        return fromAddressToShippingLabelAddress(address: address)
+    }
+
     private static func fromAddressToShippingLabelAddress(address: Address?) -> ShippingLabelAddress? {
         guard let address = address else { return nil }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -33,6 +33,9 @@ extension ShippingLabelFormViewModel {
     // We generate the default origin address using the information
     // of the logged Account and of the website.
     private static func getDefaultOriginAddress() -> ShippingLabelAddress? {
+        // TODO: 2973 - for populating the origin address with the correct first and last name of the store owner
+        // we need to explicitly ask for first_name,last_name parameters in loadAccountSettings method
+        // and add the new properties to AccountSettings entity.
         let address = Address(firstName: ServiceLocator.stores.sessionManager.defaultAccount?.displayName ?? "",
                 lastName: "", company: ServiceLocator.stores.sessionManager.defaultSite?.name ?? "",
                 address1: SiteAddress().address,


### PR DESCRIPTION
Part of #2973 

## Description 
As part of Shipping Labels M2, during the shipping label creation, we need to display the store address as the origin address, and we also need to display this info in the address form screen. In this PR, now the address will be shown in the Address Form Screen, and also the origin address will be generated (the name is still a WIP. For populating the origin address with the correct first and last name of the store owner, we need to explicitly ask for `first_name,last_name` parameters in `loadAccountSettings` method and add the new properties to `AccountSettings` entity. This will be part of a separate PR).

## Changes
- Display the address info in `ShippingLabelAddressFormViewController` cells.
- Generated the origin address in `ShippingLabelFormViewModel`.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in the Create Shipping Label form.
5. The new screen for validating an address should be presented with all the information. Since at this moment just the "Ship From" option is enabled, you will be able to see the address and the info of your store.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/108223891-9a8e7000-713a-11eb-9469-1a6f34a2fdf0.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
