### PR TITLE
[Mobile payments] Add networking - plugins

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		26E83A022554683A00390DD9 /* GeneratedFakeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E83A012554683A00390DD9 /* GeneratedFakeable.swift */; };
 		26FB056C25F6CB9100A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056B25F6CB9100A40B26 /* Fakes.framework */; };
 		311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */; };
+		31884A3B2603F3C7003FE338 /* SitePluginStatusEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */; };
 		31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C802602889C002EDB1D /* SitePluginsRemote.swift */; };
 		31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */; };
 		31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C8A26028D96002EDB1D /* SitePlugin.swift */; };
@@ -541,6 +542,7 @@
 		26E83A012554683A00390DD9 /* GeneratedFakeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedFakeable.swift; sourceTree = "<group>"; };
 		26FB056B25F6CB9100A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapperTests.swift; sourceTree = "<group>"; };
+		31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStatusEnum.swift; sourceTree = "<group>"; };
 		31D27C802602889C002EDB1D /* SitePluginsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsRemote.swift; sourceTree = "<group>"; };
 		31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapper.swift; sourceTree = "<group>"; };
 		31D27C8A26028D96002EDB1D /* SitePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlugin.swift; sourceTree = "<group>"; };
@@ -1259,6 +1261,7 @@
 				7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */,
 				4568E2232459D3230007E478 /* Post.swift */,
 				31D27C8A26028D96002EDB1D /* SitePlugin.swift */,
+				31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */,
 				74046E1C217A6989007DD7BF /* SiteSetting.swift */,
 				74159624224D4045003C21CF /* SiteSettingGroup.swift */,
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
@@ -2014,6 +2017,7 @@
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */,
 				B567AF2920A0FA1E00AB6C62 /* Mapper.swift in Sources */,
+				31884A3B2603F3C7003FE338 /* SitePluginStatusEnum.swift in Sources */,
 				CE50345E21B571A7007573C6 /* SitePlanMapper.swift in Sources */,
 				D8FBFF2022D52553006E3336 /* OrderStatsV4Totals.swift in Sources */,
 				02C254B925637BA000A04423 /* OrderShippingLabelListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -107,6 +107,12 @@
 		26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */; };
 		26E83A022554683A00390DD9 /* GeneratedFakeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E83A012554683A00390DD9 /* GeneratedFakeable.swift */; };
 		26FB056C25F6CB9100A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056B25F6CB9100A40B26 /* Fakes.framework */; };
+		311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */; };
+		31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C802602889C002EDB1D /* SitePluginsRemote.swift */; };
+		31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */; };
+		31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C8A26028D96002EDB1D /* SitePlugin.swift */; };
+		31D27C8F2602B553002EDB1D /* plugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 31D27C8E2602B553002EDB1D /* plugins.json */; };
+		31D27C952602B737002EDB1D /* SitePluginsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
@@ -534,6 +540,12 @@
 		26E5A08B25A66FD3000DF8F6 /* ProductAttributeTermRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermRemoteTests.swift; sourceTree = "<group>"; };
 		26E83A012554683A00390DD9 /* GeneratedFakeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedFakeable.swift; sourceTree = "<group>"; };
 		26FB056B25F6CB9100A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapperTests.swift; sourceTree = "<group>"; };
+		31D27C802602889C002EDB1D /* SitePluginsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsRemote.swift; sourceTree = "<group>"; };
+		31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapper.swift; sourceTree = "<group>"; };
+		31D27C8A26028D96002EDB1D /* SitePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlugin.swift; sourceTree = "<group>"; };
+		31D27C8E2602B553002EDB1D /* plugins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = plugins.json; sourceTree = "<group>"; };
+		31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsRemoteTests.swift; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -1046,6 +1058,7 @@
 				7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */,
 				743E84F9221742E300FAC9D7 /* ShipmentsRemoteTests.swift */,
 				74AB5B5021AF426D00859C12 /* SiteAPIRemoteTests.swift */,
