### PR TITLE
Shipping Labels: address formatting in the Shipping Label Form and loader indicator in the Address Validation Form

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
@@ -6,9 +6,17 @@ public struct ShippingLabelAddressValidationResponse: Equatable {
     public let address: ShippingLabelAddress?
     public let errors: ShippingLabelAddressValidationError?
 
-    public init(address: ShippingLabelAddress?, errors: ShippingLabelAddressValidationError?) {
+    /// When sending an address to normalize to the server, if the response has the is_trivial_normalization property set to true,
+    /// then the normalized address will be automatically accepted without user intervention.
+    /// As its name indicates, that flag will be set when the changes made by the address normalizator were trivial,
+    /// such as adding the +4 portion to a ZIP code, or changing capitalization, or changing street to st for example.
+    ///
+    public let isTrivialNormalization: Bool?
+
+    public init(address: ShippingLabelAddress?, errors: ShippingLabelAddressValidationError?, isTrivialNormalization: Bool?) {
         self.address = address
         self.errors = errors
+        self.isTrivialNormalization = isTrivialNormalization
     }
 }
 
@@ -17,7 +25,8 @@ extension ShippingLabelAddressValidationResponse: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let address = try container.decodeIfPresent(ShippingLabelAddress.self, forKey: .address)
         let errors = try container.decodeIfPresent(ShippingLabelAddressValidationError.self, forKey: .errors)
-        self.init(address: address, errors: errors)
+        let isTrivialNormalization = try container.decodeIfPresent(Bool.self, forKey: .isTrivialNormalization)
+        self.init(address: address, errors: errors, isTrivialNormalization: isTrivialNormalization)
     }
 }
 
@@ -27,5 +36,6 @@ private extension ShippingLabelAddressValidationResponse {
     enum CodingKeys: String, CodingKey {
         case address = "normalized"
         case errors = "field_errors"
+        case isTrivialNormalization = "is_trivial_normalization"
     }
 }

