### PR TITLE
Update state flow on ReviewsViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [*] Fix: Update the downloadable files row to read-only, if the product is accessed from Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3669]
 - [*] Fix: Thumbnail image of a product wasn't being loaded correctly in Order Details. [https://github.com/woocommerce/woocommerce-ios/pull/3678]
 - [*] Fix: Allow product's `regular_price` to be a number and `sold_individually` to be `null` as some third-party plugins could alter the type in the API. This could help with the products tab not loading due to product decoding errors. [https://github.com/woocommerce/woocommerce-ios/pull/3679]
+- [*] Fix: Loading state stuck in Reviews List. [https://github.com/woocommerce/woocommerce-ios/pull/3753]
 - [internal] Attempted fix for a crash in product image upload. [https://github.com/woocommerce/woocommerce-ios/pull/3693]
 
 6.0

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -124,10 +124,9 @@ final class ReviewsViewController: UIViewController {
         super.viewWillAppear(animated)
 
         resetApplicationBadge()
-        transitionToResultsUpdatedState()
 
-        if isEmpty {
-            transitionToSyncingState(pageNumber: SyncingCoordinator.Defaults.pageFirstIndex)
+        if state == .emptyUnfiltered {
+            syncingCoordinator.resynchronize()
         }
 
         if AppRatingManager.shared.shouldPromptForAppReview(section: Constants.section) {


### PR DESCRIPTION
## Description

This PR fixes endless loading state on empty Reviews tab.

## Changes

1. Removes UI state switch in `viewWillAppear`
2. Adds resync call in `viewWillAppear` after UI state check instead of model check - so it won't trigger additional reload while model is empty, but synchronization is already in process.

## Test

### To reproduce the bug:

1. Open reviews tab.
2. On first open it should correctly show loading animation, then switch to empty state.
3. Switch to another tab and then back to reviews.
4. Never-ending loading animation will appear.
5. Try pull-to refresh to force resync and correctly switch to empty state.

### To validate the fix

1. Open reviews tab.
2. Wait until empty state.
3. Switch to another tab and then back to reviews.
4. Observe correct switch from loading -> empty.

## Video

https://user-images.githubusercontent.com/3132438/109297724-84239b00-7843-11eb-90fd-16c698774c8d.mp4

https://user-images.githubusercontent.com/3132438/109297733-85ed5e80-7843-11eb-8665-0c16c4e704cd.mp4


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
