### PR TITLE
Enable large titles behind a feature flag (scrolling animation is only available in Products and Reviews tab)

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
@@ -9,11 +9,24 @@ extension UINavigationBar {
     /// Applies the default WC's Appearance
     ///
     class func applyWooAppearance() {
-        let appearance = UINavigationBar.appearance()
-        appearance.barTintColor = .appBar
-        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-        appearance.isTranslucent = false
-        appearance.tintColor = .white
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .appBar
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.text]
+            appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.text]
+
+            UINavigationBar.appearance().tintColor = .accent // The color of bar button items in the navigation bar
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().compactAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        } else {
+            let appearance = UINavigationBar.appearance()
+            appearance.barTintColor = .appBar
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+            appearance.isTranslucent = false
+            appearance.tintColor = .white
+        }
     }
 
     /// Applies UIKit's Default Appearance

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -144,8 +144,12 @@ extension UIColor {
     /// App Navigation Bar.
     ///
     static var appBar: UIColor {
-        return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                       dark: .systemColor(.secondarySystemGroupedBackground))
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            return UIColor(light: .white, dark: .black)
+        } else {
+            return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
+                           dark: .systemColor(.secondarySystemGroupedBackground))
+        }
     }
 
     /// App Tab Bar.

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,6 +9,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .largeTitles:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -18,6 +18,10 @@ enum FeatureFlag: Int {
     ///
     case cardPresentPayments
 
+    /// Large titles on the main tabs
+    ///
+    case largeTitles
+
     /// Product Reviews
     ///
     case reviews

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -1,5 +1,45 @@
 import UIKit
 
+/// Navigation controller for a Woo tab, shown as the root view controller of one of the tab bar.
+/// The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
+/// The following view controllers can override `preferredLargeTitleDisplayMode` function to change the large title display mode.
+final class WooTabNavigationController: UINavigationController {
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        navigationBar.prefersLargeTitles = true
+        delegate = self
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .default
+    }
+}
+
+extension WooTabNavigationController: UINavigationControllerDelegate {
+    // The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if navigationController.viewControllers.count == 1 {
+            viewController.navigationItem.largeTitleDisplayMode = .always
+        } else {
+            viewController.navigationItem.largeTitleDisplayMode = viewController.preferredLargeTitleDisplayMode()
+        }
+    }
+}
+
+// MARK: - Large title customizations
+
+extension UIViewController {
+    /// A view controller is default not to show large title.
+    /// This function allows each view controller to override the default large title display mode.
+    @objc func preferredLargeTitleDisplayMode() -> UINavigationItem.LargeTitleDisplayMode {
+        .never
+    }
+}
+
 /// Subclass to set Woo styling.
 /// Use this when presenting modals.
 ///

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -1,45 +1,5 @@
 import UIKit
 
-/// Navigation controller for a Woo tab, shown as the root view controller of one of the tab bar.
-/// The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
-/// The following view controllers can override `preferredLargeTitleDisplayMode` function to change the large title display mode.
-final class WooTabNavigationController: UINavigationController {
-    init() {
-        super.init(nibName: nil, bundle: nil)
-        navigationBar.prefersLargeTitles = true
-        delegate = self
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        .default
-    }
-}
-
-extension WooTabNavigationController: UINavigationControllerDelegate {
-    // The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        if navigationController.viewControllers.count == 1 {
-            viewController.navigationItem.largeTitleDisplayMode = .always
-        } else {
-            viewController.navigationItem.largeTitleDisplayMode = viewController.preferredLargeTitleDisplayMode()
-        }
-    }
-}
-
-// MARK: - Large title customizations
-
-extension UIViewController {
-    /// A view controller is default not to show large title.
-    /// This function allows each view controller to override the default large title display mode.
-    @objc func preferredLargeTitleDisplayMode() -> UINavigationItem.LargeTitleDisplayMode {
-        .never
-    }
-}
-
 /// Subclass to set Woo styling.
 /// Use this when presenting modals.
 ///

