### PR TITLE
Products: Make products and variations with decimal stock quantities read-only

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -109,6 +109,14 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         return ProductTaxStatus(rawValue: taxStatusKey)
     }
 
+    /// Whether the product has a decimal (non-integer) stock quantity.
+    /// Can be used to determine if the product should be loaded as read-only.
+    /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+    ///
+    public var hasDecimalStockQuantity: Bool {
+        stockQuantity?.exponent ?? 0 < 0
+    }
+
     /// Product struct initializer.
     ///
     public init(siteID: Int64,

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -55,6 +55,17 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
 
     public let menuOrder: Int64
 
+    /// Computed Properties
+    ///
+
+    /// Whether the product variation has a decimal (non-integer) stock quantity.
+    /// Can be used to determine if the product variation should be loaded as read-only.
+    /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+    ///
+    public var hasDecimalStockQuantity: Bool {
+        stockQuantity?.exponent ?? 0 < 0
+    }
+
     /// ProductVariation struct initializer.
     ///
     public init(siteID: Int64,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+6.2
+-----
+- [*] Fix: Load product details in read-only mode when the product has a decimal stock quantity. This fixes the products tab not loading due to product decoding errors when third-party plugins enable decimal stock quantities. [https://github.com/woocommerce/woocommerce-ios/pull/3707]
+
 6.1
 -----
 - [**] Products: When editing variable products, you can now edit the variation attributes to select different attribute options. [https://github.com/woocommerce/woocommerce-ios/pull/3628]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -212,6 +212,21 @@ extension EditableProductVariationModel {
     var isEnabledAndMissingPrice: Bool {
         isEnabled && regularPrice.isNilOrEmpty
     }
+
+    /// Whether the variation has a decimal stock quantity
+    ///
+    var hasDecimalStockQuantity: Bool {
+        stockQuantity?.exponent ?? 0 < 0
+    }
+
+    /// Defines if the variation should be read-only based on variation settings
+    ///
+    var isReadOnly: Bool {
+        // If the product has a decimal (non-integer) stock quantity, force read-only mode.
+        // An API change is required to support updating a product with a decimal stock quantity.
+        // Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+        return hasDecimalStockQuantity
+    }
 }
 
 extension EditableProductVariationModel: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -212,21 +212,6 @@ extension EditableProductVariationModel {
     var isEnabledAndMissingPrice: Bool {
         isEnabled && regularPrice.isNilOrEmpty
     }
-
-    /// Whether the variation has a decimal stock quantity
-    ///
-    var hasDecimalStockQuantity: Bool {
-        stockQuantity?.exponent ?? 0 < 0
-    }
-
-    /// Defines if the variation should be read-only based on variation settings
-    ///
-    var isReadOnly: Bool {
-        // If the product has a decimal (non-integer) stock quantity, force read-only mode.
-        // An API change is required to support updating a product with a decimal stock quantity.
-        // Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
-        return hasDecimalStockQuantity
-    }
 }
 
 extension EditableProductVariationModel: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -350,7 +350,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 let variationsViewModel = ProductVariationsViewModel(product: product.product, isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 let variationsViewController = ProductVariationsViewController(viewModel: variationsViewModel,
                                                                                product: product.product,
-                                                                               formType: viewModel.formType,
                                                                                isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 variationsViewController.onProductUpdate = { [viewModel] updatedProduct in
                     viewModel.updateProductVariations(from: updatedProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
@@ -207,7 +207,7 @@ private extension ProductLoaderViewController {
     func presentProductDetails(for product: Product) {
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .contained(containerViewController: self),
-                                             forceReadOnly: forceReadOnly) { [weak self] viewController in
+                                             forceReadOnly: forceReadOnly || product.hasDecimalStockQuantity) { [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }
     }
@@ -218,7 +218,7 @@ private extension ProductLoaderViewController {
         ProductVariationDetailsFactory.productVariationDetails(productVariation: productVariation,
                                                                parentProduct: parentProduct,
                                                                presentationStyle: .contained(containerViewController: self),
-                                                               forceReadOnly: forceReadOnly) { [weak self] viewController in
+                                                               forceReadOnly: forceReadOnly || productVariation.hasDecimalStockQuantity) { [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
@@ -218,7 +218,8 @@ private extension ProductLoaderViewController {
         ProductVariationDetailsFactory.productVariationDetails(productVariation: productVariation,
                                                                parentProduct: parentProduct,
                                                                presentationStyle: .contained(containerViewController: self),
-                                                               forceReadOnly: forceReadOnly || productVariation.hasDecimalStockQuantity) { [weak self] viewController in
+                                                               forceReadOnly: forceReadOnly || productVariation.hasDecimalStockQuantity) {
+            [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -510,7 +510,20 @@ extension ProductsViewController: UITableViewDelegate {
 
 private extension ProductsViewController {
     func didSelectProduct(product: Product) {
-        ProductDetailsFactory.productDetails(product: product, presentationStyle: .navigationStack, forceReadOnly: false) { [weak self] viewController in
+        // If the product has a decimal (non-integer) stock quantity, force read-only mode.
+        // Editable mode with decimal stock quantities requires an API change.
+        // Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+        var forceReadOnly: Bool
+        if let stockQuantity = product.stockQuantity {
+            let hasIntegerStockQuantity = stockQuantity.exponent >= 0
+            forceReadOnly = !hasIntegerStockQuantity
+        } else {
+            forceReadOnly = false // Don't force read-only when stock quantity is nil
+        }
+
+        ProductDetailsFactory.productDetails(product: product,
+                                             presentationStyle: .navigationStack,
+                                             forceReadOnly: forceReadOnly) { [weak self] viewController in
             self?.navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -510,21 +510,9 @@ extension ProductsViewController: UITableViewDelegate {
 
 private extension ProductsViewController {
     func didSelectProduct(product: Product) {
-        // If the product has a decimal (non-integer) stock quantity, force read-only mode.
-        // An API change is required to support updating a product with a decimal stock quantity.
-        // Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
-//        var hasDecimalStockQuantity: Bool {
-//            if let stockQuantity = product.stockQuantity {
-//                return stockQuantity.exponent < 0
-//            } else {
-//                return false
-//            }
-//        }
-        let hasDecimalStockQuantity = product.stockQuantity?.exponent ?? 0 < 0
-
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             forceReadOnly: hasDecimalStockQuantity) { [weak self] viewController in
+                                             forceReadOnly: product.hasDecimalStockQuantity) { [weak self] viewController in
             self?.navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -511,19 +511,20 @@ extension ProductsViewController: UITableViewDelegate {
 private extension ProductsViewController {
     func didSelectProduct(product: Product) {
         // If the product has a decimal (non-integer) stock quantity, force read-only mode.
-        // Editable mode with decimal stock quantities requires an API change.
+        // An API change is required to support updating a product with a decimal stock quantity.
         // Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
-        var forceReadOnly: Bool
-        if let stockQuantity = product.stockQuantity {
-            let hasIntegerStockQuantity = stockQuantity.exponent >= 0
-            forceReadOnly = !hasIntegerStockQuantity
-        } else {
-            forceReadOnly = false // Don't force read-only when stock quantity is nil
-        }
+//        var hasDecimalStockQuantity: Bool {
+//            if let stockQuantity = product.stockQuantity {
+//                return stockQuantity.exponent < 0
+//            } else {
+//                return false
+//            }
+//        }
+        let hasDecimalStockQuantity = product.stockQuantity?.exponent ?? 0 < 0
 
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             forceReadOnly: forceReadOnly) { [weak self] viewController in
+                                             forceReadOnly: hasDecimalStockQuantity) { [weak self] viewController in
             self?.navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -409,7 +409,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,
                                                       parentProductSKU: parentProductSKU,
-                                                      formType: formType,
+                                                      formType: model.isReadOnly ? .readonly : .edit,
                                                       productImageActionHandler: productImageActionHandler)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -112,7 +112,6 @@ final class ProductVariationsViewController: UIViewController {
         product.sku
     }
 
-    private let formType: ProductFormType
     private let imageService: ImageService = ServiceLocator.imageService
     private let isAddProductVariationsEnabled: Bool
 
@@ -125,11 +124,9 @@ final class ProductVariationsViewController: UIViewController {
 
     init(viewModel: ProductVariationsViewModel,
          product: Product,
-         formType: ProductFormType,
          isAddProductVariationsEnabled: Bool,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.product = product
-        self.formType = formType
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         self.viewModel = viewModel
         self.noticePresenter = noticePresenter

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -409,7 +409,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,
                                                       parentProductSKU: parentProductSKU,
-                                                      formType: model.isReadOnly ? .readonly : .edit,
+                                                      formType: productVariation.hasDecimalStockQuantity ? .readonly : .edit,
                                                       productImageActionHandler: productImageActionHandler)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),


### PR DESCRIPTION
Related: #3494
Depends on: #3705 

## Description

The WooCommerce Core API only supports stock quantities with `Int` or `nil` values. However, certain third-party extensions can enable decimal (non-integer) stock quantities. In #3705 we added support for loading products and variations with decimal stock quantities in the app.

This PR restricts products and variations with decimal stock quantities to be read-only. Any products or variations without decimal stock quantities can still be edited as usual. (We currently can't edit products with decimal stock quantities, since that requires an API change.)

## Changes

* Adds a computed property `hasDecimalStockQuantity` to `Product` and `ProductVariation`.
* Wherever an editable product or variation may be loaded in the app, `hasDecimalStockQuantity` is used to force a ready-only mode for that product or variation:
   * `ProductsViewController` to open details for selected product
   * `ProductVariationsViewController` to open details for selected variation
   * `ProductLoaderViewController` to open details for selected product or variation (used to load details from My Store > Top Performers list and Orders > Order details)

<img src="https://user-images.githubusercontent.com/8658164/108543637-3bb52c00-72dd-11eb-8a5f-2f703ab3f477.gif" width="300px">


## Testing

1. On your store, enable decimal stock quantities by installing a third-party extension on your store like [WPC Product Quantity](https://wordpress.org/plugins/wpc-product-quantity/).
2. Update the inventory for at least one product and one product variation to have a decimal stock quantity.
3. Create a new order for products/variations with and without decimal stock quantities.

**Products**
1. In the app, go to the Products tab.
2. Select a product that **doesn't** have a decimal stock quantity.
3. Confirm the product details open and they are editable.
4. Go back to the product list and select a product that **does** have a decimal stock quantity.
5. Confirm the product details open and they are read-only.
6. Go back to the product list and select a variable product with a mix of decimal and non-decimal stock quantities.
7. Select "Variations."
8. Select a variation that **doesn't** have a decimal stock quantity.
9. Confirm the variation details open and they are editable.
10. Go back to the variation list and select a variation that **does** have a decimal stock quantity.
11. Confirm the variation details open and they are read-only.

**Top Performers**
1. In the app, go to the My store tab.
2. Go to the Top Performers list and select a product/variation that **doesn't** have a decimal stock quantity.
3. Confirm the product details open and they are editable.
4. Select a product/variation that **does** have a decimal stock quantity.
5. Confirm the product details open and they are read-only.

**Order Details**
1. In the app, go to the Orders tab.
2. Select the order you created for products/variations with and without decimal stock quantities.
3. Select a product/variation that **doesn't** have a decimal stock quantity.
4. Confirm the product details open and they are read-only. (Products in order details should always be read-only.)
5. Select a product/variation that **does** have a decimal stock quantity.
6. Confirm the product details open and they are read-only.

## Submitter Checklist

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
