### PR TITLE
Variations: Remove product attributes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -347,7 +347,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard let product = product as? EditableProductModel, row.isActionable else {
                     return
                 }
-                let variationsViewModel = ProductVariationsViewModel(product: product.product, isAddProductVariationsEnabled: isAddProductVariationsEnabled)
+                let variationsViewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: isAddProductVariationsEnabled)
                 let variationsViewController = ProductVariationsViewController(viewModel: variationsViewModel,
                                                                                product: product.product,
                                                                                formType: viewModel.formType,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -390,7 +390,7 @@ extension AddAttributeOptionsViewController {
             case let .success(product):
                 self.onCompletion(product)
             case let .failure(error):
-                // TODO: Show error notice
+                self.noticePresenter.enqueue(notice: .init(title: Localization.removeAttributeError, feedbackType: .error))
                 DDLogError(error.localizedDescription)
             }
         }
@@ -434,6 +434,8 @@ private extension AddAttributeOptionsViewController {
                                                             comment: "Placeholder of cell presenting the title of the new attribute option.")
         static let updateAttributeError = NSLocalizedString("The attribute couldn't be saved.",
                                                             comment: "Error title when trying to update or create an attribute remotely.")
+        static let removeAttributeError = NSLocalizedString("The attribute couldn't be removed.",
+                                                            comment: "Error title when trying to remove an attribute remotely.")
 
         static let removeAction = NSLocalizedString("Remove", comment: "Title for removing an attribute in the edit attribute action sheet.")
         static let cancelAction = NSLocalizedString("Cancel", comment: "Title for canceling the edit attribute action sheet.")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -84,7 +84,7 @@ private extension AddAttributeOptionsViewController {
     }
 
     func createNextButton(enabled: Bool) -> UIBarButtonItem {
-        let button = UIBarButtonItem(title: Localization.nextNavBarButton, style: .plain, target: self, action: #selector(nextButtonPressed(_:)))
+        let button = UIBarButtonItem(title: Localization.nextNavBarButton, style: .plain, target: self, action: #selector(moreButtonPressed(_:)))
         button.isEnabled = enabled
         return button
     }
@@ -346,7 +346,21 @@ extension AddAttributeOptionsViewController {
     }
 
     @objc private func moreButtonPressed(_ sender: UIBarButtonItem) {
-        // TODO: Show Edit action sheet
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        let removeAction = UIAlertAction(title: Localization.removeAction, style: .default) { [weak self] _ in
+            // TODO: Remove
+        }
+        actionSheet.addAction(removeAction)
+
+        let cancelAction = UIAlertAction(title: Localization.cancelAction, style: .cancel)
+        actionSheet.addAction(cancelAction)
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = sender
+
+        present(actionSheet, animated: true)
     }
 }
 
@@ -387,5 +401,8 @@ private extension AddAttributeOptionsViewController {
                                                             comment: "Placeholder of cell presenting the title of the new attribute option.")
         static let updateAttributeError = NSLocalizedString("The attribute couldn't be saved.",
                                                             comment: "Error title when trying to update or create an attribute remotely.")
+
+        static let removeAction = NSLocalizedString("Remove", comment: "Title for removing an attribute in the edit attribute action sheet.")
+        static let cancelAction = NSLocalizedString("Cancel", comment: "Title for canceling the edit attribute action sheet.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -345,12 +345,14 @@ extension AddAttributeOptionsViewController {
         }
     }
 
+    /// Present an action-sheet with `Remove` and `Rename` options.
+    ///
     @objc private func moreButtonPressed(_ sender: UIBarButtonItem) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
         let removeAction = UIAlertAction(title: Localization.removeAction, style: .default) { [weak self] _ in
-            // TODO: Remove
+            self?.presentRemoveAttributeConfirmation()
         }
         actionSheet.addAction(removeAction)
 
@@ -361,6 +363,22 @@ extension AddAttributeOptionsViewController {
         popoverController?.barButtonItem = sender
 
         present(actionSheet, animated: true)
+    }
+
+    /// Presents a confirmation alert and removes the attribute if the merchant confirms it.
+    ///
+    @objc private func presentRemoveAttributeConfirmation() {
+        let alertController = UIAlertController(title: Localization.removeConfirmationTitle,
+                                                message: Localization.removeConfirmationInfo,
+                                                preferredStyle: .alert)
+        alertController.view.tintColor = .text
+
+        alertController.addCancelActionWithTitle(Localization.cancelAction)
+        alertController.addDestructiveActionWithTitle(Localization.removeAction) { [weak self] _ in
+            // Call view model
+        }
+
+        present(alertController, animated: true)
     }
 }
 
