### PR TITLE
Variations: Accessibility details

### DIFF
--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -261,6 +261,16 @@ extension UIColor {
     static var ratingStarEmpty: UIColor {
         return .systemColor(.systemGray4)
     }
+
+    /// Color for loading indicators within navigation bars
+    ///
+    static var navigationBarLoadingIndicator: UIColor {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            return .accent
+        } else {
+            return .white
+        }
+    }
 }
 
 // MARK: - UI elements.

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -159,7 +159,7 @@ private extension ProductsTabProductTableViewCell {
     }
 
     func configureDetailsLabel() {
-        detailsLabel.numberOfLines = 1
+        detailsLabel.numberOfLines = 0
     }
 
     func configureProductImageView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -95,11 +95,7 @@ private extension AddAttributeOptionsViewController {
 
     func createUpdateIndicatorButton() -> UIBarButtonItem {
         let indicator = UIActivityIndicatorView(style: .medium)
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            indicator.color = .accent
-        } else {
-            indicator.color = .primaryButtonTitle
-        }
+        indicator.color = .navigationBarLoadingIndicator
         indicator.startAnimating()
         return UIBarButtonItem(customView: indicator)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -95,7 +95,11 @@ private extension AddAttributeOptionsViewController {
 
     func createUpdateIndicatorButton() -> UIBarButtonItem {
         let indicator = UIActivityIndicatorView(style: .medium)
-        indicator.color = .primaryButtonTitle
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
+            indicator.color = .accent
+        } else {
+            indicator.color = .primaryButtonTitle
+        }
         indicator.startAnimating()
         return UIBarButtonItem(customView: indicator)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,17 +21,17 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="HX8-cS-brJ">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="HX8-cS-brJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="EJy-Kn-N0n"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="HX8-cS-brJ" secondAttribute="bottom" id="FGA-hr-JzF"/>
-                <constraint firstItem="HX8-cS-brJ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="H8F-hl-J8P"/>
-                <constraint firstItem="HX8-cS-brJ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="pjN-8m-lLX"/>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="EJy-Kn-N0n"/>
+                <constraint firstAttribute="bottom" secondItem="HX8-cS-brJ" secondAttribute="bottom" id="FGA-hr-JzF"/>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="H8F-hl-J8P"/>
+                <constraint firstItem="HX8-cS-brJ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="pjN-8m-lLX"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="69.642857142857139"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,17 +21,17 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="aaD-Eh-yvS">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="aaD-Eh-yvS" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="R6u-xM-VZ6"/>
-                <constraint firstItem="aaD-Eh-yvS" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Ymh-lV-iDF"/>
-                <constraint firstItem="aaD-Eh-yvS" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="dAM-MK-P8z"/>
-                <constraint firstItem="aaD-Eh-yvS" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="p58-I3-2uN"/>
+                <constraint firstItem="aaD-Eh-yvS" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="R6u-xM-VZ6"/>
+                <constraint firstItem="aaD-Eh-yvS" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Ymh-lV-iDF"/>
+                <constraint firstItem="aaD-Eh-yvS" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="dAM-MK-P8z"/>
+                <constraint firstItem="aaD-Eh-yvS" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="p58-I3-2uN"/>
             </constraints>
             <point key="canvasLocation" x="138" y="129"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -277,7 +277,7 @@ private extension ProductVariationsViewController {
     func configureHeaderContainerView() {
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
         headerContainer.addSubview(topStackView)
-        headerContainer.pinSubviewToSafeArea(topStackView)
+        headerContainer.pinSubviewToAllEdges(topStackView)
         topStackView.addArrangedSubview(topBannerView)
 
         tableView.tableHeaderView = headerContainer

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,19 +21,24 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-yK-YZD">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fCF-yK-YZD" secondAttribute="trailing" id="9Tw-76-jV7"/>
-                <constraint firstItem="fCF-yK-YZD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="LpE-Hf-Tza"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="fCF-yK-YZD" secondAttribute="bottom" id="bPq-aC-chC"/>
-                <constraint firstItem="fCF-yK-YZD" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="gfX-HE-oqD"/>
+                <constraint firstAttribute="trailing" secondItem="fCF-yK-YZD" secondAttribute="trailing" id="9Tw-76-jV7"/>
+                <constraint firstItem="fCF-yK-YZD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="LpE-Hf-Tza"/>
+                <constraint firstAttribute="bottom" secondItem="fCF-yK-YZD" secondAttribute="bottom" id="bPq-aC-chC"/>
+                <constraint firstItem="fCF-yK-YZD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gfX-HE-oqD"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="132" y="122"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
closes #3704

# Why

Since the variations project is almost finished, it's time to review a few accessibility details before releasing it to the public.

# How

This PR makes the following changes

- Update variations list screen to properly support big fonts - the details text in each cell didn't spawn over two lines - 
- Update variations list screen to cover all edges in landscape - the table view was pinned to the safe area-
- Update add attribute screen to cover all edges in landscape - the table view was pinned to the safe area-
- Update add attribute options screen to cover all edges in landscape - the table view was pinned to the safe area-
- Updates loading indicator view color when updating attributes - Now that we have large titles(behind a feature flag), the navigation bar color changed - 

# Screenshots

Variations big font before | Variations big font after
--- | ---
<img width="405" alt="variations-list-before" src="https://user-images.githubusercontent.com/562080/109876440-ced85500-7c3f-11eb-8390-c82d637f7fb7.png"> | <img width="405" alt="variations-list-after" src="https://user-images.githubusercontent.com/562080/109876447-d0a21880-7c3f-11eb-96b4-ae885dfcc9f0.png">


Variations landscape before | Variations landscape after
--- | ---
<img width="848" alt="variation-list-landscape-before" src="https://user-images.githubusercontent.com/562080/109876445-d0a21880-7c3f-11eb-999e-b025c3fb9482.png"> | <img width="860" alt="variation-list-landscape-after" src="https://user-images.githubusercontent.com/562080/109876443-d0098200-7c3f-11eb-9b72-b074fccf27b9.png">


Add Attribute landscape before | Add Attribute landscape after
--- | ---
<img width="856" alt="add-attribute-before" src="https://user-images.githubusercontent.com/562080/109876452-d13aaf00-7c3f-11eb-9e78-18eec1d3ea3d.png"> | <img width="854" alt="add-attribute-after" src="https://user-images.githubusercontent.com/562080/109876451-d13aaf00-7c3f-11eb-90e8-1a7944e5420a.png">


Add Options landscape before | Add Options landscape after
--- | ---
<img width="857" alt="add-option-before" src="https://user-images.githubusercontent.com/562080/109876454-d1d34580-7c3f-11eb-9ea3-5d051283c4a6.png"> | <img width="849" alt="add-options-after" src="https://user-images.githubusercontent.com/562080/109876455-d1d34580-7c3f-11eb-9416-442c67350d5c.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