--- a/WooCommerce/Classes/System/WooTabNavigationController.swift
+++ b/WooCommerce/Classes/System/WooTabNavigationController.swift
@@ -17,7 +17,7 @@ final class WooTabNavigationController: UINavigationController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default: StyleManager.statusBarLight
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default : StyleManager.statusBarLight
     }
 }
 

--- a/WooCommerce/Classes/System/WooTabNavigationController.swift
+++ b/WooCommerce/Classes/System/WooTabNavigationController.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+/// Navigation controller for a Woo tab, shown as the root view controller of one of the tab bar.
+/// The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
+/// The following view controllers can override `preferredLargeTitleDisplayMode` function to change the large title display mode.
+final class WooTabNavigationController: UINavigationController {
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            navigationBar.prefersLargeTitles = true
+            delegate = self
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default: StyleManager.statusBarLight
+    }
+}
+
+extension WooTabNavigationController: UINavigationControllerDelegate {
+    // The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if navigationController.viewControllers.count == 1 {
+            viewController.navigationItem.largeTitleDisplayMode = .always
+        } else {
+            viewController.navigationItem.largeTitleDisplayMode = viewController.preferredLargeTitleDisplayMode()
+        }
+    }
+}
+
+// MARK: - Large title customizations
+
+extension UIViewController {
+    /// A view controller is default not to show large title.
+    /// This function allows each view controller to override the default large title display mode.
+    @objc func preferredLargeTitleDisplayMode() -> UINavigationItem.LargeTitleDisplayMode {
+        .never
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -70,7 +70,7 @@ final class MainTabBarController: UITabBarController {
     /// Used for overriding the status bar style for all child view controllers
     ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return StyleManager.statusBarLight
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default: StyleManager.statusBarLight
     }
 
     /// Notifications badge

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -83,10 +83,10 @@ final class MainTabBarController: UITabBarController {
 
     /// Tab view controllers
     ///
-    private let dashboardNavigationController: UINavigationController = WooNavigationController()
-    private let ordersNavigationController: UINavigationController = WooNavigationController()
-    private let productsNavigationController: UINavigationController = WooNavigationController()
-    private let reviewsNavigationController: UINavigationController = WooNavigationController()
+    private let dashboardNavigationController = WooTabNavigationController()
+    private let ordersNavigationController = WooTabNavigationController()
+    private let productsNavigationController = WooTabNavigationController()
+    private let reviewsNavigationController = WooTabNavigationController()
     private var reviewsTabCoordinator: Coordinator?
 
     private var cancellableSiteID: ObservationToken?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -75,14 +75,9 @@ final class OrderStatusListViewController: UIViewController {
 //
 extension OrderStatusListViewController {
     func configureNavigationBar() {
-        configureNavigationBarStyle()
         configureTitle()
         configureLeftButton()
         configureRightButton()
-    }
-
-    func configureNavigationBarStyle() {
-        navigationController?.navigationBar.barStyle = .black
     }
 
     func configureTitle() {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,19 +21,24 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="i5V-XB-HZ3">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="i5V-XB-HZ3" secondAttribute="bottom" id="Exe-g8-l8x"/>
-                <constraint firstItem="i5V-XB-HZ3" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="L2p-AO-VA3"/>
+                <constraint firstItem="i5V-XB-HZ3" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="L2p-AO-VA3"/>
                 <constraint firstItem="i5V-XB-HZ3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ZFu-2m-NQX"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="i5V-XB-HZ3" secondAttribute="trailing" id="oja-Bt-7RE"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="139" y="86"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */; };
 		02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9423A774C500707A0C /* UnitInputFormatter.swift */; };
 		02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9623A774E600707A0C /* DecimalInputFormatter.swift */; };
+		0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0294F8AA25E8A12C005B537A /* WooTabNavigationController.swift */; };
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
 		029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EB24FE38C900D242F8 /* ScrollWatcher.swift */; };
 		029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */; };
@@ -1395,6 +1396,7 @@
 		0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		02913E9423A774C500707A0C /* UnitInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitInputFormatter.swift; sourceTree = "<group>"; };
 		02913E9623A774E600707A0C /* DecimalInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatter.swift; sourceTree = "<group>"; };
+		0294F8AA25E8A12C005B537A /* WooTabNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabNavigationController.swift; sourceTree = "<group>"; };
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
 		029700EB24FE38C900D242F8 /* ScrollWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcher.swift; sourceTree = "<group>"; };
 		029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcherTests.swift; sourceTree = "<group>"; };
@@ -4456,6 +4458,7 @@
 				CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */,
 				B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */,
 				CE2409F0215D12D30091F887 /* WooNavigationController.swift */,
