### PR TITLE
Products: Update navigation bar button behaviour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.3
 -----
 - [**] Products: Now you can add variable products from the create product action sheet. [https://github.com/woocommerce/woocommerce-ios/pull/3836]
+- [**] Products: Now you can easily publish a product draft or pending product using the navigation bar buttons [https://github.com/woocommerce/woocommerce-ios/pull/3846]
 - [*] Fix: In landscape orientation, all backgrounds on detail screens and their subsections now extend edge-to-edge. [https://github.com/woocommerce/woocommerce-ios/pull/3808]
 - [*] Fix: Creating an attribute or a variation no longer saves your product pending changes. [https://github.com/woocommerce/woocommerce-ios/pull/3832]
 - [*] Enhancement/fix: image & text footnote info link rows are now center aligned in order details reprint shipping label info row and reprint screen. [https://github.com/woocommerce/woocommerce-ios/pull/3805]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -768,7 +768,7 @@ private extension ProductFormViewController {
 
     func updateNavigationBar() {
         // Create action buttons based on view model
-        let rightBarButtonItems: [UIBarButtonItem] = viewModel.actionButtons.reversed().compactMap { buttonType in
+        let rightBarButtonItems: [UIBarButtonItem] = viewModel.actionButtons.reversed().map { buttonType in
             switch buttonType {
             case .publish:
                 return createPublishBarButtonItem()
@@ -793,8 +793,7 @@ private extension ProductFormViewController {
     }
 
     func createSaveBarButtonItem() -> UIBarButtonItem {
-        let saveTitle = NSLocalizedString("Save", comment: "Action for saving a Product remotely")
-        return UIBarButtonItem(title: saveTitle, style: .done, target: self, action: #selector(saveProductAndLogEvent))
+        return UIBarButtonItem(title: Localization.saveTitle, style: .done, target: self, action: #selector(saveProductAndLogEvent))
     }
 
     func createMoreOptionsBarButtonItem() -> UIBarButtonItem {
@@ -1328,6 +1327,7 @@ private extension ProductFormViewController {
 //
 private enum Localization {
     static let publishTitle = NSLocalizedString("Publish", comment: "Action for creating a new product remotely with a published status")
+    static let saveTitle = NSLocalizedString("Save", comment: "Action for saving a Product remotely")
     static let groupedProductsViewTitle = NSLocalizedString("Grouped Products",
                                                             comment: "Navigation bar title for editing linked products for a grouped product")
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -167,7 +167,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         if viewModel.formType == .add {
             ServiceLocator.analytics.track(.addProductPublishTapped, withProperties: ["product_type": product.productType.rawValue])
         }
-        saveProduct()
+        saveProduct(status: .publish)
     }
 
     func saveProductAsDraft() {
@@ -761,17 +761,14 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
 
     func updateNavigationBar(isUpdateEnabled: Bool) {
-        var rightBarButtonItems = [UIBarButtonItem]()
-
-        switch viewModel.formType {
-        case .add:
-            rightBarButtonItems.append(createPublishBarButtonItem())
-        case .edit:
-            if isUpdateEnabled {
-                rightBarButtonItems.append(createUpdateBarButtonItem())
+        // Create action buttons based on view model
+        var rightBarButtonItems: [UIBarButtonItem] = viewModel.actionButtons.reversed().compactMap { buttonType in
+            switch buttonType {
+            case .publish:
+                return createPublishBarButtonItem()
+            case .update:
+                return createUpdateBarButtonItem()
             }
-        case .readonly:
-            break
         }
 
         if viewModel.shouldShowMoreOptionsMenu() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -391,7 +391,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 //
 private extension ProductFormViewController {
     func configureNavigationBar() {
-        updateNavigationBar(isUpdateEnabled: false)
+        updateNavigationBar()
         removeNavigationBackBarButtonText()
     }
 
@@ -484,8 +484,8 @@ private extension ProductFormViewController {
     }
 
     func observeUpdateCTAVisibility() {
-        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { [weak self] isUpdateEnabled in
-            self?.updateNavigationBar(isUpdateEnabled: isUpdateEnabled)
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { [weak self] _ in
+            self?.updateNavigationBar()
         }
     }
 
@@ -760,19 +760,17 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
 
-    func updateNavigationBar(isUpdateEnabled: Bool) {
+    func updateNavigationBar() {
         // Create action buttons based on view model
-        var rightBarButtonItems: [UIBarButtonItem] = viewModel.actionButtons.reversed().compactMap { buttonType in
+        let rightBarButtonItems: [UIBarButtonItem] = viewModel.actionButtons.reversed().compactMap { buttonType in
             switch buttonType {
             case .publish:
                 return createPublishBarButtonItem()
             case .save:
                 return createSaveBarButtonItem()
+            case .more:
+                return createMoreOptionsBarButtonItem()
             }
-        }
-
-        if viewModel.shouldShowMoreOptionsMenu() {
-            rightBarButtonItems.insert(createMoreOptionsBarButtonItem(), at: 0)
         }
 
         navigationItem.rightBarButtonItems = rightBarButtonItems

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -158,7 +158,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
     }
 
-    @objc func updateProduct() {
+    @objc func saveProductAndLogEvent() {
         eventLogger.logUpdateButtonTapped()
         saveProduct()
     }
@@ -766,8 +766,8 @@ private extension ProductFormViewController {
             switch buttonType {
             case .publish:
                 return createPublishBarButtonItem()
-            case .update:
-                return createUpdateBarButtonItem()
+            case .save:
+                return createSaveBarButtonItem()
             }
         }
 
@@ -789,9 +789,9 @@ private extension ProductFormViewController {
         return UIBarButtonItem(title: publishTitle, style: .done, target: self, action: #selector(publishProduct))
     }
 
-    func createUpdateBarButtonItem() -> UIBarButtonItem {
-        let updateTitle = NSLocalizedString("Update", comment: "Action for updating a Product remotely")
-        return UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))
+    func createSaveBarButtonItem() -> UIBarButtonItem {
+        let saveTitle = NSLocalizedString("Save", comment: "Action for saving a Product remotely")
+        return UIBarButtonItem(title: saveTitle, style: .done, target: self, action: #selector(saveProductAndLogEvent))
     }
 
     func createMoreOptionsBarButtonItem() -> UIBarButtonItem {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -195,6 +195,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
+        if viewModel.canShowPublishOption() {
+            actionSheet.addDefaultActionWithTitle(Localization.publishTitle) { [weak self] _ in
+                self?.publishProduct()
+            }
+        }
+
         if viewModel.canSaveAsDraft() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.saveProductAsDraft) { [weak self] _ in
                 self?.saveProductAsDraft()
@@ -783,8 +789,7 @@ private extension ProductFormViewController {
     }
 
     func createPublishBarButtonItem() -> UIBarButtonItem {
-        let publishTitle = NSLocalizedString("Publish", comment: "Action for creating a new Product remotely")
-        return UIBarButtonItem(title: publishTitle, style: .done, target: self, action: #selector(publishProduct))
+        return UIBarButtonItem(title: Localization.publishTitle, style: .done, target: self, action: #selector(publishProduct))
     }
 
     func createSaveBarButtonItem() -> UIBarButtonItem {
@@ -1322,6 +1327,7 @@ private extension ProductFormViewController {
 // MARK: Constants
 //
 private enum Localization {
+    static let publishTitle = NSLocalizedString("Publish", comment: "Action for creating a new product remotely with a published status")
     static let groupedProductsViewTitle = NSLocalizedString("Grouped Products",
                                                             comment: "Navigation bar title for editing linked products for a grouped product")
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -85,6 +85,11 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         }
     }
 
+    /// The action buttons that should be rendered in the navigation bar.
+    var actionButtons: [ActionButtonType] {
+        []
+    }
+
     private let productImageActionHandler: ProductImageActionHandler
 
     private var cancellable: ObservationToken?

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -92,16 +92,16 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
             return [.publish]
 
         case (.add, .publish, _, false, _): // New product with a different status
-            return [.publish, .update]
+            return [.publish, .save]
 
         case (.edit, .publish, _, true, true): // Existing published product with changes
-            return [.update]
+            return [.save]
 
         case (.edit, .publish, _, true, false): // Existing published product with no changes
             return []
 
         case (.edit, _, _, true, true): // Any other existing product with changes
-            return [.publish, .update]
+            return [.publish, .save]
 
         case (.edit, _, _, true, false): // Any other existing product with no changes
             return [.publish]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -162,8 +162,21 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 // MARK: - More menu
 //
 extension ProductFormViewModel {
+
+    /// Show publish button if the product can be published and the publish button is not already part of the action buttons.
+    ///
+    func canShowPublishOption() -> Bool {
+        let newProduct = formType == .add && !originalProduct.product.existsRemotely
+        let existingUnpublishedProduct = formType == .edit && originalProduct.product.existsRemotely && originalProduct.status != .publish
+
+        let productCanBePublished = newProduct || existingUnpublishedProduct
+        let publishIsNotAlreadyVisible = !actionButtons.contains(.publish)
+
+        return productCanBePublished && publishIsNotAlreadyVisible
+    }
+
     func canSaveAsDraft() -> Bool {
-        formType == .add
+        formType == .add && productModel.status != .draft
     }
 
     func canEditProductSettings() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -87,7 +87,31 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     /// The action buttons that should be rendered in the navigation bar.
     var actionButtons: [ActionButtonType] {
-        []
+        switch (formType, originalProductModel.status, productModel.status, originalProduct.product.existsRemotely, hasUnsavedChanges()) {
+        case (.add, .publish, .publish, false, _): // New product with publish status
+            return [.publish]
+
+        case (.add, .publish, _, false, _): // New product with a different status
+            return [.publish, .update]
+
+        case (.edit, .publish, _, true, true): // Existing published product with changes
+            return [.update]
+
+        case (.edit, .publish, _, true, false): // Existing published product with no changes
+            return []
+
+        case (.edit, _, _, true, true): // Any other existing product with changes
+            return [.publish, .update]
+
+        case (.edit, _, _, true, false): // Any other existing product with no changes
+            return [.publish]
+
+        case (.readonly, _, _, _, _): // Any product on readonly mode
+             return []
+
+        default: // Impossible cases
+            return []
+        }
     }
 
     private let productImageActionHandler: ProductImageActionHandler

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -87,31 +87,41 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     /// The action buttons that should be rendered in the navigation bar.
     var actionButtons: [ActionButtonType] {
-        switch (formType, originalProductModel.status, productModel.status, originalProduct.product.existsRemotely, hasUnsavedChanges()) {
-        case (.add, .publish, .publish, false, _): // New product with publish status
-            return [.publish]
+        // Figure out main action button first
+        var buttons: [ActionButtonType] = {
+            switch (formType, originalProductModel.status, productModel.status, originalProduct.product.existsRemotely, hasUnsavedChanges()) {
+            case (.add, .publish, .publish, false, _): // New product with publish status
+                return [.publish]
 
-        case (.add, .publish, _, false, _): // New product with a different status
-            return [.publish, .save]
+            case (.add, .publish, _, false, _): // New product with a different status
+                return [.save] // And publish in more
 
-        case (.edit, .publish, _, true, true): // Existing published product with changes
-            return [.save]
+            case (.edit, .publish, _, true, true): // Existing published product with changes
+                return [.save]
 
-        case (.edit, .publish, _, true, false): // Existing published product with no changes
-            return []
+            case (.edit, .publish, _, true, false): // Existing published product with no changes
+                return []
 
-        case (.edit, _, _, true, true): // Any other existing product with changes
-            return [.publish, .save]
+            case (.edit, _, _, true, true): // Any other existing product with changes
+                return [.save] // And publish in more
 
-        case (.edit, _, _, true, false): // Any other existing product with no changes
-            return [.publish]
+            case (.edit, _, _, true, false): // Any other existing product with no changes
+                return [.publish]
 
-        case (.readonly, _, _, _, _): // Any product on readonly mode
-             return []
+            case (.readonly, _, _, _, _): // Any product on readonly mode
+                 return []
 
-        default: // Impossible cases
-            return []
+            default: // Impossible cases
+                return []
+            }
+        }()
+
+        // Add more button if needed
+        if shouldShowMoreOptionsMenu() {
+            buttons.append(.more)
         }
+
+        return buttons
     }
 
     private let productImageActionHandler: ProductImageActionHandler

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -55,6 +55,8 @@ protocol ProductFormViewModelProtocol {
 
     func canSaveAsDraft() -> Bool
 
+    func canShowPublishOption() -> Bool
+
     func canEditProductSettings() -> Bool
 
     func canViewProductInStore() -> Bool

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -11,7 +11,7 @@ enum ProductFormType {
 /// The type of action that can be performed in the product.
 enum ActionButtonType {
     case publish
-    case update
+    case save
 }
 
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -12,6 +12,7 @@ enum ProductFormType {
 enum ActionButtonType {
     case publish
     case save
+    case more
 }
 
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -8,6 +8,12 @@ enum ProductFormType {
     case readonly
 }
 
+/// The type of action that can be performed in the product.
+enum ActionButtonType {
+    case publish
+    case update
+}
+
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).
 ///
 protocol ProductFormViewModelProtocol {
@@ -36,6 +42,9 @@ protocol ProductFormViewModelProtocol {
 
     /// The latest product password, if the product is password protected.
     var password: String? { get }
+
+    /// The action buttons that should be rendered in the navigation bar.
+    var actionButtons: [ActionButtonType] { get }
 
     // Unsaved changes
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -64,7 +64,12 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     /// The action buttons that should be rendered in the navigation bar.
     var actionButtons: [ActionButtonType] {
-        []
+        switch (formType, hasUnsavedChanges()) {
+        case (.edit, true):
+            return [.update]
+        default:
+            return []
+        }
     }
 
     /// Assign this closure to get notified when the variation is deleted.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -66,7 +66,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     var actionButtons: [ActionButtonType] {
         switch (formType, hasUnsavedChanges()) {
         case (.edit, true):
-            return [.update]
+            return [.save]
         default:
             return []
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -3,6 +3,7 @@ import Observables
 
 /// Provides data for product form UI on a `ProductVariation`, and handles product editing actions.
 final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
+
     typealias ProductModel = EditableProductVariationModel
 
     /// Emits product variation on change.
@@ -117,6 +118,12 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 // MARK: - More menu
 //
 extension ProductVariationFormViewModel {
+    /// Variations can't be published independently
+    ///
+    func canShowPublishOption() -> Bool {
+        false
+    }
+
     func canSaveAsDraft() -> Bool {
         false
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -62,6 +62,11 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         }
     }
 
+    /// The action buttons that should be rendered in the navigation bar.
+    var actionButtons: [ActionButtonType] {
+        []
+    }
+
     /// Assign this closure to get notified when the variation is deleted.
     ///
     var onVariationDeletion: ((ProductVariation) -> Void)?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -213,6 +213,135 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.originalProductModel.status, newProduct.productStatus)
         XCTAssertEqual(viewModel.formType, .edit)
     }
+
+    func test_action_buttons_for_new_product_with_published_status_and_pending_changes() {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+        viewModel.updateName("new name")
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish])
+    }
+
+    func test_action_buttons_for_new_product_with_published_status_and_no_pending_changes() {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish])
+    }
+
+    func test_action_buttons_for_new_product_with_different_status() {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        let updatedProduct = product.copy(statusKey: ProductStatus.draft.rawValue)
+        let settings = ProductSettings(from: updatedProduct, password: nil)
+        viewModel.updateProductSettings(settings)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish, .update])
+    }
+
+    func test_action_buttons_for_existing_published_product_and_pending_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+        viewModel.updateName("new name")
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.update])
+    }
+
+    func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [])
+    }
+
+    func test_action_buttons_for_existing_draft_product_and_pending_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+        viewModel.updateName("new name")
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish, .update])
+    }
+
+    func test_action_buttons_for_existing_draft_product_and_no_pending_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish])
+    }
+
+    func test_action_buttons_for_existing_product_with_other_status_and_peding_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: "other")
+        let viewModel = createViewModel(product: product, formType: .edit)
+        viewModel.updateName("new name")
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish, .update])
+    }
+
+    func test_action_buttons_for_existing_product_with_other_status_and_no_peding_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: "other")
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish])
+    }
+
+    func test_action_buttons_for_any_product_in_read_only_mode() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .readonly)
+        viewModel.updateName("new name")
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [])
+    }
 }
 
 private extension ProductFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -224,7 +224,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish])
+        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 
     func test_action_buttons_for_new_product_with_published_status_and_no_pending_changes() {
@@ -236,7 +236,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish])
+        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 
     func test_action_buttons_for_new_product_with_different_status() {
@@ -252,7 +252,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .save])
+        XCTAssertEqual(actionButtons, [.save, .more])
     }
 
     func test_action_buttons_for_existing_published_product_and_pending_changes() {
@@ -265,7 +265,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.save])
+        XCTAssertEqual(actionButtons, [.save, .more])
     }
 
     func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