--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -13,7 +13,7 @@ extension ShippingLabelAddress {
     var fullNameWithCompanyAndAddress: String {
         var output: [String] = [fullNameWithCompany]
 
-        if let formattedPostalAddress = formattedPostalAddress, formattedPostalAddress.isEmpty == false {
+        if let formattedPostalAddress = formattedPostalAddress, formattedPostalAddress.isNotEmpty {
             output.append(formattedPostalAddress)
         }
 
@@ -35,10 +35,10 @@ private extension ShippingLabelAddress {
     var fullNameWithCompany: String {
         var output: [String] = []
 
-        if name.isEmpty == false {
+        if name.isNotEmpty {
             output.append(name)
         }
-        if company.isEmpty == false {
+        if company.isNotEmpty {
             output.append(company)
         }
 
@@ -49,7 +49,7 @@ private extension ShippingLabelAddress {
     /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
     ///
     var combinedAddress: String {
-        guard address2.isEmpty == false else {
+        guard address2.isNotEmpty else {
             return address1
         }
 

--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Contacts
+import Yosemite
+
+
+// Yosemite.ShippingLabelAddress Helper Methods
+//
+extension ShippingLabelAddress {
+
+    /// Returns the `name`, `company`, and `address`. Basically this var combines the
+    /// various components of a ShippingLabelAddress.
+    ///
+    var fullNameWithCompanyAndAddress: String {
+        var output: [String] = [fullNameWithCompany]
+
+        if let formattedPostalAddress = formattedPostalAddress, formattedPostalAddress.isEmpty == false {
+            output.append(formattedPostalAddress)
+        }
+
+        return output.joined(separator: "\n")
+    }
+}
+
+private extension ShippingLabelAddress {
+
+    /// Returns the Postal Address, formated and ready for display.
+    ///
+    var formattedPostalAddress: String? {
+        return postalAddress.formatted(as: .mailingAddress)
+    }
+
+    /// Returns the `name` and `company` (on a new line). If either the `name` or `company` is empty,
+    /// then a single line is returned containing the other value.
+    ///
+    var fullNameWithCompany: String {
+        var output: [String] = []
+
+        if name.isEmpty == false {
+            output.append(name)
+        }
+        if company.isEmpty == false {
+            output.append(company)
+        }
+
+        return output.joined(separator: "\n")
+    }
+
+    /// Returns the two Address Lines combined (if there are, effectively, two lines).
+    /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
+    ///
+    var combinedAddress: String {
+        guard address2.isEmpty == false else {
+            return address1
+        }
+
+        return address1 + " " + address2
+    }
+
+    /// Returns a CNPostalAddress with the receiver's properties
+    ///
+    var postalAddress: CNPostalAddress {
+        let address = CNMutablePostalAddress()
+        address.street = combinedAddress
+        address.city = city
+        address.state = state
+        address.postalCode = postcode
+        address.country = country
+        address.isoCountryCode = country
+
+        return address
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -107,7 +107,7 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func updateTopBannerView() {
-        topBannerView.isHidden = viewModel.shouldShowTopBannerView
+        topBannerView.isHidden = !viewModel.shouldShowTopBannerView
         tableView.updateHeaderHeight()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -25,8 +25,8 @@ final class ShippingLabelAddressFormViewController: UIViewController {
 
     private let viewModel: ShippingLabelAddressFormViewModel
 
-    // Completion callback
-    //
+    /// Completion callback
+    ///
     typealias Completion = (_ address: ShippingLabelAddress?) -> Void
     private let onCompletion: Completion
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -63,7 +63,7 @@ private extension ShippingLabelAddressFormViewController {
 
         removeNavigationBackBarButtonText()
     }
-    
+
     func configureRightButtonItemAsLoader() {
         let indicator = UIActivityIndicatorView(style: .medium)
         indicator.color = .primaryButtonTitle
@@ -212,7 +212,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      text: viewModel.address?.phone,
                                                                      placeholder: Localization.phoneFieldPlaceholder,
                                                                      state: .normal,
-                                                                     keyboardType: .default,
+                                                                     keyboardType: .phonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
@@ -266,7 +266,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      text: viewModel.address?.postcode,
                                                                      placeholder: Localization.postcodeFieldPlaceholder,
                                                                      state: .normal,
-                                                                     keyboardType: .default,
+                                                                     keyboardType: .phonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -131,6 +131,8 @@ private extension ShippingLabelAddressFormViewController {
             self.updateTopBannerView()
             self.tableView.reloadData()
             if success {
+                // TODO: If the API response returns a suggested address,
+                // we need to display the suggested response and allow the users to select the suggested address.
                 self.onCompletion(self.viewModel.address)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -107,7 +107,7 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func updateTopBannerView() {
-        topBannerView.isHidden = viewModel.addressValidationError?.generalError != nil
+        topBannerView.isHidden = viewModel.addressValidationError?.generalError == nil
         tableView.updateHeaderHeight()
     }
 
@@ -228,10 +228,11 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func configureAddress(cell: TitleAndTextFieldTableViewCell, row: Row) {
+        let state: TitleAndTextFieldTableViewCell.ViewModel.State = viewModel.addressValidationError?.addressError == nil ? .normal : .error
         let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.addressField,
                                                                      text: viewModel.address?.address1,
                                                                      placeholder: Localization.addressFieldPlaceholder,
-                                                                     state: .normal,
+                                                                     state: state,
                                                                      keyboardType: .default,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -68,8 +68,7 @@ private extension ShippingLabelAddressFormViewController {
         removeNavigationBackBarButtonText()
         if viewModel.showLoadingIndicator {
             configureRightButtonItemAsLoader()
-        }
-        else {
+        } else {
             configureRightBarButtonItemAsDone()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -25,6 +25,11 @@ final class ShippingLabelAddressFormViewController: UIViewController {
 
     private let viewModel: ShippingLabelAddressFormViewModel
 
+    // Completion callback
+    //
+    typealias Completion = (_ address: ShippingLabelAddress?) -> Void
+    private let onCompletion: Completion
+
     /// Needed to scroll content to a visible area when the keyboard appears.
     ///
     private lazy var keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: { [weak self] frame in
@@ -33,8 +38,9 @@ final class ShippingLabelAddressFormViewController: UIViewController {
 
     /// Init
     ///
-    init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?) {
+    init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, completion: @escaping Completion) {
         viewModel = ShippingLabelAddressFormViewModel(siteID: siteID, type: type, address: address)
+        onCompletion = completion
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -118,15 +124,17 @@ private extension ShippingLabelAddressFormViewController {
 private extension ShippingLabelAddressFormViewController {
 
     @objc func doneButtonTapped() {
-        // TODO: after the validation, return to the previous controller passing the new address.
         configureRightButtonItemAsLoader()
         viewModel.validateAddress { [weak self] (success, error) in
-            self?.configureNavigationBar()
-            self?.updateTopBannerView()
-            self?.tableView.reloadData()
+            guard let self = self else { return }
+            self.configureNavigationBar()
+            self.updateTopBannerView()
+            self.tableView.reloadData()
+            if success {
+                self.onCompletion(self.viewModel.address)
+            }
         }
     }
-
 }
 
 // MARK: - UITableViewDataSource Conformance

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -107,7 +107,7 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func updateTopBannerView() {
-        topBannerView.isHidden = viewModel.addressValidationError?.generalError == nil
+        topBannerView.isHidden = viewModel.shouldShowTopBannerView
         tableView.updateHeaderHeight()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -63,6 +63,13 @@ private extension ShippingLabelAddressFormViewController {
 
         removeNavigationBackBarButtonText()
     }
+    
+    func configureRightButtonItemAsLoader() {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = .primaryButtonTitle
+        indicator.startAnimating()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: indicator)
+    }
 
     func configureMainView() {
         view.backgroundColor = .listBackground
@@ -112,7 +119,9 @@ private extension ShippingLabelAddressFormViewController {
 
     @objc func doneButtonTapped() {
         // TODO: after the validation, return to the previous controller passing the new address.
+        configureRightButtonItemAsLoader()
         viewModel.validateAddress { [weak self] (success, error) in
+            self?.configureNavigationBar()
             self?.updateTopBannerView()
             self?.tableView.reloadData()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -15,7 +15,7 @@ final class ShippingLabelAddressFormViewModel: NSObject {
     private let stores: StoresManager
 
     var shouldShowTopBannerView: Bool {
-        return addressValidationError?.generalError == nil
+        return addressValidationError?.generalError != nil
     }
 
     init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, stores: StoresManager = ServiceLocator.stores) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -3,6 +3,15 @@ import Yosemite
 
 final class ShippingLabelAddressFormViewModel: NSObject {
 
+    /// Defines the necessary state to produce the ViewModel's outputs.
+    ///
+    fileprivate struct State {
+
+        /// Indicates if the view model is validating an address
+        ///
+        var isLoading: Bool = false
+    }
+
     typealias Section = ShippingLabelAddressFormViewController.Section
     typealias Row = ShippingLabelAddressFormViewController.Row
 
@@ -14,8 +23,24 @@ final class ShippingLabelAddressFormViewModel: NSObject {
 
     private let stores: StoresManager
 
+    /// Closure to notify the `ViewController` when the view model properties change.
+    ///
+    var onChange: (() -> (Void))?
+
+    /// Current `ViewModel` state.
+    ///
+    private var state: State = State() {
+        didSet {
+            onChange?()
+        }
+    }
+
     var shouldShowTopBannerView: Bool {
         return addressValidationError?.generalError != nil
+    }
+
+    var showLoadingIndicator: Bool {
+        return state.isLoading
     }
 
     init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, stores: StoresManager = ServiceLocator.stores) {
@@ -68,6 +93,7 @@ final class ShippingLabelAddressFormViewModel: NSObject {
 extension ShippingLabelAddressFormViewModel {
     func validateAddress(onSuccess: ((Bool, ShippingLabelAddressValidationError?) -> ())? = nil) {
 
+        state.isLoading = true
         let addressToBeVerified = ShippingLabelAddressVerification(address: address, type: type)
 
         let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in
@@ -76,17 +102,20 @@ extension ShippingLabelAddressFormViewModel {
                 if (try? result.get().errors) == nil {
                     self?.isAddressValidated = true
                     self?.addressValidationError = nil
+                    self?.state.isLoading = false
                     onSuccess?(true, nil)
                 }
                 else {
                     self?.isAddressValidated = false
                     self?.addressValidationError = try? result.get().errors
+                    self?.state.isLoading = false
                     onSuccess?(false, try? result.get().errors)
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error validating shipping label address: \(error)")
                 self?.isAddressValidated = false
                 self?.addressValidationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
+                self?.state.isLoading = false
                 onSuccess?(false, nil)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -82,7 +82,7 @@ extension ShippingLabelAddressFormViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Error validating shipping label address: \(error)")
                 self?.isAddressValidated = false
-                self?.addressValidationError = nil
+                self?.addressValidationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
                 onSuccess?(false, nil)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -14,6 +14,10 @@ final class ShippingLabelAddressFormViewModel: NSObject {
 
     private let stores: StoresManager
 
+    var shouldShowTopBannerView: Bool {
+        return addressValidationError?.generalError == nil
+    }
+
     init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.type = type

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -113,7 +113,9 @@ private extension ShippingLabelFormViewController {
             let shippingLabelAddress = self.viewModel.originAddress
             let shippingAddressValidationVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
                                                                                      type: .origin,
-                                                                                     address: shippingLabelAddress)
+                                                                                     address: shippingLabelAddress, completion: { (shippingLabelAddress) in
+                                                                                        // TODO: handle updated shipping label address
+                                                                                     })
             self.navigationController?.pushViewController(shippingAddressValidationVC, animated: true)
         }
     }
@@ -128,7 +130,9 @@ private extension ShippingLabelFormViewController {
             let shippingLabelAddress = self.viewModel.destinationAddress
             let shippingAddressValidationVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
                                                                                      type: .destination,
-                                                                                     address: shippingLabelAddress)
+                                                                                     address: shippingLabelAddress, completion: { (shippingLabelAddress) in
+                                                                                        // TODO: handle updated shipping label address
+                                                                                     })
             self.navigationController?.pushViewController(shippingAddressValidationVC, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -111,12 +111,14 @@ private extension ShippingLabelFormViewController {
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             let shippingLabelAddress = self.viewModel.originAddress
-            let shippingAddressValidationVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
-                                                                                     type: .origin,
-                                                                                     address: shippingLabelAddress, completion: { (shippingLabelAddress) in
-                                                                                        // TODO: handle updated shipping label address
-                                                                                     })
-            self.navigationController?.pushViewController(shippingAddressValidationVC, animated: true)
+            let shippingAddressVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
+                                                                           type: .origin,
+                                                                           address: shippingLabelAddress,
+                                                                           completion: { [weak self] (shippingLabelAddress) in
+                                                                            guard let self = self else { return }
+                                                                            self.viewModel.handleOriginAddressValueChanges(address: shippingLabelAddress)
+                                                                           })
+            self.navigationController?.pushViewController(shippingAddressVC, animated: true)
         }
     }
 
@@ -128,12 +130,14 @@ private extension ShippingLabelFormViewController {
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             let shippingLabelAddress = self.viewModel.destinationAddress
-            let shippingAddressValidationVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
-                                                                                     type: .destination,
-                                                                                     address: shippingLabelAddress, completion: { (shippingLabelAddress) in
-                                                                                        // TODO: handle updated shipping label address
-                                                                                     })
-            self.navigationController?.pushViewController(shippingAddressValidationVC, animated: true)
+            let shippingAddressVC = ShippingLabelAddressFormViewController(siteID: self.viewModel.siteID,
+                                                                           type: .destination,
+                                                                           address: shippingLabelAddress,
+                                                                           completion: { [weak self] (shippingLabelAddress) in
+                                                                            guard let self = self else { return }
+                                                                            self.viewModel.handleDestinationAddressValueChanges(address: shippingLabelAddress)
+                                                                           })
+            self.navigationController?.pushViewController(shippingAddressVC, animated: true)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -107,7 +107,7 @@ private extension ShippingLabelFormViewController {
         cell.configure(state: row.cellState,
                        icon: .shippingImage,
                        title: Localization.shipFromCellTitle,
-                       body: "To be implemented",
+                       body: viewModel.originAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             let shippingLabelAddress = self.viewModel.originAddress
@@ -126,7 +126,7 @@ private extension ShippingLabelFormViewController {
         cell.configure(state: row.cellState,
                        icon: .houseOutlinedImage,
                        title: Localization.shipToCellTitle,
-                       body: "To be implemented",
+                       body: viewModel.destinationAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             let shippingLabelAddress = self.viewModel.destinationAddress

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -9,8 +9,8 @@ final class ShippingLabelFormViewModel {
     typealias Row = ShippingLabelFormViewController.Row
 
     let siteID: Int64
-    let originAddress: ShippingLabelAddress?
-    let destinationAddress: ShippingLabelAddress?
+    private(set) var originAddress: ShippingLabelAddress?
+    private(set) var destinationAddress: ShippingLabelAddress?
 
     init(siteID: Int64, originAddress: Address?, destinationAddress: Address?) {
 
@@ -36,6 +36,14 @@ final class ShippingLabelFormViewModel {
         let paymentMethod = Row(type: .paymentMethod, dataState: .pending, displayMode: .disabled)
         let rows: [Row] = [shipFrom, shipTo, packageDetails, shippingCarrierAndRates, paymentMethod]
         return [Section(rows: rows)]
+    }
+
+    func handleOriginAddressValueChanges(address: ShippingLabelAddress?) {
+        originAddress = address
+    }
+
+    func handleDestinationAddressValueChanges(address: ShippingLabelAddress?) {
+        destinationAddress = address
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -55,7 +55,7 @@ private extension ShippingLabelFormViewModel {
                               city: siteAddress.city,
                               state: siteAddress.state,
                               postcode: siteAddress.postalCode,
-                              country: siteAddress.countryName ?? "",
+                              country: siteAddress.countryCode,
                               phone: "",
                               email: account?.email)
         return fromAddressToShippingLabelAddress(address: address)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */; };
 		45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift */; };
 		45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FD23D0FB25005F87D0 /* Throttler.swift */; };
+		45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3C8F225E7D30300102E84 /* ShippingLabelAddress+Woo.swift */; };
 		45E9A6E424DAE1EA00A600E8 /* ProductReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E9A6E224DAE1EA00A600E8 /* ProductReviewsViewController.swift */; };
 		45E9A6E524DAE1EA00A600E8 /* ProductReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45E9A6E324DAE1EA00A600E8 /* ProductReviewsViewController.xib */; };
 		45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E9A6E624DAE23300A600E8 /* ProductReviewsViewModel.swift */; };
@@ -1682,6 +1683,7 @@
 		45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		45D685FD23D0FB25005F87D0 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
+		45E3C8F225E7D30300102E84 /* ShippingLabelAddress+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAddress+Woo.swift"; sourceTree = "<group>"; };
 		45E9A6E224DAE1EA00A600E8 /* ProductReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsViewController.swift; sourceTree = "<group>"; };
 		45E9A6E324DAE1EA00A600E8 /* ProductReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductReviewsViewController.xib; sourceTree = "<group>"; };
 		45E9A6E624DAE23300A600E8 /* ProductReviewsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsViewModel.swift; sourceTree = "<group>"; };
@@ -4306,6 +4308,7 @@
 				CECC759423D6057E00486676 /* OrderItem+Woo.swift */,
 				CECC759623D607C900486676 /* OrderItemRefund+Woo.swift */,
 				7435E58D21C0151B00216F0F /* OrderNote+Woo.swift */,
+				45E3C8F225E7D30300102E84 /* ShippingLabelAddress+Woo.swift */,
 				D8C2A28723190B2300F503E9 /* StorageProductReview+Woo.swift */,
 				B59D1EE92190AE96009D1978 /* StorageNote+Woo.swift */,
 				CE24BCD7212F25D4001CD12E /* StorageOrder+Woo.swift */,
@@ -6110,6 +6113,7 @@
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
+				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -166,4 +166,34 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isAddressValidated, false)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
+
+    func test_address_validation_toggle_shouldShowTopBannerView() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: shippingAddress,
+                                                                                errors: nil,
+                                                                                isTrivialNormalization: true)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                DispatchQueue.main.async {
+                    onCompletion(.success(expectedValidationResponse))
+                }
+            default:
+                break
+            }
+        }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        viewModel.validateAddress()
+
+        // Then
+        XCTAssertTrue(viewModel.showLoadingIndicator)
+        waitUntil { () -> Bool in
+            !viewModel.showLoadingIndicator
+        }
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -59,7 +59,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: nil,
-                                                                                errors: validationError)
+                                                                                errors: validationError,
+                                                                                isTrivialNormalization: nil)
 
         // When
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
@@ -92,9 +93,9 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         // Given
         let shippingAddress = MockShippingLabelAddress.sampleAddress()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        //let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: shippingAddress,
-                                                                                errors: nil)
+                                                                                errors: nil,
+                                                                                isTrivialNormalization: true)
 
         // When
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
@@ -120,7 +121,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: nil,
-                                                                                errors: validationError)
+                                                                                errors: validationError,
+                                                                                isTrivialNormalization: nil)
 
         // When
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
@@ -160,7 +162,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         viewModel.validateAddress()
 
         // Then
+        let validationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
         XCTAssertEqual(viewModel.isAddressValidated, false)
-        XCTAssertEqual(viewModel.addressValidationError, nil)
+        XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -36,4 +36,44 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(originAddress?.city, "San Francisco")
         XCTAssertEqual(originAddress?.postcode, "94121-2303")
     }
+
+    func test_handleOriginAddressValueChanges_returns_updated_ShippingLabelAddress() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(siteID: 10, originAddress: nil, destinationAddress: nil)
+        let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                           name: "Skylar Ferry",
+                                                           phone: "12345",
+                                                           country: "United States",
+                                                           state: "CA",
+                                                           address1: "60 29th",
+                                                           address2: "Street #343",
+                                                           city: "San Francisco",
+                                                           postcode: "94121-2303")
+
+        // When
+        shippingLabelFormViewModel.handleOriginAddressValueChanges(address: expectedShippingAddress)
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.originAddress, expectedShippingAddress)
+    }
+
+    func test_handleDestinationAddressValueChanges_returns_updated_ShippingLabelAddress() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(siteID: 10, originAddress: nil, destinationAddress: nil)
+        let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                           name: "Skylar Ferry",
+                                                           phone: "12345",
+                                                           country: "United States",
+                                                           state: "CA",
+                                                           address1: "60 29th",
+                                                           address2: "Street #343",
+                                                           city: "San Francisco",
+                                                           postcode: "94121-2303")
+
+        // When
+        shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: expectedShippingAddress)
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.destinationAddress, expectedShippingAddress)
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -354,7 +354,9 @@ final class ShippingLabelStoreTests: XCTestCase {
     func test_validateAddress_returns_ShippingLabelAddressValidationResponse_on_success() throws {
         // Given
         let remote = MockShippingLabelRemote()
-        let expectedResult = ShippingLabelAddressValidationResponse(address: sampleShippingLabelAddress(), errors: nil)
+        let expectedResult = ShippingLabelAddressValidationResponse(address: sampleShippingLabelAddress(),
+                                                                    errors: nil,
+                                                                    isTrivialNormalization: true)
         remote.whenValidatingAddress(siteID: sampleSiteID,
                                      thenReturn: .success(expectedResult))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)


### PR DESCRIPTION
Part of #2973 

## Description
In this PR I applied some minor fixes, plus some improvements to the shipping label form. In particular, in this PR now the formatted address will be shown in the Shipping Label Form, for the origin and destination address. Also, the done button for validating the address now the done button will be transformed in a loader indicator during the address validation request.

## Changes
- Added the new property `isTrivialNormalization` in `ShippingLabelAddressValidationResponse` entity because it will be useful in the near future for implementing the possibility for the user to choose the suggested address.
- Implemented an extension of the `ShippingLabelAddress` entity, where a method returns the `name`, `company`, and `address`. Basically combines the various components of a ShippingLabelAddress.
- Added a completion block to `ShippingLabelAddressFormViewController` that will return the latest shipping label address updated to the previous view controller.
- Now in the `ShippingLabelAddressFormViewController` the done button will be transformed in a loader indicator during the address validation request.
- Fixed the logic of the top banner view that was wrong.
- Fixed the keyboard type for some fields in the shipping label address form.
- Fixed the state for the `address` field, which now can be in the error state.
- Showed the formatted address (origin and destination) in the Shipping Label Form.
- Handle origin and destination address value changes in `ShippingLabelFormViewModel` + tests.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. In the Shipping Label Form -> you should see the formatted address for the origin and the destination address.
5. Press the button "Continue" in the Shipping Label form (under the origin address).
6. Try to validate an address pressing the Done button on top. -> The done button should be transformed in a loader indicator during the address validation request.
7. Try to edit the various field of the address. -> Make sure that every field has the right keyboard type (standard or numeric pad).


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
