### PR TITLE
[Hack Week] Generate ".fake()" methods for all networking models

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -2,6 +2,447 @@
 // DO NOT EDIT
 import Networking
 
+extension APNSDevice {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> APNSDevice {
+        .init(
+            token: .fake(),
+            model: .fake(),
+            name: .fake(),
+            iOSVersion: .fake(),
+            identifierForVendor: .fake()
+        )
+    }
+}
+extension Account {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Account {
+        .init(
+            userID: .fake(),
+            displayName: .fake(),
+            email: .fake(),
+            username: .fake(),
+            gravatarUrl: .fake()
+        )
+    }
+}
+extension AccountSettings {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> AccountSettings {
+        .init(
+            userID: .fake(),
+            tracksOptOut: .fake(),
+            firstName: .fake(),
+            lastName: .fake()
+        )
+    }
+}
+extension Address {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Address {
+        .init(
+            firstName: .fake(),
+            lastName: .fake(),
+            company: .fake(),
+            address1: .fake(),
+            address2: .fake(),
+            city: .fake(),
+            state: .fake(),
+            postcode: .fake(),
+            country: .fake(),
+            phone: .fake(),
+            email: .fake()
+        )
+    }
+}
+extension CreateProductVariation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> CreateProductVariation {
+        .init(
+            regularPrice: .fake(),
+            attributes: .fake()
+        )
+    }
+}
+extension DotcomError {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> DotcomError {
+        .empty
+    }
+}
+extension Leaderboard {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Leaderboard {
+        .init(
+            id: .fake(),
+            label: .fake(),
+            rows: .fake()
+        )
+    }
+}
+extension Media {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Media {
+        .init(
+            mediaID: .fake(),
+            date: .fake(),
+            fileExtension: .fake(),
+            mimeType: .fake(),
+            src: .fake(),
+            thumbnailURL: .fake(),
+            name: .fake(),
+            alt: .fake(),
+            height: .fake(),
+            width: .fake()
+        )
+    }
+}
+extension Note {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Note {
+        .init(
+            noteID: .fake(),
+            hash: .fake(),
+            read: .fake(),
+            icon: .fake(),
+            noticon: .fake(),
+            timestamp: .fake(),
+            type: .fake(),
+            subtype: .fake(),
+            url: .fake(),
+            title: .fake(),
+            subject: .fake(),
+            header: .fake(),
+            body: .fake(),
+            meta: .fake()
+        )
+    }
+}
+extension NoteBlock {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NoteBlock {
+        .init(
+            media: .fake(),
+            ranges: .fake(),
+            text: .fake(),
+            actions: .fake(),
+            meta: .fake(),
+            type: .fake()
+        )
+    }
+}
+extension NoteMedia {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NoteMedia {
+        .init(
+            type: .fake(),
+            range: .fake(),
+            url: .fake(),
+            size: .fake()
+        )
+    }
+}
+extension NoteRange {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NoteRange {
+        .init(
+            type: .fake(),
+            range: .fake(),
+            url: .fake(),
+            identifier: .fake(),
+            postID: .fake(),
+            siteID: .fake(),
+            value: .fake()
+        )
+    }
+}
+extension Order {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Order {
+        .init(
+            siteID: .fake(),
+            orderID: .fake(),
+            parentID: .fake(),
+            customerID: .fake(),
+            number: .fake(),
+            status: .fake(),
+            currency: .fake(),
+            customerNote: .fake(),
+            dateCreated: .fake(),
+            dateModified: .fake(),
+            datePaid: .fake(),
+            discountTotal: .fake(),
+            discountTax: .fake(),
+            shippingTotal: .fake(),
+            shippingTax: .fake(),
+            total: .fake(),
+            totalTax: .fake(),
+            paymentMethodID: .fake(),
+            paymentMethodTitle: .fake(),
+            items: .fake(),
+            billingAddress: .fake(),
+            shippingAddress: .fake(),
+            shippingLines: .fake(),
+            coupons: .fake(),
+            refunds: .fake(),
+            fees: .fake()
+        )
+    }
+}
+extension OrderCount {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderCount {
+        .init(
+            siteID: .fake(),
+            items: .fake()
+        )
+    }
+}
+extension OrderCountItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderCountItem {
+        .init(
+            slug: .fake(),
+            name: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension OrderCouponLine {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderCouponLine {
+        .init(
+            couponID: .fake(),
+            code: .fake(),
+            discount: .fake(),
+            discountTax: .fake()
+        )
+    }
+}
+extension OrderFeeLine {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderFeeLine {
+        .init(
+            feeID: .fake(),
+            name: .fake(),
+            taxClass: .fake(),
+            taxStatus: .fake(),
+            total: .fake(),
+            totalTax: .fake(),
+            taxes: .fake(),
+            attributes: .fake()
+        )
+    }
+}
+extension OrderFeeTaxStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderFeeTaxStatus {
+        .taxable
+    }
+}
+extension OrderItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderItem {
+        .init(
+            itemID: .fake(),
+            name: .fake(),
+            productID: .fake(),
+            variationID: .fake(),
+            quantity: .fake(),
+            price: .fake(),
+            sku: .fake(),
+            subtotal: .fake(),
+            subtotalTax: .fake(),
+            taxClass: .fake(),
+            taxes: .fake(),
+            total: .fake(),
+            totalTax: .fake(),
+            attributes: .fake()
+        )
+    }
+}
+extension OrderItemAttribute {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderItemAttribute {
+        .init(
+            metaID: .fake(),
+            name: .fake(),
+            value: .fake()
+        )
+    }
+}
+extension OrderItemRefund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderItemRefund {
+        .init(
+            itemID: .fake(),
+            name: .fake(),
+            productID: .fake(),
+            variationID: .fake(),
+            quantity: .fake(),
+            price: .fake(),
+            sku: .fake(),
+            subtotal: .fake(),
+            subtotalTax: .fake(),
+            taxClass: .fake(),
+            taxes: .fake(),
+            total: .fake(),
+            totalTax: .fake()
+        )
+    }
+}
+extension OrderItemTax {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderItemTax {
+        .init(
+            taxID: .fake(),
+            subtotal: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension OrderItemTaxRefund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderItemTaxRefund {
+        .init(
+            taxID: .fake(),
+            subtotal: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension OrderNote {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderNote {
+        .init(
+            noteID: .fake(),
+            dateCreated: .fake(),
+            note: .fake(),
+            isCustomerNote: .fake(),
+            author: .fake()
+        )
+    }
+}
+extension OrderRefundCondensed {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderRefundCondensed {
+        .init(
+            refundID: .fake(),
+            reason: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension OrderStatsV4 {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderStatsV4 {
+        .init(
+            siteID: .fake(),
+            granularity: .fake(),
+            totals: .fake(),
+            intervals: .fake()
+        )
+    }
+}
+extension OrderStatsV4Interval {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderStatsV4Interval {
+        .init(
+            interval: .fake(),
+            dateStart: .fake(),
+            dateEnd: .fake(),
+            subtotals: .fake()
+        )
+    }
+}
+extension OrderStatsV4Totals {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderStatsV4Totals {
+        .init(
+            totalOrders: .fake(),
+            totalItemsSold: .fake(),
+            grossRevenue: .fake(),
+            couponDiscount: .fake(),
+            totalCoupons: .fake(),
+            refunds: .fake(),
+            taxes: .fake(),
+            shipping: .fake(),
+            netRevenue: .fake(),
+            totalProducts: .fake()
+        )
+    }
+}
+extension OrderStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderStatus {
+        .init(
+            name: .fake(),
+            siteID: .fake(),
+            slug: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension OrderStatusEnum {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> OrderStatusEnum {
+        .pending
+    }
+}
+extension PaymentGateway {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> PaymentGateway {
+        .init(
+            siteID: .fake(),
+            gatewayID: .fake(),
+            title: .fake(),
+            description: .fake(),
+            enabled: .fake(),
+            features: .fake()
+        )
+    }
+}
+extension Post {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Post {
+        .init(
+            siteID: .fake(),
+            password: .fake()
+        )
+    }
+}
 extension Product {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -87,6 +528,19 @@ extension ProductAttribute {
         )
     }
 }
+extension ProductAttributeTerm {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductAttributeTerm {
+        .init(
+            siteID: .fake(),
+            termID: .fake(),
+            name: .fake(),
+            slug: .fake(),
+            count: .fake()
+        )
+    }
+}
 extension ProductBackordersSetting {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -147,6 +601,15 @@ extension ProductDownload {
         )
     }
 }
+extension ProductDownloadDragAndDrop {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductDownloadDragAndDrop {
+        .init(
+            downloadableFile: .fake()
+        )
+    }
+}
 extension ProductImage {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -159,6 +622,32 @@ extension ProductImage {
             name: .fake(),
             alt: .fake()
         )
+    }
+}
+extension ProductReview {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductReview {
+        .init(
+            siteID: .fake(),
+            reviewID: .fake(),
+            productID: .fake(),
+            dateCreated: .fake(),
+            statusKey: .fake(),
+            reviewer: .fake(),
+            reviewerEmail: .fake(),
+            reviewerAvatarURL: .fake(),
+            review: .fake(),
+            rating: .fake(),
+            verified: .fake()
+        )
+    }
+}
+extension ProductReviewStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductReviewStatus {
+        .approved
     }
 }
 extension ProductShippingClass {
@@ -213,5 +702,426 @@ extension ProductType {
     ///
     public static func fake() -> ProductType {
         .simple
+    }
+}
+extension ProductVariation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductVariation {
+        .init(
+            siteID: .fake(),
+            productID: .fake(),
+            productVariationID: .fake(),
+            attributes: .fake(),
+            image: .fake(),
+            permalink: .fake(),
+            dateCreated: .fake(),
+            dateModified: .fake(),
+            dateOnSaleStart: .fake(),
+            dateOnSaleEnd: .fake(),
+            status: .fake(),
+            description: .fake(),
+            sku: .fake(),
+            price: .fake(),
+            regularPrice: .fake(),
+            salePrice: .fake(),
+            onSale: .fake(),
+            purchasable: .fake(),
+            virtual: .fake(),
+            downloadable: .fake(),
+            downloads: .fake(),
+            downloadLimit: .fake(),
+            downloadExpiry: .fake(),
+            taxStatusKey: .fake(),
+            taxClass: .fake(),
+            manageStock: .fake(),
+            stockQuantity: .fake(),
+            stockStatus: .fake(),
+            backordersKey: .fake(),
+            backordersAllowed: .fake(),
+            backordered: .fake(),
+            weight: .fake(),
+            dimensions: .fake(),
+            shippingClass: .fake(),
+            shippingClassID: .fake(),
+            menuOrder: .fake()
+        )
+    }
+}
+extension ProductVariationAttribute {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductVariationAttribute {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            option: .fake()
+        )
+    }
+}
+extension Refund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Refund {
+        .init(
+            refundID: .fake(),
+            orderID: .fake(),
+            siteID: .fake(),
+            dateCreated: .fake(),
+            amount: .fake(),
+            reason: .fake(),
+            refundedByUserID: .fake(),
+            isAutomated: .fake(),
+            createAutomated: .fake(),
+            items: .fake(),
+            shippingLines: .fake()
+        )
+    }
+}
+extension ShipmentTracking {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShipmentTracking {
+        .init(
+            siteID: .fake(),
+            orderID: .fake(),
+            trackingID: .fake(),
+            trackingNumber: .fake(),
+            trackingProvider: .fake(),
+            trackingURL: .fake(),
+            dateShipped: .fake()
+        )
+    }
+}
+extension ShipmentTrackingProvider {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShipmentTrackingProvider {
+        .init(
+            siteID: .fake(),
+            name: .fake(),
+            url: .fake()
+        )
+    }
+}
+extension ShipmentTrackingProviderGroup {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShipmentTrackingProviderGroup {
+        .init(
+            name: .fake(),
+            siteID: .fake(),
+            providers: .fake()
+        )
+    }
+}
+extension ShippingLabel {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabel {
+        .init(
+            siteID: .fake(),
+            orderID: .fake(),
+            shippingLabelID: .fake(),
+            carrierID: .fake(),
+            dateCreated: .fake(),
+            packageName: .fake(),
+            rate: .fake(),
+            currency: .fake(),
+            trackingNumber: .fake(),
+            serviceName: .fake(),
+            refundableAmount: .fake(),
+            status: .fake(),
+            refund: .fake(),
+            originAddress: .fake(),
+            destinationAddress: .fake(),
+            productIDs: .fake(),
+            productNames: .fake()
+        )
+    }
+}
+extension ShippingLabelAddress {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelAddress {
+        .init(
+            company: .fake(),
+            name: .fake(),
+            phone: .fake(),
+            country: .fake(),
+            state: .fake(),
+            address1: .fake(),
+            address2: .fake(),
+            city: .fake(),
+            postcode: .fake()
+        )
+    }
+}
+extension ShippingLabelAddressValidationError {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelAddressValidationError {
+        .init(
+            addressError: .fake(),
+            generalError: .fake()
+        )
+    }
+}
+extension ShippingLabelAddressValidationResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelAddressValidationResponse {
+        .init(
+            address: .fake(),
+            errors: .fake(),
+            isTrivialNormalization: .fake()
+        )
+    }
+}
+extension ShippingLabelAddressVerification {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelAddressVerification {
+        .init(
+            address: .fake(),
+            type: .fake()
+        )
+    }
+}
+extension ShippingLabelAddressVerification.ShipType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelAddressVerification.ShipType {
+        .origin
+    }
+}
+extension ShippingLabelPaperSize {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPaperSize {
+        .a4
+    }
+}
+extension ShippingLabelPrintData {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPrintData {
+        .init(
+            mimeType: .fake(),
+            base64Content: .fake()
+        )
+    }
+}
+extension ShippingLabelRefund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelRefund {
+        .init(
+            dateRequested: .fake(),
+            status: .fake()
+        )
+    }
+}
+extension ShippingLabelRefundStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelRefundStatus {
+        .pending
+    }
+}
+extension ShippingLabelSettings {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelSettings {
+        .init(
+            siteID: .fake(),
+            orderID: .fake(),
+            paperSize: .fake()
+        )
+    }
+}
+extension ShippingLabelStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelStatus {
+        .purchased
+    }
+}
+extension ShippingLine {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLine {
+        .init(
+            shippingID: .fake(),
+            methodTitle: .fake(),
+            methodID: .fake(),
+            total: .fake(),
+            totalTax: .fake(),
+            taxes: .fake()
+        )
+    }
+}
+extension ShippingLineTax {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLineTax {
+        .init(
+            taxID: .fake(),
+            subtotal: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension Site {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Site {
+        .init(
+            siteID: .fake(),
+            name: .fake(),
+            description: .fake(),
+            url: .fake(),
+            plan: .fake(),
+            isWooCommerceActive: .fake(),
+            isWordPressStore: .fake(),
+            timezone: .fake(),
+            gmtOffset: .fake()
+        )
+    }
+}
+extension SiteAPI {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SiteAPI {
+        .init(
+            siteID: .fake(),
+            namespaces: .fake()
+        )
+    }
+}
+extension SitePlan {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SitePlan {
+        .init(
+            siteID: .fake(),
+            shortName: .fake()
+        )
+    }
+}
+extension SiteSetting {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SiteSetting {
+        .init(
+            siteID: .fake(),
+            settingID: .fake(),
+            label: .fake(),
+            description: .fake(),
+            value: .fake(),
+            settingGroupKey: .fake()
+        )
+    }
+}
+extension SiteSettingGroup {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SiteSettingGroup {
+        .general
+    }
+}
+extension SiteVisitStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SiteVisitStats {
+        .init(
+            siteID: .fake(),
+            date: .fake(),
+            granularity: .fake(),
+            items: .fake()
+        )
+    }
+}
+extension SiteVisitStatsItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SiteVisitStatsItem {
+        .init(
+            period: .fake(),
+            visitors: .fake()
+        )
+    }
+}
+extension StatGranularity {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> StatGranularity {
+        .day
+    }
+}
+extension StatsGranularityV4 {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> StatsGranularityV4 {
+        .hourly
+    }
+}
+extension StoredProductSettings {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> StoredProductSettings {
+        .init(
+            settings: .fake()
+        )
+    }
+}
+extension TaxClass {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> TaxClass {
+        .init(
+            siteID: .fake(),
+            name: .fake(),
+            slug: .fake()
+        )
+    }
+}
+extension TopEarnerStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> TopEarnerStats {
+        .init(
+            siteID: .fake(),
+            date: .fake(),
+            granularity: .fake(),
+            limit: .fake(),
+            items: .fake()
+        )
+    }
+}
+extension TopEarnerStatsItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> TopEarnerStatsItem {
+        .init(
+            productID: .fake(),
+            productName: .fake(),
+            quantity: .fake(),
+            price: .fake(),
+            total: .fake(),
+            currency: .fake(),
+            imageUrl: .fake()
+        )
+    }
+}
+extension UploadableMedia {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> UploadableMedia {
+        .init(
+            localURL: .fake(),
+            filename: .fake(),
+            mimeType: .fake()
+        )
     }
 }