@@ -277,7 +277,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [])
+        XCTAssertEqual(actionButtons, [.more])
     }
 
     func test_action_buttons_for_existing_draft_product_and_pending_changes() {
@@ -290,7 +290,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .save])
+        XCTAssertEqual(actionButtons, [.save, .more])
     }
 
     func test_action_buttons_for_existing_draft_product_and_no_pending_changes() {
@@ -302,7 +302,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish])
+        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 
     func test_action_buttons_for_existing_product_with_other_status_and_peding_changes() {
@@ -315,7 +315,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .save])
+        XCTAssertEqual(actionButtons, [.save, .more])
     }
 
     func test_action_buttons_for_existing_product_with_other_status_and_no_peding_changes() {
@@ -327,7 +327,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish])
+        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 
     func test_action_buttons_for_any_product_in_read_only_mode() {
@@ -340,7 +340,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [])
+        XCTAssertEqual(actionButtons, [.more])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -342,6 +342,80 @@ final class ProductFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(actionButtons, [.more])
     }
+
+    func test_canPublishOption_is_true_when_creating_new_product_with_different_status() {
+        // Given
+        let product = Product.fake().copy(productID: 0, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertTrue(canShowPublishOption)
+    }
+
+    func test_canPublishOption_is_false_when_creating_new_product_with_publish_status() {
+        // Given
+        let product = Product.fake().copy(productID: 0, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertFalse(canShowPublishOption)
+    }
+
+    func test_canPublishOption_is_true_when_editing_existing_draft_product_with_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+        viewModel.updateName("new_name")
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertTrue(canShowPublishOption)
+    }
+
+    func test_canPublishOption_is_false_when_editing_existing_draft_product_without_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertFalse(canShowPublishOption)
+    }
+
+    func test_canPublishOption_is_false_when_editing_existing_published_product_without_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertFalse(canShowPublishOption)
+    }
+
+    func test_canPublishOption_is_false_when_editing_existing_published_product_with_changes() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+        viewModel.updateName("new_name")
+
+        // When
+        let canShowPublishOption = viewModel.canShowPublishOption()
+
+        // Then
+        XCTAssertFalse(canShowPublishOption)
+    }
 }
 
 private extension ProductFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -252,7 +252,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .update])