@@ -404,5 +422,10 @@ private extension AddAttributeOptionsViewController {
 
         static let removeAction = NSLocalizedString("Remove", comment: "Title for removing an attribute in the edit attribute action sheet.")
         static let cancelAction = NSLocalizedString("Cancel", comment: "Title for canceling the edit attribute action sheet.")
+
+        static let removeConfirmationTitle = NSLocalizedString("Remove Attribute",
+                                                               comment: "Confirmation title before removing an attribute from a variation.")
+        static let removeConfirmationInfo = NSLocalizedString("Are you sure you want to remove this attribute?",
+                                                              comment: "Confirmation text before removing an attribute from a variation.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -11,7 +11,7 @@ final class AddAttributeOptionsViewController: UIViewController {
 
     private let noticePresenter: NoticePresenter
 
-    /// Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
+    /// Closure to be invoked(with the updated product) when the update/create/remove attribute operation finishes successfully.
     ///
     private let onCompletion: (Product) -> Void
 
@@ -24,7 +24,7 @@ final class AddAttributeOptionsViewController: UIViewController {
     /// Initializer for `AddAttributeOptionsViewController`
     ///
     /// - Parameters:
-    ///   - onCompletion: Closure to be invoked(with the updated product)  when the update/create attribute operation finishes successfully.
+    ///   - onCompletion: Closure to be invoked(with the updated product) qwhen the update/create/remove attribute operation finishes successfully.
     init(viewModel: AddAttributeOptionsViewModel,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          onCompletion: @escaping (Product) -> Void) {
@@ -67,7 +67,7 @@ private extension AddAttributeOptionsViewController {
         }
 
         // Assemble buttons based view model visibility
-        let moreButton = UIBarButtonItem(image: .moreImage, style: .plain, target: self, action: #selector(moreButtonPressed))
+        let moreButton = UIBarButtonItem(image: .moreImage, style: .plain, target: self, action: #selector(moreButtonPressed(_:)))
         let buttons = [
             createNextButton(enabled: viewModel.isNextButtonEnabled),
             viewModel.showMoreButton ? moreButton : nil
@@ -84,7 +84,7 @@ private extension AddAttributeOptionsViewController {
     }
 
     func createNextButton(enabled: Bool) -> UIBarButtonItem {
-        let button = UIBarButtonItem(title: Localization.nextNavBarButton, style: .plain, target: self, action: #selector(moreButtonPressed(_:)))
+        let button = UIBarButtonItem(title: Localization.nextNavBarButton, style: .plain, target: self, action: #selector(nextButtonPressed))
         button.isEnabled = enabled
         return button
     }
@@ -375,10 +375,25 @@ extension AddAttributeOptionsViewController {
 
         alertController.addCancelActionWithTitle(Localization.cancelAction)
         alertController.addDestructiveActionWithTitle(Localization.removeAction) { [weak self] _ in
-            // Call view model
+            self?.removeCurrentAttribute()
         }
 
         present(alertController, animated: true)
+    }
+
+    /// Tells the view model to remove the current attribute and pops the view controller after completion
+    ///
+    func removeCurrentAttribute() {
+        viewModel.removeCurrentAttribute { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .success(product):
+                self.onCompletion(product)
+            case let .failure(error):
+                // TODO: Show error notice
+                DDLogError(error.localizedDescription)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -63,19 +63,30 @@ private extension AddAttributeOptionsViewController {
     func configureRightButtonItem() {
         // The update indicator has precedence over the next button
         if viewModel.showUpdateIndicator {
-            let indicator = UIActivityIndicatorView(style: .medium)
-            indicator.color = .primaryButtonTitle
-            indicator.startAnimating()
-            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: indicator)
-            return
+            return navigationItem.rightBarButtonItems = [createUpdateIndicatorButton()]
         }
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
-                                                            style: .plain,
-                                                            target: self,
-                                                            action: #selector(nextButtonPressed))
-        navigationItem.rightBarButtonItem?.isEnabled = viewModel.isNextButtonEnabled
+        // Assemble buttons based view model visibility
+        let moreButton = UIBarButtonItem(image: .moreImage, style: .plain, target: self, action: #selector(moreButtonPressed))
+        let buttons = [
+            createNextButton(enabled: viewModel.isNextButtonEnabled),
+            viewModel.showMoreButton ? moreButton : nil
+        ]
 
+        navigationItem.rightBarButtonItems = buttons.compactMap { $0 }
+    }
+
+    func createUpdateIndicatorButton() -> UIBarButtonItem {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = .primaryButtonTitle
+        indicator.startAnimating()
+        return UIBarButtonItem(customView: indicator)
+    }
+
+    func createNextButton(enabled: Bool) -> UIBarButtonItem {
+        let button = UIBarButtonItem(title: Localization.nextNavBarButton, style: .plain, target: self, action: #selector(nextButtonPressed(_:)))
+        button.isEnabled = enabled
+        return button
     }
 
     func configureMainView() {
@@ -332,6 +343,10 @@ extension AddAttributeOptionsViewController {
                 DDLogError(error.localizedDescription)
             }
         }
+    }
+
+    @objc private func moreButtonPressed(_ sender: UIBarButtonItem) {
+        // TODO: Show Edit action sheet
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -367,7 +367,7 @@ extension AddAttributeOptionsViewController {
 
     /// Presents a confirmation alert and removes the attribute if the merchant confirms it.
     ///
-    @objc private func presentRemoveAttributeConfirmation() {
+    private func presentRemoveAttributeConfirmation() {
         let alertController = UIAlertController(title: Localization.removeConfirmationTitle,
                                                 message: Localization.removeConfirmationInfo,
                                                 preferredStyle: .alert)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -351,7 +351,7 @@ extension AddAttributeOptionsViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
-        let removeAction = UIAlertAction(title: Localization.removeAction, style: .default) { [weak self] _ in
+        let removeAction = UIAlertAction(title: Localization.removeAction, style: .destructive) { [weak self] _ in
             self?.presentRemoveAttributeConfirmation()
         }
         actionSheet.addAction(removeAction)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -24,7 +24,7 @@ final class AddAttributeOptionsViewController: UIViewController {
     /// Initializer for `AddAttributeOptionsViewController`
     ///
     /// - Parameters:
-    ///   - onCompletion: Closure to be invoked(with the updated product) qwhen the update/create/remove attribute operation finishes successfully.
+    ///   - onCompletion: Closure to be invoked(with the updated product) when the update/create/remove attribute operation finishes successfully.
     init(viewModel: AddAttributeOptionsViewModel,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          onCompletion: @escaping (Product) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -61,6 +61,12 @@ final class AddAttributeOptionsViewModel {
         return state.selectedOptions.isNotEmpty && optionsToSubmit != attribute.previouslySelectedOptions
     }
 
+    /// Defines the more(...) button visibility
+    ///
+    var showMoreButton: Bool {
+        allowsEditing
+    }
+
     /// Defines ghost cells visibility
     ///
     var showGhostTableView: Bool {
@@ -84,6 +90,10 @@ final class AddAttributeOptionsViewModel {
     /// Main attribute dependency.
     ///
     private let attribute: Attribute
+
+    /// Main allows editing dependency.
+    ///
+    private let allowsEditing: Bool
 
     /// When an attribute exists, returns an already configured `ResultsController`
     /// When there isn't an existing attribute, returns a dummy/un-initialized `ResultsController`
@@ -127,10 +137,12 @@ final class AddAttributeOptionsViewModel {
 
     init(product: Product,
          attribute: Attribute,
+         allowsEditing: Bool = false,
          stores: StoresManager = ServiceLocator.stores,
          viewStorage: StorageManagerType = ServiceLocator.storageManager) {
         self.product = product
         self.attribute = attribute
+        self.allowsEditing = allowsEditing
         self.stores = stores
         self.viewStorage = viewStorage
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -203,8 +203,21 @@ extension AddAttributeOptionsViewModel {
     /// Gathers selected options and update the product's attributes
     ///
     func updateProductAttributes(onCompletion: @escaping ((Result<Product, ProductUpdateError>) -> Void)) {
-        state.isUpdating = true
         let newProduct = createUpdatedProduct()
+        performProductUpdate(newProduct, onCompletion: onCompletion)
+    }
+
+    /// Updates the product remotely by removing the current attribute
+    ///
+    func removeCurrentAttribute(onCompletion: @escaping ((Result<Product, ProductUpdateError>) -> Void)) {
+        let newProduct = createProductByRemovingCurrentAttribute()
+        performProductUpdate(newProduct, onCompletion: onCompletion)
+    }
+
+    /// Update the given product remotely.
+    ///
+    private func performProductUpdate(_ newProduct: Product, onCompletion: @escaping ((Result<Product, ProductUpdateError>) -> Void)) {
+        state.isUpdating = true
         let action = ProductAction.updateProduct(product: newProduct) { [weak self] result in
             guard let self = self else { return }
             self.state.isUpdating = false
@@ -231,6 +244,20 @@ extension AddAttributeOptionsViewModel {
             var attributes = product.attributes
             attributes.removeAll { $0.attributeID == newAttribute.attributeID && $0.name == newAttribute.name }
             attributes.append(newAttribute)
+            return attributes
+        }()
+
+        return product.copy(attributes: updatedAttributes)
+    }
+
+    /// Returns a product with the current attribute removed.
+    ///
+    private func createProductByRemovingCurrentAttribute() -> Product {
+        // Remove the current attribute from the product attribute array.
+        // Name has to be considered, because local attributes are zero-id based.
+        let updatedAttributes: [ProductAttribute] = {
+            var attributes = product.attributes
+            attributes.removeAll { $0.attributeID == attribute.attributeID && $0.name == attribute.name }
             return attributes
         }()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -137,6 +137,8 @@ extension EditAttributesViewController {
             self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
             self.navigationController?.popViewController(animated: true)
+
+            // TODO: Pop until product if there aren't any more attributes
         }
         show(editViewController, sender: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -121,13 +121,12 @@ extension EditAttributesViewController {
             self.viewModel.updateProduct(updatedProduct)
             self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
-            self.navigationController?.popToViewController(self, animated: true)
         }
         show(addAttributeViewController, sender: self)
     }
 
     /// Navigates to `AddAttributeOptionsViewController` to provide delete/rename/edit-options functionality.
-    /// Upon completion, update the product and pop the view controller.
+    /// Upon completion, update the product and notify invoker
     ///
     private func navigateToEditAttribute(_ attribute: ProductAttribute) {
         let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute), allowsEditing: true)
@@ -136,9 +135,6 @@ extension EditAttributesViewController {
             self.viewModel.updateProduct(updatedProduct)
             self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
-            self.navigationController?.popViewController(animated: true)
-
-            // TODO: Pop until product if there aren't any more attributes
         }
         show(editViewController, sender: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -130,7 +130,7 @@ extension EditAttributesViewController {
     /// Upon completion, update the product and pop the view controller.
     ///
     private func navigateToEditAttribute(_ attribute: ProductAttribute) {
-        let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute))
+        let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute), allowsEditing: true)
         let editViewController = AddAttributeOptionsViewController(viewModel: editViewModel) { [weak self] updatedProduct in
             guard let self = self else { return }
             self.viewModel.updateProduct(updatedProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -458,10 +458,12 @@ private extension ProductVariationsViewController {
         editAttributeViewController.onVariationCreation = { [weak self] updatedProduct in
             self?.product = updatedProduct
             self?.removeEmptyViewController()
-            self?.navigationController?.popViewController(animated: true)
+            navigationController.popViewController(animated: true)
         }
         editAttributeViewController.onAttributesUpdate = { [weak self] updatedProduct in
-            self?.product = updatedProduct
+            guard let self = self else { return }
+            self.product = updatedProduct
+            self.onAttributesUpdate(editAttributesViewController: editAttributeViewController)
         }
 
         guard let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) else {
@@ -470,6 +472,18 @@ private extension ProductVariationsViewController {
 
         let viewControllersUntilSelf = navigationController.viewControllers[0...indexOfSelf]
         navigationController.setViewControllers(viewControllersUntilSelf + [editAttributeViewController], animated: true)
+    }
+
+    /// Refreshes the product variations list and navigates to the appropriate screen.
+    /// Navigates back to edit attribute screen if the product has attributes.
+    /// Navigates back to variations list if the product doesn't has attributes.
+    ///
+    private func onAttributesUpdate(editAttributesViewController: UIViewController) {
+        // Refresh variations because updating an attribute updates the product variations,
+        syncingCoordinator.synchronizeFirstPage()
+
+        let viewControllerToShow = product.attributes.isNotEmpty ? editAttributesViewController : self
+        navigationController?.popToViewController(viewControllerToShow, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -93,7 +93,7 @@ final class ProductVariationsViewController: UIViewController {
     private var product: Product {
         didSet {
             configureRightButtonItem()
-            configureEmptyState()
+            updateEmptyState()
             onProductUpdate?(product)
         }
     }
@@ -155,7 +155,7 @@ final class ProductVariationsViewController: UIViewController {
         configureHeaderContainerView()
         configureAddButton()
         updateTopBannerView()
-        configureEmptyState()
+        updateEmptyState()
 
         syncingCoordinator.synchronizeFirstPage()
     }
@@ -238,7 +238,7 @@ private extension ProductVariationsViewController {
 
     /// Shows or hides the empty state screen.
     ///
-    func configureEmptyState() {
+    func updateEmptyState() {
         if viewModel.shouldShowEmptyState(for: product) {
             displayEmptyViewController()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -186,7 +186,7 @@ private extension ProductVariationsViewController {
     /// Configure right button item.
     ///
     func configureRightButtonItem() {
-        guard viewModel.showMoreButton(for: product) else {
+        guard viewModel.shouldShowMoreButton(for: product) else {
             return navigationItem.rightBarButtonItem = nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -92,6 +92,7 @@ final class ProductVariationsViewController: UIViewController {
 
     private var product: Product {
         didSet {
+            configureRightButtonItem()
             configureEmptyState()
             onProductUpdate?(product)
         }
@@ -179,14 +180,16 @@ private extension ProductVariationsViewController {
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."
         )
-        if viewModel.showMoreButton {
-            configureMoreOptionsButton()
-        }
+        configureRightButtonItem()
     }
 
-    /// Configure More Options button.
+    /// Configure right button item.
     ///
-    func configureMoreOptionsButton() {
+    func configureRightButtonItem() {
+        guard viewModel.showMoreButton(for: product) else {
+            return navigationItem.rightBarButtonItem = nil
+        }
+
         let moreButton = UIBarButtonItem(image: .moreImage,
                                          style: .plain,
                                          target: self,
@@ -450,6 +453,9 @@ private extension ProductVariationsViewController {
             guard let self = self else { return }
             self.product = updatedProduct
             self.navigateToEditAttributeViewController(allowVariationCreation: true)
+
+            // Update variations: Edge case product didn't had attributes but had variations
+            self.syncingCoordinator.synchronizeFirstPage()
         }
         show(addAttributeViewController, sender: self)
     }
@@ -486,7 +492,7 @@ private extension ProductVariationsViewController {
     /// Navigates back to variations list if the product doesn't has attributes.
     ///
     private func onAttributesUpdate(editAttributesViewController: UIViewController) {
-        // Refresh variations because updating an attribute updates the product variations,
+        // Refresh variations because updating an attribute updates the product variations.
         syncingCoordinator.synchronizeFirstPage()
 
         let viewControllerToShow = product.attributes.isNotEmpty ? editAttributesViewController : self
@@ -602,7 +608,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         let progressViewController = InProgressViewController(viewProperties: .init(title: Localization.generatingVariation,
                                                                                     message: Localization.waitInstructions))
         present(progressViewController, animated: true)
-        viewModel.generateVariation { [onProductUpdate, noticePresenter] result in
+        viewModel.generateVariation(for: product) { [onProductUpdate, noticePresenter] result in
             progressViewController.dismiss(animated: true)
 
             guard let variation = try? result.get() else {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -92,6 +92,7 @@ final class ProductVariationsViewController: UIViewController {
 
     private var product: Product {
         didSet {
+            configureEmptyState()
             onProductUpdate?(product)
         }
     }
@@ -153,12 +154,9 @@ final class ProductVariationsViewController: UIViewController {
         configureHeaderContainerView()
         configureAddButton()
         updateTopBannerView()
+        configureEmptyState()
 
         syncingCoordinator.synchronizeFirstPage()
-
-        if product.variations.isEmpty {
-            displayEmptyViewController()
-        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -233,6 +231,16 @@ private extension ProductVariationsViewController {
     ///
     func registerTableViewCells() {
         tableView.register(ProductsTabProductTableViewCell.self)
+    }
+
+    /// Shows or hides the empty state screen.
+    ///
+    func configureEmptyState() {
+        if viewModel.shouldShowEmptyState(for: product) {
+            displayEmptyViewController()
+        } else {
+            removeEmptyViewController()
+        }
     }
 
     /// Shows the EmptyStateViewController
@@ -457,7 +465,6 @@ private extension ProductVariationsViewController {
         let editAttributeViewController = EditAttributesViewController(viewModel: editAttributesViewModel)
         editAttributeViewController.onVariationCreation = { [weak self] updatedProduct in
             self?.product = updatedProduct
-            self?.removeEmptyViewController()
             navigationController.popViewController(animated: true)
         }
         editAttributeViewController.onAttributesUpdate = { [weak self] updatedProduct in

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -5,10 +5,6 @@ import Yosemite
 ///
 final class ProductVariationsViewModel {
 
-    /// Main product dependency.
-    ///
-    private let product: Product
-
     /// Defines if the Add Product Variations feature is enabled
     ///
     private let isAddProductVariationsEnabled: Bool
@@ -17,29 +13,30 @@ final class ProductVariationsViewModel {
     ///
     private let stores: StoresManager
 
-    /// Defines if the More Options button should be shown
-    ///
-    var showMoreButton: Bool {
-        product.variations.isNotEmpty && isAddProductVariationsEnabled
-    }
-
-    init(product: Product, isAddProductVariationsEnabled: Bool, stores: StoresManager = ServiceLocator.stores) {
-        self.product = product
+    init(isAddProductVariationsEnabled: Bool, stores: StoresManager = ServiceLocator.stores) {
         self.isAddProductVariationsEnabled = isAddProductVariationsEnabled
         self.stores = stores
     }
 
     /// Generates a variation in the host site using the product attributes
     ///
-    func generateVariation(onCompletion: @escaping (Result<Product, Error>) -> Void) {
+    func generateVariation(for product: Product, onCompletion: @escaping (Result<Product, Error>) -> Void) {
         let useCase = GenerateVariationUseCase(product: product, stores: stores)
         useCase.generateVariation(onCompletion: onCompletion)
     }
+}
 
+/// TODO: This functions need to be converted to computed variables, once the `ViewController` is refactored to use `MMVM`.
+extension ProductVariationsViewModel {
     /// Defines the empty state screen visibility
-    /// TODO: This method should turned into a computed variable, once the `ViewController` is refactored to use `MMVM`.
     ///
-    func shouldShowEmptyState(for newProduct: Product) -> Bool {
-        newProduct.variations.isEmpty || newProduct.attributes.isEmpty
+    func shouldShowEmptyState(for product: Product) -> Bool {
+        product.variations.isEmpty || product.attributes.isEmpty
+    }
+
+    /// Defines if the More Options button should be shown
+    ///
+    func showMoreButton(for product: Product) -> Bool {
+        product.variations.isNotEmpty && product.attributes.isNotEmpty && isAddProductVariationsEnabled
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -36,7 +36,7 @@ extension ProductVariationsViewModel {
 
     /// Defines if the More Options button should be shown
     ///
-    func showMoreButton(for product: Product) -> Bool {
+    func shouldShowMoreButton(for product: Product) -> Bool {
         product.variations.isNotEmpty && product.attributes.isNotEmpty && isAddProductVariationsEnabled
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -35,4 +35,11 @@ final class ProductVariationsViewModel {
         let useCase = GenerateVariationUseCase(product: product, stores: stores)
         useCase.generateVariation(onCompletion: onCompletion)
     }
+
+    /// Defines the empty state screen visibility
+    /// TODO: This method should turned into a computed variable, once the `ViewController` is refactored to use `MMVM`.
+    ///
+    func shouldShowEmptyState(for newProduct: Product) -> Bool {
+        newProduct.variations.isEmpty || newProduct.attributes.isEmpty
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -40,4 +40,42 @@ final class ProductVariationsViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.showMoreButton, false)
     }
+
+    func test_empty_state_is_shown_when_product_does_not_have_variations_but_has_attributes() {
+        // Given
+        let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
+        let product = Product().copy(attributes: [attribute], variations: [])
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+
+        // Then
+        let showEmptyState = viewModel.shouldShowEmptyState(for: product)
+
+        // Then
+        XCTAssertTrue(showEmptyState)
+    }
+
+    func test_empty_state_is_shown_when_product_does_not_have_attributes_but_has_variations() {
+        // Given
+        let product = Product().copy(attributes: [], variations: [1, 2])
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+
+        // Then
+        let showEmptyState = viewModel.shouldShowEmptyState(for: product)
+
+        // Then
+        XCTAssertTrue(showEmptyState)
+    }
+
+    func test_empty_state_is_not_shown_when_product_has_attributes_and_variations() {
+        // Given
+        let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
+        let product = Product().copy(attributes: [attribute], variations: [1, 2])
+        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+
+        // Then
+        let showEmptyState = viewModel.shouldShowEmptyState(for: product)
+
+        // Then
+        XCTAssertFalse(showEmptyState)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -4,48 +4,74 @@ import Yosemite
 
 final class ProductVariationsViewModelTests: XCTestCase {
     func test_more_button_appears_when_product_is_not_empty_and_addProductVariations_feature_is_enabled() {
-        // Arrange
+        // Given
         let variations: [Int64] = [101, 102]
-        let product = Product().copy(variations: variations)
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
+        let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
+        let product = Product().copy(attributes: [attribute], variations: variations)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
 
-        // Assert
-        XCTAssertEqual(viewModel.showMoreButton, true)
+        // When
+        let showMoreButton = viewModel.showMoreButton(for: product)
+
+        // Then
+        XCTAssertTrue(showMoreButton)
+    }
+
+    func test_more_button_does_not_appear_when_product_has_variations_does_not_have_attributes_and_addProductVariations_feature_is_enabled() {
+        // Given
+        let variations: [Int64] = [101, 102]
+        let product = Product().copy(attributes: [], variations: variations)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
+
+        // When
+        let showMoreButton = viewModel.showMoreButton(for: product)
+
+        // Then
+        XCTAssertFalse(showMoreButton)
     }
 
     func test_more_button_does_not_appear_when_product_is_not_empty_and_addProductVariations_feature_is_disabled() {
-        // Arrange
+        // Given
         let variations: [Int64] = [101, 102]
         let product = Product().copy(variations: variations)
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
-        // Assert
-        XCTAssertEqual(viewModel.showMoreButton, false)
+        // When
+        let showMoreButton = viewModel.showMoreButton(for: product)
+
+        // Then
+        XCTAssertFalse(showMoreButton)
     }
 
     func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_enabled() {
-        // Arrange
+        // Given
         let product = Product().copy()
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: true)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
 
-        // Assert
-        XCTAssertEqual(viewModel.showMoreButton, false)
+        // When
+        let showMoreButton = viewModel.showMoreButton(for: product)
+
+        // Then
+        XCTAssertFalse(showMoreButton)
     }
 
     func test_more_button_does_not_appear_when_product_is_empty_and_addProductVariations_feature_is_disabled() {
-        // Arrange
+        // Given
         let product = Product().copy()
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
-        // Assert
-        XCTAssertEqual(viewModel.showMoreButton, false)
+        // When
+        let showMoreButton = viewModel.showMoreButton(for: product)
+
+        // Then
+        XCTAssertFalse(showMoreButton)
     }
 
     func test_empty_state_is_shown_when_product_does_not_have_variations_but_has_attributes() {
         // Given
         let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
         let product = Product().copy(attributes: [attribute], variations: [])
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
         // Then
         let showEmptyState = viewModel.shouldShowEmptyState(for: product)
@@ -57,7 +83,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
     func test_empty_state_is_shown_when_product_does_not_have_attributes_but_has_variations() {
         // Given
         let product = Product().copy(attributes: [], variations: [1, 2])
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
         // Then
         let showEmptyState = viewModel.shouldShowEmptyState(for: product)
@@ -70,7 +96,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         // Given
         let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
         let product = Product().copy(attributes: [attribute], variations: [1, 2])
-        let viewModel = ProductVariationsViewModel(product: product, isAddProductVariationsEnabled: false)
+        let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
         // Then
         let showEmptyState = viewModel.shouldShowEmptyState(for: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -11,7 +11,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
 
         // When
-        let showMoreButton = viewModel.showMoreButton(for: product)
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
         XCTAssertTrue(showMoreButton)
@@ -24,7 +24,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
 
         // When
-        let showMoreButton = viewModel.showMoreButton(for: product)
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
         XCTAssertFalse(showMoreButton)
@@ -37,7 +37,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
         // When
-        let showMoreButton = viewModel.showMoreButton(for: product)
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
         XCTAssertFalse(showMoreButton)
@@ -49,7 +49,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: true)
 
         // When
-        let showMoreButton = viewModel.showMoreButton(for: product)
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
         XCTAssertFalse(showMoreButton)
@@ -61,7 +61,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let viewModel = ProductVariationsViewModel(isAddProductVariationsEnabled: false)
 
         // When
-        let showMoreButton = viewModel.showMoreButton(for: product)
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
         XCTAssertFalse(showMoreButton)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -376,6 +376,40 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         XCTAssertEqual(updatedProduct.attributes, [expectedAttribute])
     }
 
+    func test_removing_current_attribute_correctly_updates_product_attributes() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .updateProduct(product, onCompletion):
+                    onCompletion(.success(product))
+            default:
+                break
+            }
+        }
+
+        let attribute1 = sampleAttribute(name: "Color", options: ["Green", "Blue"])
+        let attribute2 = sampleAttribute(name: "Size", options: ["Large", "Small"])
+        let initialProduct = sampleProduct().copy(attributes: [attribute1, attribute2])
+        let viewModel = AddAttributeOptionsViewModel(product: initialProduct, attribute: .existing(attribute: attribute2), stores: stores)
+
+
+        // When
+        let updatedProduct: Product = waitFor { promise in
+            viewModel.removeCurrentAttribute { result in
+                switch result {
+                case .success(let product):
+                    promise(product)
+                case .failure:
+                    break
+                }
+            }
+        }
+
+        // Then
+        XCTAssertEqual(updatedProduct.attributes, [attribute1])
+    }
+
     func test_saving_new_attribute_does_not_override_existing_local_attribute() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -74,6 +74,22 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isNextButtonEnabled)
     }
 
+    func test_more_button_is_not_visible_when_editing_is_disabled() {
+        // Given, When
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName), allowsEditing: false)
+
+        // Then
+        XCTAssertFalse(viewModel.showMoreButton)
+    }
+
+    func test_more_button_is_visible_when_editing_is_enabled() {
+        // Given, When
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName), allowsEditing: true)
+
+        // Then
+        XCTAssertTrue(viewModel.showMoreButton)
+    }
+
     func test_empty_names_are_not_added_as_options() throws {
         // Given
         let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .new(name: sampleAttributeName))


### PR DESCRIPTION
closes #3212

# Why

This PR allows the merchant to remove a product attribute, removing an attribute affects the product's variations in **Core**, so on each attribute update, we need to re-fetch the variations.

Also, when removing the last attribute, we need to show the user the empty state screen to allow them to trigger the first variation flow.

# How

- In `AddAttributeOptionsViewModel`:
  - Added `showMoreButton` property for VC to consume
  - Added `removeCurrentAttribute` that removes the attribute remotely.

- In `AddAttributeOptionsViewController`: 
  - Add "More" button, together with the existing "Next" Button
  - Present action sheet with remove option when tapping the "More" button
  - Present confirmation alert when selecting the remove action
  - Call `ViewModel.removeCurrentAttribute` and notify the parent controller 

- Update `EditAttributesViewController` to provide a `AddAttributeOptionsViewModel` with edit mode.

- Update `ProductVariationsViewModel` to:
  - Add an `shouldShowEmptyState()` method
  - Remove product dependency: Before this PR, there were two sources for the product(VM and VC) that can go out of sync. We need to stick with one(The VC) until the VC is refactored to use `MVVM`

- Update `ProductVariationsViewController` to: 
  - Configure its right button item based on the `VM` 
  - Display or hide the empty state screen when the product attributes are updated
  - Re-fetch variations when the product attributes are updated
  - Make sure the user is on the right screen after deleting the last variation. (EditAttributes after deleting/updating an attribute. VariationsList after deleting the last attribute)
  
  # Demo
  
Delete Any | Delete Last
--- | --- 
![remove-attribute](https://user-images.githubusercontent.com/562080/109062862-7ab8f800-76b6-11eb-87ce-ca631c6a5a8b.gif) | ![remove-last-attribute](https://user-images.githubusercontent.com/562080/109062842-742a8080-76b6-11eb-9062-2450076d078e.gif)

# Testing Steps
- Go to a product with variations and at least two attributes.
- Navigate to the variations list
- Tap on the "more" button and go to edit attributes
- Tap on an attribute
- Tap on the "more" button and see that an action sheet with a "remove" option appears.
- Tap on the "remove" action and see that an alert confirmation appears.
- Tap on the "remove" confirmation and see that you are brought back to the edit attribute screen and that the attribute was removed.
**Repeat process with all other attributes**
- Once the last attribute is removed, see that you are taken back to the variation list screen with the empty state on top of it.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
