### PR TITLE
Order Details: Fix Product Variations showing empty data if attribute equals Any

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -27,8 +27,12 @@ struct VariationAttributeViewModel {
         self.value = value
     }
 
-    init(variationAttribute: ProductVariationAttribute) {
-        self.init(name: variationAttribute.name, value: variationAttribute.option)
+    init(orderItemAttribute: OrderItemAttribute) {
+        self.init(name: orderItemAttribute.name, value: orderItemAttribute.value)
+    }
+
+    init(productVariationAttribute: ProductVariationAttribute) {
+        self.init(name: productVariationAttribute.name, value: productVariationAttribute.option)
     }
 }
 
@@ -122,7 +126,7 @@ struct ProductDetailsCellViewModel {
                   positiveTotal: formatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero,
                   positivePrice: item.price.abs(),
                   skuText: item.sku,
-                  attributes: item.attributes.map { VariationAttributeViewModel(name: $0.name, value: $0.value) })
+                  attributes: item.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) })
     }
 
     /// Aggregate Order Item initializer
@@ -139,7 +143,7 @@ struct ProductDetailsCellViewModel {
                   positiveTotal: aggregateItem.total?.abs(),
                   positivePrice: aggregateItem.price?.abs(),
                   skuText: aggregateItem.sku,
-                  attributes: aggregateItem.attributes.map { VariationAttributeViewModel(name: $0.name, value: $0.value) })
+                  attributes: aggregateItem.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) })
     }
 
     /// Refunded Order Item initializer

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -21,7 +21,7 @@ struct VariationAttributeViewModel: AnyAttributeDisplayable {
     }
 }
 
