### PR TITLE
Fix Failing Stats Availability Network Request

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -10,23 +10,25 @@ public final class OrderStatsRemoteV4: Remote {
     ///   - siteID: The site ID
     ///   - unit: Defines the granularity of the stats we are fetching (one of 'hourly', 'daily', 'weekly', 'monthly', or 'yearly')
     ///   - latestDateToInclude: The latest date to include in the results.
-    ///     This string is ISO8601 compliant
     ///   - completion: Closure to be executed upon completion.
     ///
     /// Note: by limiting the return values with the `_fields` param, we shrink the response size by over 90%! (~40kb to ~3kb)
     ///
     public func loadOrderStats(for siteID: Int64,
                                unit: StatsGranularityV4,
-                               earliestDateToInclude: String,
-                               latestDateToInclude: String,
+                               earliestDateToInclude: Date,
+                               latestDateToInclude: Date,
                                quantity: Int,
                                completion: @escaping (OrderStatsV4?, Error?) -> Void) {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+
         // Workaround for #1183: random number between 31-100 for `num_page` param.
         // Replace `randomQuantity` with `quantity` in `num_page` param when API issue is fixed.
         let randomQuantity = arc4random_uniform(70) + 31
+
         let parameters = [ParameterKeys.interval: unit.rawValue,
-                          ParameterKeys.after: earliestDateToInclude,
-                          ParameterKeys.before: latestDateToInclude,
+                          ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+                          ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
                           ParameterKeys.quantity: String(randomQuantity)]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.orderStatsPath, parameters: parameters)

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -30,8 +30,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
 
         remote.loadOrderStats(for: sampleSiteID,
                               unit: .hourly,
-                              earliestDateToInclude: "1955-11-05",
-                              latestDateToInclude: "1955-11-05",
+                              earliestDateToInclude: Date(),
+                              latestDateToInclude: Date(),
                               quantity: 24) { (orderStatsV4, error) in
                                 XCTAssertNil(error)
                                 XCTAssertNotNil(orderStatsV4)
@@ -53,8 +53,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
 
         remote.loadOrderStats(for: sampleSiteID,
                               unit: .weekly,
-                              earliestDateToInclude: "1955-11-05",
-                              latestDateToInclude: "1955-11-05",
+                              earliestDateToInclude: Date(),
+                              latestDateToInclude: Date(),
                               quantity: 2) { (orderStatsV4, error) in
                                 XCTAssertNil(error)
                                 XCTAssertNotNil(orderStatsV4)
@@ -73,8 +73,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
 
         remote.loadOrderStats(for: sampleSiteID,
                               unit: .daily,
-                              earliestDateToInclude: "1955-11-05",
-                              latestDateToInclude: "1955-11-05",
+                              earliestDateToInclude: Date(),
+                              latestDateToInclude: Date(),
                               quantity: 31) { (orderStats, error) in
             XCTAssertNil(orderStats)
             XCTAssertNotNil(error)

--- a/Yosemite/Yosemite/Stores/AvailabilityStore.swift
+++ b/Yosemite/Yosemite/Stores/AvailabilityStore.swift
@@ -39,11 +39,10 @@ private extension AvailabilityStore {
     ///
     func checkStatsV4Availability(siteID: Int64,
                                   onCompletion: @escaping (_ isStatsV4Available: Bool) -> Void) {
-        let date = String(describing: Date().timeIntervalSinceReferenceDate)
         orderStatsRemote.loadOrderStats(for: siteID,
                               unit: .yearly,
-                              earliestDateToInclude: date,
-                              latestDateToInclude: date,
+                              earliestDateToInclude: Date(),
+                              latestDateToInclude: Date(),
                               quantity: 1) { (_, error) in
                                 if let error = error as? DotcomError, error == .noRestRoute {
                                     onCompletion(false)

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -97,14 +97,10 @@ public extension StatsStoreV4 {
                        latestDateToInclude: Date,
                        quantity: Int,
                        onCompletion: @escaping (Error?) -> Void) {
-        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
-        let earliestDate = dateFormatter.string(from: earliestDateToInclude)
-        let latestDate = dateFormatter.string(from: latestDateToInclude)
-
         orderStatsRemote.loadOrderStats(for: siteID,
                               unit: timeRange.intervalGranularity,
-                              earliestDateToInclude: earliestDate,
-                              latestDateToInclude: latestDate,
+                              earliestDateToInclude: earliestDateToInclude,
+                              latestDateToInclude: latestDateToInclude,
                               quantity: quantity) { [weak self] (orderStatsV4, error) in
             guard let orderStatsV4 = orderStatsV4 else {
                 onCompletion(error)


### PR DESCRIPTION
Ref p4a5px-2If-p2#comment-11882.

I found out that the [`checkStatsAvailability`](https://github.com/woocommerce/woocommerce-ios/blob/59ab55ba14463c84bc4f6b9cef0eea0b0e4963ab/Yosemite/Yosemite/Stores/AvailabilityStore.swift#L40-L54) action was always failing because we were passing an incorrect date format (not ISO-8601). 

This PR fixes that. 

@jaclync Can you confirm if the failing API call is not intentional? 

## Testing

1. Use WC > 4.0. 
1. Add a breakpoint here:
    https://github.com/woocommerce/woocommerce-ios/blob/de627f40debb3897d4cc6f93654e35f15343bdb6/Yosemite/Yosemite/Stores/AvailabilityStore.swift#L50
2. Run the app and log in. 
3. Open the Stats page. 
4. Confirm the breakpoint was hit and that the `error` object is `nil`. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

