### PR TITLE
[Mobile Payments] Connect card reader discovery completion to UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -3,6 +3,20 @@ import Yosemite
 
 final class CardReaderSettingsConnectedReaderView: NSObject {
 
+    private enum DefaultStrings: String {
+        case noSerialNumber
+
+        var userFacingString: String {
+            switch self {
+            case .noSerialNumber:
+                return NSLocalizedString(
+                    "Unknown",
+                    comment: "Settings > Manage Card Reader > Connected Reader > Displayed for card readers without a serial number"
+                )
+            }
+        }
+    }
+
     /// A simple model for this "ViewModel" - just a reference to the CardReaderSettingsViewModel connected reader
     var connectedReader: CardReader?
 
@@ -47,11 +61,11 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
 
         let batteryLabelFormat = NSLocalizedString(
             "%1$@%% Battery",
-            comment: "Settings > Manage Card Reader > Connected Reader >> Battery level as a percentage"
+            comment: "Settings > Manage Card Reader > Connected Reader > Battery level as a percentage"
         )
 
         cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
-        cell.serialNumberLabel?.text = connectedReader?.serial ?? "Unknown"
+        cell.serialNumberLabel?.text = connectedReader?.serial ?? DefaultStrings.noSerialNumber.userFacingString
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -2,24 +2,7 @@ import UIKit
 import Yosemite
 
 final class CardReaderSettingsConnectedReaderView: NSObject {
-
-    private enum DefaultStrings: String {
-        case noSerialNumber
-
-        var userFacingString: String {
-            switch self {
-            case .noSerialNumber:
-                return NSLocalizedString(
-                    "Unknown",
-                    comment: "Settings > Manage Card Reader > Connected Reader > Displayed for card readers without a serial number"
-                )
-            }
-        }
-    }
-
-    /// A simple model for this "ViewModel" - just a reference to the CardReaderSettingsViewModel connected reader
-    var connectedReader: CardReader?
-
+    var viewModel = CardReaderViewModel()
     var onPressedDisconnect: (() -> ())?
 
     private var rows = [Row]()
@@ -39,10 +22,6 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
         ]
     }
 
-    public func update(reader: CardReader) {
-        connectedReader = reader
-    }
-
     private func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
         case let cell as ConnectedReaderTableViewCell where row == .connectedReader:
@@ -55,17 +34,8 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
-        let batteryLevel = connectedReader?.batteryLevel ?? 1.0
-        let batteryLevelPercent = Int(100 * batteryLevel)
-        let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
-
-        let batteryLabelFormat = NSLocalizedString(
-            "%1$@%% Battery",
-            comment: "Settings > Manage Card Reader > Connected Reader > Battery level as a percentage"
-        )
-
-        cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
-        cell.serialNumberLabel?.text = connectedReader?.serial ?? DefaultStrings.noSerialNumber.userFacingString
+        cell.serialNumberLabel?.text = viewModel.displayName
+        cell.batteryLevelLabel?.text = viewModel.batteryStatus
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectedReaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 final class CardReaderSettingsConnectedReaderView: NSObject {
 
@@ -50,7 +51,7 @@ final class CardReaderSettingsConnectedReaderView: NSObject {
         )
 
         cell.batteryLevelLabel?.text = String.localizedStringWithFormat(batteryLabelFormat, batteryLevelString)
-        cell.serialNumberLabel?.text = connectedReader?.serialNumber ?? "Unknown"
+        cell.serialNumberLabel?.text = connectedReader?.serial ?? "Unknown"
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Combine
+import Yosemite
 
 final class CardReaderSettingsViewController: UIViewController {
 
@@ -129,7 +130,7 @@ final class CardReaderSettingsViewController: UIViewController {
 
     private func addFoundReaderModal() {
         // TODO Use FancyAlert instead
-        let foundReaderName = self.viewmodel.foundReader?.serialNumber ?? ""
+        let foundReaderName = self.viewmodel.foundReader?.serial ?? ""
         alert = UIAlertController(
             title: "Found reader",
             message: "Do you want to connect to " + foundReaderName + "?",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -7,7 +7,7 @@ final class CardReaderSettingsViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
 
     private var subscriptions = Set<AnyCancellable>()
-    private var viewmodel = CardReaderSettingsViewModel()
+    private var viewModel = CardReaderSettingsViewModel()
     private var alert: UIAlertController?
 
     private lazy var connectView = CardReaderSettingsConnectView()
@@ -19,30 +19,30 @@ final class CardReaderSettingsViewController: UIViewController {
         setTableSource()
         setTableFooter()
 
-        self.viewmodel = CardReaderSettingsViewModel()
-        viewmodel.$activeView
+        self.viewModel = CardReaderSettingsViewModel()
+        viewModel.$activeView
             .receive(on: DispatchQueue.main)
             .sink { [weak self] activeView in
                 self?.setTableSource()
             }
             .store(in: &subscriptions)
-        viewmodel.$activeAlert
+        viewModel.$activeAlert
             .receive(on: DispatchQueue.main)
             .sink { [weak self] activeAlert in
                 self?.setAlert()
             }
             .store(in: &subscriptions)
-        viewmodel.$connectedReader
+        viewModel.$connectedReaderViewModel
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] connectedReader in
-                self?.connectedView.connectedReader = connectedReader
+            .sink { [weak self] connectedReaderViewModel in
+                self?.connectedView.viewModel = connectedReaderViewModel
                 self?.tableView.reloadData()
             }
             .store(in: &subscriptions)
     }
 
     private func setTableSource() {
-        switch viewmodel.activeView {
+        switch viewModel.activeView {
         case .connectYourReader:
             addCleanSlateView()
         case .connectedToReader:
@@ -59,7 +59,7 @@ final class CardReaderSettingsViewController: UIViewController {
 
     private func setAlert() {
         alert?.dismiss(animated: true, completion: nil)
-        switch self.viewmodel.activeAlert {
+        switch viewModel.activeAlert {
         case .none:
             noop()
         case .searching:
@@ -81,7 +81,7 @@ final class CardReaderSettingsViewController: UIViewController {
 
     private func addCleanSlateView() {
         connectView.onPressedConnect = {
-            self.viewmodel.startSearch()
+            self.viewModel.startSearch()
         }
 
         for rowType in connectView.rowTypes() {
@@ -95,14 +95,14 @@ final class CardReaderSettingsViewController: UIViewController {
 
     private func addConnectedView() {
         connectedView.onPressedDisconnect = {
-            self.viewmodel.disconnectAndForget()
+            self.viewModel.disconnectAndForget()
         }
 
         for rowType in connectedView.rowTypes() {
             tableView.registerNib(for: rowType)
         }
 
-        connectedView.connectedReader = viewmodel.connectedReader
+        connectedView.viewModel = viewModel.connectedReaderViewModel
         tableView.dataSource = connectedView
         tableView.delegate = connectedView
         tableView.reloadData()
@@ -113,14 +113,14 @@ final class CardReaderSettingsViewController: UIViewController {
     }
 
     private func addSearchingModal() {
-        // TODO Use FancyAlert instead
+        // TODO Use FancyAlert instead - all these strings will be moved there
         alert = UIAlertController(
             title: "Scanning for readers",
             message: "Press the power button of your reader until you see a flashing blue light",
             preferredStyle: UIAlertController.Style.alert
         )
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { UIAlertAction in
-            self.viewmodel.stopSearch()
+            self.viewModel.stopSearch()
         }
         alert?.addAction(cancelAction)
         if alert != nil {
@@ -129,19 +129,19 @@ final class CardReaderSettingsViewController: UIViewController {
     }
 
     private func addFoundReaderModal() {
-        // TODO Use FancyAlert instead
-        let foundReaderName = self.viewmodel.foundReader?.serial ?? ""
+        // TODO Use FancyAlert instead - all these strings will be moved there
+        let foundReaderName = viewModel.foundReadersViewModels[0].displayName
         alert = UIAlertController(
             title: "Found reader",
             message: "Do you want to connect to " + foundReaderName + "?",
             preferredStyle: UIAlertController.Style.alert
         )
         let okAction = UIAlertAction(title: "Connect to Reader", style: .default) { UIAlertAction in
-            self.viewmodel.connect()
+            self.viewModel.connect()
         }
         alert?.addAction(okAction)
         let cancelAction = UIAlertAction(title: "Keep Searching", style: .cancel) { UIAlertAction in
-            self.viewmodel.startSearch()
+            self.viewModel.startSearch()
         }
         alert?.addAction(cancelAction)
         if alert != nil {
@@ -157,7 +157,7 @@ final class CardReaderSettingsViewController: UIViewController {
             preferredStyle: UIAlertController.Style.alert
         )
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { UIAlertAction in
-            self.viewmodel.stopConnect()
+            self.viewModel.stopConnect()
         }
         alert?.addAction(cancelAction)
         if alert != nil {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -94,6 +94,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         foundReadersViewModels = foundReaders.map { CardReaderViewModel($0) }
     }
 
+    /// Views can call this method to start searching for readers.
     func startSearch() {
         activeAlert = .searching
 
@@ -106,6 +107,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         ServiceLocator.stores.dispatch(action)
     }
 
+    /// Called when a reader has been discovered (with an array of discovered readers).
     private func didDiscoverReaders(cardReaders: [CardReader]) -> Void {
         // TODO - more than one reader? sort in the manner in which we'd like the rows presented
         guard activeAlert != .foundReader else {
@@ -125,21 +127,23 @@ final class CardReaderSettingsViewModel: ObservableObject {
         activeAlert = .foundReader
     }
 
+    /// Views can call this method to stop searching for readers.
     func stopSearch() {
         // TODO dispatch an action to stop searching.
         activeAlert = .none
     }
 
+    /// Views can call this method to connect to a found reader.
     func connect() {
-        // TODO dispatch an action to connect.
         activeAlert = .connecting
 
         let action = CardPresentPaymentAction.connect(reader: foundReaders[0], onCompletion: { [weak self] result in
             switch result {
             case .success(let cardReaders):
                 self?.didConnectToReader(cardReaders: cardReaders)
-            case .failure(_):
-                // TODO failure message
+            case .failure(let error):
+                DDLogWarn(error.localizedDescription)
+                // TODO failure message to the user?
                 self?.activeAlert = .none
             }
         })
@@ -147,11 +151,13 @@ final class CardReaderSettingsViewModel: ObservableObject {
         ServiceLocator.stores.dispatch(action)
     }
 
+    /// Views can call this method to abort connecting to a reader.
     func stopConnect() {
         // TODO dispatch an action to interrupt connecting.
         activeAlert = .none
     }
 
+    /// Views can call this method to disconnect from the connected reader.
     func disconnectAndForget() {
         // TODO dispatch an action to disconnect.
         connectedReader = nil
@@ -159,6 +165,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         activeAlert = .none
     }
 
+    /// Called when a reader has been connected to.
     private func didConnectToReader(cardReaders: [CardReader]) -> Void {
         activeAlert = .none
         guard cardReaders.count > 0 else {
@@ -170,6 +177,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         self.connectedReader = cardReaders[0]
     }
 
+    /// Views can call this method to initiate a software update on the connected reader.
     func updateSoftware() {
         // TODO dispatch an action to update software on the connected reader
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -2,11 +2,6 @@ import Foundation
 import Combine
 import Yosemite
 
-struct CardReader {
-    var serialNumber: String
-    var batteryLevel: Float
-}
-
 enum CardReaderSettingsViewActiveView {
     case connectYourReader
     case connectedToReader
@@ -33,9 +28,6 @@ final class CardReaderSettingsViewModel: ObservableObject {
     var knownReaders: [CardReader]
     var foundReader: CardReader?
 
-    var timer: Timer? // TODO Remove
-    var batteryTimer: Timer? // TODO Remove
-
     init() {
         // TODO fetch initial state from Yosemite.CardReader.
         // The initial activeView and alert will be based on the knownReaders, connectedReaders and serviceState
@@ -44,14 +36,6 @@ final class CardReaderSettingsViewModel: ObservableObject {
         knownReaders = []
         foundReader = nil
         connectedReader = nil
-        timer = nil // TODO Remove
-
-        // TODO Remove - simulates a declining battery level with a timer
-        batteryTimer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyUpdateBattery), userInfo: nil, repeats: true)
-    }
-
-    deinit {
-        batteryTimer?.invalidate()
     }
 
     func startSearch() {
@@ -59,48 +43,36 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in
-            // TODO. To be implemented
-            // Leaving these prints here to help test the PR
-            print("==== new card readers discovered begins ====")
-            print("new readers: ", cardReaders)
-            print("==== new card readers discovered ends   ====")
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { [weak self] cardReaders in
+            self?.discoveredReader(cardReaders: cardReaders)
         })
 
         ServiceLocator.stores.dispatch(action)
-
-        // TODO Remove - simulates searching with a timer
-        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyFoundReader), userInfo: nil, repeats: false)
     }
 
-    // TODO Remove
-    @objc private func dummyFoundReader() {
-        foundReader = CardReader(serialNumber: "CHB204909001234", batteryLevel: 0.885)
-        activeAlert = .foundReader
-    }
-
-    // TODO Remove
-    @objc private func dummyUpdateBattery() {
-        guard var batteryLevel = connectedReader?.batteryLevel else {
+    private func discoveredReader(cardReaders: [CardReader]) -> Void {
+        if activeAlert == .foundReader {
             return
         }
 
-        batteryLevel = batteryLevel * 0.99
-        connectedReader?.batteryLevel = batteryLevel
+        if cardReaders.isEmpty {
+            return
+        }
+
+        // TODO - show the multiple-readers-found UITableView when more than one reader is found
+        // For now, just show the tail of the array
+        foundReader = cardReaders.last
+        activeAlert = .foundReader
     }
 
     func stopSearch() {
         // TODO dispatch an action to stop searching.
-        timer?.invalidate() // TODO Remove
         activeAlert = .none
     }
 
     func connect() {
         // TODO dispatch an action to connect.
         activeAlert = .connecting
-
-        // TODO Remove - simulates connecting with a timer
-        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyConnectedReader), userInfo: nil, repeats: false)
     }
 
     func stopConnect() {
@@ -112,14 +84,6 @@ final class CardReaderSettingsViewModel: ObservableObject {
         // TODO dispatch an action to disconnect.
         connectedReader = nil
         activeView = .connectYourReader
-        activeAlert = .none
-    }
-
-    // TODO Remove
-    @objc private func dummyConnectedReader() {
-        connectedReader = foundReader
-        foundReader = nil
-        activeView = .connectedToReader
         activeAlert = .none
     }
 


### PR DESCRIPTION
Ready for review.

Note: This does not change the UI. This only replaces the timer based simulations with actual service data.

To test:

- Settings
- Manage card readers
- Connect card reader
- Scanning for readers
- Found reader: Connect to reader
- Observe Connected Reader
- Disconnect


<img src="https://user-images.githubusercontent.com/1595739/110170674-6f995280-7daf-11eb-9548-1a585b43a56a.gif" width=40% />


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
