### PR TITLE
Variations: Edit attribute options(offered) for generating variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -136,12 +136,13 @@ final class AddAttributeOptionsViewModel {
         switch attribute {
         case .new:
             updateSections()
-        case let .existing(attribute) where attribute.isGlobal:
-            synchronizeGlobalOptions(of: attribute)
-        case let .existing(attribute) where attribute.isLocal:
-            populateLocalOptions(of: attribute)
-        default:
-            break
+        case let .existing(attribute):
+            preselectCurrentOptions(of: attribute)
+            if attribute.isGlobal {
+                synchronizeGlobalOptions(of: attribute)
+            } else {
+                populateLocalOptions(of: attribute)
+            }
         }
     }
 }
@@ -265,6 +266,14 @@ private extension AddAttributeOptionsViewModel {
         return Section(header: Localization.headerExistingOptions, footer: nil, rows: rows, allowsReorder: false, allowsSelection: true)
     }
 
+    /// Pre-selects options of a product attribute.
+    ///
+    func preselectCurrentOptions(of attribute: ProductAttribute) {
+        state.selectedOptions = attribute.options.map { option in
+            .local(name: option)
+        }
+    }
+
     /// Synchronizes options for global attributes
     ///
     func synchronizeGlobalOptions(of attribute: ProductAttribute) {
@@ -278,6 +287,8 @@ private extension AddAttributeOptionsViewModel {
         stores.dispatch(fetchOptions)
     }
 
+    /// Populates existing options for a local attribute.
+    ///
     func populateLocalOptions(of attribute: ProductAttribute) {
         state.existingOptions = attribute.options.map { option in
             .local(name: option)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -251,7 +251,17 @@ private extension AddAttributeOptionsViewModel {
             AddAttributeOptionsViewModel.Row.selectedOptions(name: option.name)
         }
 
-        return Section(header: Localization.headerSelectedOptions, footer: nil, rows: rows, allowsReorder: true, allowsSelection: false)
+        // Only allow reorder for local attributes(existing and new)
+        let allowsReorder: Bool = {
+            switch attribute {
+            case .new:
+                return true
+            case let .existing(productAttribute):
+                return productAttribute.isLocal
+            }
+        }()
+
+        return Section(header: Localization.headerSelectedOptions, footer: nil, rows: rows, allowsReorder: allowsReorder, allowsSelection: false)
     }
 
     func createExistingSection() -> Section? {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -57,7 +57,8 @@ final class AddAttributeOptionsViewModel {
     /// Defines next button visibility
     ///
     var isNextButtonEnabled: Bool {
-        state.selectedOptions.isNotEmpty
+        let optionsToSubmit = state.selectedOptions.map { $0.name }
+        return state.selectedOptions.isNotEmpty && optionsToSubmit != attribute.previouslySelectedOptions
     }
 
     /// Defines ghost cells visibility
@@ -349,6 +350,17 @@ private extension AddAttributeOptionsViewModel.Attribute {
             return name
         case let .existing(attribute):
             return attribute.name
+        }
+    }
+
+    /// Returns the previously selected options of an attribute. (ie: set when creating a variation)
+    ///
+    var previouslySelectedOptions: [String] {
+        switch self {
+        case .new:
+            return []
+        case let .existing(attribute):
+            return attribute.options
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -125,6 +125,21 @@ extension EditAttributesViewController {
         }
         show(addAttributeViewController, sender: self)
     }
+
+    /// Navigates to `AddAttributeOptionsViewController` to provide delete/rename/edit-options functionality.
+    /// Upon completion, update the product and pop the view controller.
+    ///
+    // TODO: Make sure that the screens before this are being updated
+    func navigateToEditAttribute(_ attribute: ProductAttribute) {
+        let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute))
+        let editViewController = AddAttributeOptionsViewController(viewModel: editViewModel) { [weak self] updatedProduct in
+            guard let self = self else { return }
+            self.viewModel.updateProduct(updatedProduct)
+            self.tableView.reloadData()
+            self.navigationController?.popViewController(animated: true)
+        }
+        show(editViewController, sender: true)
+    }
 }
 
 // MARK: - UITableView conformance
@@ -143,7 +158,9 @@ extension EditAttributesViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: Navigate to edit attribute
+        tableView.deselectRow(at: indexPath, animated: true)
+        let attribute = viewModel.productAttributeAtIndex(indexPath.row)
+        navigateToEditAttribute(attribute)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -17,7 +17,7 @@ final class EditAttributesViewController: UIViewController {
     ///
     var onVariationCreation: ((Product) -> Void)?
 
-    /// Assign this closure to be notified after an attribute  is created.
+    /// Assign this closure to be notified after an attribute  is created or updated.
     ///
     var onAttributeCreation: ((Product) -> Void)?
 
@@ -129,12 +129,12 @@ extension EditAttributesViewController {
     /// Navigates to `AddAttributeOptionsViewController` to provide delete/rename/edit-options functionality.
     /// Upon completion, update the product and pop the view controller.
     ///
-    // TODO: Make sure that the screens before this are being updated
     func navigateToEditAttribute(_ attribute: ProductAttribute) {
         let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute))
         let editViewController = AddAttributeOptionsViewController(viewModel: editViewModel) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.viewModel.updateProduct(updatedProduct)
+            self.onAttributeCreation?(updatedProduct)
             self.tableView.reloadData()
             self.navigationController?.popViewController(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -19,7 +19,7 @@ final class EditAttributesViewController: UIViewController {
 
     /// Assign this closure to be notified after an attribute  is created or updated.
     ///
-    var onAttributeCreation: ((Product) -> Void)?
+    var onAttributesUpdate: ((Product) -> Void)?
 
     init(viewModel: EditAttributesViewModel, noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.viewModel = viewModel
@@ -119,7 +119,7 @@ extension EditAttributesViewController {
         let addAttributeViewController = AddAttributeViewController(viewModel: addAttributeVM) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.viewModel.updateProduct(updatedProduct)
-            self.onAttributeCreation?(updatedProduct)
+            self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
             self.navigationController?.popToViewController(self, animated: true)
         }
@@ -129,12 +129,12 @@ extension EditAttributesViewController {
     /// Navigates to `AddAttributeOptionsViewController` to provide delete/rename/edit-options functionality.
     /// Upon completion, update the product and pop the view controller.
     ///
-    func navigateToEditAttribute(_ attribute: ProductAttribute) {
+    private func navigateToEditAttribute(_ attribute: ProductAttribute) {
         let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute))
         let editViewController = AddAttributeOptionsViewController(viewModel: editViewModel) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.viewModel.updateProduct(updatedProduct)
-            self.onAttributeCreation?(updatedProduct)
+            self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
             self.navigationController?.popViewController(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -52,6 +52,12 @@ extension EditAttributesViewModel {
         let useCase = GenerateVariationUseCase(product: product, stores: stores)
         useCase.generateVariation(onCompletion: onCompletion)
     }
+
+    /// Returns the underlying `ProductAttribute` that fuels an `attributes` type  at the given index.
+    ///
+    func productAttributeAtIndex(_ index: Int) -> ProductAttribute {
+        return product.attributes[index]
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -459,7 +459,7 @@ private extension ProductVariationsViewController {
             self?.removeEmptyViewController()
             self?.navigationController?.popViewController(animated: true)
         }
-        editAttributeViewController.onAttributeCreation = { [weak self] updatedProduct in
+        editAttributeViewController.onAttributesUpdate = { [weak self] updatedProduct in
             self?.product = updatedProduct
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -58,6 +58,22 @@ final class EditAttributesViewModelTests: XCTestCase {
                                                                       numberOfLinesForText: 0)
         XCTAssertEqual(viewModel.attributes, [expectedVM, expectedVM2])
     }
+
+    func test_product_attributes_indexes_match_attributes_viewModel_indexes() {
+        // Given
+        let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
+        let attribute2 = sampleAttribute(name: "attr-2", options: ["Option 3", "Option 4"])
+        let product = Product().copy(attributes: [attribute, attribute2])
+
+        // When
+        let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
+
+        // Then
+        XCTAssertTrue(viewModel.attributes.isNotEmpty)
+        viewModel.attributes.enumerated().forEach { index, vm in
+            XCTAssertEqual(vm.title, viewModel.productAttributeAtIndex(index).name)
+        }
+    }
 }
 
 private extension EditAttributesViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -69,7 +69,7 @@ final class EditAttributesViewModelTests: XCTestCase {
         let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
 
         // Then
-        XCTAssertTrue(viewModel.attributes.isNotEmpty)
+        XCTAssertEqual(viewModel.attributes.count, 2)
         viewModel.attributes.enumerated().forEach { index, vm in
             XCTAssertEqual(vm.title, viewModel.productAttributeAtIndex(index).name)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -429,6 +429,43 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
             AddAttributeOptionsViewController.Row.selectedOptions(name: "L")
         ])
     }
+
+    func test_new_attribute_should_allow_reorder() throws {
+        // Given
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))
+
+        // When
+        viewModel.addNewOption(name: "Option 1")
+        viewModel.addNewOption(name: "Option 2")
+
+        // Then
+        let selectedSection = try XCTUnwrap(viewModel.sections.last)
+        XCTAssertTrue(selectedSection.allowsReorder)
+    }
+
+    func test_local_attribute_should_allow_reorder() throws {
+        // Given, When
+        let attribute = sampleAttribute(attributeID: 0, name: "Color", options: ["Green", "Blue", "Red"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+
+        // Then
+        let selectedSection = try XCTUnwrap(viewModel.sections.last)
+        XCTAssertTrue(selectedSection.allowsReorder)
+        XCTAssertTrue(attribute.isLocal)
+    }
+
+    func test_global_attribute_should_not_allow_reorder() throws {
+        // Given, When
+        let attribute = sampleAttribute(name: "Color", options: ["Green", "Blue", "Red"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+
+        // Then
+        let selectedSection = try XCTUnwrap(viewModel.sections.last)
+        XCTAssertFalse(selectedSection.allowsReorder)
+        XCTAssertTrue(attribute.isGlobal)
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -61,6 +61,19 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isNextButtonEnabled)
     }
 
+    func test_next_button_is_enabled_after_removing_preselected_options() {
+        // Given
+        let attribute = sampleAttribute(name: "Size", options: ["S", "M", "L"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+
+        // When
+        viewModel.removeSelectedOption(atIndex: 2)
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonEnabled)
+    }
+
     func test_empty_names_are_not_added_as_options() throws {
         // Given
         let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -382,6 +382,40 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         let expectedAttribute = sampleAttribute(attributeID: 0, name: "attr-2", options: ["Option 1", "Option 2"])
         XCTAssertEqual(updatedProduct.attributes, [initialAttribute, expectedAttribute])
     }
+
+    func test_existing_local_attribute_should_preselect_options() throws {
+        // Given
+        let attribute = sampleAttribute(attributeID: 0, name: "Color", options: ["Green", "Blue", "Red"])
+        XCTAssertTrue(attribute.isLocal)
+
+        // When
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+        // Then
+        let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(textFieldSection, [
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "Green"),
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "Blue"),
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "Red")
+        ])
+    }
+
+    func test_existing_global_attribute_should_preselect_options() throws {
+        // Given
+        let attribute = sampleAttribute(name: "Size", options: ["S", "M", "L"])
+        XCTAssertTrue(attribute.isGlobal)
+
+        // When
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+        // Then
+        let textFieldSection = try XCTUnwrap(viewModel.sections.last?.rows)
+        XCTAssertEqual(textFieldSection, [
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "S"),
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "M"),
+            AddAttributeOptionsViewController.Row.selectedOptions(name: "L")
+        ])
+    }
 }
 
 // MARK: Helpers


### PR DESCRIPTION
closes #3540 

# Why

After being able to create variations(and attributes), we need to add the ability to edit those attributes so merchants can keep creating and updating variations on mobile.

This PR gives the ability to merchants to edit the product attribute options offered.

# How

- Update `EditAttributesViewController` to navigate the merchant to the `AddAttributeOptionsViewController` after tapping on an attribute row.

- Update `AddAttributeOptionsViewModel` to preselect(show in the options offered section) all the attributes that the merchant selected in past sessions(reside in `product.attributes[index].options`)

- Update `AddAttributeOptionsViewModel.isNextButtonEnabled` to not enable the next button if the previously selected options are the same as the options about to submit.

# Demo

![Update Attribute](https://user-images.githubusercontent.com/562080/108773304-1ec26800-752c-11eb-894f-9d8aa99463ee.gif)

# Testing Steps

- Go to a variable product with variations
- Tap on the variations row
- Tap on the more menu(...) and select edit attributes
- Tap on an attribute to edit.
- See that the next button is disabled and that there are some options pre-selected
- Edit the attribute by adding, removing or re-ordering an option.
- Tap Next
- Go back to the product variation detail screen and see that the variations row is updated with the new data

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
