### PR TITLE
Remove Sentry logging for the unexpected app state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -39,11 +39,7 @@ final class AppCoordinator {
 
                 // More details about the UI states: https://github.com/woocommerce/woocommerce-ios/pull/3498
                 switch (isLoggedIn, needsDefaultStore) {
-                case (false, true):
-                    self.displayAuthenticator()
-                case (false, false):
-                    // TODO-3711: let's delete the logging once we verify the crash is caused by this case.
-                    CrashLogging.logMessage("Unexpected app state where `isLoggedIn` and `needsDefaultStore` are both `false`", level: .info)
+                case (false, true), (false, false):
                     self.displayAuthenticator()
                 case (true, true):
                     self.displayStorePicker()


### PR DESCRIPTION
Cleanup for #3711 

## Why

In a previous PR https://github.com/woocommerce/woocommerce-ios/pull/3713 as an attempted fix for crash #3711, I added an info-level logging for the unexpected app state. Now that we know from the Sentry log that it's possible to reach this path, we can remove this logging for the next release. I'm still following up possible leads (like if I see anyone on the team in the logs) to understand how this path might be reached.

## Changes

Removed logging for the unexpected app state.

## Testing

Please confidence check on logging out and in:

- Launch the app in logged in state
- Log out from the app
- Log in to a store --> the whole flow should work like before

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
