### PR TITLE
Variations: single variation deletion - Networking, Storage and Yosemite

### DIFF
--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -17,6 +17,7 @@ public protocol ProductVariationsRemoteProtocol {
                                 newVariation: CreateProductVariation,
                                 completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void)
+    func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
 }
 
 /// ProductVariation: Remote Endpoints
@@ -111,6 +112,22 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         } catch {
             completion(.failure(error))
         }
+    }
+
+    /// Deletes a specific `ProductVariation`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the ProductVariation.
+    ///     - productID: Identifier of the Product.
+    ///     - variationID: Identifier of the Variation.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        let path = "\(Path.products)/\(productID)/variations/\(variationID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .delete, siteID: siteID, path: path, parameters: ["force": true])
+        let mapper = ProductVariationMapper(siteID: siteID, productID: productID)
+
+        enqueue(request, mapper: mapper, completion: completion)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -282,7 +282,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
 
     /// Verifies that deleteProductVariation properly relays Networking Layer errors.
     ///
-    func test_deleteProductVariation_properly_relays_networking_errors() throws {
+    func test_deleteProductVariation_properly_relays_networking_errors() {
         // Given
         let remote = ProductVariationsRemote(network: network)
         let sampleProductVariationID: Int64 = 1275
@@ -297,7 +297,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+        XCTAssertTrue(result.isFailure)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -252,6 +252,53 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Then
         XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
+
+    // MARK: - Delete ProductVariation
+
+    /// Verifies that deleteProductVariation properly parses the `product-variation` sample response.
+    ///
+    func test_deleteProductVariation_properly_returns_parsed_ProductVariation() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let sampleProductVariationID: Int64 = 1275
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations/\(sampleProductVariationID)", filename: "product-variation")
+
+        // When
+        let result = waitFor { promise in
+            remote.deleteProductVariation(siteID: self.sampleSiteID,
+                                          productID: self.sampleProductID,
+                                          variationID: sampleProductVariationID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+
+        let productVariation = try result.get()
+        XCTAssertEqual(productVariation.productID, sampleProductID)
+        XCTAssertEqual(productVariation.productVariationID, sampleProductVariationID)
+    }
+
+    /// Verifies that deleteProductVariation properly relays Networking Layer errors.
+    ///
+    func test_deleteProductVariation_properly_relays_networking_errors() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let sampleProductVariationID: Int64 = 1275
+
+        // When
+        let result = waitFor { promise in
+            remote.deleteProductVariation(siteID: self.sampleSiteID,
+                                          productID: self.sampleProductID,
+                                          variationID: sampleProductVariationID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+    }
 }
 
 private extension ProductVariationsRemoteTests {

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -33,8 +33,7 @@ public extension StorageType {
     /// Deletes single stored Product Variation for the provided siteID and productVariationID.
     ///
     func deleteProductVariation(siteID: Int64, productVariationID: Int64) {
-        guard let productVariation = loadProductVariation(siteID: siteID,
-                                                          productVariationID: productVariationID) else {
+        guard let productVariation = loadProductVariation(siteID: siteID, productVariationID: productVariationID) else {
             return
         }
 

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -30,6 +30,17 @@ public extension StorageType {
         }
     }
 
+    /// Deletes single stored Product Variation for the provided siteID and productVariationID.
+    ///
+    func deleteProductVariation(siteID: Int64, productVariationID: Int64) {
+        guard let productVariation = loadProductVariation(siteID: siteID,
+                                                          productVariationID: productVariationID) else {
+            return
+        }
+
+        deleteObject(productVariation)
+    }
+
     /// Deletes all of the stored Product Shipping Class models for the provided siteID.
     ///
     func deleteProductShippingClasses(siteID: Int64) {

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -28,4 +28,8 @@ public enum ProductVariationAction: Action {
     /// Requests the variations in a specified Order that have not been fetched.
     ///
     case requestMissingVariations(for: Order, onCompletion: (Error?) -> Void)
+
+    /// Delete an existing ProductVariation.
+    ///
+    case deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -31,5 +31,5 @@ public enum ProductVariationAction: Action {
 
     /// Delete an existing ProductVariation.
     ///
-    case deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
+    case deleteProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -31,5 +31,5 @@ public enum ProductVariationAction: Action {
 
     /// Delete an existing ProductVariation.
     ///
-    case deleteProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
+    case deleteProductVariation(productVariation: ProductVariation, onCompletion: (Result<Void, ProductUpdateError>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -207,7 +207,7 @@ private extension ProductVariationStore {
 
     /// Deletes the product variation.
     ///
-    func deleteProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
+    func deleteProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {
         remote.deleteProductVariation(siteID: productVariation.siteID,
                                       productID: productVariation.productID,
                                       variationID: productVariation.productVariationID) { [weak self] result in
@@ -215,7 +215,7 @@ private extension ProductVariationStore {
             switch result {
             case .success(let productVariation):
                 self.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
-                onCompletion(.success(productVariation))
+                onCompletion(.success(()))
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
             }

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -213,11 +213,11 @@ private extension ProductVariationStore {
                                       variationID: productVariation.productVariationID) { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .failure(let error):
-                onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariation):
                 self.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
                 onCompletion(.success(productVariation))
+            case .failure(let error):
+                onCompletion(.failure(ProductUpdateError(error: error)))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -211,9 +211,7 @@ private extension ProductVariationStore {
         remote.deleteProductVariation(siteID: productVariation.siteID,
                                       productID: productVariation.productID,
                                       variationID: productVariation.productVariationID) { [weak self] result in
-            guard let self = self else {
-                return
-            }
+            guard let self = self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -46,8 +46,8 @@ public final class ProductVariationStore: Store {
             updateProductVariation(productVariation: productVariation, onCompletion: onCompletion)
         case .requestMissingVariations(let order, let onCompletion):
             requestMissingVariations(for: order, onCompletion: onCompletion)
-        case .deleteProductVariation(let siteID, let productID, let variationID, let onCompletion):
-            deleteProductVariation(siteID: siteID, productID: productID, variationID: variationID, onCompletion: onCompletion)
+        case .deleteProductVariation(let productVariation, let onCompletion):
+            deleteProductVariation(productVariation: productVariation, onCompletion: onCompletion)
         }
     }
 }
@@ -207,11 +207,10 @@ private extension ProductVariationStore {
 
     /// Deletes the product variation.
     ///
-    func deleteProductVariation(siteID: Int64,
-                                productID: Int64,
-                                variationID: Int64,
-                                onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
-        remote.deleteProductVariation(siteID: siteID, productID: productID, variationID: variationID) { [weak self] result in
+    func deleteProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
+        remote.deleteProductVariation(siteID: productVariation.siteID,
+                                      productID: productVariation.productID,
+                                      variationID: productVariation.productVariationID) { [weak self] result in
             guard let self = self else {
                 return
             }
@@ -219,7 +218,7 @@ private extension ProductVariationStore {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariation):
-                self.deleteStoredProductVariation(siteID: siteID, productVariationID: variationID)
+                self.deleteStoredProductVariation(siteID: productVariation.siteID, productVariationID: productVariation.productVariationID)
                 onCompletion(.success(productVariation))
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -22,6 +22,9 @@ final class MockProductVariationsRemote {
     /// The results to return based on the given arguments in `loadProductVariation`
     private var productVariationLoadResults = [ResultKey: Result<ProductVariation, Error>]()
 
+    /// The results to return based on the given arguments in `deleteProductVariation`
+    private var productVariationDeleteResults = [ResultKey: Result<ProductVariation, Error>]()
+
     /// Set the value passed to the `completion` block if `createProductVariation()` is called.
     ///
     func whenCreatingProductVariation(siteID: Int64,
@@ -45,6 +48,13 @@ final class MockProductVariationsRemote {
     func whenLoadingProductVariation(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
         let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
         productVariationLoadResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `deleteProductVariation()` is called.
+    ///
+    func whenDeletingProductVariation(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
+        let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
+        productVariationDeleteResults[key] = result
     }
 }
 
@@ -107,6 +117,23 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                 productID: productVariation.productID,
                                 productVariationIDs: [productVariation.productVariationID])
             if let result = self.productVariationUpdateResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: siteID,
+                                productID: productID,
+                                productVariationIDs: [variationID])
+            if let result = self.productVariationDeleteResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -674,7 +674,7 @@ final class ProductVariationStoreTests: XCTestCase {
 
     // MARK: - ProductVariationAction.deleteProductVariation
 
-    func test_deleteProductVariation_deletes_data_from_storage_and_returns_expected_data() throws {
+    func test_deleteProductVariation_deletes_data_from_storage_and_returns_expected_data() {
         // Given
         let remote = MockProductVariationsRemote()
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
@@ -690,7 +690,7 @@ final class ProductVariationStoreTests: XCTestCase {
                                             thenReturn: .success(sampleVariation))
 
         // When
-        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+        let result: Result<Void, ProductUpdateError> = waitFor { promise in
             let action = ProductVariationAction.deleteProductVariation(productVariation: sampleVariation) { result in
                 promise(result)
             }
@@ -698,9 +698,7 @@ final class ProductVariationStoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
-        let returnedProductVariation = try result.get()
-        XCTAssertEqual(returnedProductVariation, sampleVariation)
+        XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
     }
 
@@ -720,7 +718,7 @@ final class ProductVariationStoreTests: XCTestCase {
                                             thenReturn: .failure(NSError(domain: "", code: 400, userInfo: nil)))
 
         // When
-        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+        let result: Result<Void, ProductUpdateError> = waitFor { promise in
             let action = ProductVariationAction.deleteProductVariation(productVariation: sampleVariation) { result in
                 promise(result)
             }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -691,9 +691,7 @@ final class ProductVariationStoreTests: XCTestCase {
 
         // When
         let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
-            let action = ProductVariationAction.deleteProductVariation(siteID: self.sampleSiteID,
-                                                                       productID: self.sampleProductID,
-                                                                       variationID: sampleProductVariationID) { result in
+            let action = ProductVariationAction.deleteProductVariation(productVariation: sampleVariation) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -711,9 +709,10 @@ final class ProductVariationStoreTests: XCTestCase {
         let remote = MockProductVariationsRemote()
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
         let sampleProductVariationID: Int64 = 1275
-        storageManager.insertSampleProductVariation(readOnlyProductVariation: sampleProductVariation(siteID: sampleSiteID,
-                                                                                                     productID: sampleProductID,
-                                                                                                     id: sampleProductVariationID))
+        let sampleVariation = sampleProductVariation(siteID: sampleSiteID,
+                                                     productID: sampleProductID,
+                                                     id: sampleProductVariationID)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: sampleVariation)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
         remote.whenDeletingProductVariation(siteID: sampleSiteID,
                                             productID: sampleProductID,
@@ -722,9 +721,7 @@ final class ProductVariationStoreTests: XCTestCase {
 
         // When
         let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
-            let action = ProductVariationAction.deleteProductVariation(siteID: self.sampleSiteID,
-                                                                       productID: self.sampleProductID,
-                                                                       variationID: sampleProductVariationID) { result in
+            let action = ProductVariationAction.deleteProductVariation(productVariation: sampleVariation) { result in
                 promise(result)
             }
             store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -671,6 +671,69 @@ final class ProductVariationStoreTests: XCTestCase {
         // The successfully loaded variation should still be saved to storage.
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
     }
+
+    // MARK: - ProductVariationAction.deleteProductVariation
+
+    func test_deleteProductVariation_deletes_data_from_storage_and_returns_expected_data() throws {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let sampleProductVariationID: Int64 = 1275
+        let sampleVariation = sampleProductVariation(siteID: sampleSiteID,
+                                                     productID: sampleProductID,
+                                                     id: sampleProductVariationID)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: sampleVariation)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
+        remote.whenDeletingProductVariation(siteID: sampleSiteID,
+                                            productID: sampleProductID,
+                                            productVariationID: sampleProductVariationID,
+                                            thenReturn: .success(sampleVariation))
+
+        // When
+        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+            let action = ProductVariationAction.deleteProductVariation(siteID: self.sampleSiteID,
+                                                                       productID: self.sampleProductID,
+                                                                       variationID: sampleProductVariationID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+        let returnedProductVariation = try result.get()
+        XCTAssertEqual(returnedProductVariation, sampleVariation)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
+    }
+
+    func test_deleteProductVariation_returns_error_upon_response_error() throws {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let sampleProductVariationID: Int64 = 1275
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: sampleProductVariation(siteID: sampleSiteID,
+                                                                                                     productID: sampleProductID,
+                                                                                                     id: sampleProductVariationID))
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
+        remote.whenDeletingProductVariation(siteID: sampleSiteID,
+                                            productID: sampleProductID,
+                                            productVariationID: sampleProductVariationID,
+                                            thenReturn: .failure(NSError(domain: "", code: 400, userInfo: nil)))
+
+        // When
+        let result: Result<Yosemite.ProductVariation, ProductUpdateError> = waitFor { promise in
+            let action = ProductVariationAction.deleteProductVariation(siteID: self.sampleSiteID,
+                                                                       productID: self.sampleProductID,
+                                                                       variationID: sampleProductVariationID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
+    }
 }
 
 

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -704,7 +704,7 @@ final class ProductVariationStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
     }
 
-    func test_deleteProductVariation_returns_error_upon_response_error() throws {
+    func test_deleteProductVariation_returns_error_upon_response_error() {
         // Given
         let remote = MockProductVariationsRemote()
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
@@ -728,7 +728,7 @@ final class ProductVariationStoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+        XCTAssertTrue(result.isFailure)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
     }
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/3193.

## Description

This PR adds Networking, Storage and Yosemite integrations to allow deleting a single variation.

Related API doc: https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-a-product-variation

## Changes

1. Adds `deleteProductVariation` case to `ProductVariationAction`
2. Adds handling for new action in `ProductVariationStore` (+ tests)
3. Adds local storage function to remove a single variation
4. Adds networking for deleting a single variation (+ tests)

## Test

Nothing is exposed to the UI here, so just check the code and unit tests status.
(UI is added in https://github.com/woocommerce/woocommerce-ios/pull/3730, feel free to test actions from there.)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