+        XCTAssertEqual(actionButtons, [.publish, .save])
     }
 
     func test_action_buttons_for_existing_published_product_and_pending_changes() {
@@ -265,7 +265,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.update])
+        XCTAssertEqual(actionButtons, [.save])
     }
 
     func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
@@ -290,7 +290,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .update])
+        XCTAssertEqual(actionButtons, [.publish, .save])
     }
 
     func test_action_buttons_for_existing_draft_product_and_no_pending_changes() {
@@ -315,7 +315,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .update])
+        XCTAssertEqual(actionButtons, [.publish, .save])
     }
 
     func test_action_buttons_for_existing_product_with_other_status_and_no_peding_changes() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -162,7 +162,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.update])
+        XCTAssertEqual(actionButtons, [.save])
     }
 
     func test_action_buttons_for_existing_product_and_no_pending_changes() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -147,6 +147,37 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
+
+    func test_action_buttons_for_existing_product_and_pending_changes() {
+        // Given
+        let productVariation = MockProductVariation().productVariation()
+        let variationModel = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: variationModel)
+        let viewModel = ProductVariationFormViewModel(productVariation: variationModel, formType: .edit, productImageActionHandler: productImageActionHandler)
+
+        let attributes = [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]
+        viewModel.updateVariationAttributes(attributes)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.update])
+    }
+
+    func test_action_buttons_for_existing_product_and_no_pending_changes() {
+        // Given
+        let productVariation = MockProductVariation().productVariation()
+        let variationModel = EditableProductVariationModel(productVariation: productVariation)
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: variationModel)
+        let viewModel = ProductVariationFormViewModel(productVariation: variationModel, formType: .edit, productImageActionHandler: productImageActionHandler)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [])
+    }
 }
 
 // Helper in unit tests


