### PR TITLE
Filter attributes for variations

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -109,6 +109,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         return ProductTaxStatus(rawValue: taxStatusKey)
     }
 
+    public var attributesForVariations: [ProductAttribute] {
+        attributes.filter { $0.variation }
+    }
+
     /// Whether the product has an integer (or nil) stock quantity.
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -109,6 +109,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         return ProductTaxStatus(rawValue: taxStatusKey)
     }
 
+    /// Filtered product attributes available for variations
+    /// (attributes with `variation == true`)
+    ///
     public var attributesForVariations: [ProductAttribute] {
         attributes.filter { $0.variation }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -378,7 +378,7 @@ private extension DefaultProductFormTableViewModel {
 
         switch product.variations.count {
         case 1...:
-            details = product.attributes
+            details = product.attributesForVariations
                 .map({ String.localizedStringWithFormat(format, $0.name, $0.options.count) })
                 .joined(separator: "\n")
         default:

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -87,7 +87,7 @@ private extension AddAttributeViewModel {
     func updateSections(attributes: [ProductAttribute]) {
 
         /// Sum fetched attributes + attributes inside the product (global + local), and remove duplicated product attributes, then sort it
-        localAndGlobalAttributes = attributes + product.attributes.filter { element in
+        localAndGlobalAttributes = attributes + product.attributesForVariations.filter { element in
             return !attributes.contains { $0.attributeID == element.attributeID }
         }.sorted(by: > )
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewModel.swift
@@ -56,7 +56,7 @@ extension EditAttributesViewModel {
     /// Returns the underlying `ProductAttribute` that fuels an `attributes` type  at the given index.
     ///
     func productAttributeAtIndex(_ index: Int) -> ProductAttribute {
-        return product.attributes[index]
+        return product.attributesForVariations[index]
     }
 }
 
@@ -65,7 +65,7 @@ private extension EditAttributesViewModel {
 
     /// Creates an array of `ImageAndTitleAndTextTableViewCell.ViewModel` based on the `product.attributes`
     func createAttributeViewModels() -> [ImageAndTitleAndTextTableViewCell.ViewModel] {
-        product.attributes.map { attribute in
+        product.attributesForVariations.map { attribute in
             ImageAndTitleAndTextTableViewCell.ViewModel(title: attribute.name,
                                                         text: attribute.options.joined(separator: ", "),
                                                         numberOfLinesForTitle: 0,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationUseCase.swift
@@ -58,7 +58,7 @@ final class GenerateVariationUseCase {
     /// Returns a `CreateProductVariation` type with no price and no options selected for any of it's attributes.
     ///
     private func createVariationParameter() -> CreateProductVariation {
-        let attributes = product.attributes.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: "") }
+        let attributes = product.attributesForVariations.map { ProductVariationAttribute(id: $0.attributeID, name: $0.name, option: "") }
         return CreateProductVariation(regularPrice: "", attributes: attributes)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -107,7 +107,7 @@ final class ProductVariationsViewController: UIViewController {
     }
 
     private var allAttributes: [ProductAttribute] {
-        product.attributes
+        product.attributesForVariations
     }
 
     private var parentProductSKU: String? {
@@ -500,7 +500,7 @@ private extension ProductVariationsViewController {
         // Refresh variations because updating an attribute updates the product variations.
         syncingCoordinator.synchronizeFirstPage()
 
-        let viewControllerToShow = product.attributes.isNotEmpty ? editAttributesViewController : self
+        let viewControllerToShow = allAttributes.isNotEmpty ? editAttributesViewController : self
         navigationController?.popToViewController(viewControllerToShow, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -26,12 +26,12 @@ extension ProductVariationsViewModel {
     /// Defines the empty state screen visibility
     ///
     func shouldShowEmptyState(for product: Product) -> Bool {
-        product.variations.isEmpty || product.attributes.isEmpty
+        product.variations.isEmpty || product.attributesForVariations.isEmpty
     }
 
     /// Defines if the More Options button should be shown
     ///
     func shouldShowMoreButton(for product: Product) -> Bool {
-        product.variations.isNotEmpty && product.attributes.isNotEmpty
+        product.variations.isNotEmpty && product.attributesForVariations.isNotEmpty
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditAttributesViewModelTests.swift
@@ -23,7 +23,8 @@ final class EditAttributesViewModelTests: XCTestCase {
     func test_product_attributes_are_correctly_converted_into_view_models() {
         // Given
         let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
-        let product = Product().copy(attributes: [attribute])
+        let attribute2 = sampleNonVariationAttribute(name: "attr-extra", options: ["Option X", "Option Y"])
+        let product = Product().copy(attributes: [attribute, attribute2])
 
         // When
         let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
@@ -40,8 +41,9 @@ final class EditAttributesViewModelTests: XCTestCase {
         // Given
         let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
         let attribute2 = sampleAttribute(name: "attr-2", options: ["Option 3", "Option 4"])
+        let attribute3 = sampleNonVariationAttribute(name: "attr-extra", options: ["Option X", "Option Y"])
         let product = Product().copy(attributes: [attribute])
-        let product2 = product.copy(attributes: [attribute, attribute2])
+        let product2 = product.copy(attributes: [attribute, attribute2, attribute3])
 
         // When
         let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
@@ -63,7 +65,8 @@ final class EditAttributesViewModelTests: XCTestCase {
         // Given
         let attribute = sampleAttribute(name: "attr", options: ["Option 1", "Option 2"])
         let attribute2 = sampleAttribute(name: "attr-2", options: ["Option 3", "Option 4"])
-        let product = Product().copy(attributes: [attribute, attribute2])
+        let attribute3 = sampleNonVariationAttribute(name: "attr-extra", options: ["Option X", "Option Y"])
+        let product = Product().copy(attributes: [attribute, attribute2, attribute3])
 
         // When
         let viewModel = EditAttributesViewModel(product: product, allowVariationCreation: false)
@@ -80,10 +83,20 @@ private extension EditAttributesViewModelTests {
     func sampleAttribute(attributeID: Int64 = 1234, name: String, options: [String] = []) -> ProductAttribute {
         ProductAttribute(siteID: 123,
                          attributeID: attributeID,
-                         name: name ,
+                         name: name,
                          position: 0,
                          visible: true,
                          variation: true,
+                         options: options)
+    }
+
+    func sampleNonVariationAttribute(attributeID: Int64 = 9999, name: String, options: [String] = []) -> ProductAttribute {
+        ProductAttribute(siteID: 123,
+                         attributeID: attributeID,
+                         name: name,
+                         position: 0,
+                         visible: true,
+                         variation: false,
                          options: options)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
@@ -72,7 +72,7 @@ private extension GenerateVariationUseCaseTests {
     func sampleAttribute(attributeID: Int64 = 1234, name: String, options: [String] = []) -> ProductAttribute {
         ProductAttribute(siteID: 123,
                          attributeID: attributeID,
-                         name: name ,
+                         name: name,
                          position: 0,
                          visible: true,
                          variation: true,
@@ -82,7 +82,7 @@ private extension GenerateVariationUseCaseTests {
     func sampleNonVariationAttribute(attributeID: Int64 = 9999, name: String, options: [String] = []) -> ProductAttribute {
         ProductAttribute(siteID: 123,
                          attributeID: attributeID,
-                         name: name ,
+                         name: name,
                          position: 0,
                          visible: true,
                          variation: false,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/GenerateVariationUseCaseTests.swift
@@ -7,7 +7,8 @@ final class GenerateVariationUseCaseTests: XCTestCase {
         // Given
         let attribute = sampleAttribute(attributeID: 0, name: "attr", options: ["Option 1", "Option 2"])
         let attribute2 = sampleAttribute(attributeID: 1, name: "attr-2", options: ["Option 3", "Option 4"])
-        let product = Product().copy(attributes: [attribute, attribute2])
+        let attribute3 = sampleNonVariationAttribute(name: "attr-extra", options: ["Option X", "Option Y"])
+        let product = Product().copy(attributes: [attribute, attribute2, attribute3])
 
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
         let useCase = GenerateVariationUseCase(product: product, stores: mockStores)
@@ -75,6 +76,16 @@ private extension GenerateVariationUseCaseTests {
                          position: 0,
                          visible: true,
                          variation: true,
+                         options: options)
+    }
+
+    func sampleNonVariationAttribute(attributeID: Int64 = 9999, name: String, options: [String] = []) -> ProductAttribute {
+        ProductAttribute(siteID: 123,
+                         attributeID: attributeID,
+                         name: name ,
+                         position: 0,
+                         visible: true,
+                         variation: false,
                          options: options)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Variations/Add Attributes/AddAttributeOptionsViewModelTests.swift
@@ -375,7 +375,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         let initialAttribute = sampleAttribute()
-        let initialProduct = sampleProduct().copy(attributes: [initialAttribute])
+        let initialNonVarAttribute = sampleNonVariationAttribute()
+        let initialProduct = sampleProduct().copy(attributes: [initialAttribute, initialNonVarAttribute])
         let viewModel = AddAttributeOptionsViewModel(product: initialProduct, attribute: .existing(attribute: initialAttribute), stores: stores)
 
         viewModel.setCurrentAttributeName("New Attribute Name")
@@ -396,7 +397,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // Then
         let expectedAttribute = sampleAttribute(name: "New Attribute Name", options: ["Option 1", "Option 2"])
-        XCTAssertEqual(updatedProduct.attributes, [expectedAttribute])
+        XCTAssertEqual(updatedProduct.attributes, [initialNonVarAttribute, expectedAttribute])
     }
 
     func test_removing_current_attribute_correctly_updates_product_attributes() throws {
@@ -413,7 +414,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         let attribute1 = sampleAttribute(name: "Color", options: ["Green", "Blue"])
         let attribute2 = sampleAttribute(name: "Size", options: ["Large", "Small"])
-        let initialProduct = sampleProduct().copy(attributes: [attribute1, attribute2])
+        let attribute3 = sampleNonVariationAttribute()
+        let initialProduct = sampleProduct().copy(attributes: [attribute1, attribute2, attribute3])
         let viewModel = AddAttributeOptionsViewModel(product: initialProduct, attribute: .existing(attribute: attribute2), stores: stores)
 
 
@@ -430,7 +432,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(updatedProduct.attributes, [attribute1])
+        XCTAssertEqual(updatedProduct.attributes, [attribute1, attribute3])
     }
 
     func test_saving_new_attribute_does_not_override_existing_local_attribute() throws {
@@ -446,7 +448,8 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
         }
 
         let initialAttribute = sampleAttribute(attributeID: 0, name: "attr-1")
-        let initialProduct = sampleProduct().copy(attributes: [initialAttribute])
+        let initialNonVarAttribute = sampleNonVariationAttribute()
+        let initialProduct = sampleProduct().copy(attributes: [initialAttribute, initialNonVarAttribute])
         let viewModel = AddAttributeOptionsViewModel(product: initialProduct, attribute: .new(name: "attr-2"), stores: stores)
 
         viewModel.addNewOption(name: "Option 1")
@@ -466,7 +469,7 @@ final class AddAttributeOptionsViewModelTests: XCTestCase {
 
         // Then
         let expectedAttribute = sampleAttribute(attributeID: 0, name: "attr-2", options: ["Option 1", "Option 2"])
-        XCTAssertEqual(updatedProduct.attributes, [initialAttribute, expectedAttribute])
+        XCTAssertEqual(updatedProduct.attributes, [initialAttribute, initialNonVarAttribute, expectedAttribute])
     }
 
     func test_existing_local_attribute_should_preselect_options() throws {
@@ -588,6 +591,16 @@ private extension AddAttributeOptionsViewModelTests {
                          position: 0,
                          visible: true,
                          variation: true,
+                         options: options)
+    }
+
+    func sampleNonVariationAttribute(attributeID: Int64 = 9999, name: String? = nil, options: [String] = []) -> ProductAttribute {
+        ProductAttribute(siteID: 123,
+                         attributeID: attributeID,
+                         name: name ?? sampleAttributeName,
+                         position: 0,
+                         visible: true,
+                         variation: false,
                          options: options)
     }
 


### PR DESCRIPTION
## Description

<img src="https://user-images.githubusercontent.com/3132438/110140989-bc981b80-7de5-11eb-9e0b-fcfdebf50bbe.png" width=600>
^ Notice "Used for variations" setting.

This PR removes non-variable attributes usage in variations-related part.

Related discussion - p1614883468085000-slack-CGPNUU63E

## Changes

1. Adds `attributesForVariations` computed var on `Product`
2. Switches all variations stuff to use `attributesForVariations`
3. Updates tests

## Test

1. On `wp-admin` add an attribute without "used for variations" option
2. Generate couple of variations
3. Variations cell on a product should not have non-variable attribute listed
4. Open generated variations list on a device, it should match with `wp-admin`

## Screenshots

before | after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/110143994-e6067680-7de8-11eb-8420-d89f1b19719d.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/110144005-e7d03a00-7de8-11eb-84ee-25752848cbfd.png)


### before
<img src="https://user-images.githubusercontent.com/3132438/110143596-70020f80-7de8-11eb-94cc-41d449a3ebac.png">

### after
<img src="https://user-images.githubusercontent.com/3132438/110143443-52cd4100-7de8-11eb-8fec-bb2c1c7bdb96.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.