### PR TITLE
Center align image and text for `imageAndTitleOnly` footnote style

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.3
 -----
-
+- [*] Enhancement/fix: image & text footnote info link rows are now center aligned in order details reprint shipping label info row and reprint screen. [https://github.com/woocommerce/woocommerce-ios/pull/3805]
 
 6.2
 -----


### PR DESCRIPTION
Fixes #3574 

## Why

When displaying image and text side by side, it's tricky to align the image with **the first line** of text perfectly since the image height and text line height aren't always the same at different system font sizes.

In https://github.com/woocommerce/woocommerce-ios/pull/3769, @pmusolino suggested center aligning the image and text and @Garance91540 [approved this design change](https://github.com/woocommerce/woocommerce-ios/pull/3769#issuecomment-792800259). This PR implemented the vertical center alignment for `imageAndTitleOnly` footnote style only (I tried applying the center alignment to body style but it looked odd with long text).

## Changes

In `ImageAndTitleAndTextTableViewCell`, set the horizontal image and text stack view alignment to `center` for `imageAndTitleOnly` footnote style only.

## Testing

Prerequisites: the site has [WooCommerce Shipping & Tax plugin](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) and there is an order with at least one non-refunded shipping label.

You can set up your store to use a test credit card with instructions in p91TBi-3xD-p2.

- Go to the orders tab
- Tap on an order with at least one non-refunded shipping label
- After syncing, scroll to a shipping label package card --> the "Don't know how to print from your phone?" info link shouldn't look misaligned at different font sizes
- Tap "Reprint Shipping Label" --> the three image & text rows shouldn't look misaligned at different font sizes

## Example screenshots

### Order Details - reprint shipping label info row

Please focus on the "Don't know how to print from your phone?" info link row

\ | smallest | +2 | +4 | +6 | +8 | +10
-- | -- | -- | -- | -- | -- | --
before | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 50 53](https://user-images.githubusercontent.com/1945542/110421805-2449b180-80d9-11eb-85fc-5ae610f8218d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 50 57](https://user-images.githubusercontent.com/1945542/110421813-27dd3880-80d9-11eb-98bf-2d1e4e02e01d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 01](https://user-images.githubusercontent.com/1945542/110421815-290e6580-80d9-11eb-9c9c-f0b6b3dc186e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 04](https://user-images.githubusercontent.com/1945542/110421817-29a6fc00-80d9-11eb-8280-720a35f84a99.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 12](https://user-images.githubusercontent.com/1945542/110421819-29a6fc00-80d9-11eb-9d46-083a99833738.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 18](https://user-images.githubusercontent.com/1945542/110421821-2a3f9280-80d9-11eb-9d18-1a8b6b191c38.png)
after | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 27](https://user-images.githubusercontent.com/1945542/110422098-ae921580-80d9-11eb-831f-6d543c467401.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 31](https://user-images.githubusercontent.com/1945542/110422115-b2259c80-80d9-11eb-8fa8-f9bf73bb5868.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 37](https://user-images.githubusercontent.com/1945542/110422117-b356c980-80d9-11eb-954a-44a8c3c15429.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 40](https://user-images.githubusercontent.com/1945542/110422122-b3ef6000-80d9-11eb-8253-e0c3159fc52b.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 47](https://user-images.githubusercontent.com/1945542/110422123-b487f680-80d9-11eb-887f-445e91b8830a.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 55 54](https://user-images.githubusercontent.com/1945542/110422125-b5208d00-80d9-11eb-8675-24f4cb6d72af.png)

### Order Details - reprint shipping label 

Please focus on the three image & text rows

\ | smallest | +2 | +4 | +6 | +8 | +10
-- | -- | -- | -- | -- | -- | --
before | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 19](https://user-images.githubusercontent.com/1945542/110421918-5d822180-80d9-11eb-9b66-d62cbb780edc.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 26](https://user-images.githubusercontent.com/1945542/110421926-607d1200-80d9-11eb-9b57-964c813e1d6c.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 29](https://user-images.githubusercontent.com/1945542/110421928-61ae3f00-80d9-11eb-981c-163b9180f50d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 32](https://user-images.githubusercontent.com/1945542/110421929-6246d580-80d9-11eb-9ca3-1e0ae05c0a02.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 40](https://user-images.githubusercontent.com/1945542/110421931-62df6c00-80d9-11eb-8e53-22a6c3a2fced.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 52 47](https://user-images.githubusercontent.com/1945542/110421939-64109900-80d9-11eb-82a2-960fbf14d6c2.png)
after | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 59](https://user-images.githubusercontent.com/1945542/110422274-029cfa00-80da-11eb-8e27-d53f88e971f4.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 57 02](https://user-images.githubusercontent.com/1945542/110422278-0597ea80-80da-11eb-8eff-be69995063b6.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 57 05](https://user-images.githubusercontent.com/1945542/110422279-06308100-80da-11eb-9e07-707d8c4c64d2.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 57 09](https://user-images.githubusercontent.com/1945542/110422281-06c91780-80da-11eb-90ae-00505ac9725b.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 57 16](https://user-images.githubusercontent.com/1945542/110422284-0761ae00-80da-11eb-8541-2fdfec31758f.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 57 21](https://user-images.githubusercontent.com/1945542/110422287-0892db00-80da-11eb-99e8-f9372e180c35.png)

### Order Details - create shipping label info row

Please focus on the "Learn more about creating labels with your phone" info link row

\ | smallest | +2 | +4 | +6 | +8 | +10
-- | -- | -- | -- | -- | -- | --
before | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 39](https://user-images.githubusercontent.com/1945542/110422013-8a363900-80d9-11eb-9466-919a05e0aee9.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 43](https://user-images.githubusercontent.com/1945542/110422019-8d312980-80d9-11eb-9fe3-0d5a52cac414.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 46](https://user-images.githubusercontent.com/1945542/110422024-8e625680-80d9-11eb-902a-4c074a94524f.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 49](https://user-images.githubusercontent.com/1945542/110422027-8efaed00-80d9-11eb-8211-b9aede796a2b.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 53](https://user-images.githubusercontent.com/1945542/110422028-8f938380-80d9-11eb-93ac-bee6b504054e.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 51 59](https://user-images.githubusercontent.com/1945542/110422029-902c1a00-80d9-11eb-83de-f8acd6790826.png)
after | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 08](https://user-images.githubusercontent.com/1945542/110422346-24967c80-80da-11eb-95ac-82c38a284fa8.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 11](https://user-images.githubusercontent.com/1945542/110422352-282a0380-80da-11eb-9983-726d62d08727.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 13](https://user-images.githubusercontent.com/1945542/110422354-28c29a00-80da-11eb-9914-68e02cef8e75.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 16](https://user-images.githubusercontent.com/1945542/110422357-295b3080-80da-11eb-81fb-bd2d75bb652f.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 19](https://user-images.githubusercontent.com/1945542/110422359-29f3c700-80da-11eb-9354-6223fc58583b.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-09 at 10 56 37](https://user-images.githubusercontent.com/1945542/110422362-2a8c5d80-80da-11eb-8971-b254111f3ee7.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