+				31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */,
 				453305EE2459E46000264E50 /* SitePostsRemoteTests.swift */,
 				74D5BECD217E0F98007B0348 /* SiteSettingsRemoteTests.swift */,
 				74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */,
@@ -1168,6 +1181,7 @@
 				7412A8E921B6E192005D182A /* ReportRemote.swift */,
 				743E84E922171C5800FAC9D7 /* ShipmentsRemote.swift */,
 				7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */,
+				31D27C802602889C002EDB1D /* SitePluginsRemote.swift */,
 				74046E1A217A684D007DD7BF /* SiteSettingsRemote.swift */,
 				74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */,
 				4568E2212459ADC60007E478 /* SitePostsRemote.swift */,
@@ -1244,6 +1258,7 @@
 				B56C1EB720EA76F500D749F9 /* Site.swift */,
 				7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */,
 				4568E2232459D3230007E478 /* Post.swift */,
+				31D27C8A26028D96002EDB1D /* SitePlugin.swift */,
 				74046E1C217A6989007DD7BF /* SiteSetting.swift */,
 				74159624224D4045003C21CF /* SiteSettingGroup.swift */,
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
@@ -1312,6 +1327,7 @@
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
+				31D27C8E2602B553002EDB1D /* plugins.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
 				02698CF524C17FC1005337C4 /* product-alternative-types.json */,
@@ -1429,6 +1445,7 @@
 				B56C1EB520EA757B00D749F9 /* SiteListMapper.swift */,
 				CE50345D21B571A7007573C6 /* SitePlanMapper.swift */,
 				453305E82459DF2100264E50 /* PostMapper.swift */,
+				31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */,
 				74046E1E217A6B70007DD7BF /* SiteSettingsMapper.swift */,
 				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
@@ -1528,6 +1545,7 @@
 				743E84F722172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift */,
 				74AB5B4C21AF354E00859C12 /* SiteAPIMapperTests.swift */,
 				453305EA2459E01A00264E50 /* PostMapperTests.swift */,
+				311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */,
 				74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */,
 				74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */,
 				45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */,
@@ -1797,6 +1815,7 @@
 				02698CFA24C188E9005337C4 /* product-variations-load-all-alternative-types.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
+				31D27C8F2602B553002EDB1D /* plugins.json in Resources */,
 				261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */,
 				268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */,
 				028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */,
@@ -1907,6 +1926,7 @@
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
 				020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */,
+				31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,
@@ -1933,6 +1953,7 @@
 				26B2F74524C5573F0065CCC8 /* LeaderboardListMapper.swift in Sources */,
 				24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */,
 				26E83A022554683A00390DD9 /* GeneratedFakeable.swift in Sources */,
+				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
@@ -2011,6 +2032,7 @@
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
+				31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,
 				B518662220A097C200037A38 /* Network.swift in Sources */,
@@ -2106,6 +2128,7 @@
 				45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */,
 				CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */,
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
+				311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,
@@ -2118,6 +2141,7 @@
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,
 				45152835257A8F490076B03C /* ProductAttributeListMapperTests.swift in Sources */,
+				31D27C952602B737002EDB1D /* SitePluginsRemoteTests.swift in Sources */,
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/SitePluginsMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginsMapper.swift
@@ -13,7 +13,6 @@ struct SitePluginsMapper: Mapper {
     ///
     func map(response: Data) throws -> [SitePlugin] {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [
             .siteID: siteID
         ]

--- a/Networking/Networking/Mapper/SitePluginsMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginsMapper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Mapper: SitePlugins
+///
+struct SitePluginsMapper: Mapper {
+
+    /// Site Identifier associated to the plugins that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the plugin endpoint.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into [SitePlugin].
+    ///
+    func map(response: Data) throws -> [SitePlugin] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(SitePluginsEnvelope.self, from: response).plugins
+    }
+}
+
+
+/// SitePluginsEnvelope Disposable Entity:
+/// The plugins endpoint returns the document within a `data` key. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct SitePluginsEnvelope: Decodable {
+    let plugins: [SitePlugin]
+
+    private enum CodingKeys: String, CodingKey {
+        case plugins = "data"
+    }
+}

