### PR TITLE
Large titles design enhancements

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -121,10 +121,10 @@ extension UIImage {
         return UIImage.gridicon(.cross)
     }
 
-    /// Cog Icon
+    /// Gear Icon - used in `UIBarButtonItem`
     ///
-    static var cogImage: UIImage {
-        return UIImage.gridicon(.cog)
+    static var gearBarButtonItemImage: UIImage {
+        return UIImage(systemName: "gear", withConfiguration: Configurations.barButtonItemSymbol)!
     }
 
     /// Comment Icon
@@ -439,10 +439,16 @@ extension UIImage {
         return UIImage.gridicon(.plus)
     }
 
-    /// Search Icon
+    /// Plus Icon - used in `UIBarButtonItem`
     ///
-    static var searchImage: UIImage {
-        return UIImage.gridicon(.search)
+    static var plusBarButtonItemImage: UIImage {
+        return UIImage(systemName: "plus", withConfiguration: Configurations.barButtonItemSymbol)!
+    }
+
+    /// Search Icon - used in `UIBarButtonItem`
+    ///
+    static var searchBarButtonItemImage: UIImage {
+        return UIImage(systemName: "magnifyingglass", withConfiguration: Configurations.barButtonItemSymbol)!
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
@@ -605,5 +611,9 @@ private extension UIImage {
 
     enum Metrics {
         static let defaultWooLogoSize = CGSize(width: 30, height: 18)
+    }
+
+    enum Configurations {
+        static let barButtonItemSymbol = UIImage.SymbolConfiguration(pointSize: 22, weight: .regular, scale: .medium)
     }
 }

--- a/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
@@ -12,7 +12,8 @@ extension UINavigationBar {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = .appBar
+            appearance.backgroundColor = .listForeground
+            appearance.shadowColor = .clear // Hides the navigation bar bottom border
             appearance.titleTextAttributes = [.foregroundColor: UIColor.text]
             appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.text]
 

--- a/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
@@ -13,7 +13,6 @@ extension UINavigationBar {
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = .listForeground
-            appearance.shadowColor = .clear // Hides the navigation bar bottom border
             appearance.titleTextAttributes = [.foregroundColor: UIColor.text]
             appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.text]
 

--- a/WooCommerce/Classes/System/WooTabNavigationController.swift
+++ b/WooCommerce/Classes/System/WooTabNavigationController.swift
@@ -19,6 +19,20 @@ final class WooTabNavigationController: UINavigationController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) ? .default : StyleManager.statusBarLight
     }
+
+    private func updateNavigationBarAppearance(largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode) {
+        let appearance = UINavigationBar.appearance().standardAppearance.copy()
+        switch largeTitleDisplayMode {
+        case .always:
+            appearance.shadowColor = .clear // Hides the navigation bar bottom border
+        default:
+            break
+        }
+
+        navigationBar.standardAppearance = appearance
+        navigationBar.compactAppearance = appearance
+        navigationBar.scrollEdgeAppearance = appearance
+    }
 }
 
 extension WooTabNavigationController: UINavigationControllerDelegate {
@@ -29,6 +43,7 @@ extension WooTabNavigationController: UINavigationControllerDelegate {
         } else {
             viewController.navigationItem.largeTitleDisplayMode = viewController.preferredLargeTitleDisplayMode()
         }
+        updateNavigationBarAppearance(largeTitleDisplayMode: viewController.navigationItem.largeTitleDisplayMode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -82,7 +82,7 @@ private extension DashboardViewController {
     }
 
     private func configureNavigationItem() {
-        let rightBarButton = UIBarButtonItem(image: .cogImage,
+        let rightBarButton = UIBarButtonItem(image: .gearBarButtonItemImage,
                                              style: .plain,
                                              target: self,
                                              action: #selector(settingsTapped))

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -89,7 +89,7 @@ private extension OrdersRootViewController {
     /// For `viewDidLoad` only, set up `navigationItem` buttons.
     ///
     func configureNavigationButtons() {
-        navigationItem.leftBarButtonItem = ordersViewController.createSearchBarButtonItem()
+        navigationItem.rightBarButtonItem = ordersViewController.createSearchBarButtonItem()
 
         removeNavigationBackBarButtonText()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -161,7 +161,7 @@ extension OrdersTabbedViewController {
     /// Create a `UIBarButtonItem` to be used as the search button on the top-left.
     ///
     func createSearchBarButtonItem() -> UIBarButtonItem {
-        let button = UIBarButtonItem(image: .searchImage,
+        let button = UIBarButtonItem(image: .searchBarButtonItemImage,
                                      style: .plain,
                                      target: self,
                                      action: #selector(displaySearchOrders))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -229,22 +229,6 @@ private extension ProductsViewController {
             comment: "Title that appears on top of the Product List screen (plural form of the word Product)."
         )
 
-        navigationItem.leftBarButtonItem = {
-            let button = UIBarButtonItem(image: .searchBarButtonItemImage,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(displaySearchProducts))
-            button.accessibilityTraits = .button
-            button.accessibilityLabel = NSLocalizedString("Search products", comment: "Search Products")
-            button.accessibilityHint = NSLocalizedString(
-                "Retrieves a list of products that contain a given keyword.",
-                comment: "VoiceOver accessibility hint, informing the user the button can be used to search products."
-            )
-            button.accessibilityIdentifier = "product-search-button"
-
-            return button
-        }()
-
         configureNavigationBarRightButtonItems()
     }
 
@@ -278,6 +262,23 @@ private extension ProductsViewController {
             }()
             rightBarButtonItems.append(buttonItem)
         }
+
+        let searchItem: UIBarButtonItem = {
+            let button = UIBarButtonItem(image: .searchBarButtonItemImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(displaySearchProducts))
+            button.accessibilityTraits = .button
+            button.accessibilityLabel = NSLocalizedString("Search products", comment: "Search Products")
+            button.accessibilityHint = NSLocalizedString(
+                "Retrieves a list of products that contain a given keyword.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to search products."
+            )
+            button.accessibilityIdentifier = "product-search-button"
+
+            return button
+        }()
+        rightBarButtonItems.append(searchItem)
 
         navigationItem.rightBarButtonItems = rightBarButtonItems
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -230,7 +230,7 @@ private extension ProductsViewController {
         )
 
         navigationItem.leftBarButtonItem = {
-            let button = UIBarButtonItem(image: .searchImage,
+            let button = UIBarButtonItem(image: .searchBarButtonItemImage,
                                          style: .plain,
                                          target: self,
                                          action: #selector(displaySearchProducts))
@@ -251,7 +251,7 @@ private extension ProductsViewController {
     func configureNavigationBarRightButtonItems() {
         var rightBarButtonItems = [UIBarButtonItem]()
         let buttonItem: UIBarButtonItem = {
-            let button = UIBarButtonItem(image: .plusImage,
+            let button = UIBarButtonItem(image: .plusBarButtonItemImage,
                                          style: .plain,
                                          target: self,
                                          action: #selector(addProduct(_:)))

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -67,8 +67,8 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.closeButton)
     }
 
-    func testCogImageIconIsNotNil() {
-        XCTAssertNotNil(UIImage.cogImage)
+    func testGearBarButtonItemImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.gearBarButtonItemImage)
     }
 
     func testCommentImageIconIsNotNil() {
@@ -222,6 +222,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.plusImage)
     }
 
+    func testPlusBarButtonItemImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.plusBarButtonItemImage)
+    }
+
     func testPriceImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.priceImage)
     }
@@ -268,8 +272,8 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.scanImage)
     }
 
-    func testSearchImageIconIsNotNil() {
-        XCTAssertNotNil(UIImage.searchImage)
+    func testSearchBarButtonItemImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.searchBarButtonItemImage)
     }
 
     func testShippingImageIconIsNotNil() {


### PR DESCRIPTION
Part of #3751 

## Why

After enabling large titles for the main tabs, there are a couple of design enhancements we can make:

<img src="https://user-images.githubusercontent.com/28450084/109961834-c0934300-7cea-11eb-9c0e-bed6dfbbf5fa.png" width="300" />

## Changes

- Navigation bar appearance: updated background color to be the same as the list view, and hid the bottom border only when large title is always shown https://github.com/woocommerce/woocommerce-ios/commit/bb51a8800f81a35273d8d299534eb979d029c963 https://github.com/woocommerce/woocommerce-ios/commit/85fd3bc946eec110704a823a09488059dccf3eea
- Update `UIImage` icons in navigation bar to use [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/) (thankfully we're iOS 13+!) https://github.com/woocommerce/woocommerce-ios/commit/ab55332bfbb70de66c8f6d2f741cff5f6650c048
- Orders and Products tab: moved the search CTA from left to right https://github.com/woocommerce/woocommerce-ios/commit/83e1cc1c0f5eb8928dd55d0a1fab85ec2bf05ae0

## Testing

- Launch the app and log in if needed --> the main tabs should look up to design, while the rest of the screens look like before except for the navigation bar background color change

## Example screenshots

@woocommerce/mobile-designers you can also try the installable build #19090!

\ | light - before | light - after | dark - before | dark - after
-- | -- | -- | -- | --
Dashboard | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 14](https://user-images.githubusercontent.com/1945542/110100873-e2212700-7ddd-11eb-9063-2755aee2b0d6.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 12](https://user-images.githubusercontent.com/1945542/110100888-e5b4ae00-7ddd-11eb-9887-c44166a1209f.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 37](https://user-images.githubusercontent.com/1945542/110100941-f2d19d00-7ddd-11eb-82c9-7398b69a860c.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 32](https://user-images.githubusercontent.com/1945542/110100949-f6652400-7ddd-11eb-9e01-91bdd62a6004.png)
Orders | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 17](https://user-images.githubusercontent.com/1945542/110101051-15fc4c80-7dde-11eb-8031-148b582e0554.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 15](https://user-images.githubusercontent.com/1945542/110101055-198fd380-7dde-11eb-80ea-ec0ceb0b2e91.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 39](https://user-images.githubusercontent.com/1945542/110101076-1eed1e00-7dde-11eb-961e-4b36c7bfcf0d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 35](https://user-images.githubusercontent.com/1945542/110101096-2280a500-7dde-11eb-9795-ccd2fa6aff7d.png)
Products | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 22](https://user-images.githubusercontent.com/1945542/110101143-2d3b3a00-7dde-11eb-96cf-54477d343d02.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 20](https://user-images.githubusercontent.com/1945542/110101157-31ffee00-7dde-11eb-9286-c7a4a04ceb8d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 41](https://user-images.githubusercontent.com/1945542/110101168-362c0b80-7dde-11eb-879a-999cf3cb4a26.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 37](https://user-images.githubusercontent.com/1945542/110101172-37f5cf00-7dde-11eb-8367-f066ac8c9fb9.png)
Reviews | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 26](https://user-images.githubusercontent.com/1945542/110101426-7a1f1080-7dde-11eb-9fee-0ccd34ded472.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 23](https://user-images.githubusercontent.com/1945542/110101439-7f7c5b00-7dde-11eb-92b9-2fcb97b38493.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 05 43](https://user-images.githubusercontent.com/1945542/110101466-860ad280-7dde-11eb-94ac-36a65f29f0d4.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 18 07 40](https://user-images.githubusercontent.com/1945542/110101473-873bff80-7dde-11eb-9525-d48b95ed8ff5.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
