### PR TITLE
Products: Make inventory settings read-only for decimal stock quantities

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
+		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -772,6 +773,7 @@
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
+		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -1479,6 +1481,7 @@
 				B5C6FCC720A32E4800A4F8E4 /* DateFormatterWooTests.swift */,
 				02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */,
 				0212683424C046CB00F8A892 /* MockNetwork+Path.swift */,
+				CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2122,6 +2125,7 @@
 				CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
 				26B64548259BF2B900EF3FB3 /* ProductAttributeTermListMapperTests.swift in Sources */,
+				CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */,
 				B554FA8B2180B1D500C54DFF /* NotificationsRemoteTests.swift in Sources */,
 				B518662A20A09C6F00037A38 /* OrdersRemoteTests.swift in Sources */,
 				B5969E1520A47F99005E9DF1 /* RemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */; };
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
+		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -770,6 +771,7 @@
 		B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsRemote.swift; sourceTree = "<group>"; };
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
+		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -1458,6 +1460,7 @@
 				CE6D666B2379E19D007835A1 /* Array+Woo.swift */,
 				B58E5BE920FFB3D0003C986E /* CodingUserInfoKey+Woo.swift */,
 				B5BB1D0B20A2050300112D92 /* DateFormatter+Woo.swift */,
+				CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */,
 				B53EF5312180F21C003E146F /* Dictionary+Woo.swift */,
 				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 				021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */,
@@ -1934,6 +1937,7 @@
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
 				45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift in Sources */,
+				CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */,
 				45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */,
 				D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */,
 				B5C151BB217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift in Sources */,

--- a/Networking/Networking/Extensions/Decimal+Extensions.swift
+++ b/Networking/Networking/Extensions/Decimal+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension Decimal {
+
+    /// Returns true if the decimal is an integer.
+    ///
+    public var isInteger: Bool {
+        // Based on floating-point arithmetic, we can check the exponent to find out whether the decimal is an integer.
+        // Integer example: 12300 has the significand 123 and exponent 2: 123 * 10^2
+        // Non-integer example: 12.345 has the significand 12345 and exponent -3: 12345 * 10^-3
+        self.exponent >= 0
+    }
+}

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -109,6 +109,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         return ProductTaxStatus(rawValue: taxStatusKey)
     }
 
+    /// Whether the product variation has an integer stock quantity.
+    /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
+    /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+    public var hasIntegerStockQuantity: Bool {
+        stockQuantity?.exponent ?? 0 >= 0
+    }
+
     /// Product struct initializer.
     ///
     public init(siteID: Int64,
@@ -465,8 +472,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         try container.encode(soldIndividually, forKey: .soldIndividually)
 
         // API currently only accepts integer values for stock quantity
-        let integerStockQuantity = Int(truncating: stockQuantity as NSDecimalNumber? ?? 0)
-        try container.encode(integerStockQuantity, forKey: .stockQuantity)
+        if hasIntegerStockQuantity {
+            try container.encode(stockQuantity, forKey: .stockQuantity)
+        }
 
         try container.encode(backordersKey, forKey: .backordersKey)
         try container.encode(stockStatusKey, forKey: .stockStatusKey)

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -109,11 +109,15 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         return ProductTaxStatus(rawValue: taxStatusKey)
     }
 
-    /// Whether the product variation has an integer stock quantity.
+    /// Whether the product has an integer (or nil) stock quantity.
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
     public var hasIntegerStockQuantity: Bool {
-        stockQuantity?.exponent ?? 0 >= 0
+        guard let stockQuantity = stockQuantity else {
+            return true
+        }
+
+        return stockQuantity.isInteger
     }
 
     /// Product struct initializer.

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -57,11 +57,15 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
 
     /// Computed Properties
     ///
-    /// Whether the product variation has an integer stock quantity.
+    /// Whether the product variation has an integer (or nil) stock quantity.
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
     public var hasIntegerStockQuantity: Bool {
-        stockQuantity?.exponent ?? 0 >= 0
+        guard let stockQuantity = stockQuantity else {
+            return true
+        }
+
+        return stockQuantity.isInteger
     }
 
     /// ProductVariation struct initializer.

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -55,6 +55,15 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
 
     public let menuOrder: Int64
 
