### PR TITLE
Variations: Refresh product list after variations update

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import WooCommerce
 import Yosemite
+import TestKit
 
 final class ProductFormViewModelTests: XCTestCase {
     // MARK: `canViewProductInStore`
@@ -154,7 +155,7 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(canDeleteProduct)
     }
 
-    func est_update_variations_updates_original_product_while_maintaining_pending_changes() throws {
+    func test_update_variations_updates_original_product_while_maintaining_pending_changes() throws {
         // Given
         let product = Product()
         let viewModel = createViewModel(product: product, formType: .edit)
@@ -170,14 +171,37 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productModel.product.variations, newProduct.variations)
         XCTAssertEqual(viewModel.productModel.product.attributes, newProduct.attributes)
     }
+
+    func test_update_variations_fires_replace_product_action() throws {
+        // Given
+        let product = Product()
+        let mockStores = MockStoresManager(sessionManager: SessionManager.testingInstance)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: mockStores)
+
+        // When
+        let attributes = ProductAttribute(siteID: 0, attributeID: 0, name: "Color", position: 0, visible: true, variation: true, options: ["Green, Blue"])
+        let newProduct = product.copy(attributes: [attributes], variations: [1])
+        viewModel.updateProductVariations(from: newProduct)
+
+        // Then
+        let action = try XCTUnwrap(mockStores.receivedActions.first as? ProductAction)
+        switch action {
+        case .replaceProductLocally:
+            break // Expected
+        default:
+            XCTFail("Unexpected action. Got \(action). Expected \(ProductAction.replaceProductLocally(product: newProduct, onCompletion: {}))")
+        }
+
+    }
 }
 
 private extension ProductFormViewModelTests {
-    func createViewModel(product: Product, formType: ProductFormType) -> ProductFormViewModel {
+    func createViewModel(product: Product, formType: ProductFormType, stores: StoresManager = ServiceLocator.stores) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
                                     formType: formType,
-                                    productImageActionHandler: productImageActionHandler)
+                                    productImageActionHandler: productImageActionHandler,
+                                    stores: stores)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -181,17 +181,21 @@ final class ProductFormViewModelTests: XCTestCase {
         // When
         let attributes = ProductAttribute(siteID: 0, attributeID: 0, name: "Color", position: 0, visible: true, variation: true, options: ["Green, Blue"])
         let newProduct = product.copy(attributes: [attributes], variations: [1])
-        viewModel.updateProductVariations(from: newProduct)
 
-        // Then
-        let action = try XCTUnwrap(mockStores.receivedActions.first as? ProductAction)
-        switch action {
-        case .replaceProductLocally:
-            break // Expected
-        default:
-            XCTFail("Unexpected action. Got \(action). Expected \(ProductAction.replaceProductLocally(product: newProduct, onCompletion: {}))")
+        let receivedReplaceProductAction: Bool = waitFor { promise in
+            mockStores.whenReceivingAction(ofType: ProductAction.self) { action in
+                switch action {
+                case .replaceProductLocally:
+                    promise(true)
+                default:
+                    promise(false)
+                }
+            }
+            viewModel.updateProductVariations(from: newProduct)
         }
 
+        // Then
+        XCTAssertTrue(receivedReplaceProductAction)
     }
 }
 

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -63,4 +63,8 @@ public enum ProductAction: Action {
     /// Checks whether a Product SKU is valid against other Products in the store.
     ///
     case validateProductSKU(_ sku: String?, siteID: Int64, onCompletion: (Bool) -> Void)
+
+    /// Upserts a product in our local storage
+    ///
+    case replaceProductLocally(product: Product, onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -79,6 +79,8 @@ public class ProductStore: Store {
             updateProduct(product: product, onCompletion: onCompletion)
         case .validateProductSKU(let sku, let siteID, let onCompletion):
             validateProductSKU(sku, siteID: siteID, onCompletion: onCompletion)
+        case let .replaceProductLocally(product, onCompletion):
+            replaceProductLocally(product: product, onCompletion: onCompletion)
         }
     }
 }
@@ -313,6 +315,12 @@ private extension ProductStore {
             let isValid = (result != nil && result == sku) ? false : true
             onCompletion(isValid)
         }
+    }
+
+    /// Upserts a product in our local storage
+    ///
+    func replaceProductLocally(product: Product, onCompletion: @escaping () -> Void) {
+        upsertStoredProductsInBackground(readOnlyProducts: [product], onCompletion: onCompletion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TestKit
 @testable import Yosemite
 @testable import Networking
 @testable import Storage
@@ -1416,6 +1417,29 @@ final class ProductStoreTests: XCTestCase {
         // Assert
         XCTAssertEqual(retrievedProducts, [])
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+    }
+
+    func test_replace_product_does_replaces_product_locally() throws {
+        // Given
+        let product = sampleProduct()
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+
+        let remote = MockProductsRemote()
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let newProduct = product.copy(variations: [1, 2, 3])
+        let finished: Bool = waitFor { promise in
+            let action = ProductAction.replaceProductLocally(product: newProduct, onCompletion: {
+                promise(true)
+            })
+            productStore.onAction(action)
+        }
+
+        // Then
+        let replacedProduct = storageManager.viewStorage.loadProduct(siteID: sampleSiteID, productID: sampleProductID)?.toReadOnly()
+        XCTAssertEqual(newProduct, replacedProduct)
+        XCTAssertTrue(finished)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1419,7 +1419,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
     }
 
-    func test_replace_product_does_replaces_product_locally() throws {
+    func test_calling_replaceProductLocally_replaces_product_locally() throws {
         // Given
         let product = sampleProduct()
         storageManager.insertSampleProduct(readOnlyProduct: product)


### PR DESCRIPTION
closes #3619 

# Why

@ealeksandrov noticed that after creating or deleting a variation, the main product list screen was not being updated.

https://user-images.githubusercontent.com/562080/109993681-8d48b800-7cda-11eb-9e4a-0a0e21b1bcbf.mp4

# How

To fix that, I'm creating a new `Yosemite` action to update the underlying product in our storage layer, after the variation update happened.

This works as the main product list screen listen to changes from its products `Results Controller`

# Demo

https://user-images.githubusercontent.com/562080/109993986-db5dbb80-7cda-11eb-819d-a5233706db26.mov

# Testing Steps

- Go to a variable product
- Add or remove a variation
- Go back until the product list screen
- See that the product cell reflects the variation count or state correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
