### PR TITLE
[Mobile Payments] Add connected reader view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -218,7 +218,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cH0-ne-ohw">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="cH0-ne-ohw">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
@@ -144,6 +144,21 @@ private enum Row: CaseIterable {
         }
     }
 
+    var height: CGFloat {
+        switch self {
+        case .connectHeader,
+             .connectButton:
+            return UITableView.automaticDimension
+        case .connectImage:
+            return 250
+        case .connectHelpHintChargeReader,
+             .connectHelpHintTurnOnReader,
+             .connectHelpHintEnableBluetooth,
+             .connectLearnMore:
+            return 70
+        }
+    }
+
     var reuseIdentifier: String {
         return type.reuseIdentifier
     }
@@ -177,16 +192,7 @@ extension CardReaderSettingsConnectView: UITableViewDataSource {
 extension CardReaderSettingsConnectView: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let row = rowAtIndexPath(indexPath)
-        if row == .connectImage {
-            return 250
-        }
-        if row == .connectHelpHintChargeReader || row == .connectHelpHintTurnOnReader || row == .connectHelpHintEnableBluetooth {
-            return 70
-        }
-        if row == .connectLearnMore {
-            return 70
-        }
-        return UITableView.automaticDimension
+        return row.height
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
@@ -55,13 +55,11 @@ final class CardReaderSettingsConnectView: NSObject {
             "Connect your card reader",
             comment: "Settings > Manage Card Reader > Prompt user to connect their first reader"
         )
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
     private func configureImage(cell: ImageTableViewCell) {
         cell.detailImageView?.image = UIImage(named: "card-reader-connect")
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
@@ -73,7 +71,6 @@ final class CardReaderSettingsConnectView: NSObject {
         cell.itemTextLabel?.text = NSLocalizedString(
             "Make sure card reader is charged",
             comment: "Settings > Manage Card Reader > Connect > Hint to charge card reader")
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
@@ -85,7 +82,6 @@ final class CardReaderSettingsConnectView: NSObject {
         cell.itemTextLabel?.text = NSLocalizedString(
             "Turn card reader on and place it next to mobile device",
             comment: "Settings > Manage Card Reader > Connect > Hint to power on reader")
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
@@ -97,7 +93,6 @@ final class CardReaderSettingsConnectView: NSObject {
         cell.itemTextLabel?.text = NSLocalizedString(
             "Turn mobile device Bluetooth on",
             comment: "Settings > Manage Card Reader > Connect > Hint to enable Bluetooth")
-        cell.hideSeparator()
         cell.selectionStyle = .none
    }
 
@@ -109,7 +104,6 @@ final class CardReaderSettingsConnectView: NSObject {
         cell.configure(title: buttonTitle) { [weak self] in
             self?.onPressedConnect?()
         }
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
@@ -118,7 +112,6 @@ final class CardReaderSettingsConnectView: NSObject {
             "Learn more about accepting payments with your mobile device and ordering card readers",
             comment: "Settings > Manage Card Reader > Connect > A prompt for new users to start accepting mobile payments"
         )
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 }
@@ -188,6 +181,9 @@ extension CardReaderSettingsConnectView: UITableViewDelegate {
             return 250
         }
         if row == .connectHelpHintChargeReader || row == .connectHelpHintTurnOnReader || row == .connectHelpHintEnableBluetooth {
+            return 70
+        }
+        if row == .connectLearnMore {
             return 70
         }
         return UITableView.automaticDimension

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -1,0 +1,92 @@
+import UIKit
+
+final class CardReaderSettingsConnectedReaderView: NSObject {
+
+    private var rows = [Row]()
+
+    var onPressedDisconnect: (() -> ())?
+
+    public func rowTypes() -> [UITableViewCell.Type] {
+        return [
+            ConnectedReaderTableViewCell.self,
+            ButtonTableViewCell.self
+        ]
+    }
+
+    private func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as ConnectedReaderTableViewCell where row == .connectedReader:
+            configureConnectedReader(cell: cell)
+        case let cell as ButtonTableViewCell where row == .disconnectButton:
+            configureButton(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
+        // TODO - set up the fields on the cell, e.g. reader name, battery level, etc
+        cell.hideSeparator()
+        cell.selectionStyle = .none
+    }
+
+    private func configureButton(cell: ButtonTableViewCell) {
+        let buttonTitle = NSLocalizedString(
+            "Disconnect",
+            comment: "Settings > Manage Card Reader > Connected Reader > A button to disconnect the reader"
+        )
+        cell.configure(title: buttonTitle) { [weak self] in
+            self?.onPressedDisconnect?()
+        }
+        cell.hideSeparator()
+        cell.selectionStyle = .none
+    }
+}
+
+private enum Row: CaseIterable {
+    case connectedReader
+    case disconnectButton
+
+    var type: UITableViewCell.Type {
+        switch self {
+        case .connectedReader:
+            return ConnectedReaderTableViewCell.self
+        case .disconnectButton:
+            return ButtonTableViewCell.self
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension CardReaderSettingsConnectedReaderView {
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return rows[indexPath.row]
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension CardReaderSettingsConnectedReaderView: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return NSLocalizedString(
+            "CONNECTED READER",
+            comment: "Settings > Manage Card Reader > Connected Reader Table Section Heading"
+        )
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+        return cell
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -2,15 +2,29 @@ import UIKit
 
 final class CardReaderSettingsConnectedReaderView: NSObject {
 
+    private var cardReader: CardReader?
+
     private var rows = [Row]()
 
     var onPressedDisconnect: (() -> ())?
+
+    override init() {
+        super.init()
+        rows = [
+            .connectedReader,
+            .disconnectButton
+        ]
+    }
 
     public func rowTypes() -> [UITableViewCell.Type] {
         return [
             ConnectedReaderTableViewCell.self,
             ButtonTableViewCell.self
         ]
+    }
+
+    public func update(reader: CardReader) {
+        cardReader = reader
     }
 
     private func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
@@ -25,7 +39,17 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
-        // TODO - set up the fields on the cell, e.g. reader name, battery level, etc
+        let batteryLevel = cardReader?.batteryLevel ?? 1.0
+        let batteryLevelPercent = Int(100 * batteryLevel)
+        let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
+
+        let batteryLabelFormat = NSLocalizedString(
+            "%1$@%% Battery",
+            comment: "Settings > Manage Card Reader > Connected Reader >> Battery level as a percentage"
+        )
+
+        cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
+        cell.serialNumberLabel?.text = cardReader?.serialNumber ?? "Unknown"
         cell.hideSeparator()
         cell.selectionStyle = .none
     }
@@ -90,3 +114,14 @@ extension CardReaderSettingsConnectedReaderView: UITableViewDataSource {
         return cell
     }
 }
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension CardReaderSettingsConnectedReaderView: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let row = rowAtIndexPath(indexPath)
+        if row == .connectedReader {
+            return 60
+        }
+        return UITableView.automaticDimension
+    }}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -51,7 +51,6 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
 
         cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
         cell.serialNumberLabel?.text = connectedReader?.serialNumber ?? "Unknown"
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 
@@ -63,7 +62,6 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
         cell.configure(title: buttonTitle) { [weak self] in
             self?.onPressedDisconnect?()
         }
-        cell.hideSeparator()
         cell.selectionStyle = .none
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -2,11 +2,12 @@ import UIKit
 
 final class CardReaderSettingsConnectedReaderView: NSObject {
 
-    private var cardReader: CardReader?
-
-    private var rows = [Row]()
+    /// A simple model for this "ViewModel" - just a reference to the CardReaderSettingsViewModel connected reader
+    var connectedReader: CardReader?
 
     var onPressedDisconnect: (() -> ())?
+
+    private var rows = [Row]()
 
     override init() {
         super.init()
@@ -24,7 +25,7 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
     }
 
     public func update(reader: CardReader) {
-        cardReader = reader
+        connectedReader = reader
     }
 
     private func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
@@ -39,7 +40,7 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
-        let batteryLevel = cardReader?.batteryLevel ?? 1.0
+        let batteryLevel = connectedReader?.batteryLevel ?? 1.0
         let batteryLevelPercent = Int(100 * batteryLevel)
         let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
 
@@ -49,7 +50,7 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
         )
 
         cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
-        cell.serialNumberLabel?.text = cardReader?.serialNumber ?? "Unknown"
+        cell.serialNumberLabel?.text = connectedReader?.serialNumber ?? "Unknown"
         cell.hideSeparator()
         cell.selectionStyle = .none
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -98,10 +98,11 @@ private extension CardReaderSettingsConnectedReaderView {
 //
 extension CardReaderSettingsConnectedReaderView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return NSLocalizedString(
-            "CONNECTED READER",
+        let sectionHeaderTitle = NSLocalizedString(
+            "Connected Reader",
             comment: "Settings > Manage Card Reader > Connected Reader Table Section Heading"
         )
+        return sectionHeaderTitle.uppercased()
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -79,6 +79,15 @@ private enum Row: CaseIterable {
         }
     }
 
+    var height: CGFloat {
+        switch self {
+        case .connectedReader:
+            return 60
+        case .disconnectButton:
+            return UITableView.automaticDimension
+        }
+    }
+
     var reuseIdentifier: String {
         return type.reuseIdentifier
     }
@@ -120,8 +129,5 @@ extension CardReaderSettingsConnectedReaderView: UITableViewDataSource {
 extension CardReaderSettingsConnectedReaderView: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let row = rowAtIndexPath(indexPath)
-        if row == .connectedReader {
-            return 60
-        }
-        return UITableView.automaticDimension
+        return row.height
     }}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -10,6 +10,7 @@ final class CardReaderSettingsViewController: UIViewController {
     private var alert: UIAlertController?
 
     private lazy var connectView = CardReaderSettingsConnectView()
+    private lazy var connectedView = CardReaderSettingsConnectedReaderView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,28 +32,27 @@ final class CardReaderSettingsViewController: UIViewController {
             .store(in: &subscriptions)    }
 
     private func setTableSource() {
-        alert?.dismiss(animated: true, completion: nil)
-
         switch self.viewmodel.activeView {
         case .connectYourReader:
             addCleanSlateView()
-        case .manageYourReader:
-            addListView()
-        case .noReaderFound:
-            addListView()
+        case .connectedToReader:
+            addConnectedView()
+        case .noReaders:
+            noop() // TODO. Not yet implemented.
         }
     }
 
     private func setAlert() {
+        alert?.dismiss(animated: true, completion: nil)
         switch self.viewmodel.activeAlert {
         case .none:
             noop()
         case .searching:
             addSearchingModal()
         case .foundReader:
-            noop()
+            addFoundReaderModal()
         case .connecting:
-            noop()
+            addConnectingToReaderModal()
         case .tutorial:
             noop()
         case .updateAvailable:
@@ -78,8 +78,8 @@ final class CardReaderSettingsViewController: UIViewController {
         tableView.reloadData()
     }
 
-    private func addListView() {
-        // TODO Implement
+    private func addConnectedView() {
+        
     }
 
     private func noop() {
@@ -95,6 +95,43 @@ final class CardReaderSettingsViewController: UIViewController {
         )
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { UIAlertAction in
             self.viewmodel.stopSearch()
+        }
+        alert?.addAction(cancelAction)
+        if alert != nil {
+            self.present(alert!, animated: true, completion: nil)
+        }
+    }
+
+    private func addFoundReaderModal() {
+        // TODO Use FancyAlert instead
+        let foundReaderName = self.viewmodel.foundReader?.name ?? ""
+        alert = UIAlertController(
+            title: "Found reader",
+            message: "Do you want to connect to " + foundReaderName + "?",
+            preferredStyle: UIAlertController.Style.alert
+        )
+        let okAction = UIAlertAction(title: "Connect to Reader", style: .default) { UIAlertAction in
+            self.viewmodel.connect()
+        }
+        alert?.addAction(okAction)
+        let cancelAction = UIAlertAction(title: "Keep Searching", style: .cancel) { UIAlertAction in
+            self.viewmodel.startSearch()
+        }
+        alert?.addAction(cancelAction)
+        if alert != nil {
+            self.present(alert!, animated: true, completion: nil)
+        }
+    }
+
+    private func addConnectingToReaderModal() {
+        // TODO Use FancyAlert instead
+        alert = UIAlertController(
+            title: "Connecting to reader",
+            message: "Please wait",
+            preferredStyle: UIAlertController.Style.alert
+        )
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { UIAlertAction in
+            self.viewmodel.stopConnect()
         }
         alert?.addAction(cancelAction)
         if alert != nil {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -31,10 +31,17 @@ final class CardReaderSettingsViewController: UIViewController {
                 self?.setAlert()
             }
             .store(in: &subscriptions)
+        viewmodel.$connectedReader
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] connectedReader in
+                self?.connectedView.connectedReader = connectedReader
+                self?.tableView.reloadData()
+            }
+            .store(in: &subscriptions)
     }
 
     private func setTableSource() {
-        switch self.viewmodel.activeView {
+        switch viewmodel.activeView {
         case .connectYourReader:
             addCleanSlateView()
         case .connectedToReader:
@@ -94,10 +101,7 @@ final class CardReaderSettingsViewController: UIViewController {
             tableView.registerNib(for: rowType)
         }
 
-        if viewmodel.connectedReader != nil {
-            connectedView.update(reader: viewmodel.connectedReader!)
-        }
-
+        connectedView.connectedReader = viewmodel.connectedReader
         tableView.dataSource = connectedView
         tableView.delegate = connectedView
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -2,7 +2,8 @@ import Foundation
 import Combine
 
 struct CardReader {
-    var name: String
+    var serialNumber: String
+    var batteryLevel: Float
 }
 
 enum CardReaderSettingsViewActiveView {
@@ -23,6 +24,7 @@ enum CardReaderSettingsViewActiveAlert {
 }
 
 final class CardReaderSettingsViewModel: ObservableObject {
+    /// Followed by CardReaderSettingsViewController to select child views and show/hide alerts.
     @Published var activeView: CardReaderSettingsViewActiveView
     @Published var activeAlert: CardReaderSettingsViewActiveAlert
 
@@ -35,12 +37,12 @@ final class CardReaderSettingsViewModel: ObservableObject {
     init() {
         // TODO fetch initial state from Yosemite.CardReader.
         // The initial activeView and alert will be based on the knownReaders, connectedReaders and serviceState
-        self.activeView = .connectYourReader
-        self.activeAlert = .none
-        self.knownReaders = []
-        self.foundReader = nil
-        self.connectedReader = nil
-        self.timer = nil // TODO Remove
+        activeView = .connectYourReader
+        activeAlert = .none
+        knownReaders = []
+        foundReader = nil
+        connectedReader = nil
+        timer = nil // TODO Remove
     }
 
     func startSearch() {
@@ -53,8 +55,8 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
     // TODO Remove
     @objc private func dummyFoundReader() {
-        self.foundReader = CardReader(name: "CHB204909001234")
-        self.activeAlert = .foundReader
+        foundReader = CardReader(serialNumber: "CHB204909001234", batteryLevel: 0.885)
+        activeAlert = .foundReader
     }
 
     func stopSearch() {
@@ -76,11 +78,19 @@ final class CardReaderSettingsViewModel: ObservableObject {
         activeAlert = .none
     }
 
+    func disconnectAndForget() {
+        // TODO dispatch an action to disconnect.
+        connectedReader = nil
+        activeView = .connectYourReader
+        activeAlert = .none
+    }
+
     // TODO Remove
     @objc private func dummyConnectedReader() {
-        self.connectedReader = self.foundReader
-        self.activeView = .connectedToReader
-        self.activeAlert = .none
+        connectedReader = foundReader
+        foundReader = nil
+        activeView = .connectedToReader
+        activeAlert = .none
     }
 
     func updateSoftware() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Combine
-import OSLog
 
 struct CardReader {
     var serialNumber: String
@@ -76,10 +75,6 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         batteryLevel = batteryLevel * 0.99
         connectedReader?.batteryLevel = batteryLevel
-
-        if #available(iOS 14.0, *) {
-            os_log("In dummyUpdateBattery, batteryLevel = %.2f", log: .default, type: .debug, batteryLevel)
-        }
     }
 
     func stopSearch() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -7,8 +7,8 @@ struct CardReader {
 
 enum CardReaderSettingsViewActiveView {
     case connectYourReader
-    case manageYourReader
-    case noReaderFound
+    case connectedToReader
+    case noReaders
 }
 
 enum CardReaderSettingsViewActiveAlert {
@@ -30,6 +30,8 @@ final class CardReaderSettingsViewModel: ObservableObject {
     var foundReader: CardReader?
     var connectedReader: CardReader?
 
+    var timer: Timer? // TODO Remove
+
     init() {
         // TODO fetch initial state from Yosemite.CardReader.
         // The initial activeView and alert will be based on the knownReaders, connectedReaders and serviceState
@@ -38,20 +40,47 @@ final class CardReaderSettingsViewModel: ObservableObject {
         self.knownReaders = []
         self.foundReader = nil
         self.connectedReader = nil
+        self.timer = nil // TODO Remove
     }
 
     func startSearch() {
         // TODO dispatch an action to start searching.
         activeAlert = .searching
+
+        // TODO Remove - simulates searching with a timer
+        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyFoundReader), userInfo: nil, repeats: false)
+    }
+
+    // TODO Remove
+    @objc private func dummyFoundReader() {
+        self.foundReader = CardReader(name: "CHB204909001234")
+        self.activeAlert = .foundReader
     }
 
     func stopSearch() {
         // TODO dispatch an action to stop searching.
+        timer?.invalidate() // TODO Remove
         activeAlert = .none
     }
 
     func connect() {
         // TODO dispatch an action to connect.
+        activeAlert = .connecting
+
+        // TODO Remove - simulates connecting with a timer
+        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyConnectedReader), userInfo: nil, repeats: false)
+    }
+
+    func stopConnect() {
+        // TODO dispatch an action to interrupt connecting.
+        activeAlert = .none
+    }
+
+    // TODO Remove
+    @objc private func dummyConnectedReader() {
+        self.connectedReader = self.foundReader
+        self.activeView = .connectedToReader
+        self.activeAlert = .none
     }
 
     func updateSoftware() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+class ConnectedReaderTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
@@ -1,15 +1,6 @@
 import UIKit
 
 class ConnectedReaderTableViewCell: UITableViewCell {
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
+    @IBOutlet weak var serialNumberLabel: UILabel!
+    @IBOutlet weak var batteryLevelLabel: UILabel!
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ConnectedReaderTableViewCell: UITableViewCell {
+final class ConnectedReaderTableViewCell: UITableViewCell {
     @IBOutlet weak var serialNumberLabel: UILabel!
     @IBOutlet weak var batteryLevelLabel: UILabel!
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="85" id="U1w-T7-U6Q" customClass="ConnectedReaderTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="U1w-T7-U6Q" id="JJm-pT-xv2">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHB204999999999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URa-xk-ZnX">
+                        <rect key="frame" x="20" y="9" width="374" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="21" id="jdk-QY-NJg"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="44% Battery" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rws-DM-4n4">
+                        <rect key="frame" x="20" y="32" width="374" height="20"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="vhv-1f-sz5"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="URa-xk-ZnX" firstAttribute="top" secondItem="JJm-pT-xv2" secondAttribute="top" constant="9" id="9ON-nS-TT9"/>
+                    <constraint firstItem="rws-DM-4n4" firstAttribute="leading" secondItem="JJm-pT-xv2" secondAttribute="leading" constant="20" id="9hB-FN-5re"/>
+                    <constraint firstItem="URa-xk-ZnX" firstAttribute="leading" secondItem="JJm-pT-xv2" secondAttribute="leading" constant="20" id="K23-JF-BdP"/>
+                    <constraint firstAttribute="bottom" secondItem="rws-DM-4n4" secondAttribute="bottom" constant="8" id="baC-l2-3kl"/>
+                    <constraint firstAttribute="trailing" secondItem="rws-DM-4n4" secondAttribute="trailing" constant="20" id="lVF-PB-1iC"/>
+                    <constraint firstAttribute="trailing" secondItem="URa-xk-ZnX" secondAttribute="trailing" constant="20" id="zX8-ar-MO5"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="batteryLevelLabel" destination="rws-DM-4n4" id="1o2-Jn-wjZ"/>
+                <outlet property="serialNumberLabel" destination="URa-xk-ZnX" id="I1s-v2-Qh2"/>
+            </connections>
+            <point key="canvasLocation" x="24.637681159420293" y="115.51339285714285"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
@@ -4,16 +4,4 @@ import UIKit
 class LearnMoreTableViewCell: UITableViewCell {
 
     @IBOutlet weak var learnMoreLabel: UILabel!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/NumberedListItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/NumberedListItemTableViewCell.swift
@@ -4,16 +4,4 @@ class NumberedListItemTableViewCell: UITableViewCell {
 
     @IBOutlet weak var numberLabel: UILabel!
     @IBOutlet weak var itemTextLabel: UILabel!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		31186FF325DF220B001A28D3 /* CardReaderSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31186FF225DF220B001A28D3 /* CardReaderSettingsViewModel.swift */; };
 		3118700725E06758001A28D3 /* CardReaderSettingsConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3118700625E06758001A28D3 /* CardReaderSettingsConnectView.swift */; };
 		31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */; };
+		31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */; };
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
 		318109C625E59E4000EE0BE7 /* TitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */; };
 		318109D625E5A7E300EE0BE7 /* TitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */; };
@@ -1590,6 +1591,7 @@
 		31186FF225DF220B001A28D3 /* CardReaderSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewModel.swift; sourceTree = "<group>"; };
 		3118700625E06758001A28D3 /* CardReaderSettingsConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectView.swift; sourceTree = "<group>"; };
 		31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModel.swift; sourceTree = "<group>"; };
+		31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectedReaderTableViewCell.xib; sourceTree = "<group>"; };
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
 		318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
 		318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleTableViewCell.xib; sourceTree = "<group>"; };
@@ -3358,6 +3360,7 @@
 			isa = PBXGroup;
 			children = (
 				31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */,
+				31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */,
 			);
 			path = CardReaderTableViewCells;
 			sourceTree = "<group>";
@@ -5586,6 +5589,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */,
 				2688642125D323C600821BA5 /* EditAttributesViewController.xib in Resources */,
 				B56DB3D72049BFAA00D4AA8E /* LaunchScreen.storyboard in Resources */,
 				CE583A0C2107937F00D73C1C /* TextViewTableViewCell.xib in Resources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -449,6 +449,8 @@
 		318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */; };
 		318109EE25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */; };
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
+		31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */; };
+		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
@@ -1596,6 +1598,8 @@
 		318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberedListItemTableViewCell.swift; sourceTree = "<group>"; };
 		318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberedListItemTableViewCell.xib; sourceTree = "<group>"; };
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
+		31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedReaderView.swift; sourceTree = "<group>"; };
+		31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedReaderTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LearnMoreTableViewCell.xib; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -3344,8 +3348,18 @@
 				318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */,
 				31186FF225DF220B001A28D3 /* CardReaderSettingsViewModel.swift */,
 				3118700625E06758001A28D3 /* CardReaderSettingsConnectView.swift */,
+				31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */,
+				31F92DFE25E86F4500DE04DF /* CardReaderTableViewCells */,
 			);
 			path = CardReaders;
+			sourceTree = "<group>";
+		};
+		31F92DFE25E86F4500DE04DF /* CardReaderTableViewCells */ = {
+			isa = PBXGroup;
+			children = (
+				31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */,
+			);
+			path = CardReaderTableViewCells;
 			sourceTree = "<group>";
 		};
 		4506BD6E2461962700FE6377 /* Visibility */ = {
@@ -5963,6 +5977,7 @@
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
+				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
@@ -6250,6 +6265,7 @@
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,
 				B5D1AFB820BC510200DB0E8C /* UIImage+Woo.swift in Sources */,
+				31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */,
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,


### PR DESCRIPTION
Ready for review.

Includes
- mocked connected reader (that is not persisted)
- light mode AND dark mode

Does not include:
- any changes to the Settings or "Connect your card reader" screens
- any changes to nav bar title (still says "Card Readers" - should say "Manage Card Reader"
- the final form of the modals for "Scanning for readers" or "Found reader" or "Connecting to reader" - for now simple Alerts are being used. FancyAlerts that match the designs will be added in a subsequent PR. This was done to keep this PR under 400 lines.
- unit tests - those will come when we integrate with the CardReaderService in a subsequent PR

To test:
- Navigate to Settings (Gear), then Manage Card Readers
- Tap on "Connect card reader" button
- A "Scanning for Readers" alert will appear. Wait 3 seconds.
- A "Found reader" alert will replace it. Click on "Connect to Reader." Wait 3 seconds.
- A "Connecting to Reader" alert will replace it. Wait 3 seconds.
- A "Connected Readers" list will appear with the mocked reader. Note that its battery level declines 1% every 3 seconds.
- Click on the Disconnect button. You'll be returned to the Connect card reader view.

A light mode movie and a dark mode still:

<img src="https://user-images.githubusercontent.com/1595739/109572115-8a16b780-7aa1-11eb-9c7d-7db38f57273a.gif" width=40%/>

<img src="https://user-images.githubusercontent.com/1595739/109572189-a9ade000-7aa1-11eb-9edf-0b0921550f97.PNG" width=40%/>

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