+    /// Computed Properties
+    ///
+    /// Whether the product variation has an integer stock quantity.
+    /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
+    /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
+    public var hasIntegerStockQuantity: Bool {
+        stockQuantity?.exponent ?? 0 >= 0
+    }
+
     /// ProductVariation struct initializer.
     ///
     public init(siteID: Int64,
@@ -295,7 +304,9 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
         try container.encode(sku, forKey: .sku)
         try container.encode(manageStock, forKey: .manageStock)
         try container.encode(stockStatus.rawValue, forKey: .stockStatusKey)
-        try container.encode(stockQuantity, forKey: .stockQuantity)
+        if hasIntegerStockQuantity {
+            try container.encode(stockQuantity, forKey: .stockQuantity)
+        }
         try container.encode(backordersKey, forKey: .backordersKey)
 
         // Variation (Local) Attributes

--- a/Networking/NetworkingTests/Extensions/Decimal+ExtensionsTests.swift
+++ b/Networking/NetworkingTests/Extensions/Decimal+ExtensionsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+/// Decimal+Extensions: Unit Tests
+
+class Decimal_ExtensionsTests: XCTestCase {
+
+    func test_isInteger_check() {
+        XCTAssertTrue(Decimal(12345678).isInteger)
+        XCTAssertTrue(Decimal(10000000).isInteger)
+        XCTAssertTrue(Decimal(12.0).isInteger)
+        XCTAssertTrue(Decimal(0).isInteger)
+        XCTAssertTrue(Decimal(-12.0).isInteger)
+        XCTAssertTrue(Decimal(-10000000).isInteger)
+        XCTAssertTrue(Decimal(-12345678).isInteger)
+
+        XCTAssertFalse(Decimal(12.345678).isInteger)
+        XCTAssertFalse(Decimal(0.0000000001).isInteger)
+        XCTAssertFalse(Decimal(-0.0000000001).isInteger)
+        XCTAssertFalse(Decimal(-12.345678).isInteger)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+6.2
+-----
+- [*] Fix: Load product inventory settings in read-only mode when the product has a decimal stock quantity. This fixes the products tab not loading due to product decoding errors when third-party plugins enable decimal stock quantities. [https://github.com/woocommerce/woocommerce-ios/pull/3717]
+
 6.1
 -----
 - [**] Products: When editing variable products, you can now edit the variation attributes to select different attribute options. [https://github.com/woocommerce/woocommerce-ios/pull/3628]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -43,6 +43,7 @@ private extension ProductVariationFormActionsFactory {
         let shouldShowPriceSettingsRow = editable || productVariation.regularPrice?.isNotEmpty == true
         let shouldShowNoPriceWarningRow = productVariation.isEnabledAndMissingPrice
         let shouldShowShippingSettingsRow = productVariation.isShippingEnabled()
+        let canEditInventorySettingsRow = editable && productVariation.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: editable): nil,
@@ -50,7 +51,7 @@ private extension ProductVariationFormActionsFactory {
             .attributes(editable: editable),
             .status(editable: editable),
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
-            .inventorySettings(editable: editable),
+            .inventorySettings(editable: canEditInventorySettingsRow),
         ]
         return actions.compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -73,8 +73,7 @@ private extension DefaultProductFormTableViewModel {
             case .shippingSettings(let editable):
                 return .shipping(viewModel: shippingSettingsRow(product: product, isEditable: editable), isEditable: editable)
             case .inventorySettings(let editable):
-                let isEditable = editable && product.hasIntegerStockQuantity
-                return .inventory(viewModel: inventorySettingsRow(product: product, isEditable: isEditable), isEditable: isEditable)
+                return .inventory(viewModel: inventorySettingsRow(product: product, isEditable: editable), isEditable: editable)
             case .categories(let editable):
                 return .categories(viewModel: categoriesRow(product: product.product, isEditable: editable), isEditable: editable)
             case .tags(let editable):
@@ -110,8 +109,7 @@ private extension DefaultProductFormTableViewModel {
             case .shippingSettings(let editable):
                 return .shipping(viewModel: shippingSettingsRow(product: productVariation, isEditable: editable), isEditable: editable)
             case .inventorySettings(let editable):
-                let isEditable = editable && productVariation.hasIntegerStockQuantity
-                return .inventory(viewModel: inventorySettingsRow(product: productVariation, isEditable: isEditable), isEditable: isEditable)
+                return .inventory(viewModel: inventorySettingsRow(product: productVariation, isEditable: editable), isEditable: editable)
             case .status(let editable):
                 return .status(viewModel: variationStatusRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .noPriceWarning:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -73,7 +73,8 @@ private extension DefaultProductFormTableViewModel {
             case .shippingSettings(let editable):
                 return .shipping(viewModel: shippingSettingsRow(product: product, isEditable: editable), isEditable: editable)
             case .inventorySettings(let editable):
-                return .inventory(viewModel: inventorySettingsRow(product: product, isEditable: editable), isEditable: editable)
+                let isEditable = editable && product.hasIntegerStockQuantity
+                return .inventory(viewModel: inventorySettingsRow(product: product, isEditable: isEditable), isEditable: isEditable)
             case .categories(let editable):
                 return .categories(viewModel: categoriesRow(product: product.product, isEditable: editable), isEditable: editable)
             case .tags(let editable):
@@ -109,7 +110,8 @@ private extension DefaultProductFormTableViewModel {
             case .shippingSettings(let editable):
                 return .shipping(viewModel: shippingSettingsRow(product: productVariation, isEditable: editable), isEditable: editable)
             case .inventorySettings(let editable):
-                return .inventory(viewModel: inventorySettingsRow(product: productVariation, isEditable: editable), isEditable: editable)
+                let isEditable = editable && productVariation.hasIntegerStockQuantity
+                return .inventory(viewModel: inventorySettingsRow(product: productVariation, isEditable: isEditable), isEditable: isEditable)
             case .status(let editable):
                 return .status(viewModel: variationStatusRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .noPriceWarning:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -119,6 +119,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.stockQuantity
     }
 
+    var hasIntegerStockQuantity: Bool {
+        product.hasIntegerStockQuantity
+    }
+
     var backordersKey: String {
         product.backordersKey
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -143,6 +143,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.stockQuantity
     }
 
+    var hasIntegerStockQuantity: Bool {
+        productVariation.hasIntegerStockQuantity
+    }
+
     var backordersKey: String {
         productVariation.backordersKey
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -91,12 +91,13 @@ private extension ProductFormActionsFactory {
         let shouldShowProductTypeRow = formType != .add
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowDownloadableProduct = product.downloadable
+        let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
-            .inventorySettings(editable: editable),
+            .inventorySettings(editable: canEditInventorySettingsRow),
             .categories(editable: editable),
             .tags(editable: editable),
             shouldShowDownloadableProduct ? .downloadableFiles(editable: editable): nil,
@@ -148,12 +149,13 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowProductTypeRow = formType != .add
+        let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
             .variations,
             shouldShowReviewsRow ? .reviews: nil,
             .shippingSettings(editable: editable),
-            .inventorySettings(editable: editable),
+            .inventorySettings(editable: canEditInventorySettingsRow),
             .categories(editable: editable),
             .tags(editable: editable),
             .shortDescription(editable: editable),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -50,6 +50,7 @@ protocol ProductFormDataModel {
     var manageStock: Bool { get }
     var stockStatus: ProductStockStatus { get }
     var stockQuantity: Decimal? { get }
+    var hasIntegerStockQuantity: Bool { get }
     var backordersKey: String { get }
     var soldIndividually: Bool? { get }
     // Whether stock status is available for the product.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -46,6 +46,25 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
+    func test_readonly_simple_product_with_decimal_stock_quantities_has_readonly_inventory_settings() {
+        // Arrange
+        let product = Product().copy(productTypeKey: ProductType.simple.rawValue, stockQuantity: 1.5)
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit)
+
+        // Assert
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .reviews,
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+    }
+
     // MARK: - Affiliate products
 
     func test_readonly_affiliate_product_form_actions_are_all_not_editable() {
@@ -185,6 +204,25 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func test_readonly_variable_product_with_decimal_stock_quantities_has_readonly_inventory_settings() {
+        // Arrange
+        let product = Product().copy(productTypeKey: ProductType.variable.rawValue, stockQuantity: 1.5)
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit)
+
+        // Assert
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations,
+                                                                       .reviews,
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
@@ -54,6 +54,22 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
+
+    func test_variation_with_decimal_stock_quantities_has_read_only_inventory() {
+        // Arrange
+        let productVariation = Fixtures.variationWithDecimalStockQuantity
+        let model = EditableProductVariationModel(productVariation: productVariation)
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: model, editable: true)
+
+        // Assert
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+                                                                       .attributes(editable: true),
+                                                                       .status(editable: true),
+                                                                       .inventorySettings(editable: false)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+    }
 }
 
 private extension ProductVariationFormActionsFactory_ReadonlyVariationTests {
@@ -72,5 +88,7 @@ private extension ProductVariationFormActionsFactory_ReadonlyVariationTests {
         static let variation = MockProductVariation().productVariation()
             .copy(image: image, description: "hello", regularPrice: "1", manageStock: false,
                   weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // Variation with decimal stock quantity
+        static let variationWithDecimalStockQuantity = MockProductVariation().productVariation().copy(regularPrice: "1", stockQuantity: 1.5)
     }
 }


### PR DESCRIPTION
Related: #3494
Depends on: #3705

## Description

The WooCommerce Core API only supports stock quantities with Int or nil values. However, certain third-party extensions can enable decimal (non-integer) stock quantities. In #3705 we added support for loading products and variations with decimal stock quantities in the app.

This PR makes a product or variation's inventory settings read-only if it has decimal stock quantities, since the API currently doesn't accept decimal stock quantities. Other settings (and all settings for products or variations without decimal stock quantities) can still be edited as usual.

## Changes

* Adds a computed property `hasIntegerStockQuantity` to the `Product` and `ProductVariation` Networking models.
* Networking only encodes the stock quantity if `hasIntegerStockQuantity` is true. This prevents decimal quantities from being sent to the API, while allowing other settings to be updated as usual.
* The property `hasIntegerStockQuantity` is then used in `ProductFormActionsFactory` and  `ProductVariationFormActionsFactory` to determine if the Inventory settings cell is editable.
* Adds unit tests to check that the inventory settings cell is not editable when a product or variation has a decimal stock quantity.

/|Integer stock quantity|Decimal stock quantity
-|-|-
Product|![Simulator Screen Shot - iPhone 12 - 2021-02-22 at 16 57 46](https://user-images.githubusercontent.com/8658164/108742247-6e566300-752f-11eb-9d3c-8fc45cd17e0b.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-22 at 16 57 36](https://user-images.githubusercontent.com/8658164/108742254-70202680-752f-11eb-9cf8-eedaedae9b54.png)
Product variation|![Simulator Screen Shot - iPhone 12 - 2021-02-22 at 16 58 00](https://user-images.githubusercontent.com/8658164/108742261-71e9ea00-752f-11eb-80ff-942d7ffe53f5.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-22 at 16 57 56](https://user-images.githubusercontent.com/8658164/108742268-731b1700-752f-11eb-8b6b-5119f844b96c.png)

**Editing product settings with/without decimal stock quantities**

<img src="https://user-images.githubusercontent.com/8658164/108741503-b7f27e00-752e-11eb-9f0d-89d9894bc650.gif" width="300px">


## Testing

**Setup**

1. On your store, enable decimal stock quantities by installing a third-party extension on your store like [WPC Product Quantity](https://wordpress.org/plugins/wpc-product-quantity/).
2. Update the inventory for at least one product and one product variation to have a decimal stock quantity.
3. Create a new order for products/variations with and without decimal stock quantities.

**Products**

1. In the app, go to the Products tab.
2. Select a product that **doesn't** have a decimal stock quantity.
3. Confirm the product details open and they are all editable, including Inventory.
4. Go back to the product list and select a product that **does** have a decimal stock quantity.
5. Confirm the product details open and Inventory is not editable, while other product settings are.
6. Make a change to the product settings and confirm you can update the product without any changes to the decimal stock quantity.

**Product Variations**

1. Go back to the product list and select a variable product with a mix of decimal and non-decimal stock quantities.
2. Select "Variations."
3. Select a variation that **doesn't** have a decimal stock quantity.
4. Confirm the variation details open and they are all editable, including Inventory.
5. Go back to the variation list and select a variation that **does** have a decimal stock quantity.
6. Confirm the variation details open and Inventory is not editable, while other variation settings are.
7. Make a change to the variation settings and confirm you can update the variation without any changes to the decimal stock quantity.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