--- a/Networking/Networking/Model/SitePlugin.swift
+++ b/Networking/Networking/Model/SitePlugin.swift
@@ -120,27 +120,6 @@ private extension SitePlugin {
     }
 }
 
-// MARK: - Equatable Conformance
-//
-extension SitePlugin: Equatable {
-    public static func == (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
-        return lhs.plugin == rhs.plugin &&
-            lhs.status == rhs.status &&
-            lhs.name == rhs.name &&
-            lhs.pluginUri == rhs.pluginUri &&
-            lhs.author == rhs.author &&
-            lhs.authorUri == rhs.authorUri &&
-            lhs.descriptionRaw == rhs.descriptionRaw &&
-            lhs.descriptionRendered == rhs.descriptionRendered &&
-            lhs.version == rhs.version &&
-            lhs.networkOnly == rhs.networkOnly &&
-            lhs.requiresWPVersion == rhs.requiresWPVersion &&
-            lhs.requiresPHPVersion == rhs.requiresPHPVersion &&
-            lhs.textDomain == rhs.textDomain
-    }
-}
-
-
 // MARK: - Decoding Errors
 //
 enum SitePluginError: Error {

--- a/Networking/Networking/Model/SitePlugin.swift
+++ b/Networking/Networking/Model/SitePlugin.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct SitePlugin: Decodable, GeneratedFakeable {
     public let siteID: Int64
     public let plugin: String                   // e.g. woocommerce/woocommerce (i.e. [folder/]main php file)
-    public let status: String                   // e.g. active, inactive, ...
+    public let status: SitePluginStatusEnum     // i.e. .active | .networkActive | .inactive
     public let name: String                     // e.g. WooCommerce
     public let pluginUri: String                // e.g. https://woocommerce.com/
     public let author: String                   // e.g. Automattic
@@ -23,7 +23,7 @@ public struct SitePlugin: Decodable, GeneratedFakeable {
     public init(
         siteID: Int64,
         plugin: String,
-        status: String,
+        status: SitePluginStatusEnum,
         name: String,
         pluginUri: String,
         author: String,
@@ -61,7 +61,7 @@ public struct SitePlugin: Decodable, GeneratedFakeable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let plugin = try container.decode(String.self, forKey: .plugin)
-        let status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        let status = try container.decode(SitePluginStatusEnum.self, forKey: .status)
         let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         let pluginUri = try container.decodeIfPresent(String.self, forKey: .pluginUri) ?? ""
         let author = try container.decodeIfPresent(String.self, forKey: .author) ?? ""
@@ -120,9 +120,9 @@ private extension SitePlugin {
     }
 }
 
-// MARK: - Comparable Conformance
+// MARK: - Equatable Conformance
 //
-extension SitePlugin: Comparable {
+extension SitePlugin: Equatable {
     public static func == (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
         return lhs.plugin == rhs.plugin &&
             lhs.status == rhs.status &&
@@ -137,14 +137,6 @@ extension SitePlugin: Comparable {
             lhs.requiresWPVersion == rhs.requiresWPVersion &&
             lhs.requiresPHPVersion == rhs.requiresPHPVersion &&
             lhs.textDomain == rhs.textDomain
-    }
-
-    public static func < (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
-        return lhs.plugin < rhs.plugin
-    }
-
-    public static func > (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
-        return lhs.plugin > rhs.plugin
     }
 }
 

--- a/Networking/Networking/Model/SitePlugin.swift
+++ b/Networking/Networking/Model/SitePlugin.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Represents a specific plugin entity for a specific site.
+///
+public struct SitePlugin: Decodable, GeneratedFakeable {
+    public let siteID: Int64
+    public let plugin: String                   // e.g. woocommerce/woocommerce (i.e. [folder/]main php file)
+    public let status: String                   // e.g. active, inactive, ...
+    public let name: String                     // e.g. WooCommerce
+    public let pluginUri: String                // e.g. https://woocommerce.com/
+    public let author: String                   // e.g. Automattic
+    public let authorUri: String                // e.g. https://woocommerce.com
+    public let descriptionRaw: String           // e.g. An eCommerce toolkit that helps you sell anything...
+    public let descriptionRendered: String      // e.g. An eCommerce toolkit... (likely to contain HTML tags)
+    public let version: String                  // e.g. 5.1.0
+    public let networkOnly: Bool                // i.e. false | true
+    public let requiresWPVersion: String        // e.g. 5.4 (but often empty)
+    public let requiresPHPVersion: String       // e.g. 7.0 (but often empty)
+    public let textDomain: String               // e.g. woocommerce (occassionally empty)
+
+    /// Struct initializer.
+    ///
+    public init(
+        siteID: Int64,
+        plugin: String,
+        status: String,
+        name: String,
+        pluginUri: String,
+        author: String,
+        authorUri: String,
+        descriptionRaw: String,
+        descriptionRendered: String,
+        version: String,
+        networkOnly: Bool,
+        requiresWPVersion: String,
+        requiresPHPVersion: String,
+        textDomain: String
+    ) {
+        self.siteID = siteID
+        self.plugin = plugin
+        self.status = status
+        self.name = name
+        self.pluginUri = pluginUri
+        self.author = author
+        self.authorUri = authorUri
+        self.descriptionRaw = descriptionRaw
+        self.descriptionRendered = descriptionRendered
+        self.version = version
+        self.networkOnly = networkOnly
+        self.requiresWPVersion = requiresWPVersion
+        self.requiresPHPVersion = requiresPHPVersion
+        self.textDomain = textDomain
+    }
+
+    /// The public initializer for SitePlugin.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw SitePluginError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let plugin = try container.decode(String.self, forKey: .plugin)
+        let status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        let pluginUri = try container.decodeIfPresent(String.self, forKey: .pluginUri) ?? ""
+        let author = try container.decodeIfPresent(String.self, forKey: .author) ?? ""
+        let authorUri = try container.decodeIfPresent(String.self, forKey: .authorUri) ?? ""
+        let version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
+        let networkOnly = try container.decodeIfPresent(Bool.self, forKey: .networkOnly) ?? false
+        let requiresWPVersion = try container.decodeIfPresent(String.self, forKey: .requiresWPVersion) ?? ""
+        let requiresPHPVersion = try container.decodeIfPresent(String.self, forKey: .requiresPHPVersion) ?? ""
+        let textDomain = try container.decodeIfPresent(String.self, forKey: .textDomain) ?? ""
+
+        let descriptionContainer = try container.nestedContainer(keyedBy: DescriptionCodingKeys.self, forKey: .description)
+        let descriptionRaw = try descriptionContainer.decodeIfPresent(String.self, forKey: .raw) ?? ""
+        let descriptionRendered = try descriptionContainer.decodeIfPresent(String.self, forKey: .rendered) ?? ""
+
+        self.init(
+            siteID: siteID,
+            plugin: plugin,
+            status: status,
+            name: name,
+            pluginUri: pluginUri,
+            author: author,
+            authorUri: authorUri,
+            descriptionRaw: descriptionRaw,
+            descriptionRendered: descriptionRendered,
+            version: version,
+            networkOnly: networkOnly,
+            requiresWPVersion: requiresWPVersion,
+            requiresPHPVersion: requiresPHPVersion,
+            textDomain: textDomain
+        )
+    }
+}
+
+/// Defines all of the SitePlugin CodingKeys.
+///
+private extension SitePlugin {
+
+    enum CodingKeys: String, CodingKey {
+        case plugin              = "plugin"
+        case status              = "status"
+        case name                = "name"
+        case pluginUri           = "plugin_uri"
+        case author              = "author"
+        case authorUri           = "author_uri"
+        case description         = "description"
+        case version             = "version"
+        case networkOnly         = "network_only"
+        case requiresWPVersion   = "requires_wp"
+        case requiresPHPVersion  = "requires_php"
+        case textDomain          = "textdomain"
+    }
+
+    enum DescriptionCodingKeys: String, CodingKey {
+        case raw      = "raw"
+        case rendered = "rendered"
+    }
+}
+
+// MARK: - Comparable Conformance
+//
+extension SitePlugin: Comparable {
+    public static func == (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
+        return lhs.plugin == rhs.plugin &&
+            lhs.status == rhs.status &&
+            lhs.name == rhs.name &&
+            lhs.pluginUri == rhs.pluginUri &&
+            lhs.author == rhs.author &&
+            lhs.authorUri == rhs.authorUri &&
+            lhs.descriptionRaw == rhs.descriptionRaw &&
+            lhs.descriptionRendered == rhs.descriptionRendered &&
+            lhs.version == rhs.version &&
+            lhs.networkOnly == rhs.networkOnly &&
+            lhs.requiresWPVersion == rhs.requiresWPVersion &&
+            lhs.requiresPHPVersion == rhs.requiresPHPVersion &&
+            lhs.textDomain == rhs.textDomain
+    }
+
+    public static func < (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
+        return lhs.plugin < rhs.plugin
+    }
+
+    public static func > (lhs: SitePlugin, rhs: SitePlugin) -> Bool {
+        return lhs.plugin > rhs.plugin
+    }
+}
+
+
+// MARK: - Decoding Errors
+//
+enum SitePluginError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Model/SitePluginStatusEnum.swift
+++ b/Networking/Networking/Model/SitePluginStatusEnum.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Represents all of the possible Site Plugin Statuses in enum form
+///
+public enum SitePluginStatusEnum: Decodable, Hashable, GeneratedFakeable {
+    case active
+    case networkActive
+    case inactive
+    case unknown
+}
+
+/// RawRepresentable Conformance
+///
+extension SitePluginStatusEnum: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.active:
+            self = .active
+        case Keys.networkActive:
+            self = .networkActive
+        case Keys.inactive:
+            self = .inactive
+        default:
+            self = .unknown
+        }
+    }
+
+    /// Returns the current Enum Case's raw value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .active:        return Keys.active
+        case .networkActive: return Keys.networkActive
+        case .inactive:      return Keys.inactive
+        case .unknown:       return Keys.unknown
+        }
+    }
+}
+
+/// Enum containing all possible plugin status keys
+/// Based on wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+/// Note that unknown is NOT a core WP plugin REST API concept, but
+/// is included for graceful degradation if an unrecognized plugin state
+/// were to arrive in the GET plugins API response
+///
+private enum Keys {
+    static let active        = "active"
+    static let networkActive = "network-active"
+    static let inactive      = "inactive"
+    static let unknown       = "unknown"
+}

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// SitePlugins: Remote Endpoints
 ///
