### PR TITLE
[Mobile Payments] Create Payment Intent

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		C5D2CB7D21CEE28FEBF18BF6 /* Pods_Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9F0AC202B287C1221EA2C99 /* Pods_Hardware.framework */; };
+		D80409A625FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */; };
 		D81AE85A25E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81AE85925E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift */; };
 		D81AE85E25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81AE85D25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift */; };
 		D81AE86425E6B77F00D9CFD3 /* CardReaderServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81AE86325E6B77F00D9CFD3 /* CardReaderServiceError.swift */; };
@@ -61,6 +62,7 @@
 		9726331F55A9621F2F887E13 /* Pods-Hardware.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release.xcconfig"; sourceTree = "<group>"; };
 		B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HardwareTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C61D1642BE09D1A1AD6AA9FA /* Pods-HardwareTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.release.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.release.xcconfig"; sourceTree = "<group>"; };
+		D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIntentParameters+Stripe.swift"; sourceTree = "<group>"; };
 		D81AE85925E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCardReaderDiscoveryCache.swift; sourceTree = "<group>"; };
 		D81AE85D25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCardReaderCacheTests.swift; sourceTree = "<group>"; };
 		D81AE86325E6B77F00D9CFD3 /* CardReaderServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderServiceError.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				D89B8F1125DDCBCD0001C726 /* Charge+Stripe.swift */,
 				D89B8F1525DDCC810001C726 /* ChargeStatus+Stripe.swift */,
 				D89B8F1D25DDCD3D0001C726 /* PaymentIntent+Stripe.swift */,
+				D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */,
 				D89B8F2325DDCD800001C726 /* PaymentIntentStatus+Stripe.swift */,
 				D88FDB3725DD21D200CB0DBD /* StripeCardReaderService.swift */,
 				D88FDB3825DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift */,
@@ -408,6 +411,7 @@
 				D88FDB2D25DD21B000CB0DBD /* PaymentIntentParameters.swift in Sources */,
 				D89B8F0825DDC8F60001C726 /* Charge.swift in Sources */,
 				D88FDB2E25DD21B000CB0DBD /* CardReaderEvent.swift in Sources */,
