### PR TITLE
Shipping Labels: local validation of address fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -422,7 +422,7 @@ private extension ShippingLabelAddressFormViewController {
                                                       comment: "Error showed in Shipping Label Address Validation for the address field")
         static let missingCity = NSLocalizedString("City missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the city field")
-        static let missingPostcode = NSLocalizedString("Postcode invalid",
+        static let missingPostcode = NSLocalizedString("Postcode missing",
                                                        comment: "Error showed in Shipping Label Address Validation for the postcode field")
         static let missingState = NSLocalizedString("State missing",
                                                     comment: "Error showed in Shipping Label Address Validation for the state field")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -143,21 +143,27 @@ private extension ShippingLabelAddressFormViewController {
 private extension ShippingLabelAddressFormViewController {
 
     @objc func doneButtonTapped() {
-        viewModel.validateAddress(onlyLocally: false) { [weak self] (success, error) in
+        viewModel.validateAddress(onlyLocally: false) { [weak self] (result) in
             guard let self = self else { return }
-            if success {
+            switch result {
+            case .success:
                 self.onCompletion(self.viewModel.address)
                 self.navigationController?.popViewController(animated: true)
+            case .failure:
+                break
             }
         }
     }
 
     @objc func confirmButtonTapped() {
-        viewModel.validateAddress(onlyLocally: true) { [weak self] (success, error) in
+        viewModel.validateAddress(onlyLocally: true) { [weak self] (result) in
             guard let self = self else { return }
-            if success {
+            switch result {
+            case .success:
                 self.onCompletion(self.viewModel.address)
                 self.navigationController?.popViewController(animated: true)
+            case .failure:
+                break
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -84,7 +84,7 @@ private extension ShippingLabelAddressFormViewController {
 
     func configureRightButtonItemAsLoader() {
         let indicator = UIActivityIndicatorView(style: .medium)
-        indicator.color = .primaryButtonTitle
+        indicator.color = .navigationBarLoadingIndicator
         indicator.startAnimating()
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: indicator)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -282,17 +282,17 @@ private extension ShippingLabelAddressFormViewController {
         var errorMessage = viewModel.addressValidationError?.addressError
         switch error {
         case .name:
-            errorMessage = Localization.invalidName
+            errorMessage = Localization.missingName
         case .address:
-            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.invalidAddress
+            errorMessage = viewModel.addressValidationError?.addressError ?? Localization.missingAddress
         case .city:
-            errorMessage = Localization.invalidCity
+            errorMessage = Localization.missingCity
         case .postcode:
-            errorMessage = Localization.invalidPostcode
+            errorMessage = Localization.missingPostcode
         case .state:
-            errorMessage = Localization.invalidState
+            errorMessage = Localization.missingState
         case .country:
-            errorMessage = Localization.invalidCountry
+            errorMessage = Localization.missingCountry
         }
 
         cell.textLabel?.text = errorMessage
@@ -416,18 +416,18 @@ private extension ShippingLabelAddressFormViewController {
 
         static let confirmButtonTitle = NSLocalizedString("Use Address as Entered",
                                                           comment: "Action to use the address in Shipping Label Validation screen as entered")
-        static let invalidName = NSLocalizedString("Name invalid",
+        static let missingName = NSLocalizedString("Name missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the name field")
-        static let invalidAddress = NSLocalizedString("Address invalid",
+        static let missingAddress = NSLocalizedString("Address missing",
                                                       comment: "Error showed in Shipping Label Address Validation for the address field")
-        static let invalidCity = NSLocalizedString("City invalid",
+        static let missingCity = NSLocalizedString("City missing",
                                                    comment: "Error showed in Shipping Label Address Validation for the city field")
-        static let invalidPostcode = NSLocalizedString("Postcode invalid",
+        static let missingPostcode = NSLocalizedString("Postcode invalid",
                                                        comment: "Error showed in Shipping Label Address Validation for the postcode field")
-        static let invalidState = NSLocalizedString("State invalid",
+        static let missingState = NSLocalizedString("State missing",
                                                     comment: "Error showed in Shipping Label Address Validation for the state field")
-        static let invalidCountry = NSLocalizedString("Country invalid",
-                                                      comment: "Error showed in Shipping Label Address Validation for the cointry field")
+        static let missingCountry = NSLocalizedString("Country missing",
+                                                      comment: "Error showed in Shipping Label Address Validation for the country field")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -174,7 +174,7 @@ extension ShippingLabelAddressFormViewModel {
 
         addressValidationError = nil
         if validateAddressLocally().isNotEmpty {
-            addressValidated = .local
+            addressValidated = .none
             state.isLoading = false
             onSuccess?(false, nil)
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -173,9 +173,9 @@ extension ShippingLabelAddressFormViewModel {
             onSuccess?(false, nil)
             return
         }
+        isAddressLocallyValidated = true
 
         if onlyLocally {
-            isAddressLocallyValidated = true
             onSuccess?(true, nil)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -90,27 +90,27 @@ final class ShippingLabelAddressFormViewModel {
                 rows.insert(.fieldError(.name), at: rows.index(after: index))
             }
         }
-        else if addressValidationError?.addressError != nil || localErrors.contains(.address) {
+        if addressValidationError?.addressError != nil || localErrors.contains(.address) {
             if let index = rows.firstIndex(where: { $0 == .address }) {
                 rows.insert(.fieldError(.address), at: rows.index(after: index))
             }
         }
-        else if localErrors.contains(.city) {
+        if localErrors.contains(.city) {
             if let index = rows.firstIndex(where: { $0 == .city }) {
                 rows.insert(.fieldError(.city), at: rows.index(after: index))
             }
         }
-        else if localErrors.contains(.postcode) {
+        if localErrors.contains(.postcode) {
             if let index = rows.firstIndex(where: { $0 == .postcode }) {
                 rows.insert(.fieldError(.postcode), at: rows.index(after: index))
             }
         }
-        else if localErrors.contains(.state) {
+        if localErrors.contains(.state) {
             if let index = rows.firstIndex(where: { $0 == .state }) {
                 rows.insert(.fieldError(.state), at: rows.index(after: index))
             }
         }
-        else if localErrors.contains(.country) {
+        if localErrors.contains(.country) {
             if let index = rows.firstIndex(where: { $0 == .country }) {
                 rows.insert(.fieldError(.country), at: rows.index(after: index))
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -73,14 +73,14 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress()
+        viewModel.validateAddress(onlyLocally: false)
 
         // Then
         let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
                                                                      .company,
                                                                      .phone,
                                                                      .address,
-                                                                     .fieldError,
                                                                      .address2,
                                                                      .city,
                                                                      .postcode,
@@ -91,7 +91,15 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
 
     func test_address_validation_returns_correct_values_if_succeeded() {
         // Given
-        let shippingAddress = MockShippingLabelAddress.sampleAddress()
+        let shippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                   name: "Skylar Ferry",
+                                                   phone: "12345",
+                                                   country: "United States",
+                                                   state: "CA",
+                                                   address1: "60 29th",
+                                                   address2: "Street #343",
+                                                   city: "San Francisco",
+                                                   postcode: "94121-2303")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: shippingAddress,
                                                                                 errors: nil,
@@ -108,16 +116,25 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress()
+        viewModel.validateAddress(onlyLocally: false)
 
         // Then
-        XCTAssertEqual(viewModel.isAddressValidated, true)
+        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
+        XCTAssertEqual(viewModel.isAddressFullyValidated, true)
         XCTAssertEqual(viewModel.addressValidationError, nil)
     }
 
     func test_address_validation_returns_correct_values_if_the_validation_fails() {
         // Given
-        let shippingAddress = MockShippingLabelAddress.sampleAddress()
+        let shippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                                         name: "Skylar Ferry",
+                                                                         phone: "12345",
+                                                                         country: "United States",
+                                                                         state: "CA",
+                                                                         address1: "60 29th",
+                                                                         address2: "Street #343",
+                                                                         city: "San Francisco",
+                                                                         postcode: "94121-2303")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: nil,
@@ -135,16 +152,25 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress()
+        viewModel.validateAddress(onlyLocally: false)
 
         // Then
-        XCTAssertEqual(viewModel.isAddressValidated, false)
+        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
+        XCTAssertEqual(viewModel.isAddressFullyValidated, false)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 
     func test_address_validation_returns_correct_values_if_the_validation_returns_an_error() {
         // Given
-        let shippingAddress = MockShippingLabelAddress.sampleAddress()
+        let shippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                   name: "Skylar Ferry",
+                                                   phone: "12345",
+                                                   country: "United States",
+                                                   state: "CA",
+                                                   address1: "60 29th",
+                                                   address2: "Street #343",
+                                                   city: "San Francisco",
+                                                   postcode: "94121-2303")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let error = SampleError.first
 
@@ -159,17 +185,26 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress()
+        viewModel.validateAddress(onlyLocally: false)
 
         // Then
         let validationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
-        XCTAssertEqual(viewModel.isAddressValidated, false)
+        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
+        XCTAssertEqual(viewModel.isAddressFullyValidated, false)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 
     func test_address_validation_toggle_shouldShowTopBannerView() {
         // Given
-        let shippingAddress = MockShippingLabelAddress.sampleAddress()
+        let shippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                   name: "Skylar Ferry",
+                                                   phone: "12345",
+                                                   country: "United States",
+                                                   state: "CA",
+                                                   address1: "60 29th",
+                                                   address2: "Street #343",
+                                                   city: "San Francisco",
+                                                   postcode: "94121-2303")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let expectedValidationResponse = ShippingLabelAddressValidationResponse(address: shippingAddress,
                                                                                 errors: nil,
@@ -188,7 +223,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress()
+        viewModel.validateAddress(onlyLocally: false)
 
         // Then
         XCTAssertTrue(viewModel.showLoadingIndicator)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -81,11 +81,16 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                                      .company,
                                                                      .phone,
                                                                      .address,
+                                                                     .fieldError(.address),
                                                                      .address2,
                                                                      .city,
+                                                                     .fieldError(.city),
                                                                      .postcode,
+                                                                     .fieldError(.postcode),
                                                                      .state,
-                                                                     .country]
+                                                                     .fieldError(.state),
+                                                                     .country,
+                                                                     .fieldError(.country)]
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
@@ -154,7 +159,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         viewModel.validateAddress(onlyLocally: false)
 
         // Then
-        XCTAssertEqual(viewModel.addressValidated, .local)
+        XCTAssertEqual(viewModel.addressValidated, .none)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 
@@ -187,7 +192,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
 
         // Then
         let validationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
-        XCTAssertEqual(viewModel.addressValidated, .local)
+        XCTAssertEqual(viewModel.addressValidated, .none)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -73,7 +73,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress(onlyLocally: false)
+        viewModel.validateAddress(onlyLocally: false) { (result) in
+        }
 
         // Then
         let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
@@ -121,7 +122,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress(onlyLocally: false)
+        viewModel.validateAddress(onlyLocally: false) { (result) in
+        }
 
         // Then
         XCTAssertEqual(viewModel.addressValidated, .remote)
@@ -156,7 +158,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress(onlyLocally: false)
+        viewModel.validateAddress(onlyLocally: false) { (result) in
+        }
 
         // Then
         XCTAssertEqual(viewModel.addressValidated, .none)
@@ -188,7 +191,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress(onlyLocally: false)
+        viewModel.validateAddress(onlyLocally: false) { (result) in
+        }
 
         // Then
         let validationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
@@ -225,7 +229,8 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         }
 
         let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
-        viewModel.validateAddress(onlyLocally: false)
+        viewModel.validateAddress(onlyLocally: false) { (result) in
+        }
 
         // Then
         XCTAssertTrue(viewModel.showLoadingIndicator)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -119,8 +119,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         viewModel.validateAddress(onlyLocally: false)
 
         // Then
-        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
-        XCTAssertEqual(viewModel.isAddressFullyValidated, true)
+        XCTAssertEqual(viewModel.addressValidated, .remote)
         XCTAssertEqual(viewModel.addressValidationError, nil)
     }
 
@@ -155,8 +154,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         viewModel.validateAddress(onlyLocally: false)
 
         // Then
-        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
-        XCTAssertEqual(viewModel.isAddressFullyValidated, false)
+        XCTAssertEqual(viewModel.addressValidated, .local)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 
@@ -189,8 +187,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
 
         // Then
         let validationError = ShippingLabelAddressValidationError(addressError: nil, generalError: error.localizedDescription)
-        XCTAssertEqual(viewModel.isAddressLocallyValidated, true)
-        XCTAssertEqual(viewModel.isAddressFullyValidated, false)
+        XCTAssertEqual(viewModel.addressValidated, .local)
         XCTAssertEqual(viewModel.addressValidationError, validationError)
     }
 


### PR DESCRIPTION
Part of #2973 

## Description
As part of the Shipping Labels M2, we should validate some fields of the Shipping Label Address also locally, in particular, we want to make sure that the user can't proceed without adding some fields that are mandatory, like name, address, city, country, ecc...
I fixed also an issue with the color of the activity indicator that substitute the "Done" button in the navigation bar when pressed. 

## Changes
- `Row` now conform to `Equatable` because we want to manage different type of errors in `fieldError` case.
- The `validateAddress` method allow us to validate an address locally or both locally + remotely.
- Refactor of how `sections` are managed and refreshed. Before, we built sections on the fly, when they were requested by the view controller. This could cause a misalignment with the state of the view model. Sections are now updated when the `State` undergoes a change.
- Updated unit tests.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the **Ship From** cell.
5. Go to the editing address screen, and try to delete one of the mandatory fields (like `name`). Press the Done button. -> You should see an error under the name field. 
6. The same things should happen pressing the button `Use address as Entered`, with the only difference that the address will be validated only locally, checking that the mandatory fields are fulfilled.

## Screenshots
<img src="https://user-images.githubusercontent.com/495617/111469909-8b91e200-8727-11eb-80ea-39289dc4a09b.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
