### PR TITLE
Yosemite: add placeholder action for checking shipping label creation eligibility for an order

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -40,7 +40,7 @@ final class OrderDetailsDataSource: NSObject {
 
     /// Whether the order is eligible for shipping label creation.
     ///
-    var isEligibleForShippingLabelCreation: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2)
+    var isEligibleForShippingLabelCreation: Bool = false
 
     /// Closure to be executed when the cell was tapped.
     ///

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -384,6 +384,17 @@ extension OrderDetailsViewModel {
         stores.dispatch(action)
     }
 
+    func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
+        let isFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2)
+        let action = ShippingLabelAction.checkCreationEligibility(siteID: order.siteID,
+                                                                  orderID: order.orderID,
+                                                                  isFeatureFlagEnabled: isFeatureFlagEnabled) { [weak self] isEligible in
+            self?.dataSource.isEligibleForShippingLabelCreation = isEligible
+            onCompletion?()
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
     func deleteTracking(_ tracking: ShipmentTracking, onCompletion: @escaping (Error?) -> Void) {
         let siteID = order.siteID
         let orderID = order.orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -72,6 +72,7 @@ final class OrderDetailsViewController: UIViewController {
         syncRefunds()
         syncShippingLabels()
         syncTrackingsHidingAddButtonIfNecessary()
+        checkShippingLabelCreationEligibility()
     }
 
     override func viewDidLayoutSubviews() {
@@ -303,6 +304,11 @@ extension OrderDetailsViewController {
             group.leave()
         }
 
+        group.enter()
+        checkShippingLabelCreationEligibility {
+            group.leave()
+        }
+
         group.notify(queue: .main) { [weak self] in
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             self?.refreshControl.endRefreshing()
@@ -349,6 +355,13 @@ private extension OrderDetailsViewController {
 
     func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
         viewModel.syncShippingLabels(onCompletion: onCompletion)
+    }
+
+    func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
+        viewModel.checkShippingLabelCreationEligibility { [weak self] in
+            self?.reloadTableViewSectionsAndData()
+            onCompletion?()
+        }
     }
 
     func deleteTracking(_ tracking: ShipmentTracking) {

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -26,4 +26,8 @@ public enum ShippingLabelAction: Action {
     case validateAddress(siteID: Int64,
                          address: ShippingLabelAddressVerification,
                          completion: (Result<ShippingLabelAddressValidationResponse, Error>) -> Void)
+
+    /// Checks whether an order is eligible for shipping label creation.
+    ///
+    case checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: (_ isEligible: Bool) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -47,6 +47,8 @@ public final class ShippingLabelStore: Store {
             loadShippingLabelSettings(shippingLabel: shippingLabel, completion: completion)
         case .validateAddress(let siteID, let address, let completion):
             validateAddress(siteID: siteID, address: address, completion: completion)
+        case .checkCreationEligibility(let siteID, let orderID, let isFeatureFlagEnabled, let onCompletion):
+            checkCreationEligibility(siteID: siteID, orderID: orderID, isFeatureFlagEnabled: isFeatureFlagEnabled, onCompletion: onCompletion)
         }
     }
 }
@@ -103,6 +105,11 @@ private extension ShippingLabelStore {
                          address: ShippingLabelAddressVerification,
                          completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void) {
         remote.addressValidation(siteID: siteID, address: address, completion: completion)
+    }
+
+    func checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: @escaping (_ isEligible: Bool) -> Void) {
+        // TODO-2971: implement shipping label creation eligibility check, hopefully with the new `/creation_eligibility` endpoint.
+        onCompletion(isFeatureFlagEnabled)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -396,6 +396,27 @@ final class ShippingLabelStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
+
+    // MARK: `checkCreationEligibility`
+
+    func test_checkCreationEligibility_returns_feature_flag_value() throws {
+        // Given
+        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let isFeatureFlagEnabled = false
+        let isEligibleForCreation: Bool = waitFor { promise in
+            let action = ShippingLabelAction.checkCreationEligibility(siteID: self.sampleSiteID,
+                                                                      orderID: 134,
+                                                                      isFeatureFlagEnabled: isFeatureFlagEnabled) { isEligible in
+                promise(isEligible)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(isEligibleForCreation, isFeatureFlagEnabled)
+    }
 }
 
 private extension ShippingLabelStoreTests {


### PR DESCRIPTION
Part of #2971 

## Why

The [shipping label creation eligibility endpoint](https://github.com/Automattic/woocommerce-services/pull/2334) is still in code review, and I thought I could add a placeholder Yosemite action that keeps the current feature flag logic in the meantime. When the endpoint is completed, we can then add the Networking logic to check shipping label creation eligibility from the new `/creation_eligibility` endpoint.

## Changes

In Yosemite layer:
- Added `ShippingLabelAction.checkCreationEligibility` for checking whether an order is eligible for shipping label creation
- Implemented the action that returns the given feature flag value

In app layer:
- Added a function to dispatch `ShippingLabelAction.checkCreationEligibility` in `OrderDetailsViewModel`, and set the eligibility flag in `OrderDetailsDataSource` on completion
- In `OrderDetailsViewController`, called the above view model function in `viewWillAppear` and pull to refresh (same as other sync actions)

## Testing

### Feature flag on

- Launch the app from Xcode (debug build)
- Go to the orders tab
- Tap on an order --> there should be a "Create Shipping Label" CTA

### Feature flag off

- In `DefaultFeatureFlagService`, hard code to return `false` for `shippingLabelsRelease2` feature flag
- Launch the app
- Go to the orders tab --> there should be no "Create Shipping Label" CTA

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