+				D80409A625FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift in Sources */,
 				D89B8F0C25DDC9D30001C726 /* ChargeStatus.swift in Sources */,
 				D88FDB3125DD21B000CB0DBD /* CardReader.swift in Sources */,
 				D81AE85A25E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift in Sources */,

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -5,4 +5,5 @@
 public enum CardReaderServiceError: Error {
     case discovery
     case connection
+    case intentCreation
 }

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -3,7 +3,12 @@
 /// Proper error handling is coming in
 /// https://github.com/woocommerce/woocommerce-ios/issues/3734
 public enum CardReaderServiceError: Error {
+    /// Error thrown during reader discovery
     case discovery
+
+    /// Error thrown while connecting to a reader
     case connection
+
+    /// Error thrown while creating a payment intent
     case intentCreation
 }

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -5,13 +5,13 @@
 public struct PaymentIntentParameters {
     /// The amount of the payment, provided in the currency’s smallest unit.
     /// Note: in testmode, only amounts ending in “00” will be approved. All other amounts will be declined by the Stripe API
-    let amount: UInt
+    public let amount: UInt
 
     /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
-    let currency: String
+    public let currency: String
 
     ///An arbitrary string attached to the object. If you send a receipt email for this payment, the email will include the description.
-    let receiptDescription: String?
+    public let receiptDescription: String?
 
     /**
      * A string to be displayed on your customer’s credit card statement.
@@ -21,5 +21,15 @@ public struct PaymentIntentParameters {
      * Non-ASCII characters are automatically stripped.
      * While most banks and card issuers display this information consistently, some may display it incorrectly or not at all.
      */
-    let statementDescription: String?
+    public let statementDescription: String?
+
+    public init(amount: UInt,
+                currency: String,
+                receiptDescription: String? = nil,
+                statementDescription: String? = nil) {
+        self.amount = amount
+        self.currency = currency
+        self.receiptDescription = receiptDescription
+        self.statementDescription = statementDescription
+    }
 }

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -10,7 +10,7 @@ public struct PaymentIntentParameters {
     /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
     public let currency: String
 
-    ///An arbitrary string attached to the object. If you send a receipt email for this payment, the email will include the description.
+    /// An arbitrary string attached to the object. If you send a receipt email for this payment, the email will include the description.
     public let receiptDescription: String?
 
     /**

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -5,7 +5,7 @@
 public struct PaymentIntentParameters {
     /// The amount of the payment, provided in the currency’s smallest unit.
     /// Note: in testmode, only amounts ending in “00” will be approved. All other amounts will be declined by the Stripe API
-    let amount: Int
+    let amount: UInt
 
     /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
     let currency: String

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -1,4 +1,25 @@
 /// Encapsulates the parameters needed to create a PaymentIntent
+/// The Stripe Terminal SDK provides support for several parameters
+/// i.e. metadata,onBehalfOf...
+/// We will start with supporting the basics
 public struct PaymentIntentParameters {
+    /// The amount of the payment, provided in the currency’s smallest unit.
+    /// Note: in testmode, only amounts ending in “00” will be approved. All other amounts will be declined by the Stripe API
+    let amount: Int
 
+    /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+    let currency: String
+
+    ///An arbitrary string attached to the object. If you send a receipt email for this payment, the email will include the description.
+    let receiptDescription: String?
+
+    /**
+     * A string to be displayed on your customer’s credit card statement.
+     * This may be up to 22 characters.
+     * The statement descriptor must contain at least one letter, may not include <>"' characters,
+     * and will appear on your customer’s statement in capital letters.
+     * Non-ASCII characters are automatically stripped.
+     * While most banks and card issuers display this information consistently, some may display it incorrectly or not at all.
+     */
+    let statementDescription: String?
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -1,0 +1,30 @@
+import StripeTerminal
+
+extension Hardware.PaymentIntentParameters {
+//    /// Convenience initializer
+//    /// - Parameter intentParameters: An instance of a StripeTerminal.PaymentIntentParameters
+//    init(intentParameters: StripePaymentIntentParameters) {
+//        self.amount = intentParameters.amount
+//        self.currency = intentParameters.currency
+//        self.receiptDescription = intentParameters.stripeDescription
+//        self.statementDescription = intentParameters.statementDescriptor
+//    }
+//
+    func toStripe() -> StripeTerminal.PaymentIntentParameters {
+        let returnValue = StripeTerminal.PaymentIntentParameters(amount: self.amount, currency: self.currency)
+        returnValue.stripeDescription = self.receiptDescription
+        returnValue.statementDescriptor = self.statementDescription
+
+        return returnValue
+    }
+}
+
+
+//protocol StripePaymentIntentParameters {
+//    var amount: UInt { get }
+//    var currency: String { get }
+//    var stripeDescription: String { get set }
+//    var statementDescriptor: String { get set }
+//}
+//
+//extension StripeTerminal.PaymentIntentParameters: StripePaymentIntentParameters {}

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -1,15 +1,8 @@
 import StripeTerminal
 
 extension Hardware.PaymentIntentParameters {
-//    /// Convenience initializer
-//    /// - Parameter intentParameters: An instance of a StripeTerminal.PaymentIntentParameters
-//    init(intentParameters: StripePaymentIntentParameters) {
-//        self.amount = intentParameters.amount
-//        self.currency = intentParameters.currency
-//        self.receiptDescription = intentParameters.stripeDescription
-//        self.statementDescription = intentParameters.statementDescriptor
-//    }
-//
+    /// Initializes a StripeTerminal.PaymentIntentParameters from a
+    /// Hardware.PaymentIntentParameters
     func toStripe() -> StripeTerminal.PaymentIntentParameters {
         let returnValue = StripeTerminal.PaymentIntentParameters(amount: self.amount, currency: self.currency)
         returnValue.stripeDescription = self.receiptDescription
@@ -18,13 +11,3 @@ extension Hardware.PaymentIntentParameters {
         return returnValue
     }
 }
-
-
-//protocol StripePaymentIntentParameters {
-//    var amount: UInt { get }
-//    var currency: String { get }
-//    var stripeDescription: String { get set }
-//    var statementDescriptor: String { get set }
-//}
-//
-//extension StripeTerminal.PaymentIntentParameters: StripePaymentIntentParameters {}

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -64,8 +64,8 @@ extension StripeCardReaderService: CardReaderService {
 
         // Attack the test terminal, provided by the SDK
         let config = DiscoveryConfiguration(
-            discoveryMethod: .internet,
-            simulated: true
+            discoveryMethod: .bluetoothScan,
+            simulated: false
         )
 
         switchStatusToDiscovering()
@@ -215,6 +215,12 @@ extension StripeCardReaderService: DiscoveryDelegate {
         let wooReaders = readers.map {
             CardReader(reader: $0)
         }
+
+        print("==== did updated discovered")
+        print(wooReaders)
+        print("count ", wooReaders.count)
+        print("//// did updated discovered")
+
 
         discoveredReadersSubject.send(wooReaders)
     }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -64,7 +64,7 @@ extension StripeCardReaderService: CardReaderService {
 
         // Attack the test terminal, provided by the SDK
         let config = DiscoveryConfiguration(
-            discoveryMethod: .bluetoothScan,
+            discoveryMethod: .bluetoothProximity,
             simulated: false
         )
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -126,6 +126,8 @@ extension StripeCardReaderService: CardReaderService {
     public func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
             Terminal.shared.createPaymentIntent(parameters.toStripe()) { (intent, error) in
+                print("==== intent ", intent)
+                print("==== error ", error)
                 guard let _ = self else {
                     promise(Result.failure(CardReaderServiceError.intentCreation))
                     return

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -218,12 +218,6 @@ extension StripeCardReaderService: DiscoveryDelegate {
             CardReader(reader: $0)
         }
 
-        print("==== did updated discovered")
-        print(wooReaders)
-        print("count ", wooReaders.count)
-        print("//// did updated discovered")
-
-
         discoveredReadersSubject.send(wooReaders)
     }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -125,6 +125,7 @@ extension StripeCardReaderService: CardReaderService {
 
     public func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
+            // Contains enough implementation just to pass a test on the happy path.
             // We are not doing any proper error handling yet, but for now we
             // will propagate an error specific to this operation (.intentCreation)
             Terminal.shared.createPaymentIntent(parameters.toStripe()) { (intent, error) in

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -126,8 +126,6 @@ extension StripeCardReaderService: CardReaderService {
     public func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
             Terminal.shared.createPaymentIntent(parameters.toStripe()) { (intent, error) in
-                print("==== intent ", intent)
-                print("==== error ", error)
                 guard let _ = self else {
                     promise(Result.failure(CardReaderServiceError.intentCreation))
                     return

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -125,6 +125,8 @@ extension StripeCardReaderService: CardReaderService {
 
     public func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
+            // We are not doing any proper error handling yet, but for now we
+            // will propagate an error specific to this operation (.intentCreation)
             Terminal.shared.createPaymentIntent(parameters.toStripe()) { (intent, error) in
                 guard let _ = self else {
                     promise(Result.failure(CardReaderServiceError.intentCreation))

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -114,6 +114,7 @@ final class OrderDetailsViewModel {
         // For now, this defaults to the feature flag, but here we should take into
         // account wheter the store is enrolled into WCPay and the order is elegible
         // for collecting card present payments
+        // https://github.com/woocommerce/woocommerce-ios/issues/3828
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -108,6 +108,15 @@ final class OrderDetailsViewModel {
         }
     }
 
+    /// Indicates if payment for the order can be collected using an external card reader
+    ///
+    var canCollectPayment: Bool {
+        // For now, this defaults to the feature flag, but here we should take into
+        // account wheter the store is enrolled into WCPay and the order is elegible
+        // for collecting card present payments
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments)
+    }
+
     /// Helpers
     ///
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -442,6 +442,8 @@ extension OrderDetailsViewModel {
     }
 
     func collectPayment() {
+        // Mock Payment. We will have to instantiate these parameters with
+        // the proper amount, currency and readable descripitions later.
         let paymentParameters = PaymentParameters(amount: 100,
                                                   currency: "usd",
                                                   receiptDescription: "Receipt",

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -431,4 +431,18 @@ extension OrderDetailsViewModel {
 
         stores.dispatch(deleteTrackingAction)
     }
+
+    func collectPayment() {
+        let paymentParameters = PaymentParameters(amount: 100,
+                                                  currency: "usd",
+                                                  receiptDescription: "Receipt",
+                                                  statementDescription: "Statement")
+
+        let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
+                                                             orderID: order.orderID, parameters: paymentParameters) { (result) in
+            print("===== result ", result)
+        }
+
+        ServiceLocator.stores.dispatch(action)
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -449,7 +449,7 @@ extension OrderDetailsViewModel {
 
         let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
                                                              orderID: order.orderID, parameters: paymentParameters) { (result) in
-            print("===== result ", result)
+            print("===== proof that collectPayment completes with success ", result)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -449,7 +449,7 @@ extension OrderDetailsViewModel {
 
         let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
                                                              orderID: order.orderID, parameters: paymentParameters) { (result) in
-            print("===== proof that collectPayment completes with success ", result)
+            // TODO. Show success
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -446,8 +446,8 @@ extension OrderDetailsViewModel {
         // the proper amount, currency and readable descripitions later.
         let paymentParameters = PaymentParameters(amount: 100,
                                                   currency: "usd",
-                                                  receiptDescription: "Receipt description. No need to localize for now",
-                                                  statementDescription: "Statement description. No need to localize for now")
+                                                  receiptDescription: "Receipt description.",
+                                                  statementDescription: "Statement description.")
 
         let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
                                                              orderID: order.orderID, parameters: paymentParameters) { (result) in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -446,8 +446,8 @@ extension OrderDetailsViewModel {
         // the proper amount, currency and readable descripitions later.
         let paymentParameters = PaymentParameters(amount: 100,
                                                   currency: "usd",
-                                                  receiptDescription: "Receipt",
-                                                  statementDescription: "Statement")
+                                                  receiptDescription: "Receipt description. No need to localize for now",
+                                                  statementDescription: "Statement description. No need to localize for now")
 
         let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
                                                              orderID: order.orderID, parameters: paymentParameters) { (result) in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -113,6 +113,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
     /// Called when a reader has been discovered (with an array of discovered readers).
     private func didDiscoverReaders(cardReaders: [CardReader]) -> Void {
         // TODO - more than one reader? sort in the manner in which we'd like the rows presented
+        print("=== is main thread ", Thread.isMainThread)
         guard activeAlert != .foundReader else {
             return
         }
@@ -123,7 +124,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         // TODO - show the multiple-readers-found UITableView when more than one reader is found
         // For now, just show the tail (last) of the array
-        guard let cardReader = cardReaders.last else {
+        guard let cardReader = cardReaders.first else {
             return
         }
         foundReaders = [cardReader]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -113,7 +113,6 @@ final class CardReaderSettingsViewModel: ObservableObject {
     /// Called when a reader has been discovered (with an array of discovered readers).
     private func didDiscoverReaders(cardReaders: [CardReader]) -> Void {
         // TODO - more than one reader? sort in the manner in which we'd like the rows presented
-        print("=== is main thread ", Thread.isMainThread)
         guard activeAlert != .foundReader else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -115,6 +115,17 @@ private extension OrderDetailsViewController {
         let titleFormat = NSLocalizedString("Order #%1$@", comment: "Order number title. Parameters: %1$@ - order number")
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
         removeNavigationBackBarButtonText()
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: "$",
+                                                               style: .plain,
+                                                               target: self,
+                                                               action: #selector(collectPayment))
+        }
+    }
+
+    @objc private func collectPayment() {
+        viewModel.collectPayment()
     }
 
     /// Setup: EntityListener

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -116,16 +116,17 @@ private extension OrderDetailsViewController {
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
         removeNavigationBackBarButtonText()
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
+        /// To be removed
+        /// To keep the PR short, and to avoid going down the rabbit hole of
+        /// updating the UI to look final, we add a toolbar button item
+        /// to trigger payment collection.
+        /// Will be made obsolete by https://github.com/woocommerce/woocommerce-ios/issues/3826
+        if viewModel.canCollectPayment {
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: "$",
                                                                style: .plain,
                                                                target: self,
                                                                action: #selector(collectPayment))
         }
-    }
-
-    @objc private func collectPayment() {
-        viewModel.collectPayment()
     }
 
     /// Setup: EntityListener
@@ -505,6 +506,10 @@ private extension OrderDetailsViewController {
         popoverController?.sourceView = sourceView
 
         present(actionSheet, animated: true)
+    }
+
+    @objc private func collectPayment() {
+        viewModel.collectPayment()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -109,6 +109,26 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
         wait(for: [discoveredReaders, connectedToReader, connectedreaderIsPublished], timeout: Constants.expectationTimeout)
     }
 
+    func test_creating_intent_returns_valid_intent() {
+        let intentCreation = expectation(description: "Creating a Payment Intent")
+
+        let readerService = ServiceLocator.cardReaderService
+        //readerService.start(MockTokenProvider())
+
+        let parameters = PaymentIntentParameters(amount: 100, currency: "usd", receiptDescription: "receipt", statementDescription: "statement")
+
+        readerService.createPaymentIntent(parameters).sink { completion in
+            print("==== completion ")
+        } receiveValue: { intent in
+            print("== new intent")
+            XCTAssertFalse(intent.id.isEmpty)
+            XCTAssertEqual(intent.amount, parameters.amount)
+            XCTAssertEqual(intent.currency, parameters.currency)
+        }.store(in: &cancellables)
+
+
+        wait(for: [intentCreation], timeout: Constants.expectationTimeout)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -166,6 +166,6 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
 private final class MockTokenProvider: CardReaderConfigProvider {
     func fetchToken(completion: @escaping(String?, Error?) -> Void) {
-        completion("pst_test_YWNjdF8xSU84MnIySERPb0MxYlRjLEg1VkVXMHBlY2FuUlFybzc0YXNKcHA3cG93MUxLUFA_00HPM91Gau", nil)
+        completion("a token", nil)
     }
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -14,7 +14,7 @@ public enum CardPresentPaymentAction: Action {
     ///
     case connect(reader: CardReader, onCompletion: (Result<[CardReader], Error>) -> Void)
 
-    /// Collected a payment for a given order.
+    /// Collected payment for an order.
     ///
     case collectPayment(siteID: Int64, orderID: Int64, parameters: PaymentParameters, onCompletion: (Result<Bool, Error>) -> Void )
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -13,4 +13,8 @@ public enum CardPresentPaymentAction: Action {
     /// Stops Card Reader discovery
     ///
     case connect(reader: CardReader, onCompletion: (Result<[CardReader], Error>) -> Void)
+
+    /// Collected a payment for a given order.
+    ///
+    case collectPayment(siteID: Int64, orderID: Int64, parameters: PaymentParameters, onCompletion: (Result<Bool, Error>) -> Void )
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -96,6 +96,7 @@ public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias StoredProductSettings = Networking.StoredProductSettings
 public typealias CardReader = Hardware.CardReader
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
+public typealias PaymentParameters = Hardware.PaymentIntentParameters
 
 
 // MARK: - Exported Storage Symbols

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -103,6 +103,7 @@ private extension CardPresentPaymentStore {
 
         // For now, we will only implement step 1.
         // Create an intent.
+        // And for now, we are not doing any error handling.
         cardReaderService.createPaymentIntent(parameters).sink(receiveCompletion: {error in
             switch error {
             case .failure(let error):
@@ -113,7 +114,8 @@ private extension CardPresentPaymentStore {
                 onCompletion(result)
             }
         }) { (intent) in
-            // TODO. Initiate step 2. Collect payment method
+            // TODO. Initiate step 2. Collect payment method.
+            // Deferred to https://github.com/woocommerce/woocommerce-ios/issues/3825
             let result: Result<Bool, Error> = .success(true)
             onCompletion(result)
         }.store(in: &cancellables)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -114,6 +114,9 @@ private extension CardPresentPaymentStore {
                 onCompletion(result)
             }
         }) { (intent) in
+            print("==== Log for testing purposes. payment intent collected ")
+            print(intent)
+            print("//// payment intent collected ")
             // TODO. Initiate step 2. Collect payment method.
             // Deferred to https://github.com/woocommerce/woocommerce-ios/issues/3825
             let result: Result<Bool, Error> = .success(true)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -42,6 +42,11 @@ public final class CardPresentPaymentStore: Store {
             cancelCardReaderDiscovery(completion: completion)
         case .connect(let reader, let completion):
             connect(reader: reader, onCompletion: completion)
+        case .collectPayment(let siteID, let orderID, let parameters, let completion):
+            collectPayment(siteID: siteID,
+                           orderID: orderID,
+                           parameters: parameters,
+                           onCompletion: completion)
         }
     }
 }
@@ -85,6 +90,31 @@ private extension CardPresentPaymentStore {
         // collection of connected readers
         cardReaderService.connectedReaders.sink { connectedHardwareReaders in
             onCompletion(.success(connectedHardwareReaders))
+        }.store(in: &cancellables)
+    }
+
+    func collectPayment(siteID: Int64, orderID: Int64, parameters: PaymentParameters, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        // The high-level logic of this method would be:
+        // 1. Attack the CardReaderService to create a payment intent.
+        // When that is completed...
+        // 2. Attack the CardReaderService to collect payment methods for that intent
+        // When that is completed...
+        // 3. Attack the CardReaderService to process the payment
+
+        // For now, we will only implement step 1.
+        // Create an intent.
+        cardReaderService.createPaymentIntent(parameters).sink(receiveCompletion: {error in
+            switch error {
+            case .failure(let error):
+                let result: Result<Bool, Error> = .failure(error)
+                onCompletion(result)
+            case .finished:
+                let result: Result<Bool, Error> = .success(true)
+                onCompletion(result)
+            }
+        }) { (intent) in
+            let result: Result<Bool, Error> = .success(true)
+            onCompletion(result)
         }.store(in: &cancellables)
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -113,6 +113,7 @@ private extension CardPresentPaymentStore {
                 onCompletion(result)
             }
         }) { (intent) in
+            // TODO. Initiate step 2. Collect payment method
             let result: Result<Bool, Error> = .success(true)
             onCompletion(result)
         }.store(in: &cancellables)

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,27 @@
+# Hardware
+
+## High level class diagram
+
+## Public interfaces
+
+## Model objects
+
+## Integration with Stripe Terminal
+
+The initial release of Hardware provides an integration with the [Stripe Terminal SDK](https://github.com/stripe/stripe-terminal-ios)
+
+### Initialization
+
+### Discovering readers
+
+### Pairing (connecting) with a reader
+
+### Processing a payment
+
+Collecting a payment is a three step process that needs to be performed in this specific sequence:
+
+1. [Create a Payment Intent](https://stripe.com/docs/terminal/payments#create-payment). There are two ways to create a payment intent, depending on the external card reader being used. Intents can be created on device, with the exception of the Verifone P400 reader, that requires creating the PaymentIntent server-side.
+2. [Collect a Payment Method](https://stripe.com/docs/terminal/payments#collect-payment). In order to collect a payment method, the app needs to be connected to a reader. The connected reader will wait for a card to be presented after the app calls collectPaymentMethod. This method collects encrypted payment method data using the connected card reader, and associates the encrypted data with the local PaymentIntent.
+3. [Process the Payment](https://stripe.com/docs/terminal/payments#process-payment). After successfully collecting a payment method from the customer, the next step is to process the payment with the SDK. We can either process automatically or display a confirmation screen, where the customer can choose to proceed with the payment or cancel (e.g., to pay with cash, or use a different payment method).
+
+For more details, see [Stripe's documentation](https://stripe.com/docs/terminal/payments)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
     - [Networking](NETWORKING.md)
     - [Storage](STORAGE.md)
     - [Yosemite](YOSEMITE.md)
+    - [Hardware](HARDWARE.md)
 - Coding Guidelines
     - [Coding Style](coding-style-guide.md)
     - [Naming Conventions](naming-conventions.md)


### PR DESCRIPTION
Closes #3748 and #3749 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

🔴🔴 Testing this PR requires a hardware reader and setting up a store for testing🔴🔴

We continue building our prototype (for reference, p91TBi-4q4-p2), this time, by implementing logic in Yosemite and Hardware to create a Payment Intent on device. 

The significance of a Payment Intent is, hopefully, explained in [the README accompanying the PR](https://github.com/woocommerce/woocommerce-ios/blob/issue/3748-intent-service/docs/HARDWARE.md).

## Changes
* Implemented `createPaymentIntent` in StripeCardReaderService to implement just enough functionality to attack the Stripe Terminal SDK and create a PaymentIntent. This does not include error handling for now. #3741 and #3747 will cover error handling.
* Implements support in `CardPresentPaymentAction` and `CardPresentPaymentStore` for a new high-level action to collect a payment. The reason why the high level action exposed to the app is "collect a payment" instead of just "create an intent" is covered [in the README that is part of the PR diff](https://github.com/woocommerce/woocommerce-ios/blob/issue/3748-intent-service/docs/HARDWARE.md).
* Adds a variable to `OrderDetailsViewModel` that exposes if an order is eligible for card present payments. At this point, that variable relies only on the feature flag, but eventually this is where we would check if the user is a WCPay user and the order is eligible.
* Adds a button to the toolbar of the OrderDetailsViewController only for testing purposes. This button is available in all orders for now, and triggers the "collect payment" high level action exposed by Yosemite The button will be removed and implemented properly in #3826 

## How to test
Testing is complicated because:
1. Requires setting up a store for [Card Present Payment Testing](https://github.com/woocommerce/woocommerce-ios/blob/issue/3748-intent-service/docs/stripe-tests.md#integration-tests) (also P91TBi-4BH-p2 for more specific instructions)  
2. Requires an external hardware reader.

The process to test this PR requires interacting with the UI while running the app on a device, and also looking at the Xcode console for some logs.
1. Checkout the branch. Run `bundle exec pod install`. 
2. Build and run on a device. 
3. Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
4. Log in to an account that matches a store that has been configured for testing.
5. Navigate to Settings in the app. (Tap the gear button in the top right)
6. In the "Store Settings" section, tap "Manage Card Reader".
7. Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
8. Tap "Connect card reader"
9. Wait until the app suggests one reader to connect to.
10. Tap "Connect to reader"
11. Make sure the reader light turns solid blue.
12. Navigate to an order (any order).
13. Tap the dollar sign in the top right corner
14. Check the console in Xcode. There should be a log similar to this:
```
==== Log for testing purposes. payment intent collected 
PaymentIntent(id: "pi_1IVHva2HDOoC1bTcjSAC5BAc", status: Hardware.PaymentIntentStatus.requiresPaymentMethod, created: 2021-03-15 15:01:54 +0000, amount: 100, currency: "usd", metadata: Optional([:]), charges: [])
//// payment intent collected 
```

The status should indicate that the PaymentIntent still requires a payment method.

Step by step screenshots:
Step 1:
<img src="https://user-images.githubusercontent.com/2722505/111180448-6ebca980-8583-11eb-8852-a72bba1a72f8.PNG" width="350"/>

Step 2:
<img src="https://user-images.githubusercontent.com/2722505/111180466-72503080-8583-11eb-8358-1bec5676ae5c.PNG" width="350"/>

Step 3:
<img src="https://user-images.githubusercontent.com/2722505/111180457-6fedd680-8583-11eb-860c-29bd69c96de3.PNG" width="350"/>

Step 4:
<img src="https://user-images.githubusercontent.com/2722505/111180453-6f554000-8583-11eb-907f-a7476b0dce89.PNG" width="350"/>

Step 5:
<img src="https://user-images.githubusercontent.com/2722505/111180461-70866d00-8583-11eb-924d-03cd174466b3.PNG" width="350"/>

Step 6:
<img src="https://user-images.githubusercontent.com/2722505/111180463-71b79a00-8583-11eb-96cf-c56e678acb13.PNG" width="350"/>

Step 7:
<img src="https://user-images.githubusercontent.com/2722505/111180464-71b79a00-8583-11eb-8672-2b0dc9e7a762.PNG" width="350"/>


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
