### PR TITLE
Order Details: update "Mark Order Complete" CTA to secondary style when shipping label creation CTA is visible

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -284,8 +284,10 @@ private extension OrderDetailsDataSource {
             configureAggregateOrderItem(cell: cell, at: indexPath)
         case let cell as ButtonTableViewCell where row == .shippingLabelCreateButton:
             configureCreateShippingLabelButton(cell: cell, at: indexPath)
-        case let cell as ButtonTableViewCell where row == .markCompleteButton:
-            configureMarkCompleteButton(cell: cell)
+        case let cell as ButtonTableViewCell where row == .markCompletePrimaryButton:
+            configureMarkCompleteButton(cell: cell, buttonStyle: .primary)
+        case let cell as ButtonTableViewCell where row == .markCompleteSecondaryButton:
+            configureMarkCompleteButton(cell: cell, buttonStyle: .secondary)
         case let cell as ButtonTableViewCell where row == .shippingLabelReprintButton:
             configureReprintShippingLabelButton(cell: cell, at: indexPath)
         case let cell as OrderTrackingTableViewCell where row == .tracking:
@@ -603,8 +605,8 @@ private extension OrderDetailsDataSource {
         )
     }
 
-    private func configureMarkCompleteButton(cell: ButtonTableViewCell) {
-        cell.configure(title: Titles.markComplete) { [weak self] in
+    private func configureMarkCompleteButton(cell: ButtonTableViewCell, buttonStyle: ButtonTableViewCell.Style) {
+        cell.configure(style: buttonStyle, title: Titles.markComplete) { [weak self] in
             self?.onCellAction?(.markComplete, nil)
         }
         cell.showSeparator()
@@ -763,7 +765,8 @@ extension OrderDetailsDataSource {
             }
 
             if isProcessingPayment {
-                rows.append(.markCompleteButton)
+                let markCompleteButtonRow: Row = rows.contains(.shippingLabelCreateButton) ? .markCompleteSecondaryButton : .markCompletePrimaryButton
+                rows.append(markCompleteButtonRow)
             } else if isRefundedStatus == false {
                 rows.append(.details)
             }
@@ -1186,7 +1189,8 @@ extension OrderDetailsDataSource {
     enum Row {
         case summary
         case aggregateOrderItem
-        case markCompleteButton
+        case markCompletePrimaryButton
+        case markCompleteSecondaryButton
         case details
         case refundedProducts
         case issueRefundButton
@@ -1218,7 +1222,7 @@ extension OrderDetailsDataSource {
                 return SummaryTableViewCell.reuseIdentifier
             case .aggregateOrderItem:
                 return ProductDetailsTableViewCell.reuseIdentifier
-            case .markCompleteButton:
+            case .markCompletePrimaryButton, .markCompleteSecondaryButton:
                 return ButtonTableViewCell.reuseIdentifier
             case .details:
                 return WooBasicTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -288,9 +288,9 @@ private extension OrderDetailsDataSource {
             configureAggregateOrderItem(cell: cell, at: indexPath)
         case let cell as ButtonTableViewCell where row == .shippingLabelCreateButton:
             configureCreateShippingLabelButton(cell: cell, at: indexPath)
-        case let cell as ButtonTableViewCell where row == .markCompletePrimaryButton:
+        case let cell as ButtonTableViewCell where row == .markCompleteButton(style: .primary):
             configureMarkCompleteButton(cell: cell, buttonStyle: .primary)
-        case let cell as ButtonTableViewCell where row == .markCompleteSecondaryButton:
+        case let cell as ButtonTableViewCell where row == .markCompleteButton(style: .secondary):
             configureMarkCompleteButton(cell: cell, buttonStyle: .secondary)
         case let cell as ButtonTableViewCell where row == .shippingLabelReprintButton:
             configureReprintShippingLabelButton(cell: cell, at: indexPath)
@@ -769,8 +769,8 @@ extension OrderDetailsDataSource {
             }
 
             if isProcessingPayment {
-                let markCompleteButtonRow: Row = rows.contains(.shippingLabelCreateButton) ? .markCompleteSecondaryButton : .markCompletePrimaryButton
-                rows.append(markCompleteButtonRow)
+                let buttonStyle: ButtonTableViewCell.Style = rows.contains(.shippingLabelCreateButton) ? .secondary : .primary
+                rows.append(.markCompleteButton(style: buttonStyle))
             } else if isRefundedStatus == false {
                 rows.append(.details)
             }
@@ -1190,11 +1190,10 @@ extension OrderDetailsDataSource {
 
     /// Rows listed in the order they appear on screen
     ///
-    enum Row {
+    enum Row: Equatable {
         case summary
         case aggregateOrderItem
-        case markCompletePrimaryButton
-        case markCompleteSecondaryButton
+        case markCompleteButton(style: ButtonTableViewCell.Style)
         case details
         case refundedProducts
         case issueRefundButton
@@ -1226,7 +1225,7 @@ extension OrderDetailsDataSource {
                 return SummaryTableViewCell.reuseIdentifier
             case .aggregateOrderItem:
                 return ProductDetailsTableViewCell.reuseIdentifier
-            case .markCompletePrimaryButton, .markCompleteSecondaryButton:
+            case .markCompleteButton:
                 return ButtonTableViewCell.reuseIdentifier
             case .details:
                 return WooBasicTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -38,6 +38,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var trackingIsReachable: Bool = false
 
+    /// Whether the order is eligible for shipping label creation.
+    ///
+    var isEligibleForShippingLabelCreation: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2)
+
     /// Closure to be executed when the cell was tapped.
     ///
     var onCellAction: ((CellActionType, IndexPath?) -> Void)?
@@ -760,7 +764,7 @@ extension OrderDetailsDataSource {
 
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2) {
+            if isEligibleForShippingLabelCreation {
                 rows.append(.shippingLabelCreateButton)
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -84,18 +84,34 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(issueRefundRow)
     }
 
-    func test_markOrderComplete_button_is_visible_if_order_is_processing() throws {
+    func test_markOrderComplete_button_is_visible_and_primary_style_if_order_is_processing_and_not_eligible_for_shipping_label_creation() throws {
         // Given
         let order = makeOrder().copy(status: .processing)
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = false
 
         // When
         dataSource.reloadSections()
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        let buttonRow = row(row: .markCompletePrimaryButton, in: productsSection)
-        XCTAssertNotNil(buttonRow)
+        XCTAssertNotNil(row(row: .markCompletePrimaryButton, in: productsSection))
+        XCTAssertNil(row(row: .markCompleteSecondaryButton, in: productsSection))
+    }
+
+    func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
+        // Given
+        let order = makeOrder().copy(status: .processing)
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = true
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productsSection = try section(withTitle: Title.products, from: dataSource)
+        XCTAssertNotNil(row(row: .markCompleteSecondaryButton, in: productsSection))
+        XCTAssertNil(row(row: .markCompletePrimaryButton, in: productsSection))
     }
 
     func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -94,7 +94,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        let buttonRow = row(row: .markCompleteButton, in: productsSection)
+        let buttonRow = row(row: .markCompletePrimaryButton, in: productsSection)
         XCTAssertNotNil(buttonRow)
     }
 
@@ -108,8 +108,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        let buttonRow = row(row: .markCompleteButton, in: productsSection)
-        XCTAssertNil(buttonRow)
+        XCTAssertNil(row(row: .markCompletePrimaryButton, in: productsSection))
+        XCTAssertNil(row(row: .markCompleteSecondaryButton, in: productsSection))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -95,8 +95,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNotNil(row(row: .markCompletePrimaryButton, in: productsSection))
-        XCTAssertNil(row(row: .markCompleteSecondaryButton, in: productsSection))
+        XCTAssertNotNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
     }
 
     func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
@@ -110,8 +110,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNotNil(row(row: .markCompleteSecondaryButton, in: productsSection))
-        XCTAssertNil(row(row: .markCompletePrimaryButton, in: productsSection))
+        XCTAssertNotNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
     }
 
     func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() throws {
@@ -124,8 +124,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNil(row(row: .markCompletePrimaryButton, in: productsSection))
-        XCTAssertNil(row(row: .markCompleteSecondaryButton, in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
     }
 }
 


### PR DESCRIPTION
Fixes #3680 

## Why

When an order is processing and eligible for shipping label creation, two CTAs are shown in the Products section (example screenshots below). In this case, "Mark Order Complete" CTA should be secondary style while the shipping label creation CTA is primary style.

## Changes

In `OrderDetailsDataSource`:
- Updated `Row.markCompleteButton` case to have an associated value for button style that could be primary or secondary
- When configuring the Products section for a processing order, set the "Mark Order Complete" row button style based on the shipping label creation CTA row visible
- Updated shipping label creation eligibility check to a public variable, which will be set by `OrderDetailsViewModel` when we implement the eligibility check. Right now, this is used for unit tests

## Testing

### Shipping label creation CTA is shown (feature flag is on for now)

- Launch from Xcode
- Go to the orders tab
- Tap an order in the Processing tab --> should see both "Create Shipping Label" and "Mark Order Complete" CTAs, where "Create Shipping Label" is primary style and "Mark Order Complete" is secondary style (before this PR, both CTAs are primary style)

### Shipping label creation CTA is not shown (feature flag is off for now)

- In `DefaultFeatureFlagService`, update to return `false` for `shippingLabelsRelease2` feature flag
- Launch from Xcode
- Go to the orders tab
- Tap an order in the Processing tab --> should only see "Mark Order Complete" CTA of primary style

## Example screenshots

\ | shipping label creation CTA is visible | shipping label creation CTA is invisible
-- | -- | --
dark | ![Simulator Screen Shot - iPhone 11 - 2021-03-01 at 16 22 23](https://user-images.githubusercontent.com/1945542/109474102-1aa7c480-7aaf-11eb-949a-51463ca4a537.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-01 at 16 23 30](https://user-images.githubusercontent.com/1945542/109474111-1e3b4b80-7aaf-11eb-99d1-14e4d76ea11f.png)
light | ![Simulator Screen Shot - iPhone 11 - 2021-03-01 at 16 24 42](https://user-images.githubusercontent.com/1945542/109474115-1f6c7880-7aaf-11eb-8721-2ddd4a8e31a5.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-01 at 16 55 25](https://user-images.githubusercontent.com/1945542/109474117-20050f00-7aaf-11eb-9d52-56fdba39be80.png)





Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
