### PR TITLE
Add view model for ProductVariationsViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -347,7 +347,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard let product = product as? EditableProductModel, row.isActionable else {
                     return
                 }
-                let variationsViewController = ProductVariationsViewController(product: product.product,
+                let variationsViewModel = ProductVariationsViewModel(product: product.product, isAddProductVariationsEnabled: isAddProductVariationsEnabled)
+                let variationsViewController = ProductVariationsViewController(viewModel: variationsViewModel,
+                                                                               product: product.product,
                                                                                formType: viewModel.formType,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 show(variationsViewController, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -100,7 +100,9 @@ final class ProductVariationsViewController: UIViewController {
     private let imageService: ImageService = ServiceLocator.imageService
     private let isAddProductVariationsEnabled: Bool
 
-    init(product: Product, formType: ProductFormType, isAddProductVariationsEnabled: Bool) {
+    private let viewModel: ProductVariationsViewModel
+
+    init(viewModel: ProductVariationsViewModel, product: Product, formType: ProductFormType, isAddProductVariationsEnabled: Bool) {
         self.product = product
         self.siteID = product.siteID
         self.productID = product.productID
@@ -108,6 +110,7 @@ final class ProductVariationsViewController: UIViewController {
         self.parentProductSKU = product.sku
         self.formType = formType
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -156,7 +159,7 @@ private extension ProductVariationsViewController {
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."
         )
-        if product.variations.isNotEmpty && isAddProductVariationsEnabled {
+        if viewModel.showMoreButton {
             configureMoreOptionsButton()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Yosemite
+
+/// Provides view data for Product Variations.
+///
+final class ProductVariationsViewModel {
+
+    /// Main product dependency.
+    ///
+    private let product: Product
+
+    /// Defines if the Add Product Variations feature is enabled
+    ///
+    private let isAddProductVariationsEnabled: Bool
+
+    /// Defines if the More Options button should be shown
+    ///
+    var showMoreButton: Bool {
+        product.variations.isNotEmpty && isAddProductVariationsEnabled
+    }
+
+    init(product: Product,
+         isAddProductVariationsEnabled: Bool) {
+        self.product = product
+        self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -828,6 +828,7 @@
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
+		CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
 		CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
@@ -1982,6 +1983,7 @@
 		B5FD111521D3F13700560344 /* BordersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BordersView.swift; sourceTree = "<group>"; };
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModel.swift; sourceTree = "<group>"; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2776,6 +2778,7 @@
 			children = (
 				026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */,
 				026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */,
+				CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */,
 				0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */,
 				02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
@@ -6152,6 +6155,7 @@
 				0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */,
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,
+				CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */,
 				02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */,
 				45C11B7C2508E156006C2089 /* SelectedSiteSettings.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -829,6 +829,7 @@
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
 		CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */; };
+		CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
 		CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
@@ -1984,6 +1985,7 @@
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModel.swift; sourceTree = "<group>"; };
+		CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModelTests.swift; sourceTree = "<group>"; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2739,6 +2741,7 @@
 				0248B3522457CF1500A271A4 /* Filters */,
 				027B8BBB23FE0DCD0040944E /* Media */,
 				0279F0E0252DC4A30098D7DE /* Product Loader */,
+				CCD2E68725DD528000BD975D /* Variations */,
 				020B2F9723BDF2D000BD79AD /* Edit Product */,
 				45FBDF29238BF87800127F77 /* Collection View Cells */,
 				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
@@ -4490,6 +4493,14 @@
 				455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		CCD2E68725DD528000BD975D /* Variations */ = {
+			isa = PBXGroup;
+			children = (
+				CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */,
+			);
+			path = Variations;
 			sourceTree = "<group>";
 		};
 		CCDC49CB23FFFFF4003166BA /* WooCommerceUITests */ = {
@@ -6506,6 +6517,7 @@
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
+				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import WooCommerce
+
+final class ProductVariationsViewModelTests: XCTestCase {
+    func test_more_button_appears_when_product_is_not_empty_and_addProductVariations_feature_is_enabled() {
+        // Arrange
+        let variations: [Int64] = [101, 102]
+        let product = MockProduct().product(variations: variations)
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
+
+        // Assert
+        XCTAssertEqual(viewModel.showMoreButton, true)
+    }
+
+    func test_more_button_does_not_appear_when_product_is_not_empty_and_addProductVariations_feature_is_disabled() {
+        // Arrange
+        let variations: [Int64] = [101, 102]
+        let product = MockProduct().product(variations: variations)
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+
+        // Assert
+        XCTAssertEqual(viewModel.showMoreButton, false)
+    }
+
+    func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_enabled() {
+        // Arrange
+        let product = MockProduct().product()
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
+
+        // Assert
+        XCTAssertEqual(viewModel.showMoreButton, false)
+    }
+
+    func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_disabled() {
+        // Arrange
+        let product = MockProduct().product()
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+
+        // Assert
+        XCTAssertEqual(viewModel.showMoreButton, false)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -1,11 +1,12 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 final class ProductVariationsViewModelTests: XCTestCase {
     func test_more_button_appears_when_product_is_not_empty_and_addProductVariations_feature_is_enabled() {
         // Arrange
         let variations: [Int64] = [101, 102]
-        let product = MockProduct().product(variations: variations)
+        let product = Product().copy(variations: variations)
         let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
 
         // Assert
@@ -15,7 +16,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
     func test_more_button_does_not_appear_when_product_is_not_empty_and_addProductVariations_feature_is_disabled() {
         // Arrange
         let variations: [Int64] = [101, 102]
-        let product = MockProduct().product(variations: variations)
+        let product = Product().copy(variations: variations)
         let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
 
         // Assert
@@ -24,7 +25,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
 
     func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_enabled() {
         // Arrange
-        let product = MockProduct().product()
+        let product = Product().copy()
         let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
 
         // Assert
@@ -33,7 +34,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
 
     func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_disabled() {
         // Arrange
-        let product = MockProduct().product()
+        let product = Product().copy()
         let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
 
         // Assert


### PR DESCRIPTION
Related discussion: https://github.com/woocommerce/woocommerce-ios/pull/3671#discussion_r576917870

## Description

This PR introduces the view model `ProductVariationsViewModel` for `ProductVariationsViewController`, and accompanying unit tests. For now the view model is very small, just introducing the `showMoreButton` variable to control whether the `...` more button appears (when the product has variations and the `addProductVariations` feature flag is enabled).

## Changes

* New view model `ProductVariationsViewModel` with `showMoreButton`.
* `ProductVariationsViewController` is updated to use the new view model.
* New unit tests to check that the more button is only displayed when expected.

(This is my first time adding a new view model — please share any thoughts, big or nitpicky, about how it's done!)

## Testing

* Check the code and confirm all unit tests pass.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
