### PR TITLE
Fix error state crash on AddAttributeOptionsViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -23,21 +23,17 @@ final class AddAttributeOptionsViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    /// Sync error state screen
+    /// Empty state screen
     ///
-    private lazy var syncErrorViewController: EmptyStateViewController = {
-        let syncErrorVC = EmptyStateViewController(style: .list)
+    private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
 
+    /// Sync error state config for EmptyStateViewController
+    ///
+    private lazy var errorStateConfig: EmptyStateViewController.Config = {
         let message = NSAttributedString(string: Localization.syncErrorMessage, attributes: [.font: EmptyStateViewController.Config.messageFont])
-        let errorStateConfig = EmptyStateViewController.Config.withButton(message: message,
-                                                   image: .errorImage,
-                                                   details: "",
-                                                   buttonTitle: Localization.retryAction) { [weak self] in
+        return .withButton(message: message, image: .errorImage, details: "", buttonTitle: Localization.retryAction) { [weak self] in
             self?.viewModel.synchronizeOptions()
         }
-
-        syncErrorVC.configure(errorStateConfig)
-        return syncErrorVC
     }()
 
     /// Initializer for `AddAttributeOptionsViewController`
@@ -166,30 +162,31 @@ private extension AddAttributeOptionsViewController {
         if viewModel.showSyncError {
             displaySyncErrorViewController()
         } else {
-            removeSyncErrorViewController()
+            removeEmptyStateViewController()
         }
     }
 
     /// Shows the EmptyStateViewController for options sync error state
     ///
     func displaySyncErrorViewController() {
-        addChild(syncErrorViewController)
+        addChild(emptyStateViewController)
 
-        syncErrorViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(syncErrorViewController.view)
+        emptyStateViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(emptyStateViewController.view)
 
-        syncErrorViewController.view.pinSubviewToAllEdges(view)
-        syncErrorViewController.didMove(toParent: self)
+        emptyStateViewController.view.pinSubviewToAllEdges(view)
+        emptyStateViewController.didMove(toParent: self)
+        emptyStateViewController.configure(errorStateConfig)
     }
 
-    func removeSyncErrorViewController() {
-        guard syncErrorViewController.parent == self else {
+    func removeEmptyStateViewController() {
+        guard emptyStateViewController.parent == self else {
             return
         }
 
-        syncErrorViewController.willMove(toParent: nil)
-        syncErrorViewController.view.removeFromSuperview()
-        syncErrorViewController.removeFromParent()
+        emptyStateViewController.willMove(toParent: nil)
+        emptyStateViewController.view.removeFromSuperview()
+        emptyStateViewController.removeFromParent()
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes crash introduced in https://github.com/woocommerce/woocommerce-ios/pull/3695.

## Changes

Mostly a rollback of refactor from 56d4a38. Calling `configure` on `EmptyStateViewController` too early leads to a crash because IBOutlets are nil at this point. Moved `configure` to be called after adding view to hierarchy.

## Test

1. Open variable product, with existing variations or not
2. Tap "variations" (or "add variation")
3. For no variations:
a. Tap "Add Variation"
For existing variations:
a. Tap "•••" in navbar, pick "Edit Attributes"
b. Tap "Add New Attribute"
4. Turn off internet connection
5. Select global attribute
6. Observe error state (without a crash 🙂)
7. Turn on internet connection and tap "Retry"
8. Observe correctly synced options list

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
