### PR TITLE
Variations: Add More Variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -49,19 +49,8 @@ extension EditAttributesViewModel {
     /// Generates a variation in the host site using the product attributes
     ///
     func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
-        let action = ProductVariationAction.createProductVariation(siteID: product.siteID,
-                                                                   productID: product.productID,
-                                                                   newVariation: createVariationParameter()) { [weak self] result in
-            guard let self = self else { return }
-
-            // Convert the variationResult into a productResult by appending the variationID to the variations array
-            let productResult = result.map { variation in
-                self.product.copy(variations: self.product.variations + [variation.productVariationID])
-            }
-
-            onCompletion(productResult)
-        }
-        stores.dispatch(action)
+        let useCase = GenerateVariationUseCase(product: product, stores: stores)
+        useCase.generateVariation(onCompletion: onCompletion)
     }
 }
 
@@ -76,12 +65,5 @@ private extension EditAttributesViewModel {
                                                         numberOfLinesForTitle: 0,
                                                         numberOfLinesForText: 0)
         }
-    }
-
-    /// Returns a `CreateProductVariation` type with no price and no options selected for any of it's attributes.
-    ///
-    func createVariationParameter() -> CreateProductVariation {
-        let attributes = product.attributes.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: "") }
-        return CreateProductVariation(regularPrice: "", attributes: attributes)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Yosemite
+
+/// Generates a new variation for a product, with no price and no options selected
+///
+final class GenerateVariationUseCase {
+    
+    /// Main product dependency
+    ///
+    private let product: Product
+
+    /// Stores to dispatch the generate variation action.
+    ///
+    private let stores: StoresManager
+
+    init(product: Product, stores: StoresManager = ServiceLocator.stores) {
+        self.product = product
+        self.stores = stores
+    }
+
+    /// Generates a variation in the host site using the product attributes
+    ///
+    func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
+        let action = ProductVariationAction.createProductVariation(siteID: product.siteID,
+                                                                   productID: product.productID,
+                                                                   newVariation: createVariationParameter()) { [weak self] result in
+            guard let self = self else { return }
+
+            // Convert the variationResult into a productResult by appending the variationID to the variations array
+            let productResult = result.map { variation in
+                self.product.copy(variations: self.product.variations + [variation.productVariationID])
+            }
+
+            onCompletion(productResult)
+        }
+        stores.dispatch(action)
+    }
+
+    /// Returns a `CreateProductVariation` type with no price and no options selected for any of it's attributes.
+    ///
+    private func createVariationParameter() -> CreateProductVariation {
+        let attributes = product.attributes.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: "") }
+        return CreateProductVariation(regularPrice: "", attributes: attributes)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Generates a new variation for a product, with no price and no options selected
 ///
 final class GenerateVariationUseCase {
-    
+
     /// Main product dependency
     ///
     private let product: Product
@@ -23,12 +23,11 @@ final class GenerateVariationUseCase {
     func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
         let action = ProductVariationAction.createProductVariation(siteID: product.siteID,
                                                                    productID: product.productID,
-                                                                   newVariation: createVariationParameter()) { [weak self] result in
-            guard let self = self else { return }
+                                                                   newVariation: createVariationParameter()) { [product] result in
 
             // Convert the variationResult into a productResult by appending the variationID to the variations array
             let productResult = result.map { variation in
-                self.product.copy(variations: self.product.variations + [variation.productVariationID])
+                product.copy(variations: product.variations + [variation.productVariationID])
             }
 
             onCompletion(productResult)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -13,15 +13,26 @@ final class ProductVariationsViewModel {
     ///
     private let isAddProductVariationsEnabled: Bool
 
+    /// Stores dependency. Needed to generate variations
+    ///
+    private let stores: StoresManager
+
     /// Defines if the More Options button should be shown
     ///
     var showMoreButton: Bool {
         product.variations.isNotEmpty && isAddProductVariationsEnabled
     }
 
-    init(product: Product,
-         isAddProductVariationsEnabled: Bool) {
+    init(product: Product, isAddProductVariationsEnabled: Bool, stores: StoresManager = ServiceLocator.stores) {
         self.product = product
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
+        self.stores = stores
+    }
+
+    /// Generates a variation in the host site using the product attributes
+    ///
+    func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
+        let useCase = GenerateVariationUseCase(product: product, stores: stores)
+        useCase.generateVariation(onCompletion: onCompletion)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
+		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
 		26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
@@ -1561,6 +1562,7 @@
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
+		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
 		26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
@@ -4502,6 +4504,7 @@
 			isa = PBXGroup;
 			children = (
 				CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */,
+				26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */,
 			);
 			path = Variations;
 			sourceTree = "<group>";
@@ -6545,6 +6548,7 @@
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
 				570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
+				26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */,
 				77307809251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift in Sources */,
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
+		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
@@ -1559,6 +1560,7 @@
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
+		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
@@ -2784,6 +2786,7 @@
 				CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */,
 				0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */,
 				02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */,
+				26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
@@ -6013,6 +6016,7 @@
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
+				26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -58,68 +58,6 @@ final class EditAttributesViewModelTests: XCTestCase {
                                                                       numberOfLinesForText: 0)
         XCTAssertEqual(viewModel.attributes, [expectedVM, expectedVM2])
     }
-
-    func test_create_variations_is_invoked_with_correct_parameters() {
-        // Given
-        let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
-        let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
-        let product = Product().copy(attributes: [attribute, attribute2])
-
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: true, stores: mockStores)
-
-        // When
-        let variationSubmitted: CreateProductVariation = waitFor { promise in
-            mockStores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
-               switch action {
-               case let .createProductVariation(_, _, newVariation, _):
-                promise(newVariation)
-               default:
-                   break
-               }
-            }
-
-            viewModel.generateVariation { _ in }
-        }
-
-        // Then
-        let expectedAttributes = [
-            ProductVariationAttribute(id: 0, name: "attr", option: ""),
-            ProductVariationAttribute(id: 1, name: "attr-2", option: ""),
-        ]
-        let expectedVariation = CreateProductVariation(regularPrice: "", attributes: expectedAttributes)
-        XCTAssertEqual(expectedVariation, variationSubmitted)
-    }
-
-    func test_create_variations_updates_the_product_variations_array() throws {
-        // Given
-        let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
-        let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
-        let product = Product().copy(attributes: [attribute, attribute2])
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        mockStores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
-            switch action {
-            case let .createProductVariation(_, _, _, onCompletion):
-                onCompletion(.success(MockProductVariation().productVariation()))
-            default:
-                break
-            }
-        }
-
-        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: true, stores: mockStores)
-
-        // When
-        let result: Result<Product, Error> = waitFor { promise in
-            viewModel.generateVariation { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        let updatedProduct = try XCTUnwrap(result.get())
-        let expectedVariations = [MockProductVariation().productVariation().productVariationID]
-        XCTAssertEqual(updatedProduct.variations, expectedVariations)
-    }
 }
 
 private extension EditAttributesViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class GenerateVariationUseCaseTests: XCTestCase {
+    func test_create_variations_is_invoked_with_correct_parameters() {
+        // Given
+        let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
+        let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
+        let product = Product().copy(attributes: [attribute, attribute2])
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let useCase = GenerateVariationUseCase(product: product, stores: mockStores)
+
+        // When
+        let variationSubmitted: CreateProductVariation = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+               switch action {
+               case let .createProductVariation(_, _, newVariation, _):
+                promise(newVariation)
+               default:
+                   break
+               }
+            }
+
+            useCase.generateVariation { _ in }
+        }
+
+        // Then
+        let expectedAttributes = [
+            ProductVariationAttribute(id: 0, name: "attr", option: ""),
+            ProductVariationAttribute(id: 1, name: "attr-2", option: ""),
+        ]
+        let expectedVariation = CreateProductVariation(regularPrice: "", attributes: expectedAttributes)
+        XCTAssertEqual(expectedVariation, variationSubmitted)
+    }
+
+    func test_create_variations_updates_the_product_variations_array() throws {
+        // Given
+        let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
+        let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
+        let product = Product().copy(attributes: [attribute, attribute2])
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        mockStores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .createProductVariation(_, _, _, onCompletion):
+                onCompletion(.success(MockProductVariation().productVariation()))
+            default:
+                break
+            }
+        }
+
+        let useCase = GenerateVariationUseCase(product: product, stores: mockStores)
+
+        // When
+        let result: Result<Product, Error> = waitFor { promise in
+            useCase.generateVariation { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let updatedProduct = try XCTUnwrap(result.get())
+        let expectedVariations = [MockProductVariation().productVariation().productVariationID]
+        XCTAssertEqual(updatedProduct.variations, expectedVariations)
+    }
+}
+
+// MARK: Helper
+private extension GenerateVariationUseCaseTests {
+    func sampleAttribute(attributeID: Int64 = 1234, name: String, options: [String] = []) -> ProductAttribute {
+        ProductAttribute(siteID: 123,
+                         attributeID: attributeID,
+                         name: name ,
+                         position: 0,
+                         visible: true,
+                         variation: true,
+                         options: options)
+    }
+}


### PR DESCRIPTION
closes #3539 

# Why

After creating our first variation, we need to give the merchant the ability to generate more variations using the product attributes(previously added when creating the first variation).

# How

- Extract variation creation into a `GenerateVariationUseCase` to it can be reused in `EditAttributesViewModel` and in `ProductVariationsViewController`

- Call the `GenerateVariationUseCase` from the `ProductVariationsViewModel`

- Update `ProductVariationsViewController` to call the `generateVariation()` method and present a loading screen whit the action is being performed.

# Demo

![create-more-variations](https://user-images.githubusercontent.com/562080/108404969-84da8280-71ee-11eb-8988-22fdb843bbf2.gif)

# Testing Steps

- Navigate into a variable product that has variations
- Tap in the variations row
- Tap on "Add Variation" button
- See the loading screen appears
- See the new variation in the list with no options selected (Any xxx)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
