### PR TITLE
Variations: Fix issues when updating product attributes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.3
 -----
 - [*] Fix: In landscape orientation, all backgrounds on detail screens and their subsections now extend edge-to-edge. [https://github.com/woocommerce/woocommerce-ios/pull/3808]
+- [*] Fix: Creating an attribute or a variation no longer saves your product pending changes. [https://github.com/woocommerce/woocommerce-ios/pull/3832]
 - [*] Enhancement/fix: image & text footnote info link rows are now center aligned in order details reprint shipping label info row and reprint screen. [https://github.com/woocommerce/woocommerce-ios/pull/3805]
 
 6.2

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -341,12 +341,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 break
             case .variations(let row):
                 ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
-                guard let product = product as? EditableProductModel, row.isActionable else {
+                guard let originalProduct = viewModel.originalProductModel as? EditableProductModel, row.isActionable else {
                     return
                 }
                 let variationsViewModel = ProductVariationsViewModel()
                 let variationsViewController = ProductVariationsViewController(viewModel: variationsViewModel,
-                                                                               product: product.product,
+                                                                               product: originalProduct.product,
                                                                                formType: viewModel.formType)
                 variationsViewController.onProductUpdate = { [viewModel] updatedProduct in
                     viewModel.updateProductVariations(from: updatedProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -105,6 +105,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         handleSwipeBackGesture()
 
         observeProduct()
+        observeProductName()
         observeUpdateCTAVisibility()
 
         productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
@@ -468,6 +469,18 @@ private extension ProductFormViewController {
     func observeProduct() {
         cancellableProduct = viewModel.observableProduct.subscribe { [weak self] product in
             self?.onProductUpdated(product: product)
+        }
+    }
+
+    /// Observe product name changes and re-render the product if the change happened outside this screen.
+    /// The "happened outside" condition is needed to not reload the view while the user is typing a new name.
+    ///
+    func observeProductName() {
+        cancellableProductName = viewModel.productName?.subscribe { [weak self] _ in
+            guard let self = self else { return }
+            if self.view.window == nil { // If window is nil, this screen isn't the active screen.
+                self.onProductUpdated(product: self.product)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -25,6 +25,11 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         product
     }
 
+    /// The original product value.
+    var originalProductModel: EditableProductModel {
+        originalProduct
+    }
+
     /// The form type could change from .add to .edit after creation.
     private(set) var formType: ProductFormType
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -31,6 +31,9 @@ protocol ProductFormViewModelProtocol {
     /// The latest product value.
     var productModel: ProductModel { get }
 
+    /// The original product value.
+    var originalProductModel: ProductModel { get }
+
     /// The latest product password, if the product is password protected.
     var password: String? { get }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -15,6 +15,11 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         productVariation
     }
 
+    /// The original product variation.
+    var originalProductModel: EditableProductVariationModel {
+        originalProductVariation
+    }
+
     /// Emits a boolean of whether the product variation has unsaved changes for remote update.
     var isUpdateEnabled: Observable<Bool> {
         isUpdateEnabledSubject

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -661,12 +661,10 @@ private extension ProductVariationsViewController {
 
     func didLeave(state: PaginatedListViewControllerState) {
         switch state {
-        case .noResultsPlaceholder:
-            removeEmptyViewController()
         case .syncing:
             ensureFooterSpinnerIsStopped()
             removePlaceholderProducts()
-        case .results:
+        case .noResultsPlaceholder, .results:
             break
         }
     }


### PR DESCRIPTION
# Why

While working on [adding a variable product from scratch](https://github.com/woocommerce/woocommerce-ios/issues/3802) I realized that the add variations had a couple of problems.

1. If you tap back after creating an attribute(no variations) the variation list screen fails to display the empty variation state screen

2. If you add modifications to your product, then create an attribute or variation, the UI will show that there are changes pending to commit, but the changes have already been committed remotely.

3. If you updated **only** the product name, and then went out to create an attribute or variation. After coming back, the name was not correctly rendered.

# How

1. Fixed by not removing the empty state on the `didLeave.noResultsPlaceholder` state and let the empty state only be controller by the `VM`. The issue was happening because `didLeave.noResultsPlaceholder` occurs when refreshing/going into `.synced` state.

2. Fixed by passing the original product, rather than the modified product to the "Product Variations" module.

3. Fixed by observing any name change and only reloading the screen if the change happened while the screen was not visible. This in order to prevent any table update while the merchant is typing a new product name.

# Demo
Before | After
--- | ---
![bad](https://user-images.githubusercontent.com/562080/111351052-c248f900-8650-11eb-88a6-b1ffb40054eb.gif) | ![good](https://user-images.githubusercontent.com/562080/111351017-b9582780-8650-11eb-8de9-20efb9d372ac.gif)

# Testing Steps
- Open the app and go to a variable product
- Modify the name
- Tap on variations cell and create an attribute or a variation
- Tap back until the product screen 
- See that the name is still modified and the update button is visible
- Tap back until the product list screen
- See that the name has the original product name, refresh the list and verify the same.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
