### PR TITLE
Add app version to the in-app survey metadata for all types of…

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -79,11 +79,13 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagProductMilestone("5")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             case .shippingLabelsRelease1Feedback:
                 return WooConstants.URLs.shippingLabelsRelease1Feedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagShippingLabelsMilestone("1")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -32,7 +32,10 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback.asURL().tagPlatform("ios").tagProductMilestone("5").tagAppVersion(Bundle.main.bundleVersion()))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback
+                        .asURL().tagPlatform("ios")
+                        .tagProductMilestone("5")
+                        .tagAppVersion(Bundle.main.bundleVersion()))
     }
     
     func test_it_loads_the_correct_shipping_labels_release_survey() throws {
@@ -45,7 +48,11 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.shippingLabelsRelease1Feedback.asURL().tagPlatform("ios").tagShippingLabelsMilestone("1").tagAppVersion(Bundle.main.bundleVersion()))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.shippingLabelsRelease1Feedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagShippingLabelsMilestone("1")
+                        .tagAppVersion(Bundle.main.bundleVersion()))
     }
 
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -37,7 +37,7 @@ final class SurveyViewControllerTests: XCTestCase {
                         .tagProductMilestone("5")
                         .tagAppVersion(Bundle.main.bundleVersion()))
     }
-    
+
     func test_it_loads_the_correct_shipping_labels_release_survey() throws {
         // Given
         let viewController = SurveyViewController(survey: .shippingLabelsRelease1Feedback, onCompletion: {})

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -32,7 +32,20 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback.asURL().tagPlatform("ios").tagProductMilestone("5"))
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback.asURL().tagPlatform("ios").tagProductMilestone("5").tagAppVersion(Bundle.main.bundleVersion()))
+    }
+    
+    func test_it_loads_the_correct_shipping_labels_release_survey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .shippingLabelsRelease1Feedback, onCompletion: {})
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Then
+        XCTAssertTrue(mirror.webView.isLoading)
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.shippingLabelsRelease1Feedback.asURL().tagPlatform("ios").tagShippingLabelsMilestone("1").tagAppVersion(Bundle.main.bundleVersion()))
     }
 
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {


### PR DESCRIPTION
…surveys, along with corresponding tests

**Description**
I tagged app version in the metadata for the two cases that lacked it (`.productsM5Feedback`, `.shippingLabelsRelease1Feedback`), and updated the test for product feedback (`test_it_loads_the_correct_product_feedback_survey()`) accordingly. 
Additionally, `.shippingLabelsRelease1Feedback` did not appear to have a test associated with it, so one was created. Please ensure the new test, `test_it_loads_the_correct_shipping_labels_release_survey()`, matches the desired naming conventions. 

Fixes #3777 

**Type of change**
 New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
The following tests have been added to or updated in SurveyViewControllerTests.swift to ensure the changes work as expected: 
`test_it_loads_the_correct_product_feedback_survey()`
`test_it_loads_the_correct_shipping_labels_release_survey()`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

**Update release notes:**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
