### PR TITLE
Enable variation generation on empty variations list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -627,14 +627,15 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         let progressViewController = InProgressViewController(viewProperties: .init(title: Localization.generatingVariation,
                                                                                     message: Localization.waitInstructions))
         present(progressViewController, animated: true)
-        viewModel.generateVariation(for: product) { [onProductUpdate, noticePresenter] result in
+        viewModel.generateVariation(for: product) { [weak self] result in
             progressViewController.dismiss(animated: true)
 
-            guard let variation = try? result.get() else {
-                return noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
+            guard let self = self else { return }
+            guard let updatedProduct = try? result.get() else {
+                return self.noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
             }
 
-            onProductUpdate?(variation)
+            self.product = updatedProduct
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -20,7 +20,7 @@ final class ProductVariationsViewController: UIViewController {
                            image: .emptyBoxImage,
                            details: "",
                            buttonTitle: Localization.emptyStateButtonTitle) { [weak self] in
-                            self?.navigateToAddAttributeViewController()
+                            self?.createVariationFromEmptyState()
                            }
     }()
 
@@ -450,6 +450,14 @@ extension ProductVariationsViewController: UITableViewDelegate {
 
 // MARK: Navigation
 private extension ProductVariationsViewController {
+    func createVariationFromEmptyState() {
+        if product.attributesForVariations.isNotEmpty {
+            createVariation()
+        } else {
+            navigateToAddAttributeViewController()
+        }
+    }
+
     func navigateToAddAttributeViewController() {
         let viewModel = AddAttributeViewModel(product: product)
         let addAttributeViewController = AddAttributeViewController(viewModel: viewModel) { [weak self] updatedProduct in

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -32,6 +32,6 @@ extension ProductVariationsViewModel {
     /// Defines if the More Options button should be shown
     ///
     func shouldShowMoreButton(for product: Product) -> Bool {
-        product.variations.isNotEmpty && product.attributesForVariations.isNotEmpty
+        product.attributesForVariations.isNotEmpty
     }
 }


### PR DESCRIPTION
## Description

This PR updates variations list empty state for case of already existing variation attributes. It adds "edit attributes" button and changes action to generate variation right away.

More info and discussion in: p91TBi-4DP-p2

## Changes

1. Adds condition on empty state action to generate new variation if attributes exist.
2. In `createVariation()` updates product with new variation locally - to trigger empty state refresh (instead of previous passing of updated product straight to parent screen).
3. Updates condition in view model to display "edit attributes" button in navbar on empty state (when there are existing attributes).

## Test

1. Open product with variations or generate some
2. Remove every variation to see empty state
3. Check if "more" button is displayed, try opening attributes screen
4. Tap "add variation" button on empty screen and check if it generates new variation without requiring any additional steps.

## Screenshots

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 11 46 51](https://user-images.githubusercontent.com/3132438/110296974-02cac600-8004-11eb-9663-51c4baf9e80c.png)|![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 11 47 24](https://user-images.githubusercontent.com/3132438/110297026-11b17880-8004-11eb-83eb-b3f44693e4f9.png)

## Video

Video starts with a state without any attributes. That's why there is no "more" navbar button on empty state there. Updated state can be seen after 30s mark.

https://user-images.githubusercontent.com/3132438/110296629-98b22100-8003-11eb-9b06-57dbd036d486.mp4


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
