### PR TITLE
Variations: Update attribute name remotely after rename

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -149,7 +149,7 @@ private extension AddAttributeOptionsViewController {
     }
 
     func renderViewModel() {
-        title = viewModel.attributeName
+        title = viewModel.currentAttributeName
         configureRightButtonItem()
         tableView.reloadData()
 
@@ -419,8 +419,13 @@ extension AddAttributeOptionsViewController {
     /// Navigates to `RenameAttributesViewController`
     ///
     private func navigateToRenameAttribute() {
-        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.attributeName)
-        let renameAttributeViewController = RenameAttributesViewController(viewModel: viewModel)
+        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.currentAttributeName)
+        let renameAttributeViewController = RenameAttributesViewController(viewModel: viewModel) { [weak self] updatedAttributeName in
+            // Sets new attribute name and refreshes the view to reflect the change
+            self?.viewModel.currentAttributeName = updatedAttributeName
+            self?.renderViewModel()
+            self?.navigationController?.popViewController(animated: true)
+        }
         show(renameAttributeViewController, sender: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -149,7 +149,7 @@ private extension AddAttributeOptionsViewController {
     }
 
     func renderViewModel() {
-        title = viewModel.currentAttributeName
+        title = viewModel.getCurrentAttributeName()
         configureRightButtonItem()
         tableView.reloadData()
 
@@ -421,11 +421,10 @@ extension AddAttributeOptionsViewController {
     /// Navigates to `RenameAttributesViewController`
     ///
     private func navigateToRenameAttribute() {
-        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.currentAttributeName)
+        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.getCurrentAttributeName())
         let renameAttributeViewController = RenameAttributesViewController(viewModel: viewModel) { [weak self] updatedAttributeName in
-            // Sets new attribute name and refreshes the view to reflect the change
+            // Sets new attribute name
             self?.viewModel.setCurrentAttributeName(updatedAttributeName)
-            self?.renderViewModel()
             self?.navigationController?.popViewController(animated: true)
         }
         show(renameAttributeViewController, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -149,7 +149,7 @@ private extension AddAttributeOptionsViewController {
     }
 
     func renderViewModel() {
-        title = viewModel.getCurrentAttributeName()
+        title = viewModel.getCurrentAttributeName
         configureRightButtonItem()
         tableView.reloadData()
 
@@ -426,7 +426,7 @@ extension AddAttributeOptionsViewController {
     /// Navigates to `RenameAttributesViewController`
     ///
     private func navigateToRenameAttribute() {
-        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.getCurrentAttributeName())
+        let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.getCurrentAttributeName)
         let renameAttributeViewController = RenameAttributesViewController(viewModel: viewModel) { [weak self] updatedAttributeName in
             // Sets new attribute name
             self?.viewModel.setCurrentAttributeName(updatedAttributeName)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -424,7 +424,7 @@ extension AddAttributeOptionsViewController {
         let viewModel = RenameAttributesViewModel(attributeName: self.viewModel.currentAttributeName)
         let renameAttributeViewController = RenameAttributesViewController(viewModel: viewModel) { [weak self] updatedAttributeName in
             // Sets new attribute name and refreshes the view to reflect the change
-            self?.viewModel.currentAttributeName = updatedAttributeName
+            self?.viewModel.setCurrentAttributeName(updatedAttributeName)
             self?.renderViewModel()
             self?.navigationController?.popViewController(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -397,10 +397,12 @@ extension AddAttributeOptionsViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
-        let renameAction = UIAlertAction(title: Localization.renameAction, style: .default) { [weak self] _ in
-            self?.navigateToRenameAttribute()
+        if viewModel.allowsRename {
+            let renameAction = UIAlertAction(title: Localization.renameAction, style: .default) { [weak self] _ in
+                self?.navigateToRenameAttribute()
+            }
+            actionSheet.addAction(renameAction)
         }
-        actionSheet.addAction(renameAction)
 
         let removeAction = UIAlertAction(title: Localization.removeAction, style: .destructive) { [weak self] _ in
             self?.presentRemoveAttributeConfirmation()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -53,20 +53,14 @@ final class AddAttributeOptionsViewModel {
 
     /// Name of the attribute
     ///
-    var attributeName: String {
-        switch attribute {
-        case .new(let name):
-            return name
-        case .existing(let attribute):
-            return attribute.name
-        }
-    }
+    var currentAttributeName: String
 
     /// Defines next button visibility
     ///
     var isNextButtonEnabled: Bool {
         let optionsToSubmit = state.selectedOptions.map { $0.name }
-        return state.selectedOptions.isNotEmpty && optionsToSubmit != attribute.previouslySelectedOptions
+        let attributeHasChanges = currentAttributeName != attribute.name || optionsToSubmit != attribute.previouslySelectedOptions
+        return attributeHasChanges && state.selectedOptions.isNotEmpty
     }
 
     /// Defines the more(...) button visibility
@@ -161,6 +155,7 @@ final class AddAttributeOptionsViewModel {
          analytics: Analytics = ServiceLocator.analytics) {
         self.product = product
         self.attribute = attribute
+        self.currentAttributeName = attribute.name
         self.allowsEditing = allowsEditing
         self.stores = stores
         self.viewStorage = viewStorage
@@ -269,13 +264,13 @@ extension AddAttributeOptionsViewModel {
         stores.dispatch(action)
     }
 
-    /// Returns a product with its attributes updated with the new attribute to create.
+    /// Returns a product with its name and options updated with the new attribute to create.
     ///
     private func createUpdatedProduct() -> Product {
         let newOptions = state.selectedOptions.map { $0.name }
         let newAttribute = ProductAttribute(siteID: product.siteID,
                                             attributeID: attribute.attributeID,
-                                            name: attribute.name,
+                                            name: currentAttributeName,
                                             position: 0,
                                             visible: true,
                                             variation: true,
@@ -285,7 +280,7 @@ extension AddAttributeOptionsViewModel {
         // Name has to be considered, because local attributes are zero-id based.
         let updatedAttributes: [ProductAttribute] = {
             var attributes = product.attributes
-            attributes.removeAll { $0.attributeID == newAttribute.attributeID && $0.name == newAttribute.name }
+            attributes.removeAll { $0.attributeID == attribute.attributeID && $0.name == attribute.name }
             attributes.append(newAttribute)
             return attributes
         }()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -87,6 +87,17 @@ final class AddAttributeOptionsViewModel {
         state.syncState == .failed
     }
 
+    /// Defines if the attribute can be renamed (existing local attributes only)
+    ///
+    var allowsRename: Bool {
+        switch attribute {
+        case .new:
+            return false
+        case let .existing(productAttribute):
+            return productAttribute.isLocal
+        }
+    }
+
     /// Closure to notify the `ViewController` when the view model properties change.
     ///
     var onChange: (() -> (Void))?

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -49,17 +49,17 @@ final class AddAttributeOptionsViewModel {
         /// Indicates if the view model is updating the product's attributes
         ///
         var isUpdating: Bool = false
-    }
 
-    /// Name of the attribute
-    ///
-    private(set) var currentAttributeName: String
+        /// Name of the attribute
+        ///
+        var currentAttributeName: String = ""
+    }
 
     /// Defines next button visibility
     ///
     var isNextButtonEnabled: Bool {
         let optionsToSubmit = state.selectedOptions.map { $0.name }
-        let attributeHasChanges = currentAttributeName != attribute.name || optionsToSubmit != attribute.previouslySelectedOptions
+        let attributeHasChanges = state.currentAttributeName != attribute.name || optionsToSubmit != attribute.previouslySelectedOptions
         return attributeHasChanges && state.selectedOptions.isNotEmpty
     }
 
@@ -166,7 +166,7 @@ final class AddAttributeOptionsViewModel {
          analytics: Analytics = ServiceLocator.analytics) {
         self.product = product
         self.attribute = attribute
-        self.currentAttributeName = attribute.name
+        self.state.currentAttributeName = attribute.name
         self.allowsEditing = allowsEditing
         self.stores = stores
         self.viewStorage = viewStorage
@@ -233,10 +233,16 @@ extension AddAttributeOptionsViewModel {
         addNewOption(name: option.name)
     }
 
-    /// Sets the current attribute name
+    /// Sets the current attribute name to a new name
     ///
     func setCurrentAttributeName(_ newName: String) {
-        currentAttributeName = newName
+        state.currentAttributeName = newName
+    }
+
+    /// Gets the current attribute name
+    ///
+    func getCurrentAttributeName() -> String {
+        return state.currentAttributeName
     }
 
     /// Gathers selected options and update the product's attributes
@@ -285,9 +291,10 @@ extension AddAttributeOptionsViewModel {
     ///
     private func createUpdatedProduct() -> Product {
         let newOptions = state.selectedOptions.map { $0.name }
+        let newName = state.currentAttributeName
         let newAttribute = ProductAttribute(siteID: product.siteID,
                                             attributeID: attribute.attributeID,
-                                            name: currentAttributeName,
+                                            name: newName,
                                             position: 0,
                                             visible: true,
                                             variation: true,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -241,8 +241,8 @@ extension AddAttributeOptionsViewModel {
 
     /// Gets the current attribute name
     ///
-    func getCurrentAttributeName() -> String {
-        return state.currentAttributeName
+    var getCurrentAttributeName: String {
+        state.currentAttributeName
     }
 
     /// Gathers selected options and update the product's attributes

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -294,7 +294,8 @@ extension AddAttributeOptionsViewModel {
                                             options: newOptions)
 
         // Here we remove any possible existing attribute with the same ID and Name. For then re-adding the new updated attribute
-        // Name has to be considered, because local attributes are zero-id based.
+        // Name has to be considered, because local attributes are zero-id based. We use `attribute` instead of `newAttribute` because
+        // the new Name may not match the old one that needs to be removed, if the attribute was renamed.
         let updatedAttributes: [ProductAttribute] = {
             var attributes = product.attributes
             attributes.removeAll { $0.attributeID == attribute.attributeID && $0.name == attribute.name }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -53,7 +53,7 @@ final class AddAttributeOptionsViewModel {
 
     /// Name of the attribute
     ///
-    var currentAttributeName: String
+    private(set) var currentAttributeName: String
 
     /// Defines next button visibility
     ///
@@ -231,6 +231,12 @@ extension AddAttributeOptionsViewModel {
         }
 
         addNewOption(name: option.name)
+    }
+
+    /// Sets the current attribute name
+    ///
+    func setCurrentAttributeName(_ newName: String) {
+        currentAttributeName = newName
     }
 
     /// Gathers selected options and update the product's attributes

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
@@ -85,10 +85,7 @@ private extension RenameAttributesViewController {
 
 extension RenameAttributesViewController {
     @objc private func doneButtonTapped() {
-        guard let newAttributeName = viewModel.newAttributeName else {
-            return onCompletion(viewModel.attributeName)
-        }
-        onCompletion(newAttributeName)
+        onCompletion(viewModel.attributeName)
     }
 
     override func shouldPopOnBackButton() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
@@ -5,14 +5,18 @@ final class RenameAttributesViewController: UIViewController {
 
     @IBOutlet weak private var tableView: UITableView!
 
+    private let onCompletion: (String) -> Void
+
     private let viewModel: RenameAttributesViewModel
 
     private let sections: [Section]
 
     /// Initializer for `RenameAttributesViewController`
     ///
-    init(viewModel: RenameAttributesViewModel) {
+    init(viewModel: RenameAttributesViewModel,
+         onCompletion: @escaping (String) -> Void) {
         self.viewModel = viewModel
+        self.onCompletion = onCompletion
         self.sections = [Section(footer: Localization.footerText, rows: [.attributeName])]
         super.init(nibName: nil, bundle: nil)
     }
@@ -81,9 +85,10 @@ private extension RenameAttributesViewController {
 
 extension RenameAttributesViewController {
     @objc private func doneButtonTapped() {
-        // TODO: Update the attribute name if it has changed
-        // For now, just navigate back
-        navigationController?.popViewController(animated: true)
+        guard let newAttributeName = viewModel.newAttributeName else {
+            return onCompletion(viewModel.attributeName)
+        }
+        onCompletion(newAttributeName)
     }
 
     override func shouldPopOnBackButton() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewModel.swift
@@ -3,16 +3,16 @@ import Yosemite
 
 final class RenameAttributesViewModel {
 
-    /// Current name of the product attribute
+    /// Original name of the product attribute
     ///
-    let attributeName: String
+    private let originalAttributeName: String
 
     /// New name of the product attribute
     ///
-    private(set) var newAttributeName: String?
+    private var newAttributeName: String?
 
     init(attributeName: String) {
-        self.attributeName = attributeName
+        self.originalAttributeName = attributeName
     }
 
 }
@@ -26,6 +26,12 @@ extension RenameAttributesViewModel {
         newAttributeName != ""
     }
 
+    /// Name of the attribute
+    ///
+    var attributeName: String {
+        newAttributeName ?? originalAttributeName
+    }
+
     /// Sets the new attribute name
     ///
     /// - Parameter name: New attribute name
@@ -34,6 +40,6 @@ extension RenameAttributesViewModel {
     }
 
     func hasUnsavedChanges() -> Bool {
-        return newAttributeName != attributeName && newAttributeName != nil
+        return attributeName != originalAttributeName && newAttributeName != nil
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Product Variation/RenameAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Product Variation/RenameAttributesViewModelTests.swift
@@ -40,4 +40,17 @@ class RenameAttributesViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func test_attribute_name_updates_from_original_to_new_attribute_name() {
+        // Given
+        let attribute = ProductVariationAttribute(id: 0, name: "Color", option: "Blue")
+        let viewModel = RenameAttributesViewModel(attributeName: attribute.name)
+        XCTAssertEqual(viewModel.attributeName, "Color")
+
+        // When
+        viewModel.handleAttributeNameChange("New Color")
+
+        // Then
+        XCTAssertEqual(viewModel.attributeName, "New Color")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -378,6 +378,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         let initialProduct = sampleProduct().copy(attributes: [initialAttribute])
         let viewModel = AddAttributeOptionsViewModel(product: initialProduct, attribute: .existing(attribute: initialAttribute), stores: stores)
 
+        viewModel.setCurrentAttributeName("New Attribute Name")
         viewModel.addNewOption(name: "Option 1")
         viewModel.addNewOption(name: "Option 2")
 
@@ -394,7 +395,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         // Then
-        let expectedAttribute = sampleAttribute(options: ["Option 1", "Option 2"])
+        let expectedAttribute = sampleAttribute(name: "New Attribute Name", options: ["Option 1", "Option 2"])
         XCTAssertEqual(updatedProduct.attributes, [expectedAttribute])
     }
 
@@ -537,6 +538,39 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         let selectedSection = try XCTUnwrap(viewModel.sections.last)
         XCTAssertFalse(selectedSection.allowsReorder)
         XCTAssertTrue(attribute.isGlobal)
+    }
+
+    func test_local_attribute_should_allow_rename() {
+        // Given, When
+        let attribute = sampleAttribute(attributeID: 0, name: "Color", options: ["Green", "Blue", "Red"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+        // Then
+        XCTAssertTrue(attribute.isLocal)
+        XCTAssertTrue(viewModel.allowsRename)
+    }
+
+    func test_global_attribute_should_not_allow_rename() {
+        // Given, When
+        let attribute = sampleAttribute(name: "Color", options: ["Green", "Blue", "Red"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+
+        // Then
+        XCTAssertTrue(attribute.isGlobal)
+        XCTAssertFalse(viewModel.allowsRename)
+    }
+
+    func test_next_button_is_enabled_after_renaming_attribute() {
+        // Given
+        let attribute = sampleAttribute(name: "Color", options: ["Green", "Blue", "Red"])
+        let viewModel = AddAttributeOptionsViewModel(product: sampleProduct(), attribute: .existing(attribute: attribute))
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+
+        // When
+        viewModel.setCurrentAttributeName("New Color")
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonEnabled)
     }
 }
 


### PR DESCRIPTION
Related: #3212 

## Description

This is a followup to https://github.com/woocommerce/woocommerce-ios/pull/3768, to perform the remote update after a variation attribute is renamed. After renaming an attribute and tapping the "Done" button, the previous (attribute options) screen reflects the new name in the navigation bar. Tapping "Next" performs the remote update for the attribute (the new attribute name and any changes to the attribute options).

This PR also limits renaming attributes to only local attributes, to reflect the behavior in WP Admin. (Global attributes can't be renamed while editing an individual product.)

## Changes

* Adds a closure to `RenameAttributesViewController`, invoked when the Done button is tapped.
* Adds `allowsRename` to `AddAttributeOptionsViewModel` to check if the attribute is an existing local attribute. This is used to control whether the Rename menu item appears in the more (...) menu.
* Changes `attributeName` to `currentAttributeName` in `AddAttributeOptionsViewModel`. Now, `currentAttributeName` is set to the attribute `name` by default, and set to the new attribute name after the rename. That is used to set the navigation bar title, check whether the Next button should be enabled, and update the attribute name when the Next button is tapped.
* Adds unit tests.

<img src="https://user-images.githubusercontent.com/8658164/109844286-e1ed2400-7c43-11eb-9ba0-843e9ba86f68.gif" width="300px">


## Testing

1. Make sure you have a variable product with both local and global attributes.
2. Go to the Products tab.
3. Select a variable product.
4. Select Variations to open the variations list.
5. Tap the ... menu and select Edit Attributes.
6. Select a global attribute to open the Attribute Options screen.
7. Tap the ... menu and confirm there is no Rename option.
8. Go back to the Edit Attributes screen.
9. Select a local attribute to open the Attribute Options screen.
10. Tap the ... menu and select Rename.
11. On the Rename Attribute screen, enter a new name for the attribute and tap Done.
12. Confirm you are returned to the Attribute Options screen, with the new name in the navigation bar and the Next button enabled.
13. Tap the Next button and confirm the new attribute name is saved remotely.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
