### PR TITLE
Product form > image upload: try fixing crash from unbalanced `DispatchGroup` call

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Fix: Update the downloadable files row to read-only, if the product is accessed from Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3669]
 - [*] Fix: Thumbnail image of a product wasn't being loaded correctly in Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3678]
 - [*] Fix: Allow product's `regular_price` to be a number and `sold_individually` to be `null` as some third-party plugins could alter the type in the API. This could help with the products tab not loading due to product decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/3679]
+- [internal] Attempted fix for a crash in product image upload. [https://github.com/woocommerce/woocommerce-ios/pull/3693]
 
 6.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -590,14 +590,23 @@ private extension ProductFormViewController {
 
         // Waits for all product images to be uploaded before updating the product remotely.
         group.enter()
+        // Since `group.leave()` should only be called once to balance `group.enter()`, we track whether there are images pending upload in the image closure.
+        var hasNoImagesPendingUpload = false
         let observationToken = productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
-            guard productImageStatuses.hasPendingUpload == false else {
+            guard hasNoImagesPendingUpload == false else {
                 return
             }
 
             guard let self = self else {
+                group.leave()
                 return
             }
+
+            guard productImageStatuses.hasPendingUpload == false else {
+                return
+            }
+
+            hasNoImagesPendingUpload = true
 
             self.viewModel.updateImages(productImageStatuses.images)
             group.leave()


### PR DESCRIPTION
Attempted fix for #2907 

## Why

We are seeing some crashes with the following stack trace:

```
Crashed in non-app:
libdispatch +0x0377d8 dispatch_group_leave.cold.1
WooCommerce +0x26626c ProductFormViewController.waitUntilAllImagesAreUploaded(ProductFormViewController.swift:596)
WooCommerce +0x10c30c ProductImageActionHandler.addUpdateObserver<T>(ProductImageActionHandler.swift:78)
WooCommerce +0x10fe48 @callee_guaranteed(<compiler-generated>)
WooCommerce +0x10b6e8 ProductImageActionHandler.allStatuses.didset(ProductImageActionHandler.swift:27)
...
```

I haven't been able to reproduce the crash, but from some search online the crash is likely due to unbalanced `DispatchGroup` `enter`/`leave` calls. There are two scenarios I can think of so far while maintaining the product image upload behavior:

- `self` is `nil`: we can just call `group.leave()`
- When the image statuses observation closure is called more than once while `productImageStatuses.hasPendingUpload == false`: we can keep track of whether this code path has been reached before, and early return without calling `group.leave()` again

## Changes

- In `ProductFormViewController`, addressed the 2 potential scenarios as above

## Testing

Please confidence check on product image upload:

- Go to the products tab
- Tap on a product
- Tap the images header (either an existing image or one with "+" icon)
- Tap "Add Photos"
- Tap "Choose from device" and handle the Photos permission alert the way you like, as long as there is at least one photo to choose from
- Select at least one photo
- Tap "Add #" to upload the selected photo(s)
- After going back to the product form, quickly tap "Update" while the photo(s) are still being uploaded --> the photo(s) should be uploaded remotely, and the product is also updated remotely with the new image(s)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
