### PR TITLE
Make sure window's root view controller is set in all app states

### DIFF
--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -1,6 +1,7 @@
 import Combine
 import UIKit
 import Yosemite
+import class AutomatticTracks.CrashLogging
 
 /// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown
 /// when the app is logged out.
@@ -40,12 +41,14 @@ final class AppCoordinator {
                 switch (isLoggedIn, needsDefaultStore) {
                 case (false, true):
                     self.displayAuthenticator()
+                case (false, false):
+                    // TODO-3711: let's delete the logging once we verify the crash is caused by this case.
+                    CrashLogging.logMessage("Unexpected app state where `isLoggedIn` and `needsDefaultStore` are both `false`", level: .info)
+                    self.displayAuthenticator()
                 case (true, true):
                     self.displayStorePicker()
                 case (true, false):
                     self.displayLoggedInUI()
-                default:
-                    break
                 }
                 self.isLoggedIn = isLoggedIn
             }


### PR DESCRIPTION
Attempted fix for crash that is only in Xcode #3711 

## Why

We started seeing a crash that started in release 5.9 in Xcode, but this crash is somehow not visible in Sentry ([example full stack trace](https://github.com/woocommerce/woocommerce-ios/issues/3711#issuecomment-783264982)).

After some research online, [this Developer Forum post](https://developer.apple.com/forums/thread/128810) has the closest stack trace as this crash. If our crash is from the same cause, it appears to be from `Application windows are expected to have a root view controller at the end of application launch`.

I looked into the most suspicious PR https://github.com/woocommerce/woocommerce-ios/pull/3498 that I worked on for release 5.9, where I set the window's `rootViewController` based on the app state. In one scenario where `isLoggedIn` and `needsDefaultStore` are both `false`, it just does nothing. Even though this is a highly unlikely scenario where the app is logged out while it already has a default store, `needsDefaultStore` is from UserDefaults and it could be out of our control / expectation. Also, we've done a bunch of testing in release 5.9 and on `develop` and haven't been able to reproduce this crash yet - it could be because of this particular app state that it got in.

## Changes

This PR thus handled this unexpected case and added a logging to Sentry, which we will remove if this turns out to be the cause of the crash.

## Testing

Please confidence check with the following scenarios:

### Log in to a store, then log out

- Launch the app logged out --> the login UI is shown
- Enter login credentials associated with at least one WC store via any method you choose (email/password or magic link) --> the store picker should be shown
- Select a store (if more than one) and tap "Continue" --> the tab bar UI should be shown
- Relaunch the app --> the tab bar UI should be shown
- Log out from the app --> the login UI should be shown

### Log in with credentials, then restart login flow

- Launch the app logged out --> the login UI should be shown
- Enter login credentials associated with at least one WC store via any method you choose (email/password or magic link) --> the store picker should be shown
- Tap "Try another account" --> the login UI should be shown

### Log in with credentials, force close the app, then continue with a store

- Launch the app logged out --> the login UI should be shown
- Enter login credentials associated with at least one WC store via any method you choose (email/password or magic link) --> the store picker should be shown
- Force close the app and relaunch (relaunch the app from Xcode while the app is still on the store picker screen) --> the store picker should be shown
- Select a store (if more than one) and tap "Continue" --> the tab bar UI should be shown

### Log in with credentials, force close the app, then restart login flow

- Launch the app logged out --> the login UI should be shown
- Enter login credentials associated with at least one WC store via any method you choose (email/password or magic link) --> the store picker should be shown
- Force close the app and relaunch (relaunch the app from Xcode while the app is still on the store picker screen) --> the store picker should be shown
- Tap "Try another account" --> the login UI should be shown (known issue: there is a glitch when it animates to the login UI https://github.com/woocommerce/woocommerce-ios/issues/2888)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