-private extension VariationAttributeViewModel {
+extension VariationAttributeViewModel {
     enum Localization {
         static let anyAttributeFormat =
             NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -1,23 +1,34 @@
 import Foundation
 import Yosemite
 
-protocol AnyAttributeDisplayable {
-    var name: String { get set }
-    var value: String { get set }
-    var nameOrValue: String { get }
-}
+// MARK: - View Model for a Variation Attribute
+//
+struct VariationAttributeViewModel {
 
-struct VariationAttributeViewModel: AnyAttributeDisplayable {
+    /// Attribute name
+    ///
+    let name: String
 
-    var name: String = ""
+    /// Attribute value
+    ///
+    let value: String?
 
-    var value: String = ""
-
+    /// Returns the attribute value, or "Any \(name)" if the attribute value is nil or empty
+    ///
     var nameOrValue: String {
-        guard value.isNotEmpty else {
+        guard let value = value, value.isNotEmpty else {
             return String(format: Localization.anyAttributeFormat, name)
         }
         return value
+    }
+
+    init(name: String, value: String? = nil) {
+        self.name = name
+        self.value = value
+    }
+
+    init(variationAttribute: ProductVariationAttribute) {
+        self.init(name: variationAttribute.name, value: variationAttribute.option)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -1,15 +1,37 @@
 import Foundation
 import Yosemite
 
+protocol AnyAttributeDisplayable {
+    var name: String { get set }
+    var value: String { get set }
+    var nameOrValue: String { get }
+}
+
+struct VariationAttributeViewModel: AnyAttributeDisplayable {
+
+    var name: String = ""
+
+    var value: String = ""
+
+    var nameOrValue: String {
+        guard value.isNotEmpty else {
+            return String(format: Localization.anyAttributeFormat, name)
+        }
+        return value
+    }
+}
+
+private extension VariationAttributeViewModel {
+    enum Localization {
+        static let anyAttributeFormat =
+            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
+    }
+}
+
 
 // MARK: - View Model for a product details cell
 //
 struct ProductDetailsCellViewModel {
-    /// An attribute of order for product details UI.
-    struct OrderAttributeViewModel {
-        /// The value of the attribute.
-        let value: String
-    }
 
     // MARK: - Public properties
 
@@ -47,7 +69,7 @@ struct ProductDetailsCellViewModel {
                  positiveTotal: NSDecimalNumber?,
                  positivePrice: NSDecimalNumber?,
                  skuText: String?,
-                 attributes: [OrderAttributeViewModel]) {
+                 attributes: [VariationAttributeViewModel]) {
         self.imageURL = imageURL
         self.name = name
         let quantity = NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
@@ -89,7 +111,7 @@ struct ProductDetailsCellViewModel {
                   positiveTotal: formatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero,
                   positivePrice: item.price.abs(),
                   skuText: item.sku,
-                  attributes: item.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) })
+                  attributes: item.attributes.map { VariationAttributeViewModel(name: $0.name, value: $0.value) })
     }
 
     /// Aggregate Order Item initializer
@@ -106,7 +128,7 @@ struct ProductDetailsCellViewModel {
                   positiveTotal: aggregateItem.total?.abs(),
                   positivePrice: aggregateItem.price?.abs(),
                   skuText: aggregateItem.sku,
-                  attributes: aggregateItem.attributes.map { OrderAttributeViewModel(orderItemAttribute: $0) })
+                  attributes: aggregateItem.attributes.map { VariationAttributeViewModel(name: $0.name, value: $0.value) })
     }
 
     /// Refunded Order Item initializer
@@ -141,20 +163,14 @@ private extension ProductDetailsCellViewModel {
                                 + " the pattern used to show the attributes and quantity multiplied by the price. For example, “purple, has logo・23 x $400.00”."
                                 + " The %1$@ is the list of attributes (e.g. from variation)."
                                 + " The %2$@ is the quantity. The %3$@ is the formatted price with currency (e.g. $400.00).")
-        static func subtitle(quantity: String, price: String, attributes: [OrderAttributeViewModel]) -> String {
-            let attributesText = attributes.map { $0.value }.joined(separator: ", ")
+        static func subtitle(quantity: String, price: String, attributes: [VariationAttributeViewModel]) -> String {
+            let attributesText = attributes.map { $0.nameOrValue }.joined(separator: ", ")
             if attributes.isEmpty {
                 return String.localizedStringWithFormat(subtitleFormat, quantity, price)
             } else {
                 return String.localizedStringWithFormat(subtitleWithAttributesFormat, attributesText, quantity, price)
             }
         }
-    }
-}
-
-private extension ProductDetailsCellViewModel.OrderAttributeViewModel {
-    init(orderItemAttribute: OrderItemAttribute) {
-        self.value = orderItemAttribute.value
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -33,7 +33,7 @@ private extension EditableProductVariationModel {
             guard let variationAttribute = productVariation.attributes.first(where: { $0.id == attribute.attributeID && $0.name == attribute.name }) else {
                 return VariationAttributeViewModel(name: attribute.name)
             }
-            return VariationAttributeViewModel(value: variationAttribute.option)
+            return VariationAttributeViewModel(variationAttribute: variationAttribute)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -5,7 +5,10 @@ final class EditableProductVariationModel {
     let productVariation: ProductVariation
 
     let allAttributes: [ProductAttribute]
-    private lazy var variationName: String = generateName(variationAttributes: productVariation.attributes, allAttributes: allAttributes)
+
+    private lazy var variationAttributes: [VariationAttributeViewModel] = {
+        return generateVariationAttributes(productVariationAttributes: productVariation.attributes, allAttributes: allAttributes)
+    }()
 
     init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?) {
         self.allAttributes = allAttributes
@@ -19,18 +22,19 @@ final class EditableProductVariationModel {
 }
 
 private extension EditableProductVariationModel {
-    func generateName(variationAttributes: [ProductVariationAttribute], allAttributes: [ProductAttribute]) -> String {
+
+    func generateVariationAttributes(productVariationAttributes: [ProductVariationAttribute],
+                                     allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
         return allAttributes
             .sorted(by: { (lhs, rhs) -> Bool in
                 lhs.position < rhs.position
             })
-            .map { attribute in
-            guard let variationAttribute = variationAttributes.first(where: { $0.id == attribute.attributeID && $0.name == attribute.name }) else {
-                // The variation doesn't have an option set for this attribute, and we show "Any \(attributeName)" in this case.
-                return String.localizedStringWithFormat(Localization.anyAttributeFormat, attribute.name)
+            .map { attribute -> VariationAttributeViewModel in
+            guard let variationAttribute = productVariation.attributes.first(where: { $0.id == attribute.attributeID && $0.name == attribute.name }) else {
+                return VariationAttributeViewModel(name: attribute.name)
             }
-            return variationAttribute.option
-        }.joined(separator: " - ")
+            return VariationAttributeViewModel(value: variationAttribute.option)
+        }
     }
 }
 
@@ -44,7 +48,7 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     }
 
     var name: String {
-        variationName
+        variationAttributes.map { $0.nameOrValue }.joined(separator: " - ")
     }
 
     var description: String? {
@@ -217,12 +221,5 @@ extension EditableProductVariationModel {
 extension EditableProductVariationModel: Equatable {
     static func ==(lhs: EditableProductVariationModel, rhs: EditableProductVariationModel) -> Bool {
         return lhs.productVariation == rhs.productVariation
-    }
-}
-
-extension EditableProductVariationModel {
-    enum Localization {
-        static let anyAttributeFormat =
-            NSLocalizedString("Any %1$@", comment: "Format of a product variation attribute description where the attribute is set to any value.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -33,7 +33,7 @@ private extension EditableProductVariationModel {
             guard let variationAttribute = productVariation.attributes.first(where: { $0.id == attribute.attributeID && $0.name == attribute.name }) else {
                 return VariationAttributeViewModel(name: attribute.name)
             }
-            return VariationAttributeViewModel(variationAttribute: variationAttribute)
+            return VariationAttributeViewModel(productVariationAttribute: variationAttribute)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -26,7 +26,7 @@ final class EditableProductVariationModelTests: XCTestCase {
         // Assert
         let expectedName = [
             "Orange",
-            String.localizedStringWithFormat(EditableProductVariationModel.Localization.anyAttributeFormat, "Brand")
+            String.localizedStringWithFormat(VariationAttributeViewModel.Localization.anyAttributeFormat, "Brand")
         ].joined(separator: " - ")
         XCTAssertEqual(name, expectedName)
     }


### PR DESCRIPTION
Resolves https://github.com/woocommerce/woocommerce-ios/issues/3648

### Description
- Fixed a bug where the Order Detail shows empty data if the attribute equals `Any`

### How to test
1. Create a variable product and set the variation attribute(s) to `Any`
2. On wp-admin, create an order for the product you created in step 1
3. Open the order you just created in the app
4. ✅ The product variation cell should display `Any {attributeName}` instead of empty data
5. Tap "Details" then tap on the product
6. ✅ The product variation detail should display `Any {attributeName}` (regression testing)

### Screenshot

Before (Order Detail) | After (Order Detail) | After (Product Variation Detail, no regression)
--- | --- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-02-18 at 15 56 07](https://user-images.githubusercontent.com/6711616/108332402-19ef7280-7213-11eb-9682-3ec9576f47c4.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-18 at 17 47 27](https://user-images.githubusercontent.com/6711616/108332188-df85d580-7212-11eb-97ae-bfb28a8f03d7.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-02-18 at 17 47 35](https://user-images.githubusercontent.com/6711616/108332196-e14f9900-7212-11eb-91b2-9d01f7b2cdfb.png)


### Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
