### PR TITLE
Broken Tests: Update WooCommerce UI Tests to account for settings store name changes

### DIFF
--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -9,8 +9,8 @@ final class SettingsScreen: BaseScreen {
         static let logOutButton = "settings-log-out-button"
     }
 
-    private let selectedSiteUrl = XCUIApplication().cells.staticTexts[ElementStringIDs.headlineLabel]
-    private let selectedDisplayName = XCUIApplication().cells.staticTexts[ElementStringIDs.bodyLabel]
+    private let selectedStoreName = XCUIApplication().cells.staticTexts[ElementStringIDs.headlineLabel]
+    private let selectedSiteUrl = XCUIApplication().cells.staticTexts[ElementStringIDs.bodyLabel]
     private let logOutButton = XCUIApplication().cells[ElementStringIDs.logOutButton]
     private let logOutAlert = XCUIApplication().alerts.element(boundBy: 0)
 
@@ -46,16 +46,15 @@ final class SettingsScreen: BaseScreen {
 /// Assertions
 extension SettingsScreen {
 
-    func verifySelectedStoreDisplays(siteUrl expectedSiteUrl: String, displayName expectedDisplayName: String) -> SettingsScreen {
+    func verifySelectedStoreDisplays(storeName expectedStoreName: String, siteUrl expectedSiteUrl: String) -> SettingsScreen {
+        let actualStoreName = selectedStoreName.label
         let expectedSiteUrl = expectedSiteUrl.replacingOccurrences(of: "http://", with: "")
         let actualSiteUrl = selectedSiteUrl.label
-        let actualDisplayName = selectedDisplayName.label
 
+        XCTAssertEqual(expectedStoreName, actualStoreName,
+                       "Expected display name '\(expectedStoreName)' but '\(actualStoreName)' was displayed instead.")
         XCTAssertEqual(expectedSiteUrl, actualSiteUrl,
                        "Expected site URL \(expectedSiteUrl) but \(actualSiteUrl) was displayed instead.")
-        XCTAssertEqual(expectedDisplayName, actualDisplayName,
-                       "Expected display name '\(expectedDisplayName)' but '\(actualDisplayName)' was displayed instead.")
-
         return self
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -22,7 +22,7 @@ final class LoginTests: XCTestCase {
 
             // Log out
             .openSettingsPane()
-            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+            .verifySelectedStoreDisplays(storeName: TestCredentials.storeName, siteUrl: TestCredentials.siteUrl)
             .logOut()
 
 
@@ -39,7 +39,7 @@ final class LoginTests: XCTestCase {
 
             // Log out
             .openSettingsPane()
-            .verifySelectedStoreDisplays(siteUrl: TestCredentials.siteUrl, displayName: TestCredentials.displayName)
+            .verifySelectedStoreDisplays(storeName: TestCredentials.storeName, siteUrl: TestCredentials.siteUrl)
             .logOut()
 
         XCTAssert(prologue.isLoaded())

--- a/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
@@ -4,4 +4,5 @@ struct TestCredentials {
     static let password: String = "mocked_password"
     static let displayName: String = "WooCommerce Store Owner"
     static let siteUrl: String = "http://yourwoosite.com"
+    static let storeName: String = "Your WooCommerce Store"
 }


### PR DESCRIPTION
Noted the following test failures sometime after my merge of #3774 

```
Test Suite WooCommerceUITests.xctest started
LoginTests
    ✗ test_site_address_login_logout, XCTAssertEqual failed: ("yourwoosite.com") is not equal to ("Your WooCommerce Store") - Expected site URL yourwoosite.com but Your WooCommerce Store was displayed instead.
    ✗ test_WordPress_login_logout, XCTAssertEqual failed: ("yourwoosite.com") is not equal to ("Your WooCommerce Store") - Expected site URL yourwoosite.com but Your WooCommerce Store was displayed instead.
```

I think this PR should fix the failing tests, but I cannot get the tests to run locally. They fail when the automation gets to point where it is supposed to enter an email address

WooCommerceUITests > LoginTests > test_site_address_login_logout
WooCommerceUITests > LoginTests > test_WordPress_login_logout

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