@@ -11,7 +10,8 @@ public class SitePluginsRemote: Remote {
     ///   - siteID: Site for which we'll fetch the plugins.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadPlugins(for siteID: Int64, completion: @escaping ([SitePlugin]?, Error?) -> Void) {
+    public func loadPlugins(for siteID: Int64,
+                            completion: @escaping (Result<[SitePlugin], Error>) -> Void) {
         let path = Constants.sitePluginsPath
         let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = SitePluginsMapper(siteID: siteID)

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Alamofire
+
+/// SitePlugins: Remote Endpoints
+///
+public class SitePluginsRemote: Remote {
+
+    /// Retrieves all of the `SitePlugin`s for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the plugins.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadPlugins(for siteID: Int64, completion: @escaping ([SitePlugin]?, Error?) -> Void) {
+        let path = Constants.sitePluginsPath
+        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = SitePluginsMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension SitePluginsRemote {
+    enum Constants {
+        static let sitePluginsPath: String = "wp/v2/plugins"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Networking
+
+/// SitePluginsMapper Unit Tests
+///
+class SitePluginsMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 242424
+
+    /// Verifies the SitePlugin fields are parsed correctly.
+    ///
+    func test_SitePlugin_fields_are_properly_parsed() {
+        let plugins = mapLoadSitePluginsResponse()
+        XCTAssertEqual(plugins.count, 5)
+
+        let helloDollyPlugin = plugins[0]
+        XCTAssertNotNil(helloDollyPlugin)
+        XCTAssertEqual(helloDollyPlugin.siteID, dummySiteID)
+        XCTAssertEqual(helloDollyPlugin.status, "inactive")
+        XCTAssertEqual(helloDollyPlugin.name, "Hello Dolly")
+        XCTAssertEqual(helloDollyPlugin.pluginUri, "http://wordpress.org/plugins/hello-dolly/")
+        XCTAssertEqual(helloDollyPlugin.authorUri, "http://ma.tt/")
+        XCTAssertEqual(helloDollyPlugin.descriptionRaw, "This is not just a plugin, it...")
+        XCTAssertEqual(helloDollyPlugin.descriptionRendered, "This is not just a plugin, it symbolizes...")
+        XCTAssertEqual(helloDollyPlugin.version, "1.7.2")
+        XCTAssertEqual(helloDollyPlugin.textDomain, "")
+
+        let wooCommerceSubscriptionsPlugin = plugins[4]
+        XCTAssertNotNil(wooCommerceSubscriptionsPlugin)
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.siteID, dummySiteID)
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.status, "active")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.name, "WooCommerce Subscriptions")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.pluginUri, "https://www.woocommerce.com/products/woocommerce-subscriptions/")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.authorUri, "https://woocommerce.com/")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRaw, "Sell products and services...")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRendered, "Sell products and services with recurring payments...")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.version, "3.0.13")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.textDomain, "woocommerce-subscriptions")
+    }
+}
+
+
+/// Private Methods.
+///
+private extension SitePluginsMapperTests {
+
+    /// Returns the SitePluginsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapPlugins(from filename: String) -> [SitePlugin] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try! SitePluginsMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the SitePluginsMapper output upon receiving `plugins`
+    ///
+    func mapLoadSitePluginsResponse() -> [SitePlugin] {
+        return mapPlugins(from: "plugins")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
@@ -18,7 +18,7 @@ class SitePluginsMapperTests: XCTestCase {
         let helloDollyPlugin = plugins[0]
         XCTAssertNotNil(helloDollyPlugin)
         XCTAssertEqual(helloDollyPlugin.siteID, dummySiteID)
-        XCTAssertEqual(helloDollyPlugin.status, "inactive")
+        XCTAssertEqual(helloDollyPlugin.status, .inactive)
         XCTAssertEqual(helloDollyPlugin.name, "Hello Dolly")
         XCTAssertEqual(helloDollyPlugin.pluginUri, "http://wordpress.org/plugins/hello-dolly/")
         XCTAssertEqual(helloDollyPlugin.authorUri, "http://ma.tt/")
@@ -30,7 +30,7 @@ class SitePluginsMapperTests: XCTestCase {
         let wooCommerceSubscriptionsPlugin = plugins[4]
         XCTAssertNotNil(wooCommerceSubscriptionsPlugin)
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.siteID, dummySiteID)
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.status, "active")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.status, .active)
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.name, "WooCommerce Subscriptions")
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.pluginUri, "https://www.woocommerce.com/products/woocommerce-subscriptions/")
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.authorUri, "https://woocommerce.com/")

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Networking
+
+/// SitePluginsRemote Unit Tests
+///
+class SitePluginsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load plugins tests
+
+    /// Verifies that loadPlugins properly parses the sample response.
+    ///
+    func testLoadPluginsProperlyReturnsPlugins() {
+        let remote = SitePluginsRemote(network: network)
+        let expectation = self.expectation(description: "Load site plugins")
+
+        network.simulateResponse(requestUrlSuffix: "plugins", filename: "plugins")
+        remote.loadPlugins(for: sampleSiteID) { (sitePlugins, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(sitePlugins)
+            XCTAssertEqual(sitePlugins?.count, 5)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that loadGeneralSettings properly relays Networking Layer errors.
+    ///
+    func testLoadPluginsProperlyRelaysNetwokingErrors() {
+        let remote = SitePluginsRemote(network: network)
+        let expectation = self.expectation(description: "Load site plugins handles error")
+
+        remote.loadPlugins(for: sampleSiteID) { (sitePlugins, error) in
+            XCTAssertNil(sitePlugins)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SitePluginsRemoteTests.swift
@@ -23,33 +23,45 @@ class SitePluginsRemoteTests: XCTestCase {
 
     /// Verifies that loadPlugins properly parses the sample response.
     ///
-    func testLoadPluginsProperlyReturnsPlugins() {
+    func test_loadPlugins_properly_returns_plugins() {
         let remote = SitePluginsRemote(network: network)
-        let expectation = self.expectation(description: "Load site plugins")
 
         network.simulateResponse(requestUrlSuffix: "plugins", filename: "plugins")
-        remote.loadPlugins(for: sampleSiteID) { (sitePlugins, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(sitePlugins)
-            XCTAssertEqual(sitePlugins?.count, 5)
-            expectation.fulfill()
+
+        // When
+        let result: Result<[SitePlugin], Error> = waitFor { promise in
+            remote.loadPlugins(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        switch result {
+        case .success(let plugins):
+            XCTAssertEqual(plugins.count, 5)
+        case .failure(let error):
+            XCTAssertNil(error)
+        }
     }
 
-    /// Verifies that loadGeneralSettings properly relays Networking Layer errors.
+    /// Verifies that loadPlugins properly relays Networking Layer errors.
     ///
-    func testLoadPluginsProperlyRelaysNetwokingErrors() {
+    func test_loadPlugins_properly_relays_netwoking_errors() {
         let remote = SitePluginsRemote(network: network)
-        let expectation = self.expectation(description: "Load site plugins handles error")
 
-        remote.loadPlugins(for: sampleSiteID) { (sitePlugins, error) in
-            XCTAssertNil(sitePlugins)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        let result: Result<[SitePlugin], Error> = waitFor { promise in
+            remote.loadPlugins(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        switch result {
+        case .success(let plugins):
+            XCTAssertNil(plugins)
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
     }
 }

--- a/Networking/NetworkingTests/Responses/plugins.json
+++ b/Networking/NetworkingTests/Responses/plugins.json
@@ -1,0 +1,124 @@
+{
+    "data": [
+        {
+            "plugin": "hello",
+            "status": "inactive",
+            "name": "Hello Dolly",
+            "plugin_uri": "http://wordpress.org/plugins/hello-dolly/",
+            "author": "Matt Mullenweg",
+            "author_uri": "http://ma.tt/",
+            "description": {
+                "raw": "This is not just a plugin, it...",
+                "rendered": "This is not just a plugin, it symbolizes..."
+            },
+            "version": "1.7.2",
+            "network_only": false,
+            "requires_wp": "",
+            "requires_php": "",
+            "textdomain": "",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wp/v2/plugins/hello"
+                    }
+                ]
+            }
+        },
+        {
+            "plugin": "jetpack/jetpack",
+            "status": "active",
+            "name": "Jetpack by WordPress.com",
+            "plugin_uri": "https://jetpack.com",
+            "author": "Automattic",
+            "author_uri": "https://jetpack.com",
+            "description": {
+                "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
+                "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+            },
+            "version": "9.5",
+            "network_only": false,
+            "requires_wp": "5.6",
+            "requires_php": "5.6",
+            "textdomain": "jetpack",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wp/v2/plugins/jetpack/jetpack"
+                    }
+                ]
+            }
+        },
+        {
+            "plugin": "woocommerce/woocommerce",
+            "status": "active",
+            "name": "WooCommerce",
+            "plugin_uri": "https://woocommerce.com/",
+            "author": "Automattic",
+            "author_uri": "https://woocommerce.com",
+            "description": {
+                "raw": "An eCommerce toolkit that helps you sell anything. Beautifully.",
+                "rendered": "An eCommerce toolkit that helps you sell anything. Beautifully. <cite>By <a href=\"https://woocommerce.com\">Automattic</a>.</cite>"
+            },
+            "version": "5.1.0",
+            "network_only": false,
+            "requires_wp": "5.4",
+            "requires_php": "7.0",
+            "textdomain": "woocommerce",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com//wp-json/wp/v2/plugins/woocommerce/woocommerce"
+                    }
+                ]
+            }
+        },
+        {
+            "plugin": "woocommerce-payments/woocommerce-payments",
+            "status": "active",
+            "name": "WooCommerce Payments",
+            "plugin_uri": "https://woocommerce.com/payments/",
+            "author": "Automattic",
+            "author_uri": "https://woocommerce.com/",
+            "description": {
+                "raw": "Accept payments via credit card. Manage transactions within WordPress.",
+                "rendered": "Accept payments via credit card. Manage transactions within WordPress. <cite>By <a href=\"https://woocommerce.com/\">Automattic</a>.</cite>"
+            },
+            "version": "2.1.0",
+            "network_only": false,
+            "requires_wp": "",
+            "requires_php": "",
+            "textdomain": "woocommerce-payments",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com//wp-json/wp/v2/plugins/woocommerce-payments/woocommerce-payments"
+                    }
+                ]
+            }
+        },
+        {
+            "plugin": "woocommerce-subscriptions/woocommerce-subscriptions",
+            "status": "active",
+            "name": "WooCommerce Subscriptions",
+            "plugin_uri": "https://www.woocommerce.com/products/woocommerce-subscriptions/",
+            "author": "WooCommerce",
+            "author_uri": "https://woocommerce.com/",
+            "description": {
+                "raw": "Sell products and services...",
+                "rendered": "Sell products and services with recurring payments..."
+            },
+            "version": "3.0.13",
+            "network_only": false,
+            "requires_wp": "",
+            "requires_php": "",
+            "textdomain": "woocommerce-subscriptions",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com//wp-json/wp/v2/plugins/woocommerce-subscriptions/woocommerce-subscriptions"
+                    }
+                ]
+            }
+        },
+    ]
+}


### PR DESCRIPTION
Partially addresses #3839

Why are we doing this?
- This will allow us to, as part of determining if a site supports card present payments, get a list of active and inactive plugins.

Note:
- This is in support of card-present-payments, but since it doesn't directly depend on card-present-payments, I've elected to submit this against the `develop` branch, and not `feature/stripe-terminal-sdk-integration`

What it does:
- Adds networking layer support for fetching the plugins on a site, both active and inactive

How fast is it?
- Not very. On low-end shared hosting, the plugins endpoint typically takes 4-5 seconds to respond.

To test:
- Ensure SitePluginsMapperTests pass
- Ensure SitePluginsRemoteTests pass
- If you'd like to test with a real request against a real site, a quick test would be to modify `Yosemite/Yosemite/Stores/SettingStore.swift` as follows:

```diff
diff --git a/Yosemite/Yosemite/Stores/SettingStore.swift b/Yosemite/Yosemite/Stores/SettingStore.swift
index cb5ac8b18..7cd7726d3 100644
--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -8,6 +8,7 @@ import Storage
 public class SettingStore: Store {
     private let siteSettingsRemote: SiteSettingsRemote
     private let siteAPIRemote: SiteAPIRemote
+    private let sitePluginsRemote: SitePluginsRemote
 
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.newDerivedStorage()
@@ -16,6 +17,7 @@ public class SettingStore: Store {
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         self.siteSettingsRemote = SiteSettingsRemote(network: network)
         self.siteAPIRemote = SiteAPIRemote(network: network)
+        self.sitePluginsRemote = SitePluginsRemote(network: network)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -62,6 +64,9 @@ private extension SettingStore {
                 onCompletion(nil)
             }
         }
+        sitePluginsRemote.loadPlugins(for: siteID) { [weak self] (plugins, error) in
+
+        }
     }
```
and then set a breakpoint inside that completion. When the app launches and fetches settings, it will also fetch plugins and show them in the watch window.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
