### PR TITLE
Unified Login: track missing event unified_login_step

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -125,6 +125,7 @@ extension TracksProvider: WPAnalyticsTracker {
     }
 
     public func track(_ stat: WPAnalyticsStat) {
+        // no op. 
         track(stat, withProperties: nil)
     }
 

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -1,9 +1,10 @@
 import Foundation
 import Yosemite
 import AutomatticTracks
+import WordPressShared
 
 
-public class TracksProvider: AnalyticsProvider {
+public class TracksProvider: NSObject, AnalyticsProvider {
 
     lazy private var contextManager: TracksContextManager = {
         return TracksContextManager()
@@ -13,12 +14,6 @@ public class TracksProvider: AnalyticsProvider {
         tracksService.eventNamePrefix = Constants.eventNamePrefix
         return tracksService
     }()
-
-
-    /// Designated Initializer
-    ///
-    init() {
-    }
 }
 
 
@@ -27,7 +22,7 @@ public class TracksProvider: AnalyticsProvider {
 public extension TracksProvider {
     func refreshUserData() {
         switchTracksUsersIfNeeded()
-        refreshMetadata()
+        refreshTracksMetadata()
     }
 
     func track(_ eventName: String) {
@@ -88,7 +83,7 @@ private extension TracksProvider {
         }
     }
 
-    func refreshMetadata() {
+    func refreshTracksMetadata() {
         DDLogInfo("♻️ Refreshing tracks metadata...")
         var userProperties = [String: Any]()
         userProperties[UserProperties.platformKey] = "iOS"
@@ -112,5 +107,28 @@ private extension TracksProvider {
         static let platformKey          = "platform"
         static let voiceOverKey         = "accessibility_voice_over_enabled"
         static let rtlKey               = "is_rtl_language"
+    }
+}
+
+extension TracksProvider: WPAnalyticsTracker {
+    public func trackString(_ event: String?) {
+        trackString(event, withProperties: nil)
+    }
+
+    public func trackString(_ event: String?, withProperties properties: [AnyHashable: Any]?) {
+        guard let eventName = event else {
+            DDLogInfo("🔴 Attempted to track an event without name.")
+            return
+        }
+
+        track(eventName, withProperties: properties)
+    }
+
+    public func track(_ stat: WPAnalyticsStat) {
+        track(stat, withProperties: nil)
+    }
+
+    public func track(_ stat: WPAnalyticsStat, withProperties properties: [AnyHashable: Any]?) {
+        // no op
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WordPressShared
 
 public class WooAnalytics: Analytics {
 
@@ -30,10 +31,10 @@ public class WooAnalytics: Analytics {
 
     /// Designated Initializer
     ///
-    init(analyticsProvider: AnalyticsProvider) {
+    init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker) {
         self.analyticsProvider = analyticsProvider
+        WPAnalytics.register(analyticsProvider)
     }
-
 }
 
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -1,13 +1,13 @@
 import Foundation
 @testable import WooCommerce
+@testable import WordPressShared
 
-public class MockAnalyticsProvider: AnalyticsProvider {
+public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTracker {
     var receivedEvents = [String]()
     var receivedProperties = [[AnyHashable: Any]]()
     var userID: String?
     var userOptedIn = true
 }
-
 
 // MARK: - AnalyticsProvider Conformance
 //
@@ -35,5 +35,31 @@ public extension MockAnalyticsProvider {
     func clearUsers() {
         userOptedIn = false
         userID = nil
+    }
+}
+
+
+// MARK: - WPAnalyticsTracker Conformance
+//
+
+public extension MockAnalyticsProvider {
+    func trackString(_ event: String?) {
+        trackString(event, withProperties: nil)
+    }
+
+    func trackString(_ event: String?, withProperties properties: [AnyHashable: Any]?) {
+        guard let eventName = event else {
+            return
+        }
+
+        track(eventName, withProperties: properties)
+    }
+
+    func track(_ stat: WPAnalyticsStat) {
+        // no op
+    }
+
+    func track(_ stat: WPAnalyticsStat, withProperties properties: [AnyHashable: Any]?) {
+        // no op
     }
 }


### PR DESCRIPTION
fix #3758 

@jaclync noticed the `unified_login_step` event is not being tracked.

The issue is that:
* WPAuthenticator submits the event by calling `WPAnalytics.track` in WordPressShared.
* This static function calls `WPAnalytics.trackString`. This method is the one that actually sends the event to each and everyone of the trackers that have ben previously registered with it.
* We had not registered any tracker with WPAnalytics
* Therefore the method `WPAnalytics.trackString` did not submit the event, failing silently.

## Changes
* Make `TracksProvider` conform to `WPAnalyticsTracker`
* Register `TracksProvider` with `WPAnalytics` in the initializer of `WooAnalytics`
* Update the unit tests to add conformance to WPAnalyticsTracker to the mock providers

## Testing
* Checkout the branch
* Log out. Attempt to log back in.
* Check the console. Check that `unified_login_step` is logged to the console:

<img width="350" alt="Xcode console" src="https://user-images.githubusercontent.com/2722505/109326496-4748ab80-7825-11eb-958b-b1595a017859.png"/>

* Go to Tracks Live
* Check that the event is being received:
<img width="350" alt="tracks live" src="https://user-images.githubusercontent.com/2722505/109326594-63e4e380-7825-11eb-94a6-0ebdcc350fdd.png"/>


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