### PR DESCRIPTION
fix #3838 

# Why

Some time ago, when the app could not create products, It made sense to have an update button to commit changes when the product was being modified.

Later, we allowed merchants to create products and added a "publish" button to indicate that the new product was being published/created.

While this works well, there are several unhandled or not-ideal scenarios, as the merchant can change the product type, product status, and product content at any time.

Two example inconveniences / unhandled cases:

- A. There is no easy way to publish an un-published product 
- B. Creating a product with a different status(other than publish) gives the impression that the product will be published when the merchant only wants to save it.

A | B
--- | ---
![publish-draft-product](https://user-images.githubusercontent.com/562080/111553366-3ae3ae80-8752-11eb-9147-ccfcc52bb15a.gif) | ![new-pending-product-before](https://user-images.githubusercontent.com/562080/111553378-42a35300-8752-11eb-9571-b01e808cce3d.gif)


This PR updates the button rendering mechanism to makes sure those cases are handled to be able to show meaningful button actions to the merchant.

# How

- Added `actionButtons` variable and `canShowPublishOption` function to `ProductFormViewModelProtocol`
- Update `ProductFormViewModel` and `ProductVariationFormViewModel` to provide buttons based on a specific set of **rules**
- Update `ProductFormViewController` to render the buttons based on the `ViewModel` indications.
- Update `ProductFormViewController` to render show(or not) a publish option in the "more" action sheet based on the view model
- Rename the "Update" Button copy for "Save".

## Rules
**When creating a product:**
- Add a "Publish" button in the navigation bar when the product has a `.publish` status.
- Add a "Save" button in the navigation bar when the product has a status different than `.publish` and add a "Publish" option in the "more" action sheet.

**When editing a product**
- Add a "Publish" button in the navigation bar when the product has an un-published status.
- If the un-published product has modifications, show the "Save" button and add a "Publish" option in the "more" action sheet.
- For variations, show the "Save" button only when there are changes to the variation.

**When editing a product**
- Only show the "more" action button when required.


# <a name="testing-steps">Testing Steps</a>

- Go to the product tab and tap "+" to create a  product
- See that the "Publish" button is visible
- Change product status to something different than "Published"
- See that the "Save" button is visible
- Tap on the "more" button and see the "Publish" option is visible.

![new-product](https://user-images.githubusercontent.com/562080/111665434-bee47780-87e0-11eb-8011-1899a6d221ec.gif)

----

- Go to a variation from a variable product
- See that nor "save" or "publish" buttons are visible
- Modify the variation
- See that the save button is visible.

![variation](https://user-images.githubusercontent.com/562080/111666150-737e9900-87e1-11eb-9620-3b6376523954.gif)

----

- Go to an existing non-published product (draft or pending review)
- See that the "publish" button is visible
- Make any modification
- See that only the and "save" button are visible
- Tap on the "more" button and see the "Publish" option is visible.

![draft-product](https://user-images.githubusercontent.com/562080/111666381-aaed4580-87e1-11eb-8933-b6e16b1cf0bc.gif)

----

- Go to an order and tap on one of its products
- See that the product is open in read-only mode and only the "more button is visible"

![read-only=product](https://user-images.githubusercontent.com/562080/111667802-12f05b80-87e3-11eb-939d-46e0b74f6d8d.gif)

----

- Go to an existing published product
- See that none of the buttons appear
- Modify the product
- See that the save button appears

![existing-product](https://user-images.githubusercontent.com/562080/111667960-37e4ce80-87e3-11eb-8ce6-f9e0e444ffff.gif)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
