### PR TITLE
Variations: Add back button confirmation on AttributePickerViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -29,6 +29,7 @@ final class AttributePickerViewController: UIViewController {
         registerTableViewHeaderSections()
         registerTableViewCells()
         configureTableView()
+        handleSwipeBackGesture()
     }
 }
 
@@ -132,6 +133,23 @@ private extension AttributePickerViewController {
     }
 }
 
+// MARK: Back Navigation
+extension AttributePickerViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        guard viewModel.isChanged else {
+            return true
+        }
+
+        presentBackNavigationActionSheet()
+        return false
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+}
+
 // MARK: - Navigation actions handling
 //
 private extension AttributePickerViewController {
@@ -169,6 +187,12 @@ private extension AttributePickerViewController {
         viewModel.update(oldAttribute: oldAttribute, to: newAttribute)
         tableView.reloadData()
         updateDoneButton()
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -189,7 +189,7 @@ private extension AttributePickerViewController {
         updateDoneButton()
     }
 
-    private func presentBackNavigationActionSheet() {
+    func presentBackNavigationActionSheet() {
         UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })


### PR DESCRIPTION
fix #3638 

# Why

During testing, we noticed that the flow of configuring a "variation attributes options" was not presenting a confirmation action sheet when navigating back before saving changes.

**Note: This has to be tested on a device or on a simulator with a version lower than 13.4`.**

# How

- Override back button and swipe back intercepts to present the confirmation when there are pending changes.

# Demo
![back-button](https://user-images.githubusercontent.com/562080/109320088-a30f3680-781d-11eb-8f61-e7842010be00.gif)

# Testing Steps
- Navigate to a specific variation
- Tap on the attributes row
- Select an option for any attribute
- Tap back twice(option picker and attribute picker)
- See the confirmation action sheet being presented.

Update release notes
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
