### PR TITLE
Fixed autolayout issues on TopBannerView in Shipping Label address validation flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -66,6 +66,10 @@ final class ShippingLabelSuggestedAddressViewController: UIViewController {
         configureEditAddressButton()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.updateHeaderHeight()
+    }
 }
 
 // MARK: - View Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -57,6 +57,11 @@ final class ShippingLabelAddressFormViewController: UIViewController {
         configureConfirmButton()
         keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.updateHeaderHeight()
+    }
 }
 
 // MARK: - View Configuration


### PR DESCRIPTION
Part of #2973 

## Description
In this PR I fixed some auto layout issues in the TopBannerView showed when an error occurs in the Shipping Label Address Validation flow. Previously, the top banner was compacted, cutting off some of the text.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in the Create Shipping Label form. -> If there is a suggested address, you should see the suggested address screen with the top banner on top not clipped.
5. Try to edit an address and generate an error. -> You should see the top banner not clipped.

## Screenshots
| Suggested Address (Before)             |  Suggested Address (After) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-16 at 12 27 57](https://user-images.githubusercontent.com/495617/111303627-04743980-8655-11eb-8d3e-6a67fb68294b.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-16 at 12 37 44](https://user-images.githubusercontent.com/495617/111303638-06d69380-8655-11eb-8640-a0eed307318e.png)



| Edit Address (before)             |  Edit Address (after) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-16 at 12 28 23](https://user-images.githubusercontent.com/495617/111303681-1524af80-8655-11eb-9534-6082540d470c.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-16 at 12 37 49](https://user-images.githubusercontent.com/495617/111303689-16ee7300-8655-11eb-9c2c-c3ee168d594c.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
