### PR TITLE
[Variations] Update parent product after variation deletion

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -57,6 +57,10 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         }
     }
 
+    /// Assign this closure to get notified when the variation is deleted.
+    ///
+    var onVariationDeletion: ((ProductVariation) -> Void)?
+
     private let allAttributes: [ProductAttribute]
     private let parentProductSKU: String?
     private let productImageActionHandler: ProductImageActionHandler
@@ -272,6 +276,7 @@ extension ProductVariationFormViewModel {
         let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { result in
             switch result {
             case .success:
+                self.onVariationDeletion?(self.productVariation.productVariation)
                 onCompletion(.success(()))
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -273,10 +273,12 @@ extension ProductVariationFormViewModel {
     }
 
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {
-        let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { result in
+        let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { [weak self] result in
             switch result {
             case .success:
-                self.onVariationDeletion?(self.productVariation.productVariation)
+                if let self = self {
+                    self.onVariationDeletion?(self.productVariation.productVariation)
+                }
                 onCompletion(.success(()))
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -426,6 +426,14 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                       formType: formType,
                                                       productImageActionHandler: productImageActionHandler,
                                                       isAddProductVariationsEnabled: isAddProductVariationsEnabled)
+        viewModel.onVariationDeletion = { [weak self] variation in
+            guard let self = self else { return }
+
+            // Remove deleted variation from variations array
+            let variationsUpdated = self.product.variations.filter { $0 != variation.productVariationID }
+            let updatedProduct = self.product.copy(variations: variationsUpdated)
+            self.product = updatedProduct
+        }
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductVariationFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -188,6 +188,11 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
                                                       productImageActionHandler: productImageActionHandler,
                                                       storesManager: mockStoresManager)
 
+        let expectationForDeletionCallback = expectation(description: "Deletion callback")
+        viewModel.onVariationDeletion = { _ in
+            expectationForDeletionCallback.fulfill()
+        }
+
         // When
         let result: Result<Void, ProductUpdateError> = waitFor { promise in
             viewModel.deleteProductRemotely { result in
@@ -197,6 +202,7 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
+        wait(for: [expectationForDeletionCallback], timeout: Constants.expectationTimeout)
         XCTAssertEqual(mockStoresManager.receivedActions.count, 1)
         XCTAssertNotNil(mockStoresManager.receivedActions[0] as? ProductVariationAction)
     }
@@ -213,6 +219,9 @@ final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       productImageActionHandler: productImageActionHandler,
                                                       storesManager: mockStoresManager)
+        viewModel.onVariationDeletion = { _ in
+            XCTFail("Deletion callback shouldn't be called on error")
+        }
 
         // When
         let result: Result<Void, ProductUpdateError> = waitFor { promise in


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/3193, https://github.com/woocommerce/woocommerce-ios/issues/3619.

## Description

This PR fixes adds parent product updating after variation deletion.

## Changes

1. Adds `onVariationDeletion` stored closure in `ProductVariationFormViewModel`
2. Adds local product update in `onVariationDeletion` callback in `ProductVariationsViewController`

## Test

1. Open product with existing variations.
2. Open variation details
3. Tap "•••" in navbar, pick "Delete"
4. Repeat deletion for all variations
5. Observe correct empty state instead of simple empty table
6. Go back on parent product details and check that variations cell has "Add variations" text

## Video

https://user-images.githubusercontent.com/3132438/109465837-d9e18880-7a79-11eb-8839-02cfabf192e0.mp4

https://user-images.githubusercontent.com/3132438/109465846-dd750f80-7a79-11eb-8794-2ea03b547589.mp4

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
