### PR TITLE
[Mobile Payments] Cancel discovery mark II: Yosemite (and a bit of Hardware)

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -75,13 +75,13 @@ extension StripeCardReaderService: CardReaderService {
          *
          *Note that if discoverReaders is canceled, the completion block will be called with nil (rather than an SCPErrorCanceled error).
          */
-        discoveryCancellable = Terminal.shared.discoverReaders(config, delegate: self, completion: { error in
+        discoveryCancellable = Terminal.shared.discoverReaders(config, delegate: self, completion: { [weak self] error in
             guard let error = error else {
-                self.switchStatusToIdle()
-                return
+                return self?.switchStatusToIdle()
+
             }
 
-            self.internalError(error)
+            self?.internalError(error)
         })
     }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -77,8 +77,8 @@ extension StripeCardReaderService: CardReaderService {
          */
         discoveryCancellable = Terminal.shared.discoverReaders(config, delegate: self, completion: { [weak self] error in
             guard let error = error else {
-                return self?.switchStatusToIdle()
-
+                self?.switchStatusToIdle()
+                return
             }
 
             self?.internalError(error)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -57,6 +57,9 @@ final class CardReaderSettingsViewModel: ObservableObject {
     func startSearch() {
         activeAlert = .searching
 
+
+        /// This sequence is here just to test that discovery can be cancelled
+        /// Dispatching these two actions will be remoed soon
         let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
 
         let discoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -65,7 +65,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         let discoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in
             // TODO. To be implemented
             // Leaving these prints here to help test the PR
-            print("==== View model new card readers discovered begins ====")
+            print("==== View model new card readers discovered callback ====")
             print("View Model  - new readers: ", cardReaders)
             //print("==== new card readers discovered ends   ====")
         })
@@ -75,7 +75,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
         let discoveryCancellationAction = CardPresentPaymentAction.cancelCardReaderDiscovery { status in
             // TODO. To be implemented
             // Leaving these prints here to help test the PR
-            print("===== View model - cancellation begins ====")
+            print("===== View model - cancellation callback ====")
             print("View model. new status received ", status)
             //print("===== View model - cancellation ends ====")
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -70,6 +70,8 @@ final class CardReaderSettingsViewModel: ObservableObject {
         ServiceLocator.stores.dispatch(discoveryAction)
 
         let discoveryCancellationAction = CardPresentPaymentAction.cancelCardReaderDiscovery { status in
+            // TODO. To be implemented
+            // Leaving these prints here to help test the PR
             print("===== cancellation begins ====")
             print("new status ", status)
             print("===== cancellation ends ====")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -59,7 +59,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in
+        let discoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in
             // TODO. To be implemented
             // Leaving these prints here to help test the PR
             print("==== new card readers discovered begins ====")
@@ -67,7 +67,15 @@ final class CardReaderSettingsViewModel: ObservableObject {
             print("==== new card readers discovered ends   ====")
         })
 
-        ServiceLocator.stores.dispatch(action)
+        ServiceLocator.stores.dispatch(discoveryAction)
+
+        let discoveryCancellationAction = CardPresentPaymentAction.cancelCardReaderDiscovery { status in
+            print("===== cancellation begins ====")
+            print("new status ", status)
+            print("===== cancellation ends ====")
+        }
+
+        ServiceLocator.stores.dispatch(discoveryCancellationAction)
 
         // TODO Remove - simulates searching with a timer
         timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyFoundReader), userInfo: nil, repeats: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -65,9 +65,9 @@ final class CardReaderSettingsViewModel: ObservableObject {
         let discoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: siteID, onCompletion: { cardReaders in
             // TODO. To be implemented
             // Leaving these prints here to help test the PR
-            print("==== new card readers discovered begins ====")
-            print("new readers: ", cardReaders)
-            print("==== new card readers discovered ends   ====")
+            print("==== View model new card readers discovered begins ====")
+            print("View Model  - new readers: ", cardReaders)
+            //print("==== new card readers discovered ends   ====")
         })
 
         ServiceLocator.stores.dispatch(discoveryAction)
@@ -75,15 +75,15 @@ final class CardReaderSettingsViewModel: ObservableObject {
         let discoveryCancellationAction = CardPresentPaymentAction.cancelCardReaderDiscovery { status in
             // TODO. To be implemented
             // Leaving these prints here to help test the PR
-            print("===== cancellation begins ====")
-            print("new status ", status)
-            print("===== cancellation ends ====")
+            print("===== View model - cancellation begins ====")
+            print("View model. new status received ", status)
+            //print("===== View model - cancellation ends ====")
         }
 
         ServiceLocator.stores.dispatch(discoveryCancellationAction)
 
         // TODO Remove - simulates searching with a timer
-        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyFoundReader), userInfo: nil, repeats: false)
+        //timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(dummyFoundReader), userInfo: nil, repeats: false)
     }
 
     // TODO Remove

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -5,6 +5,10 @@ public enum CardPresentPaymentAction: Action {
     ///
     case startCardReaderDiscovery(siteID: Int64, onCompletion: ([CardReader]) -> Void)
 
+    /// Cancels the Card Reader discovery process.
+    ///
+    case cancelCardReaderDiscovery(onCompletion: (CardReaderServiceDiscoveryStatus) -> Void)
+
     /// Connect to a specific CardReader.
     /// Stops Card Reader discovery
     ///

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -95,6 +95,7 @@ public typealias TopEarnerStatsItem = Networking.TopEarnerStatsItem
 public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias StoredProductSettings = Networking.StoredProductSettings
 public typealias CardReader = Hardware.CardReader
+public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 
 
 // MARK: - Exported Storage Symbols

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -57,13 +57,16 @@ private extension CardPresentPaymentStore {
         // new data via the CardReaderService's stream of discovered readers
         // In here, we should redirect that data to Storage and also up to the UI.
         // For now we are sending the data up to the UI directly
+        print("**** Store. starting discovery*")
         cardReaderService.discoveredReaders.sink { readers in
             completion(readers)
         }.store(in: &cancellables)
     }
 
     func cancelCardReaderDiscovery(completion: @escaping (CardReaderServiceDiscoveryStatus) -> Void) {
+        print("**** Store. cancelling discovery*")
         cardReaderService.discoveryStatus.sink { status in
+            print("///// status received ", status)
             completion(status)
         }.store(in: &cancellables)
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -63,10 +63,11 @@ private extension CardPresentPaymentStore {
     }
 
     func cancelCardReaderDiscovery(completion: @escaping (CardReaderServiceDiscoveryStatus) -> Void) {
-        cardReaderService.cancelDiscovery()
         cardReaderService.discoveryStatus.sink { status in
             completion(status)
         }.store(in: &cancellables)
+
+        cardReaderService.cancelDiscovery()
     }
 
     func connect(reader: Yosemite.CardReader, onCompletion: @escaping (Result<[Yosemite.CardReader], Error>) -> Void) {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -38,6 +38,8 @@ public final class CardPresentPaymentStore: Store {
         switch action {
         case .startCardReaderDiscovery(let siteID, let completion):
             startCardReaderDiscovery(siteID: siteID, completion: completion)
+        case .cancelCardReaderDiscovery(let completion):
+            cancelCardReaderDiscovery(completion: completion)
         case .connect(let reader, let completion):
             connect(reader: reader, onCompletion: completion)
         }
@@ -57,6 +59,13 @@ private extension CardPresentPaymentStore {
         // For now we are sending the data up to the UI directly
         cardReaderService.discoveredReaders.sink { readers in
             completion(readers)
+        }.store(in: &cancellables)
+    }
+
+    func cancelCardReaderDiscovery(completion: @escaping (CardReaderServiceDiscoveryStatus) -> Void) {
+        cardReaderService.cancelDiscovery()
+        cardReaderService.discoveryStatus.sink { status in
+            completion(status)
         }.store(in: &cancellables)
     }
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -28,8 +28,13 @@ final class MockCardReaderService: CardReaderService {
         PassthroughSubject<CardReaderEvent, Never>().eraseToAnyPublisher()
     }
 
+    /// Boolean flag Indicates that clients have called the start method
     var didHitStart = false
+
+    /// Boolean flag Indicates that clients have called the cancel method
     var didHitCancel = false
+
+    /// Boolean flag Indicates that clients have provided a CardReaderConfigProvider
     var didReceiveAConfigurationProvider = false
 
     private let connectedReadersSubject = CurrentValueSubject<[CardReader], Never>([])
@@ -52,6 +57,7 @@ final class MockCardReaderService: CardReaderService {
     func cancelDiscovery() {
         didHitCancel = true
 
+        /// Delaying the effect of this method so that unit tests are actually async
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
             self?.discoveryStatusSubject.send(.idle)
         }
@@ -59,6 +65,7 @@ final class MockCardReaderService: CardReaderService {
 
     func connect(_ reader: Hardware.CardReader) -> Future<Void, Error> {
         Future() { promise in
+            /// Delaying the effect of this method so that unit tests are actually async
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
                 let connectedReader = MockCardReader.bbposChipper2XBT()
                 promise(Result.success(()))
@@ -70,6 +77,7 @@ final class MockCardReaderService: CardReaderService {
     func disconnect(_ reader: Hardware.CardReader) -> Future<Void, Error> {
         Future() { promise in
             // This will be removed. We just want to pretend we are doing a roundtrip to the SDK for now.
+            /// Delaying the effect of this method so that unit tests are actually async
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 promise(Result.success(()))
             }

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -167,7 +167,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    func test_cancel_discovery_after_start_changes_discovery_status_to_idle_eventually() {
+    func test_cancel_discovery_after_start_rdpchanges_discovery_status_to_idle_eventually() {
         let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
                                                        storageManager: storageManager,
                                                        network: network,

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -146,6 +146,53 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         XCTAssertTrue(mockCardReaderService.didHitCancel)
     }
 
+    /// We are still not handling errors, so we will need a new test here
+    /// for the case when cancelation fails, which apparently is a thing
+    func test_cancel_discovery_action_publishes_idle_as_new_discovery_status() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let expectation = self.expectation(description: "Cancelling discovery published idle as discoveryStatus")
+
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery { newStatus in
+            if newStatus == .idle {
+                expectation.fulfill()
+            }
+        }
+
+        cardPresentStore.onAction(action)
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_cancel_discovery_after_start_changes_discovery_status_to_idle_eventually() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let expectation = self.expectation(description: "Cancelling discovery changes discoveryStatus to idle")
+
+        let startDiscoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { _ in
+
+        }
+
+        cardPresentStore.onAction(startDiscoveryAction)
+
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery { newStatus in
+            print("=== hitting cancellation completion")
+            if newStatus == .idle {
+                expectation.fulfill()
+            }
+        }
+
+        cardPresentStore.onAction(action)
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     func test_connect_to_reader_action_updates_returns_provided_reader_on_success() {
         let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
                                                        storageManager: storageManager,

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -131,6 +131,21 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_cancel_discovery_action_hits_cancel_in_service() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery { newStatus in
+            //
+        }
+
+        cardPresentStore.onAction(action)
+
+        XCTAssertTrue(mockCardReaderService.didHitCancel)
+    }
+
     func test_connect_to_reader_action_updates_returns_provided_reader_on_success() {
         let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
                                                        storageManager: storageManager,


### PR DESCRIPTION
Closes #3742 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

We continue building our prototype (for reference, p91TBi-4q4-p2), this time, by implementing logic in Yosemite to cancel reader discovery. This is not strictly necessary to move on to the next step (processing a payment) but it's nice to provide now for UI integration.

## Caveats
* We are not doing any error handling yet (there #3734  and #3741 for that), and everything happens in the happy place
* It could be argued that there is a bit of redundancy in the API of the service, in the way the discovery status is exposed. We are still exploring where this is going, so I would suggest not considering that as final at this point.
* This is still a bit difficult to test.

## Changes
* Added logic to StripeCardReaderService to manage the state of the discovery status. This is the most basic, barebones implementation of the state handling. I am not 100% sure that we end up exposing the discovery status, so I am not sure there is a point in complicating this more now.
* Added an action to CardPresentPaymentAction
* Added logic to back that action in CardPresentPaymentStore
* A minimal update to the UI to provide a manual test.

## How to test
### The easy way:
* checkout the branch, run `bundle exec pod install`.
* look at the code, make sure the tests in CardPresentPaymentStore pass (in fact, a run of the full test suit might be a better approach)

### The manual way (requires configuring your test site)
Eventually (soon), this would be the only way to test any new PRs related to card present payments.
* Make sure your site is setup for testing payments. There is some information [in the documentation about running integration tests](https://github.com/woocommerce/woocommerce-ios/blob/feature/stripe-terminal-sdk-integration/docs/stripe-tests.md#integration-tests) and a more specific guide in P91TBi-4BH-p2)
* Navigate to settings > Manage Card Readers > tap "Connect Card Reader"
* Look at the console. You should see a trace like this in the console:

```
==== new card readers discovered begins ====
new readers:  []
==== new card readers discovered ends   ====
===== cancellation begins ====
new status  discovering
===== cancellation ends ====
===== cancellation begins ====
new status  idle
===== cancellation ends ====
===== cancellation begins ====
new status  idle
===== cancellation ends ====
```

What is happening? First, when reader discovery begins, we receive an empty collection of readers (there have been zero readers discovered). Right after that, the service changes status to "discovering", until the cancellation command is completed (the Stripe SDK cancels discovery asynchronously). That's when the service changes status to idle. This change happens twice, as expected [according to the documentation](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)discoverReaders:delegate:completion:), as there are two callbacks being called (the one when cancellation is completed and the one corresponding to the discovery delegate)

I understand these testing instructions are not great, but it will be much easier to test anything related to payments very soon.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
