### PR TITLE
Variations: Track when the rename attribute button is tapped

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -418,7 +418,7 @@ extension AddAttributeOptionsViewController {
     }
 
     func trackRenameAttributeButtonTapped() {
-        analytics.track(event: WooAnalyticsEvent.Variations.renameAttributeButtonTapped(productID: self.viewModel.product.productID))
+        analytics.track(event: WooAnalyticsEvent.Variations.renameAttributeButtonTapped(productID: viewModel.product.productID))
     }
 
     /// Navigates to `RenameAttributesViewController`

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -398,6 +398,7 @@ extension AddAttributeOptionsViewController {
         actionSheet.view.tintColor = .text
 
         let renameAction = UIAlertAction(title: Localization.renameAction, style: .default) { [weak self] _ in
+            self?.trackRenameAttributeButtonTapped()
             self?.navigateToRenameAttribute()
         }
         actionSheet.addAction(renameAction)
@@ -414,6 +415,10 @@ extension AddAttributeOptionsViewController {
         popoverController?.barButtonItem = sender
 
         present(actionSheet, animated: true)
+    }
+
+    func trackRenameAttributeButtonTapped() {
+        analytics.track(event: WooAnalyticsEvent.Variations.renameAttributeButtonTapped(productID: self.viewModel.product.productID))
     }
 
     /// Navigates to `RenameAttributesViewController`


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/3703
Related: https://github.com/woocommerce/woocommerce-ios/issues/3212

## Description

Adds tracking for when the button is tapped to rename an attribute, as defined in #3703. The event ID and event method for this event were already added in https://github.com/woocommerce/woocommerce-ios/pull/3747.

## Changes

Adds the previously defined event method for the tracks event `rename_product_attribute_button_tapped` to the `AddAttributeOptionsViewController`.

Example:
```
🔵 Tracked rename_product_attribute_button_tapped, properties: [AnyHashable("product_id"): "2532", AnyHashable("blog_id"): 137210602, AnyHashable("is_wpcom_store"): true]
```

## Testing

1. Go to the Products tab.
2. Select a variable product.
3. Select Variations to open the variations list.
4. Tap the ... menu and select Edit Attributes.
5. Select an attribute to open the Attribute Options screen.
6. Tap the ... menu and select Rename.
7. Confirm the `rename_product_attribute_button_tapped` event is tracked in the console.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