+				0294F8AA25E8A12C005B537A /* WooTabNavigationController.swift */,
 				02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */,
 			);
 			path = System;
@@ -6186,6 +6189,7 @@
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
+				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
 				025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,


### PR DESCRIPTION
Part of #3751 

## Why

Design calls for large titles in all of the four main tabs, which is already implemented in Android. This PR enables large titles behind a feature flag, and the title animation from scrolling only works in the Products and Reviews tab. Since the Dashboard and Orders tabs have multiple scroll views, we need to implement a workaround separately for to support title animation from scrolling (there's no API to inform the navigation bar on the scroll offset when there is more than one scroll view in the same level of view hierarchy).

More details are in the spike post: p91TBi-45c-p2

## Changes

- Created a feature flag `largeTitles`, which is enabled in debug or alpha build
- Updated navigation bar styles in https://github.com/woocommerce/woocommerce-ios/commit/d1e258d2299235575b630155684421a4f8520ff7
- Reviews tab: pin top edge to superview instead of safe area, otherwise large title is not shown after navigation back from review details https://github.com/woocommerce/woocommerce-ios/commit/f4d32d96fc340583155adb0c1cef8c621ce84923 (whenever we are not seeing large titles when we're supposed to, it's possible the scroll view's top edge is pinned to the safe area instead of superview)
- Created `WooTabNavigationController: UINavigationController` that is used for each Woo tab, and enables large title for the first view controller. The following view controllers in the navigation stack do not have large title by default but could override the new `func preferredLargeTitleDisplayMode() -> UINavigationItem.LargeTitleDisplayMode` to customize the large title display mode. Thanks to @Ecarrion for this simpler solution!

## Testing

### Feature flag on

- Launch the app from Xcode (debug build), and log in if needed --> each tab should have large title
- Go to the products tab, and scroll the product list --> the title should animate with scrolling
- Tap on a product while large title is shown, optionally navigate to some other screens, then navigate back to the products tab --> the products tab should still have large title
- Go to the reviews tab, and scroll the review list --> the title should animate with scrolling
- Tap on a review while large title is shown, optionally navigate to some other screens, then navigate back to the reviews tab --> the reviews tab should still have large title
- Go to the dashboard tab, and scroll in each stats tab --> there is no title animation (this will be implemented in another subtask)
- Go to the orders tab, and scroll in the processing or all tab --> there is no title animation (this will be implemented in another subtask)

### Feature flag off

- In `DefaultFeatureFlagService`, return `false` for `largeTitles` feature flag, and launch the app. Log in if needed --> there should not be large title in all four tabs, and the app should look as before

## Example screenshots

\ | dashboard | orders | products | reviews
-- | -- | -- | -- | --
light | https://user-images.githubusercontent.com/1945542/109253406-b1178400-782a-11eb-8a9d-d531b2fc2e54.mov | https://user-images.githubusercontent.com/1945542/109253419-bb398280-782a-11eb-8cb6-e26a33f43667.mov | https://user-images.githubusercontent.com/1945542/109253531-fb006a00-782a-11eb-8989-5fa49f27bc57.mov | https://user-images.githubusercontent.com/1945542/109253576-0e133a00-782b-11eb-998f-2f7d6b8865dc.mov
dark | https://user-images.githubusercontent.com/1945542/109253208-3fd7d100-782a-11eb-9973-a0d72867203a.mov | https://user-images.githubusercontent.com/1945542/109253252-58e08200-782a-11eb-9be6-fd86b62c7500.mov | https://user-images.githubusercontent.com/1945542/109253265-61d15380-782a-11eb-8d7f-4540aea5c3c1.mov | https://user-images.githubusercontent.com/1945542/109253353-934a1f00-782a-11eb-9990-d3d755fc7920.mov



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