--- a/Networking/Networking/Model/APNSDevice.swift
+++ b/Networking/Networking/Model/APNSDevice.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Apple Push Notifications Service Device.
 ///
-public struct APNSDevice {
+public struct APNSDevice: GeneratedFakeable {
 
     /// Push Notifications Token.
     ///

--- a/Networking/Networking/Model/Account.swift
+++ b/Networking/Networking/Model/Account.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// WordPress.com Account
 ///
-public struct Account: Decodable {
+public struct Account: Decodable, GeneratedFakeable {
 
     /// Dotcom UserID
     ///

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// WordPress.com Account Settings
 ///
-public struct AccountSettings: Decodable, Equatable {
+public struct AccountSettings: Decodable, Equatable, GeneratedFakeable {
 
     /// Dotcom UserID
     ///

--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Address Entity.
 ///
-public struct Address: Decodable {
+public struct Address: Decodable, GeneratedFakeable {
     public let firstName: String
     public let lastName: String
     public let company: String?

--- a/Networking/Networking/Model/DotcomError.swift
+++ b/Networking/Networking/Model/DotcomError.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// WordPress.com Request Error
 ///
-public enum DotcomError: Error, Decodable, Equatable {
+public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
 
     /// Non explicit reason
     ///

--- a/Networking/Networking/Model/Media/Media.swift
+++ b/Networking/Networking/Model/Media/Media.swift
@@ -1,6 +1,6 @@
 /// WordPress Site Media
 ///
-public struct Media {
+public struct Media: GeneratedFakeable {
     public let mediaID: Int64
     public let date: Date    // gmt iso8601
     public let fileExtension: String

--- a/Networking/Networking/Model/Media/UploadableMedia.swift
+++ b/Networking/Networking/Model/Media/UploadableMedia.swift
@@ -1,6 +1,6 @@
 /// Media that has the data fields to be uploaded to the WordPress Site Media
 ///
-public struct UploadableMedia {
+public struct UploadableMedia: GeneratedFakeable {
     public let localURL: URL
     public let filename: String
     public let mimeType: String

--- a/Networking/Networking/Model/Note.swift
+++ b/Networking/Networking/Model/Note.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - Note: Represents a WordPress.com Notification
 //
-public struct Note {
+public struct Note: GeneratedFakeable {
 
 
     /// Notification's Primary Key.

--- a/Networking/Networking/Model/NoteBlock.swift
+++ b/Networking/Networking/Model/NoteBlock.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - NotificationBlock Implementation
 //
-public struct NoteBlock: Equatable {
+public struct NoteBlock: Equatable, GeneratedFakeable {
 
     /// Parsed Media Entities.
     ///
@@ -33,7 +33,7 @@ public struct NoteBlock: Equatable {
 
     /// Designated Initializer.
     ///
-    init(media: [NoteMedia], ranges: [NoteRange], text: String?, actions: [String: Bool], meta: [String: AnyCodable], type: String?) {
+    public init(media: [NoteMedia], ranges: [NoteRange], text: String?, actions: [String: Bool], meta: [String: AnyCodable], type: String?) {
         self.media = media
         self.ranges = ranges
         self.text = text

--- a/Networking/Networking/Model/NoteMedia.swift
+++ b/Networking/Networking/Model/NoteMedia.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - NoteMedia
 //
-public struct NoteMedia: Equatable {
+public struct NoteMedia: Equatable, GeneratedFakeable {
 
     /// NoteMedia.Type expressed as a Swift Native Enum.
     ///

--- a/Networking/Networking/Model/NoteRange.swift
+++ b/Networking/Networking/Model/NoteRange.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - NoteRange
 //
-public struct NoteRange: Equatable {
+public struct NoteRange: Equatable, GeneratedFakeable {
 
     /// NoteRange.Type expressed as a Swift Native Enum.
     ///
@@ -45,7 +45,7 @@ public struct NoteRange: Equatable {
 
     /// Designated Initializer.
     ///
-    init(type: String?, range: NSRange, url: URL?, identifier: Int64?, postID: Int64?, siteID: Int64?, value: String?) {
+    public init(type: String?, range: NSRange, url: URL?, identifier: Int64?, postID: Int64?, siteID: Int64?, value: String?) {
         self.kind = NoteRange.kind(forType: type, siteID: siteID, url: url)
         self.type = type
         self.range = range

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order Entity.
 ///
-public struct Order: Decodable, GeneratedCopiable {
+public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
     public let siteID: Int64
     public let orderID: Int64
     public let parentID: Int64

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -4,7 +4,7 @@ import Foundation
 /// An OrderCount contains an array of OrderCountItem.
 /// Each OrderCountItem represents the number of Orders for a given status
 ///
-public struct OrderCount {
+public struct OrderCount: GeneratedFakeable {
     public let siteID: Int64
     public let items: [OrderCountItem]
 

--- a/Networking/Networking/Model/OrderCountItem.swift
+++ b/Networking/Networking/Model/OrderCountItem.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents an OrderCountItem Entity.
 /// OrderCountItem represents the number of Orders for a given status
 ///
-public struct OrderCountItem: Decodable {
+public struct OrderCountItem: Decodable, GeneratedFakeable {
     public let slug: String
     public let name: String
     public let total: Int

--- a/Networking/Networking/Model/OrderCouponLine.swift
+++ b/Networking/Networking/Model/OrderCouponLine.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a CouponLine Entity within an Order.
 ///
-public struct OrderCouponLine: Decodable {
+public struct OrderCouponLine: Decodable, GeneratedFakeable {
     public let couponID: Int64
     public let code: String
     public let discount: String

--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a FeeLine Entity within an Order.
 ///
-public struct OrderFeeLine: Equatable, Decodable {
+public struct OrderFeeLine: Equatable, Decodable, GeneratedFakeable {
     public let feeID: Int64
     public let name: String
     public let taxClass: String

--- a/Networking/Networking/Model/OrderFeeTaxStatus.swift
+++ b/Networking/Networking/Model/OrderFeeTaxStatus.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents a OrderFeeTaxStatus Entity.
 ///
 
-public enum OrderFeeTaxStatus: Decodable, Hashable {
+public enum OrderFeeTaxStatus: Decodable, Hashable, GeneratedFakeable {
     case taxable
     case none
 }

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order's Item Entity.
 ///
-public struct OrderItem: Decodable, Hashable {
+public struct OrderItem: Decodable, Hashable, GeneratedFakeable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -1,6 +1,6 @@
 /// Represents an attribute of an `OrderItem` in its `attributes` property.
 /// Currently, the use case is when an order item is a variation and the attributes are its variation attributes.
-public struct OrderItemAttribute: Decodable, Hashable, Equatable {
+public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable {
     public let metaID: Int64
     public let name: String
     public let value: String

--- a/Networking/Networking/Model/OrderItemTax.swift
+++ b/Networking/Networking/Model/OrderItemTax.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents the Taxes for a specific Order Item.
 ///
-public struct OrderItemTax: Codable, Hashable {
+public struct OrderItemTax: Codable, Hashable, GeneratedFakeable {
 
     /// Tax ID for line item
     ///

--- a/Networking/Networking/Model/OrderNote.swift
+++ b/Networking/Networking/Model/OrderNote.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order's Note Entity.
 ///
-public struct OrderNote: Decodable {
+public struct OrderNote: Decodable, GeneratedFakeable {
     public let noteID: Int64
     public let dateCreated: Date
     public let note: String

--- a/Networking/Networking/Model/OrderRefundCondensed.swift
+++ b/Networking/Networking/Model/OrderRefundCondensed.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order Refund Entity.
 ///
-public struct OrderRefundCondensed: Decodable {
+public struct OrderRefundCondensed: Decodable, GeneratedFakeable {
     public let refundID: Int64
     public let reason: String?
     public let total: String

--- a/Networking/Networking/Model/OrderStatus.swift
+++ b/Networking/Networking/Model/OrderStatus.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an OrderStatus Entity.
 ///
-public struct OrderStatus: Decodable {
+public struct OrderStatus: Decodable, GeneratedFakeable {
     public let name: String?
     public let siteID: Int64
     public let slug: String

--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents all of the possible Order Statuses in enum form
 ///
-public enum OrderStatusEnum: Decodable, Hashable {
+public enum OrderStatusEnum: Decodable, Hashable, GeneratedFakeable {
     case pending
     case processing
     case onHold

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Payment Gateway.
 ///
-public struct PaymentGateway: Equatable {
+public struct PaymentGateway: Equatable, GeneratedFakeable {
 
     /// Features for payment gateway.
     ///

--- a/Networking/Networking/Model/Post.swift
+++ b/Networking/Networking/Model/Post.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a Post Entity.
 ///
-public struct Post: Codable {
+public struct Post: Codable, GeneratedFakeable {
 
     /// WordPress.com Site Identifier.
     ///

--- a/Networking/Networking/Model/Product/CreateProductVariation.swift
+++ b/Networking/Networking/Model/Product/CreateProductVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the entity sent for creating a new Product Variation entity.
 ///
-public struct CreateProductVariation: Codable, Equatable {
+public struct CreateProductVariation: Codable, Equatable, GeneratedFakeable {
     public let regularPrice: String
     public let attributes: [ProductVariationAttribute]
 

--- a/Networking/Networking/Model/Product/ProductAttributeTerm.swift
+++ b/Networking/Networking/Model/Product/ProductAttributeTerm.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a `ProductAttributeTerm` entity.
 ///
-public struct ProductAttributeTerm: Equatable {
+public struct ProductAttributeTerm: Equatable, GeneratedFakeable {
     public let siteID: Int64
     public let termID: Int64
     public let name: String

--- a/Networking/Networking/Model/Product/ProductDownloadDragAndDrop.swift
+++ b/Networking/Networking/Model/Product/ProductDownloadDragAndDrop.swift
@@ -8,7 +8,7 @@ import CoreServices
 /// So the top layer object needs to be a subclass of `NSObject`
 /// And since the original `ProductDownload` is a struct, we need a new class for this purpose.
 ///
-public final class ProductDownloadDragAndDrop: NSObject, Codable {
+public final class ProductDownloadDragAndDrop: NSObject, Codable, GeneratedFakeable {
     public let downloadableFile: ProductDownload
 
     /// initializer.

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a ProductReview Entity.
 ///
-public struct ProductReview: Decodable {
+public struct ProductReview: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let reviewID: Int64
     public let productID: Int64

--- a/Networking/Networking/Model/Product/ProductReviewStatus.swift
+++ b/Networking/Networking/Model/Product/ProductReviewStatus.swift
@@ -1,6 +1,6 @@
 /// Represents a ProductReviewStatus Entity.
 ///
-public enum ProductReviewStatus: Decodable, Hashable {
+public enum ProductReviewStatus: Decodable, Hashable, GeneratedFakeable {
     case approved
     case hold
     case spam

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Product Variation Entity.
 ///
-public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
+public struct ProductVariation: Codable, GeneratedCopiable, Equatable, GeneratedFakeable {
     public let siteID: Int64
     public let productID: Int64
 

--- a/Networking/Networking/Model/Product/ProductVariationAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductVariationAttribute.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Product Variation Attribute Entity.
 ///
-public struct ProductVariationAttribute: Codable {
+public struct ProductVariationAttribute: Codable, GeneratedFakeable {
     public let id: Int64
     public let name: String
     public let option: String

--- a/Networking/Networking/Model/Product/StoredProductSettings.swift
+++ b/Networking/Networking/Model/Product/StoredProductSettings.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Models a pair of `siteID` and Product Settings
 /// These entities will be serialised to a plist file using `ProductsModuleSettings`
 ///
-public struct StoredProductSettings: Codable, Equatable {
+public struct StoredProductSettings: Codable, Equatable, GeneratedFakeable {
 
     public struct Setting: Codable, Equatable {
         public let siteID: Int64

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order Item that was refunded or will be refunded.
 ///
-public struct OrderItemRefund: Codable {
+public struct OrderItemRefund: Codable, GeneratedFakeable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64

--- a/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a Tax Refund for a specific Order Item.
 ///
-public struct OrderItemTaxRefund: Codable {
+public struct OrderItemTaxRefund: Codable, GeneratedFakeable {
 
     /// Tax ID for line item
     ///

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a decoded Refund entity.
 ///
-public struct Refund: Codable {
+public struct Refund: Codable, GeneratedFakeable {
     public let refundID: Int64
     public let orderID: Int64
     public let siteID: Int64

--- a/Networking/Networking/Model/ShipmentTracking.swift
+++ b/Networking/Networking/Model/ShipmentTracking.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a Shipment Tracking Entity (from the WC Shipment Tracking extension).
 ///
-public struct ShipmentTracking: Decodable {
+public struct ShipmentTracking: Decodable, GeneratedFakeable {
 
     /// Site Identifier.
     ///

--- a/Networking/Networking/Model/ShipmentTrackingProvider.swift
+++ b/Networking/Networking/Model/ShipmentTrackingProvider.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipment Tracking Provider Entity (from the WC Shipment Tracking extension).
 ///
-public struct ShipmentTrackingProvider {
+public struct ShipmentTrackingProvider: GeneratedFakeable {
     /// Tracking provider name
     ///
     public let name: String

--- a/Networking/Networking/Model/ShipmentTrackingProviderGroup.swift
+++ b/Networking/Networking/Model/ShipmentTrackingProviderGroup.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipment Tracking Provider Grouping Entity (from the WC Shipment Tracking extension).
 ///
-public struct ShipmentTrackingProviderGroup {
+public struct ShipmentTrackingProviderGroup: GeneratedFakeable {
     /// Tracking provider group name
     ///
     public let name: String

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaperSize.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaperSize.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Paper size options for printing a shipping label.
-public enum ShippingLabelPaperSize {
+public enum ShippingLabelPaperSize: GeneratedFakeable {
     case a4
     case label
     case legal

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelRefundStatus.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelRefundStatus.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The status of shipping label refund.
-public enum ShippingLabelRefundStatus {
+public enum ShippingLabelRefundStatus: GeneratedFakeable {
     case pending
 }
 

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatus.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatus.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The status of shipping label.
-public enum ShippingLabelStatus {
+public enum ShippingLabelStatus: GeneratedFakeable {
     case purchased
 }
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipping Label.
 ///
-public struct ShippingLabel: Equatable, GeneratedCopiable {
+public struct ShippingLabel: Equatable, GeneratedCopiable, GeneratedFakeable {
     /// The remote ID of the site that owns this shipping label.
     public let siteID: Int64
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipping Label Address.
 ///
-public struct ShippingLabelAddress: GeneratedCopiable, Equatable {
+public struct ShippingLabelAddress: GeneratedCopiable, Equatable, GeneratedFakeable {
     /// The name of the company at the address.
     public let company: String
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents Shipping Label Address Validation Error.
 ///
-public struct ShippingLabelAddressValidationError: Equatable {
+public struct ShippingLabelAddressValidationError: Equatable, GeneratedFakeable {
     public let addressError: String?
     public let generalError: String?
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents Shipping Label Address that has been validated or that generated an error.
 ///
-public struct ShippingLabelAddressValidationResponse: Equatable {
+public struct ShippingLabelAddressValidationResponse: Equatable, GeneratedFakeable {
     public let address: ShippingLabelAddress?
     public let errors: ShippingLabelAddressValidationError?
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressVerification.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddressVerification.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents Shipping Label Address that should be verified.
 ///
-public struct ShippingLabelAddressVerification: Equatable {
+public struct ShippingLabelAddressVerification: Equatable, GeneratedFakeable {
     public let address: ShippingLabelAddress?
     public let type: ShipType
 
@@ -14,7 +14,7 @@ public struct ShippingLabelAddressVerification: Equatable {
     /// Represents all of the possible Type Statuses in enum form.
     /// It can be either be destination for the `Ship TO` address OR `origin` for the `Ship FROM` address.
     ///
-    public enum ShipType: String, Encodable, Hashable {
+    public enum ShipType: String, Encodable, Hashable, GeneratedFakeable {
         case origin
         case destination
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPrintData.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPrintData.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Shipping label data for printing
 ///
-public struct ShippingLabelPrintData: Decodable, Equatable {
+public struct ShippingLabelPrintData: Decodable, Equatable, GeneratedFakeable {
     /// The media type of shipping label document.
     public let mimeType: String
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelRefund.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelRefund.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipping Label Refund.
 ///
-public struct ShippingLabelRefund: Equatable {
+public struct ShippingLabelRefund: Equatable, GeneratedFakeable {
     /// The date of refund request.
     public let dateRequested: Date
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents Shipping Label Settings.
 ///
-public struct ShippingLabelSettings: Equatable {
+public struct ShippingLabelSettings: Equatable, GeneratedFakeable {
     public let siteID: Int64
     public let orderID: Int64
 

--- a/Networking/Networking/Model/ShippingLine.swift
+++ b/Networking/Networking/Model/ShippingLine.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a Shipping Line Entity.
 ///
-public struct ShippingLine: Decodable, Equatable {
+public struct ShippingLine: Decodable, Equatable, GeneratedFakeable {
     public let shippingID: Int64
     public let methodTitle: String
     public let methodID: String

--- a/Networking/Networking/Model/ShippingLineTax.swift
+++ b/Networking/Networking/Model/ShippingLineTax.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the taxes for a specific shipping item.
 ///
-public struct ShippingLineTax: Decodable, Hashable {
+public struct ShippingLineTax: Decodable, Hashable, GeneratedFakeable {
 
     /// Tax ID for shipping item
     ///

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a WordPress.com Site.
 ///
-public struct Site: Decodable {
+public struct Site: Decodable, GeneratedFakeable {
 
     /// WordPress.com Site Identifier.
     ///

--- a/Networking/Networking/Model/SiteAPI.swift
+++ b/Networking/Networking/Model/SiteAPI.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Encapsulates API Information for a given site
 ///
-public struct SiteAPI: Decodable {
+public struct SiteAPI: Decodable, GeneratedFakeable {
 
     /// Site Identifier.
     ///

--- a/Networking/Networking/Model/SitePlan.swift
+++ b/Networking/Networking/Model/SitePlan.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a WordPress.com default Site's plan.
 ///
-public struct SitePlan: Decodable {
+public struct SitePlan: Decodable, GeneratedFakeable {
 
     /// WordPress.com Site Identifier.
     ///

--- a/Networking/Networking/Model/SiteSetting.swift
+++ b/Networking/Networking/Model/SiteSetting.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a specific setting entity for a specific site.
 ///
-public struct SiteSetting: Decodable {
+public struct SiteSetting: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let settingID: String
     public let label: String

--- a/Networking/Networking/Model/SiteSettingGroup.swift
+++ b/Networking/Networking/Model/SiteSettingGroup.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a SiteSettingGroup Entity.
 ///
-public enum SiteSettingGroup: Decodable, Hashable {
+public enum SiteSettingGroup: Decodable, Hashable, GeneratedFakeable {
     case general
     case product
     case custom(String) // catch-all

--- a/Networking/Networking/Model/Stats/Leaderboard.swift
+++ b/Networking/Networking/Model/Stats/Leaderboard.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the store leaderboad - Top Products
 ///
-public struct Leaderboard: Decodable {
+public struct Leaderboard: Decodable, GeneratedFakeable {
 
     private enum CodingKeys: String, CodingKey {
         case id

--- a/Networking/Networking/Model/Stats/OrderStatsV4.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents order stats over a specific period.
 /// v4 API
-public struct OrderStatsV4: Decodable {
+public struct OrderStatsV4: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let granularity: StatsGranularityV4
     public let totals: OrderStatsV4Totals

--- a/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
@@ -1,6 +1,6 @@
 /// Represents a single order stat for a specific period.
 /// v4 API
-public struct OrderStatsV4Interval: Decodable {
+public struct OrderStatsV4Interval: Decodable, GeneratedFakeable {
     public let interval: String
     /// Interval start date string in the site time zone.
     public let dateStart: String

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -1,6 +1,6 @@
 /// Represents the data associated with order stats over a specific period.
 /// v4
-public struct OrderStatsV4Totals: Decodable {
+public struct OrderStatsV4Totals: Decodable, GeneratedFakeable {
     public let totalOrders: Int
     public let totalItemsSold: Int
     public let grossRevenue: Decimal

--- a/Networking/Networking/Model/Stats/SiteVisitStats.swift
+++ b/Networking/Networking/Model/Stats/SiteVisitStats.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents site visit stats over a specific period.
 ///
-public struct SiteVisitStats: Decodable {
+public struct SiteVisitStats: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let date: String
     public let granularity: StatGranularity

--- a/Networking/Networking/Model/Stats/SiteVisitStatsItem.swift
+++ b/Networking/Networking/Model/Stats/SiteVisitStatsItem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an single site visit stat for a specific period.
 ///
-public struct SiteVisitStatsItem {
+public struct SiteVisitStatsItem: GeneratedFakeable {
     public let period: String
     public let visitors: Int
 

--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents data granularity for stats (e.g. day, week, month, year)
 ///
-public enum StatGranularity: String, Decodable {
+public enum StatGranularity: String, Decodable, GeneratedFakeable {
     case day
     case week
     case month

--- a/Networking/Networking/Model/Stats/StatsGranularityV4.swift
+++ b/Networking/Networking/Model/Stats/StatsGranularityV4.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents data granularity for stats v4 (e.g. hour, day, week, month, year)
 ///
-public enum StatsGranularityV4: String, Decodable {
+public enum StatsGranularityV4: String, Decodable, GeneratedFakeable {
     case hourly = "hour"
     case daily = "day"
     case weekly = "week"

--- a/Networking/Networking/Model/Stats/TopEarnerStats.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStats.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents Top Earner (aka top performer) stats over a specific period.
 ///
-public struct TopEarnerStats: Decodable {
+public struct TopEarnerStats: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let date: String
     public let granularity: StatGranularity

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a single top earner stat for a specific period.
 ///
-public struct TopEarnerStatsItem: Decodable {
+public struct TopEarnerStatsItem: Decodable, GeneratedFakeable {
 
     /// Product ID
     ///

--- a/Networking/Networking/Model/TaxClass.swift
+++ b/Networking/Networking/Model/TaxClass.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represent a Tax Class Entity.
 ///
-public struct TaxClass: Decodable {
+public struct TaxClass: Decodable, GeneratedFakeable {
 
     /// WordPress.com Site Identifier.
     ///


### PR DESCRIPTION
part of #3096 

# Why

As a continuation of https://github.com/woocommerce/woocommerce-ios/pull/3813 where the `Fakes.framework` was introduced, this PR makes all of our `Networking` models conform to `GeneratedFakeable`.

Next PRs will be focusing on updating our test to use these methods when possible.

# How

- Update models to conform to `GeneratedFakeable`
- Ran `rake generate`

# Testing steps

- Just make sure the project compiles 🤷 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
