### PR TITLE
Shipping Labels: display the correct store owner full name in the Origin Shipping Address

### DIFF
--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -97,6 +97,7 @@ public typealias StoredProductSettings = Networking.StoredProductSettings
 // MARK: - Exported Storage Symbols
 
 public typealias StorageAccount = Storage.Account
+public typealias StorageAccountSettings = Storage.AccountSettings
 public typealias StorageAttribute = Storage.GenericAttribute
 public typealias StorageNote = Storage.Note
 public typealias StorageOrder = Storage.Order

--- a/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
@@ -6,11 +6,13 @@ import Storage
 //
 extension Storage.AccountSettings: ReadOnlyConvertible {
 
-    /// Updates the Storage.AccountSettings with the a ReadOnly.
+    /// Updates the Storage.AccountSettings with the ReadOnly.
     ///
     public func update(with accountSettings: Yosemite.AccountSettings) {
         userID = accountSettings.userID
         tracksOptOut = accountSettings.tracksOptOut
+        firstName = accountSettings.firstName
+        lastName = accountSettings.lastName
     }
 
     /// Returns a ReadOnly version of the receiver.

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -20,6 +20,16 @@ extension MockStorageManager {
         return newAccount
     }
 
+    /// Inserts a new AccountSettings into the specified context.
+    ///
+    @discardableResult
+    func insertSampleAccountSettings(readOnlyAccountSettings: AccountSettings) -> StorageAccountSettings {
+        let newAccountSettings = viewStorage.insertNewObject(ofType: StorageAccountSettings.self)
+        newAccountSettings.update(with: readOnlyAccountSettings)
+
+        return newAccountSettings
+    }
+
     /// Inserts a new (Sample) Product into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -189,9 +189,12 @@ class AccountStoreTests: XCTestCase {
 
         // Then
         let account = try result.get()
+        let expectedAccount = Networking.AccountSettings(userID: 10,
+                                                         tracksOptOut: true,
+                                                         firstName: "Dem 123",
+                                                         lastName: "Nines")
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.AccountSettings.self), 1)
-        XCTAssertEqual(account?.firstName, "Dem 123")
-        XCTAssertEqual(account?.lastName, "Nines")
+        XCTAssertEqual(account, expectedAccount)
         XCTAssertTrue(result.isSuccess)
     }
 

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -169,6 +169,31 @@ class AccountStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    /// Verifies that `synchronizeAccountSettings` effectively update any retrieved settings.
+    ///
+    func test_synchronizeAccountSettings_effectively_update_retrieved_settings() throws {
+        // Given
+        let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        storageManager.insertSampleAccountSettings(readOnlyAccountSettings: sampleAccountSettings())
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.AccountSettings.self), 1)
+
+        let result: Result<Yosemite.AccountSettings?, Error> = waitFor { promise in
+            let action = AccountAction.synchronizeAccountSettings(userID: 10) { account, _ in
+                promise(.success(account))
+            }
+            accountStore.onAction(action)
+        }
+
+        // Then
+        let account = try result.get()
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.AccountSettings.self), 1)
+        XCTAssertEqual(account?.firstName, "Dem 123")
+        XCTAssertEqual(account?.lastName, "Nines")
+        XCTAssertTrue(result.isSuccess)
+    }
 
     // MARK: - AccountAction.synchronizeSites
 
@@ -334,6 +359,13 @@ private extension AccountStoreTests {
                        email: "yosemite@yosemite.com",
                        username: "YOLO",
                        gravatarUrl: "https://automattic.com/yosemite.png")
+    }
+
+    func sampleAccountSettings() -> Networking.AccountSettings {
+        return AccountSettings(userID: 10,
+                               tracksOptOut: true,
+                               firstName: nil,
+                               lastName: nil)
     }
 
     /// Sample Site


### PR DESCRIPTION
Part of #2973

## Description
As part of Shipping Labels M2, we should fetch and display the correct full name of the store owner in the origin address. After having implemented the first name and last name in the `AccountSettings` entity, in this PR we fetch the last Account Settings from the stored entity and I also fixed an issue to the `ReadOnlyConvertible` entity that was not properly handling `firstName` and `lastName`, not updating them in storage. I also added a test for this case.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in the Create Shipping Label form.
5. The new screen for validating an address should be presented with all the information. -> You should see the `name` field populated with the correct data (first name and last name of your account).

## Screenshots
<img src="https://user-images.githubusercontent.com/495617/108376881-bc9ff500-7203-11eb-9dc5-eb3cd9ca250e.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
