### PR TITLE
Large titles: workaround for Dashboard and Orders tab with multiple scroll views

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.2
 -----
 
+- [**] Large titles are shown for the four main tabs like in Android. [TODO-PR]
 - [*] Fix: Load product inventory settings in read-only mode when the product has a decimal stock quantity. This fixes the products tab not loading due to product decoding errors when third-party plugins enable decimal stock quantities. [https://github.com/woocommerce/woocommerce-ios/pull/3717]
 - [*] Fix: Loading state stuck in Reviews List. [https://github.com/woocommerce/woocommerce-ios/pull/3753]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 6.2
 -----
 
-- [**] Large titles are enabled for the four main tabs like in Android. [https://github.com/woocommerce/woocommerce-ios/pull/3763]
+- [**] Large titles are enabled for the four main tabs like in Android. In Dashboard and Orders tab, a workaround is implemented with some UI/UX tradeoffs where the title size animation is not as smooth among other minor differences from Products and Reviews tab. We can encourage beta users to share any UI issues they find with large titles. [https://github.com/woocommerce/woocommerce-ios/pull/3763]
 - [*] Fix: Load product inventory settings in read-only mode when the product has a decimal stock quantity. This fixes the products tab not loading due to product decoding errors when third-party plugins enable decimal stock quantities. [https://github.com/woocommerce/woocommerce-ios/pull/3717]
 - [*] Fix: Loading state stuck in Reviews List. [https://github.com/woocommerce/woocommerce-ios/pull/3753]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 6.2
 -----
 
-- [**] Large titles are shown for the four main tabs like in Android. [TODO-PR]
+- [**] Large titles are enabled for the four main tabs like in Android. [https://github.com/woocommerce/woocommerce-ios/pull/3763]
 - [*] Fix: Load product inventory settings in read-only mode when the product has a decimal stock quantity. This fixes the products tab not loading due to product decoding errors when third-party plugins enable decimal stock quantities. [https://github.com/woocommerce/woocommerce-ios/pull/3717]
 - [*] Fix: Loading state stuck in Reviews List. [https://github.com/woocommerce/woocommerce-ios/pull/3753]
 

--- a/WooCommerce/Classes/Extensions/UIScrollView+LargeTitleWorkaround.swift
+++ b/WooCommerce/Classes/Extensions/UIScrollView+LargeTitleWorkaround.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+// Extension for a scroll view to be the "proxy" scroll view for the navigation bar to allow large title.
+// This is a workaround for a screen with multiple scroll views in parallel (like in a tab design in Dashboard and Orders tab).
+// Reference: issue 3 in p91TBi-45c-p2
+extension UIScrollView {
+    /// Configures a scroll view to be hidden and used to relay scroll action from any of the multiple scroll views in the view hierarchy below.
+    func configureForLargeTitleWorkaround() {
+        contentInsetAdjustmentBehavior = .never
+        isHidden = true
+        bounces = false
+    }
+
+    /// Updates the hidden scroll view from `scrollViewDidScroll` events from another `UIScrollView`.
+    /// - Parameter scrollView: the scroll view where `scrollViewDidScroll` events are triggered.
+    func updateFromScrollViewDidScrollEventForLargeTitleWorkaround(_ scrollView: UIScrollView) {
+        contentSize = scrollView.contentSize
+        contentOffset = scrollView.contentOffset
+        panGestureRecognizer.state = scrollView.panGestureRecognizer.state
+    }
+}

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -10,7 +10,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .cardPresentPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .largeTitles:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -21,6 +21,9 @@ final class DashboardViewController: UIViewController {
         return UIView(frame: .zero)
     }()
 
+    // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
+    private let hiddenScrollView = UIScrollView()
+
     // MARK: View Lifecycle
 
     init(siteID: Int64) {
@@ -96,6 +99,12 @@ private extension DashboardViewController {
     }
 
     func configureDashboardUIContainer() {
+        hiddenScrollView.configureForLargeTitleWorkaround()
+        // Adds the "hidden" scroll view to the root of the UIViewController for large titles.
+        view.addSubview(hiddenScrollView)
+        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+
         // A container view is added to respond to safe area insets from the view controller.
         // This is needed when the child view controller's view has to use a frame-based layout
         // (e.g. when the child view controller is a `ButtonBarPagerTabStripViewController` subclass).
@@ -106,8 +115,15 @@ private extension DashboardViewController {
 
     func reloadDashboardUIStatsVersion() {
         dashboardUIFactory.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
+            dashboardUI.scrollDelegate = self
             self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
         })
+    }
+}
+
+extension DashboardViewController: DashboardUIScrollDelegate {
+    func dashboardUIScrollViewDidScroll(_ scrollView: UIScrollView) {
+        hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -99,11 +99,13 @@ private extension DashboardViewController {
     }
 
     func configureDashboardUIContainer() {
-        hiddenScrollView.configureForLargeTitleWorkaround()
-        // Adds the "hidden" scroll view to the root of the UIViewController for large titles.
-        view.addSubview(hiddenScrollView)
-        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            hiddenScrollView.configureForLargeTitleWorkaround()
+            // Adds the "hidden" scroll view to the root of the UIViewController for large titles.
+            view.addSubview(hiddenScrollView)
+            hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+            view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+        }
 
         // A container view is added to respond to safe area insets from the view controller.
         // This is needed when the child view controller's view has to use a frame-based layout
@@ -115,7 +117,9 @@ private extension DashboardViewController {
 
     func reloadDashboardUIStatsVersion() {
         dashboardUIFactory.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
-            dashboardUI.scrollDelegate = self
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+                dashboardUI.scrollDelegate = self
+            }
             self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -5,6 +5,9 @@ import Yosemite
 /// Contains all UI content to show on Dashboard
 ///
 protocol DashboardUI: UIViewController {
+    /// For navigation bar large title workaround.
+    var scrollDelegate: DashboardUIScrollDelegate? { get set }
+
     /// Called when the Dashboard should display syncing error
     var displaySyncingErrorNotice: () -> Void { get set }
 
@@ -15,6 +18,12 @@ protocol DashboardUI: UIViewController {
     ///
     /// - Parameter completion: called when Dashboard data reload finishes
     func reloadData(completion: @escaping () -> Void)
+}
+
+/// Relays the scroll events to a delegate for navigation bar large title workaround.
+protocol DashboardUIScrollDelegate: class {
+    /// Called when a dashboard tab `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
+    func dashboardUIScrollViewDidScroll(_ scrollView: UIScrollView)
 }
 
 final class DashboardUIFactory {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -4,6 +4,9 @@ import UIKit
 /// Empty state screen shown when the store stats version is not supported
 ///
 final class DeprecatedDashboardStatsViewController: UIViewController {
+    /// For navigation bar large title workaround.
+    ///
+    weak var scrollDelegate: DashboardUIScrollDelegate?
 
     /// Empty state screen
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -12,6 +12,9 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     // MARK: Public Interface
 
+    /// For navigation bar large title workaround.
+    weak var scrollDelegate: DashboardUIScrollDelegate?
+
     /// Time range for this period
     let timeRange: StatsTimeRangeV4
 
@@ -137,6 +140,12 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     }
 }
 
+extension StoreStatsAndTopPerformersPeriodViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollDelegate?.dashboardUIScrollViewDidScroll(scrollView)
+    }
+}
+
 // MARK: Public Interface
 extension StoreStatsAndTopPerformersPeriodViewController {
     func clearAllFields() {
@@ -215,6 +224,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         view.pinSubviewToSafeArea(scrollView)
 
         scrollView.refreshControl = refreshControl
+        scrollView.delegate = self
 
         scrollView.addSubview(stackView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -6,6 +6,8 @@ import Yosemite
 /// Each time range tab is managed by a `StoreStatsAndTopPerformersPeriodViewController`.
 ///
 final class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewController {
+    /// For navigation bar large title workaround.
+    weak var scrollDelegate: DashboardUIScrollDelegate?
 
     // MARK: - DashboardUI protocol
 
@@ -285,6 +287,7 @@ private extension StoreStatsAndTopPerformersViewController {
         periodVCs.append(yearVC)
 
         periodVCs.forEach { (vc) in
+            vc.scrollDelegate = scrollDelegate
             vc.onPullToRefresh = { [weak self] in
                 self?.onPullToRefresh()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -15,6 +15,10 @@ protocol OrderListViewControllerDelegate: class {
     /// Called when `OrderListViewController` (or `OrdersViewController`) is about to fetch Orders from the API.
     ///
     func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController)
+
+    /// Called when an order list `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
+    ///
+    func orderListScrollViewDidScroll(_ scrollView: UIScrollView)
 }
 
 /// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
@@ -454,6 +458,10 @@ extension OrderListViewController: UITableViewDelegate {
         header.rightText = nil
 
         return header
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        delegate?.orderListScrollViewDidScroll(scrollView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -95,11 +95,13 @@ private extension OrdersRootViewController {
     }
 
     func configureContainerView() {
-        hiddenScrollView.configureForLargeTitleWorkaround()
-        // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
-        view.addSubview(hiddenScrollView)
-        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            hiddenScrollView.configureForLargeTitleWorkaround()
+            // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
+            view.addSubview(hiddenScrollView)
+            hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+            view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+        }
 
         // A container view is added to respond to safe area insets from the view controller.
         // This is needed when the child view controller's view has to use a frame-based layout
@@ -115,7 +117,9 @@ private extension OrdersRootViewController {
         containerView.addSubview(contentView)
         ordersViewController.didMove(toParent: self)
 
-        ordersViewController.scrollDelegate = self
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            ordersViewController.scrollDelegate = self
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -25,6 +25,9 @@ final class OrdersRootViewController: UIViewController {
         return UIView(frame: .zero)
     }()
 
+    // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
+    private let hiddenScrollView = UIScrollView()
+
     private let siteID: Int64
 
     // MARK: View Lifecycle
@@ -92,6 +95,12 @@ private extension OrdersRootViewController {
     }
 
     func configureContainerView() {
+        hiddenScrollView.configureForLargeTitleWorkaround()
+        // Adds the "hidden" scroll view to the root of the UIViewController for large title workaround.
+        view.addSubview(hiddenScrollView)
+        hiddenScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
+
         // A container view is added to respond to safe area insets from the view controller.
         // This is needed when the child view controller's view has to use a frame-based layout
         // (e.g. when the child view controller is a `ButtonBarPagerTabStripViewController` subclass).
@@ -105,5 +114,13 @@ private extension OrdersRootViewController {
         addChild(ordersViewController)
         containerView.addSubview(contentView)
         ordersViewController.didMove(toParent: self)
+
+        ordersViewController.scrollDelegate = self
+    }
+}
+
+extension OrdersRootViewController: OrdersTabbedViewControllerScrollDelegate {
+    func orderListScrollViewDidScroll(_ scrollView: UIScrollView) {
+        hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -5,9 +5,17 @@ import struct Yosemite.OrderStatus
 import enum Yosemite.OrderStatusEnum
 import struct Yosemite.Note
 
+/// Relays the scroll events to a delegate for navigation bar large title workaround.
+protocol OrdersTabbedViewControllerScrollDelegate: class {
+    /// Called when an order list `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
+    func orderListScrollViewDidScroll(_ scrollView: UIScrollView)
+}
+
 /// The main Orders view controller that is shown when the Orders tab is accessed.
 ///
 final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
+    /// For navigation bar large title workaround.
+    weak var scrollDelegate: OrdersTabbedViewControllerScrollDelegate?
 
     private lazy var analytics = ServiceLocator.analytics
 
@@ -87,6 +95,10 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
 extension OrdersTabbedViewController: OrderListViewControllerDelegate {
     func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController) {
         viewModel.syncOrderStatuses()
+    }
+
+    func orderListScrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollDelegate?.orderListScrollViewDidScroll(scrollView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -313,9 +313,13 @@ private extension ProductsViewController {
         tableView.sectionHeaderHeight = 0
 
         tableView.backgroundColor = .listBackground
-        tableView.refreshControl = refreshControl
         tableView.tableFooterView = footerSpinnerView
         tableView.separatorStyle = .none
+
+        // Adds the refresh control to table view manually so that the refresh control always appears below the navigation bar title in
+        // large or normal size to be consistent with Dashboard and Orders tab with large titles workaround.
+        // If we do `tableView.refreshControl = refreshControl`, the refresh control appears in the navigation bar when large title is shown.
+        tableView.addSubview(refreshControl)
 
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topStackView)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -175,10 +175,14 @@ private extension ReviewsViewController {
     func configureTableView() {
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground
-        tableView.refreshControl = refreshControl
         tableView.dataSource = viewModel.dataSource
         tableView.tableFooterView = footerSpinnerView
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
+
+        // Adds the refresh control to table view manually so that the refresh control always appears below the navigation bar title in
+        // large or normal size to be consistent with Dashboard and Orders tab with large titles workaround.
+        // If we do `tableView.refreshControl = refreshControl`, the refresh control appears in the navigation bar when large title is shown.
+        tableView.addSubview(refreshControl)
 
         // We decorate the delegate informally, because we want to intercept
         // didSelectItem:at: but delegate the rest of the implementation of

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
 		023D69BC2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69BB2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift */; };
+		023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */; };
 		023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */; };
 		023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */; };
 		023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */; };
@@ -1261,6 +1262,7 @@
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		023D69BB2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelCoordinator.swift; sourceTree = "<group>"; };
+		023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+LargeTitleWorkaround.swift"; sourceTree = "<group>"; };
 		023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewModelTests.swift; sourceTree = "<group>"; };
 		023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductSKUValidationStoresManager.swift; sourceTree = "<group>"; };
 		023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductInventorySettingsViewModel+VariationTests.swift"; sourceTree = "<group>"; };
@@ -4817,6 +4819,7 @@
 				571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */,
 				D8810085257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift */,
 				025C00B925514A7100FAC222 /* BarcodeScannerFrameScaler.swift */,
+				023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6079,6 +6082,7 @@
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,
 				451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */,
 				02E8B17E23E2C8D900A43403 /* ProductImageActionHandler.swift in Sources */,
+				023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */,
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,


### PR DESCRIPTION
Part of #3751 

## Why

More details are in "Issue 3" in p91TBi-45c-p2.

Large titles are enabled in a previous PR https://github.com/woocommerce/woocommerce-ios/issues/3751, however the title animation (transitions between normal and large title on scroll events) is not available in Dashboard and Orders tab. This is because these two tabs have a tab bar in the vertical space outside of a scroll view with the current "tabbed design" (e.g. the top tab bar "Processing"/"All" in the Orders tab). In Products and Reviews tab, there is only one scroll view in the vertical space so large titles work by default.

This PR implemented a workaround with a hidden scroll view (Issue 3 - Proposed fix 2) in p91TBi-45c-p2 after confirming with the design team. A hidden scroll view is added to the top view hierarchy and pinned to the top and bottom edges. On scroll events from one of the tabbed table views, this hidden scroll view is updated with the latest scroll view offset so that the navigation bar can respond to scroll events.

This workaround comes with some UX compromises, which you might notice after comparing Dashboard/Orders tab with Products/Reviews tab:

- The title does not snap to large/normal state, so that the title could stay at a clipped state
- The large/normal state animation is not as smooth
- When navigating back from another view (e.g. orders tab --> order details --> orders tab), the large title shrinks to normal title state

We confirmed these tradeoffs with the design team in p91TBi-45c-p2#comment-3238.

## Changes

- Added `UIScrollView` extension for the hidden scroll view for large title workaround. It has a function to configure the hidden scroll view, and another function to update the scroll view itself after receiving `scrollViewDidScroll` from actual scroll events in one of the multiple scroll views
- Enabled large titles for all by turning on the feature flag (I'm leaving the feature flag since it's an app-wide change and we can remove it after one public release)
- Implemented the hidden scroll view workaround for the Dashboard and Orders tab. I didn't like having to sprinkle the code all over several files, but I couldn't find an easy alternative for passing up the scroll events from `UIScrollViewDelegate`. Please feel free to share any other suggestions!
 
## Testing

- Launch the app from Xcode (debug build), and log in if needed --> each tab should have large title
- Go to the dashboard tab, and scroll in each stats tab --> the title should shrink to normal size after scrolling up, but not as smooth as Products and Reviews tab
- Go to the orders tab, and scroll in each order list tab --> the title should shrink to normal size after scrolling up, but not as smooth as Products and Reviews tab

## Example screenshots

\ | before | after
-- | -- | --
dashboard tab | https://user-images.githubusercontent.com/1945542/109253208-3fd7d100-782a-11eb-9973-a0d72867203a.mov | https://user-images.githubusercontent.com/1945542/109465104-aa934180-7aa2-11eb-853b-24798a3704b7.mov
orders tab | https://user-images.githubusercontent.com/1945542/109253252-58e08200-782a-11eb-9be6-fd86b62c7500.mov | https://user-images.githubusercontent.com/1945542/109465165-bd0d7b00-7aa2-11eb-84a2-6ab3556dcbe8.mov

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
