### PR TITLE
Order Details: show shipping label creation info row when the order is eligible

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -266,6 +266,11 @@ private extension OrderDetailsDataSource {
             configureShippingLabelDetail(cell: cell)
         case let cell as ImageAndTitleAndTextTableViewCell where row == .shippingNotice:
             configureShippingNotice(cell: cell)
+        case let cell as ImageAndTitleAndTextTableViewCell where row == .shippingLabelCreationInfo(showsSeparator: true),
+             let cell as ImageAndTitleAndTextTableViewCell where row == .shippingLabelCreationInfo(showsSeparator: false):
+            if case .shippingLabelCreationInfo(let showsSeparator) = row {
+                configureShippingLabelCreationInfo(cell: cell, showsSeparator: showsSeparator)
+            }
         case let cell as ImageAndTitleAndTextTableViewCell where row == .shippingLabelPrintingInfo:
             configureShippingLabelPrintingInfo(cell: cell)
         case let cell as LeftImageTableViewCell where row == .addOrderNote:
@@ -288,10 +293,13 @@ private extension OrderDetailsDataSource {
             configureAggregateOrderItem(cell: cell, at: indexPath)
         case let cell as ButtonTableViewCell where row == .shippingLabelCreateButton:
             configureCreateShippingLabelButton(cell: cell, at: indexPath)
-        case let cell as ButtonTableViewCell where row == .markCompleteButton(style: .primary):
-            configureMarkCompleteButton(cell: cell, buttonStyle: .primary)
-        case let cell as ButtonTableViewCell where row == .markCompleteButton(style: .secondary):
-            configureMarkCompleteButton(cell: cell, buttonStyle: .secondary)
+        case let cell as ButtonTableViewCell where row == .markCompleteButton(style: .primary, showsBottomSpacing: true),
+             let cell as ButtonTableViewCell where row == .markCompleteButton(style: .primary, showsBottomSpacing: false),
+             let cell as ButtonTableViewCell where row == .markCompleteButton(style: .secondary, showsBottomSpacing: true),
+             let cell as ButtonTableViewCell where row == .markCompleteButton(style: .secondary, showsBottomSpacing: false):
+            if case .markCompleteButton(let style, let showsBottomSpacing) = row {
+                configureMarkCompleteButton(cell: cell, buttonStyle: style, showsBottomSpacing: showsBottomSpacing)
+            }
         case let cell as ButtonTableViewCell where row == .shippingLabelReprintButton:
             configureReprintShippingLabelButton(cell: cell, at: indexPath)
         case let cell as OrderTrackingTableViewCell where row == .tracking:
@@ -461,6 +469,25 @@ private extension OrderDetailsDataSource {
         cell.hideSeparator()
     }
 
+    private func configureShippingLabelCreationInfo(cell: ImageAndTitleAndTextTableViewCell, showsSeparator: Bool) {
+        cell.update(with: .imageAndTitleOnly(fontStyle: .footnote),
+                    data: .init(title: Title.shippingLabelCreationInfoAction,
+                                image: .infoOutlineFootnoteImage,
+                                imageTintColor: .systemColor(.secondaryLabel),
+                                numberOfLinesForTitle: 0,
+                                isActionable: false,
+                                showsSeparator: showsSeparator))
+
+        cell.selectionStyle = .default
+
+        cell.accessibilityTraits = .button
+        cell.accessibilityLabel = Title.shippingLabelCreationInfoAction
+        cell.accessibilityHint =
+            NSLocalizedString("Tap to show instructions on how to create a shipping label on the mobile device",
+                              comment:
+                                "VoiceOver accessibility hint for the row that shows instructions on how to print a shipping label on the mobile device")
+    }
+
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = Footer.showShippingLabelDetails
         cell.applyPlainTextStyle()
@@ -609,11 +636,14 @@ private extension OrderDetailsDataSource {
         )
     }
 
-    private func configureMarkCompleteButton(cell: ButtonTableViewCell, buttonStyle: ButtonTableViewCell.Style) {
-        cell.configure(style: buttonStyle, title: Titles.markComplete) { [weak self] in
+    private func configureMarkCompleteButton(cell: ButtonTableViewCell,
+                                             buttonStyle: ButtonTableViewCell.Style,
+                                             showsBottomSpacing: Bool) {
+        let bottomSpacing: CGFloat = showsBottomSpacing ? ButtonTableViewCell.Constants.defaultBottomSpacing : 0
+        cell.configure(style: buttonStyle, title: Titles.markComplete, bottomSpacing: bottomSpacing) { [weak self] in
             self?.onCellAction?(.markComplete, nil)
         }
-        cell.showSeparator()
+        cell.hideSeparator()
     }
 
     private func configureIssueRefundButton(cell: IssueRefundTableViewCell) {
@@ -769,9 +799,17 @@ extension OrderDetailsDataSource {
             }
 
             if isProcessingPayment {
-                let buttonStyle: ButtonTableViewCell.Style = rows.contains(.shippingLabelCreateButton) ? .secondary : .primary
-                rows.append(.markCompleteButton(style: buttonStyle))
+                if isEligibleForShippingLabelCreation {
+                    rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
+                    rows.append(.shippingLabelCreationInfo(showsSeparator: false))
+                } else {
+                    rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
+                }
             } else if isRefundedStatus == false {
+                if isEligibleForShippingLabelCreation {
+                    rows.append(.shippingLabelCreationInfo(showsSeparator: true))
+                }
+
                 rows.append(.details)
             }
 
@@ -1085,6 +1123,9 @@ extension OrderDetailsDataSource {
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
+        static let shippingLabelCreationInfoAction =
+            NSLocalizedString("Learn more about creating labels with your phone",
+                              comment: "Title of button in order details > info link for creating a shipping label on the mobile device.")
         static let shippingLabelPackageFormat =
             NSLocalizedString("Package %d",
                               comment: "Order shipping label package section title format. The number indicates the index of the shipping label package.")
@@ -1193,7 +1234,7 @@ extension OrderDetailsDataSource {
     enum Row: Equatable {
         case summary
         case aggregateOrderItem
-        case markCompleteButton(style: ButtonTableViewCell.Style)
+        case markCompleteButton(style: ButtonTableViewCell.Style, showsBottomSpacing: Bool)
         case details
         case refundedProducts
         case issueRefundButton
@@ -1208,6 +1249,7 @@ extension OrderDetailsDataSource {
         case tracking
         case trackingAdd
         case shippingLabelCreateButton
+        case shippingLabelCreationInfo(showsSeparator: Bool)
         case shippingLabelDetail
         case shippingLabelPrintingInfo
         case shippingLabelProduct
@@ -1255,6 +1297,8 @@ extension OrderDetailsDataSource {
                 return LeftImageTableViewCell.reuseIdentifier
             case .shippingLabelCreateButton:
                 return ButtonTableViewCell.reuseIdentifier
+            case .shippingLabelCreationInfo:
+                return ImageAndTitleAndTextTableViewCell.reuseIdentifier
             case .shippingLabelDetail:
                 return WooBasicTableViewCell.reuseIdentifier
             case .shippingLabelPrintingInfo:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -483,9 +483,8 @@ private extension OrderDetailsDataSource {
         cell.accessibilityTraits = .button
         cell.accessibilityLabel = Title.shippingLabelCreationInfoAction
         cell.accessibilityHint =
-            NSLocalizedString("Tap to show instructions on how to create a shipping label on the mobile device",
-                              comment:
-                                "VoiceOver accessibility hint for the row that shows instructions on how to print a shipping label on the mobile device")
+            NSLocalizedString("Tap to show information about creating a shipping label",
+                              comment: "VoiceOver accessibility hint for the row that shows information about creating a shipping label")
     }
 
     private func configureShippingLabelDetail(cell: WooBasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -22,6 +22,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     /// Contains configurable properties for the cell.
     struct DataConfiguration {
         let title: String?
+        let titleFontStyle: FontStyle
         let text: String?
         let textTintColor: UIColor?
         let image: UIImage?
@@ -32,6 +33,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         let showsSeparator: Bool
 
         init(title: String?,
+             titleFontStyle: FontStyle = .body,
              text: String? = nil,
              textTintColor: UIColor? = nil,
              image: UIImage? = nil,
@@ -41,6 +43,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
              isActionable: Bool = true,
              showsSeparator: Bool = true) {
             self.title = title
+            self.titleFontStyle = titleFontStyle
             self.text = text
             self.textTintColor = textTintColor
             self.image = image
@@ -54,6 +57,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
 
     struct ViewModel: Equatable {
         let title: String?
+        let titleFontStyle: FontStyle
         let text: String?
         let textTintColor: UIColor?
         let image: UIImage?
@@ -64,6 +68,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         let showsSeparator: Bool
 
         init(title: String?,
+             titleFontStyle: FontStyle = .body,
              text: String?,
              textTintColor: UIColor? = nil,
              image: UIImage? = nil,
@@ -73,6 +78,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
              isActionable: Bool = true,
              showsSeparator: Bool = true) {
             self.title = title
+            self.titleFontStyle = titleFontStyle
             self.text = text
             self.textTintColor = textTintColor
             self.image = image
@@ -132,7 +138,12 @@ extension ImageAndTitleAndTextTableViewCell {
     func updateUI(viewModel: ViewModel) {
         titleLabel.text = viewModel.title
         titleLabel.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
-        titleLabel.applyBodyStyle()
+        switch viewModel.titleFontStyle {
+        case .body:
+            titleLabel.applyBodyStyle()
+        case .footnote:
+            titleLabel.applyFootnoteStyle()
+        }
         titleLabel.textColor = viewModel.text?.isEmpty == false ? .text: .textSubtle
         titleLabel.numberOfLines = viewModel.numberOfLinesForTitle
         descriptionLabel.text = viewModel.text
@@ -185,7 +196,17 @@ extension ImageAndTitleAndTextTableViewCell {
     func update(with style: Style, data: DataConfiguration) {
         switch style {
         case .imageAndTitleOnly(let fontStyle):
-            applyImageAndTitleOnlyStyle(fontStyle: fontStyle, data: data)
+            let data = DataConfiguration(title: data.title,
+                                         titleFontStyle: fontStyle,
+                                         text: data.text,
+                                         textTintColor: data.textTintColor,
+                                         image: data.image,
+                                         imageTintColor: data.imageTintColor,
+                                         numberOfLinesForTitle: data.numberOfLinesForTitle,
+                                         numberOfLinesForText: data.numberOfLinesForText,
+                                         isActionable: data.isActionable,
+                                         showsSeparator: data.showsSeparator)
+            applyImageAndTitleOnlyStyle(data: data)
         case .warning:
             applyWarningStyle(data: data)
         }
@@ -209,13 +230,7 @@ private extension ImageAndTitleAndTextTableViewCell {
                 }
     }
 
-    func applyImageAndTitleOnlyStyle(fontStyle: FontStyle, data: DataConfiguration) {
-        switch fontStyle {
-        case .body:
-            titleLabel.applyBodyStyle()
-        case .footnote:
-            titleLabel.applyFootnoteStyle()
-        }
+    func applyImageAndTitleOnlyStyle(data: DataConfiguration) {
         applyDefaultStyle(data: data)
         contentImageViewWidthConstraint.isActive = true
     }
@@ -230,6 +245,7 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func applyDefaultStyle(data: DataConfiguration) {
         let viewModel = ViewModel(title: data.title,
+                                  titleFontStyle: data.titleFontStyle,
                                   text: data.text,
                                   textTintColor: data.textTintColor,
                                   image: data.image,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -62,7 +62,7 @@ private extension ButtonTableViewCell {
     }
 }
 
-private extension ButtonTableViewCell {
+extension ButtonTableViewCell {
     enum Constants {
         static let defaultBottomSpacing = CGFloat(20)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -95,8 +95,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNotNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
-        XCTAssertNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
+        XCTAssertNotNil(row(row: .markCompleteButton(style: .primary, showsBottomSpacing: true), in: productsSection))
     }
 
     func test_markOrderComplete_button_is_visible_and_secondary_style_if_order_is_processing_and_eligible_for_shipping_label_creation() throws {
@@ -110,8 +109,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNotNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
-        XCTAssertNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
+        XCTAssertNotNil(row(row: .markCompleteButton(style: .secondary, showsBottomSpacing: false), in: productsSection))
+        XCTAssertNotNil(row(row: .shippingLabelCreationInfo(showsSeparator: false), in: productsSection))
     }
 
     func test_markOrderComplete_button_is_hidden_if_order_is_not_processing() throws {
@@ -124,8 +123,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         // Then
         let productsSection = try section(withTitle: Title.products, from: dataSource)
-        XCTAssertNil(row(row: .markCompleteButton(style: .primary), in: productsSection))
-        XCTAssertNil(row(row: .markCompleteButton(style: .secondary), in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .primary, showsBottomSpacing: true), in: productsSection))
+        XCTAssertNil(row(row: .markCompleteButton(style: .secondary, showsBottomSpacing: false), in: productsSection))
     }
 }
 


### PR DESCRIPTION
Part of #2975 

## Why

For users who are new to shipping label creation in mobile, we want to show an info link for [more details](https://user-images.githubusercontent.com/22608780/95947034-63febc80-0e0b-11eb-9fbd-bca696ed0793.png). This PR implemented the first part of the task - adding an info link row to order details if the order is eligible for shipping label creation.

## Changes

### Pre-existing issues in `ImageAndTitleAndTextTableViewCell`

I noticed that footnote style wasn't configured correctly in `ImageAndTitleAndTextTableViewCell`, since the title label font is configured in multiple places. There's some tech debt in the cell to have different configuration styles https://github.com/woocommerce/woocommerce-ios/issues/3419, which I hope to address this sprint. For this PR, I fixed the title font style in https://github.com/woocommerce/woocommerce-ios/commit/0956a9ce7bd0113ee1b8141345cc75758eef7037.

### Showed shipping label creation info link row in `OrderDetailsDataSource`

- Added a new `Row.shippingLabelCreationInfo(showsSeparator: Bool)` enum case for the info link row
- Since there are two states where the info link is shown (whether "Mark Order Complete" CTA is visible), some associated values have to be used to configure cells up to design. This complicates the switch statement for cell configuration, lemme know if you know of a better way to unwrap the associated values!

## Testing

### Order that is processing

- Go to the orders tab
- In the Processing tab, tap on an order --> an info link row should be shown below the "Mark Order Complete" CTA

### Order that is not processing and not refunded

- Go to the orders tab
- In the All Orders tab, tap on an order that is not processing and not refunded --> an info link row should be shown below the "Create Shipping Label" CTA

## Example screenshots

Notes for design reviewers: I didn't see design where "Mark Order Complete" CTA isn't visible, so I placed the info link below the "Create Shipping Label" CTA for now. Please lemme know if you have different thoughts!

\ | eligible for shipping label creation - processing order | eligible for shipping label creation - non-processing non-refunded order | not eligible for shipping label creation - processing order | not eligible for shipping label creation - non-processing non-refunded order
-- | -- | -- | -- | --
dark | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 32 31](https://user-images.githubusercontent.com/1945542/109596004-5e063f80-7b50-11eb-8ae0-f4df1e4d3ae8.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 32 22](https://user-images.githubusercontent.com/1945542/109595985-5a72b880-7b50-11eb-8eb7-2d40a6cba5db.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 35 32](https://user-images.githubusercontent.com/1945542/109596011-61013000-7b50-11eb-864a-edd1a997ca73.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 35 29](https://user-images.githubusercontent.com/1945542/109596009-5f376c80-7b50-11eb-9209-261b276d45c3.png)
light | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 33 00](https://user-images.githubusercontent.com/1945542/109596135-9a39a000-7b50-11eb-8a3d-82397920c24d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 32 50](https://user-images.githubusercontent.com/1945542/109596127-96a61900-7b50-11eb-9a56-b89b52e580d7.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 35 43](https://user-images.githubusercontent.com/1945542/109596153-a160ae00-7b50-11eb-8aa2-2e1afa630c37.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-02 at 11 35 40](https://user-images.githubusercontent.com/1945542/109596138-9c036380-7b50-11eb-9801-575ac1b9e941.png)









Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
