### PR TITLE
Shipping Labels: open Apple Maps or Call the Customer if an error occurs in the address validation form

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -19,15 +19,15 @@ extension ShippingLabelAddress {
 
         return output.joined(separator: "\n")
     }
-}
-
-private extension ShippingLabelAddress {
 
     /// Returns the Postal Address, formated and ready for display.
     ///
     var formattedPostalAddress: String? {
         return postalAddress.formatted(as: .mailingAddress)
     }
+}
+
+private extension ShippingLabelAddress {
 
     /// Returns the `name` and `company` (on a new line). If either the `name` or `company` is empty,
     /// then a single line is returned containing the other value.

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -1,6 +1,5 @@
 import MapKit
 
-
 final class MapsHelper {
 
     /// The method accept a string of the address info you already have, and open Apple Maps on that address if found.

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -1,0 +1,41 @@
+import MapKit
+
+
+final class MapsHelper {
+
+    /// The method accept a string of the address info you already have, and open Apple Maps on that address if found.
+    ///
+    static func openAppleMaps(address: String?, completion: @escaping (Result<Void, MapsHelperError>) -> Void) {
+        guard let address = address else {
+            completion(.failure(.locationNotFound))
+            return
+        }
+        CLGeocoder().geocodeAddressString(address) { (placemarksOptional, error) -> Void in
+              if let placemarks = placemarksOptional {
+                DDLogInfo("First address found in Apple Maps: \(String(describing: placemarks.first))")
+                if let location = placemarks.first?.location {
+                  let query = "?ll=\(location.coordinate.latitude),\(location.coordinate.longitude)"
+                  let path = "http://maps.apple.com/" + query
+                  if let url = URL(string: path) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    completion(.success(()))
+                  } else {
+                    completion(.failure(.constructURL))
+                  }
+                } else {
+                    completion(.failure(.locationNotFound))
+                }
+              } else {
+                completion(.failure(.locationNotFound))
+              }
+            }
+    }
+
+    enum MapsHelperError: Error {
+        // Could not construct url.
+        case constructURL
+
+        // Could not get a location from the geocode request.
+        case locationNotFound
+    }
+}

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -10,24 +10,24 @@ final class MapsHelper {
             return
         }
         CLGeocoder().geocodeAddressString(address) { (placemarksOptional, error) -> Void in
-              if let placemarks = placemarksOptional {
-                DDLogInfo("First address found in Apple Maps: \(String(describing: placemarks.first))")
-                if let location = placemarks.first?.location {
-                  let query = "?ll=\(location.coordinate.latitude),\(location.coordinate.longitude)"
-                  let path = "http://maps.apple.com/" + query
-                  if let url = URL(string: path) {
+            guard let placemarks = placemarksOptional else {
+                completion(.failure(.locationNotFound))
+                return
+            }
+            DDLogInfo("First address found in Apple Maps: \(String(describing: placemarks.first))")
+            if let location = placemarks.first?.location {
+                let query = "?ll=\(location.coordinate.latitude),\(location.coordinate.longitude)"
+                let path = "http://maps.apple.com/" + query
+                if let url = URL(string: path) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     completion(.success(()))
-                  } else {
-                    completion(.failure(.constructURL))
-                  }
                 } else {
-                    completion(.failure(.locationNotFound))
+                    completion(.failure(.constructURL))
                 }
-              } else {
+            } else {
                 completion(.failure(.locationNotFound))
-              }
             }
+        }
     }
 
     enum MapsHelperError: Error {

--- a/WooCommerce/Classes/Tools/PhoneHelper.swift
+++ b/WooCommerce/Classes/Tools/PhoneHelper.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+final class PhoneHelper {
+
+    /// Call a specific phone number, and return success or failure
+    ///
+    static func callPhoneNumber(phone: String?) -> Bool {
+        guard let phone = phone, let url = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(url) else {
+            return false
+        }
+
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        return true
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -27,8 +27,10 @@ final class ShippingLabelAddressFormViewController: UIViewController {
                     self?.displayAppleMapsErrorNotice()
                 }
             }
-        } contactCustomerPressed: {
-
+        } contactCustomerPressed: { [weak self] in
+            if !PhoneHelper.callPhoneNumber(phone: self?.viewModel.address?.phone) {
+                self?.displayPhoneNumberErrorNotice()
+            }
         }
 
         topBanner.translatesAutoresizingMaskIntoConstraints = false
@@ -187,6 +189,13 @@ private extension ShippingLabelAddressFormViewController {
     ///
     private func displayAppleMapsErrorNotice() {
         let notice = Notice(title: Localization.appleMapsErrorNotice, feedbackType: .error, actionTitle: nil, actionHandler: nil)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Enqueues the `Phone Number`  Error Notice.
+    ///
+    private func displayPhoneNumberErrorNotice() {
+        let notice = Notice(title: Localization.phoneNumberErrorNotice, feedbackType: .error, actionTitle: nil, actionHandler: nil)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
@@ -458,6 +467,8 @@ private extension ShippingLabelAddressFormViewController {
                                                       comment: "Error showed in Shipping Label Address Validation for the country field")
         static let appleMapsErrorNotice = NSLocalizedString("Error in finding the address in Apple Maps",
                                                             comment: "Error in finding the address in the Shipping Label Address Validation in Apple Maps")
+        static let phoneNumberErrorNotice = NSLocalizedString("The phone number is not valid or you can't call the customer from this device.",
+            comment: "Error in calling the phone number of the customer in the Shipping Label Address Validation")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -18,7 +18,19 @@ final class ShippingLabelAddressFormViewController: UIViewController {
     /// Top banner that shows a warning in case there is an error in the address validation.
     ///
     private lazy var topBannerView: TopBannerView = {
-        let topBanner = ShippingLabelAddressTopBannerFactory.addressErrorTopBannerView()
+        let topBanner = ShippingLabelAddressTopBannerFactory.addressErrorTopBannerView { [weak self] in
+            MapsHelper.openAppleMaps(address: self?.viewModel.address?.formattedPostalAddress) { [weak self] (result) in
+                switch result {
+                case .success:
+                    break
+                case .failure:
+                    self?.displayAppleMapsErrorNotice()
+                }
+            }
+        } contactCustomerPressed: {
+
+        }
+
         topBanner.translatesAutoresizingMaskIntoConstraints = false
         return topBanner
     }()
@@ -166,6 +178,16 @@ private extension ShippingLabelAddressFormViewController {
                 break
             }
         }
+    }
+}
+
+// MARK: - Utils
+private extension ShippingLabelAddressFormViewController {
+    /// Enqueues the `Apple Maps` Error Notice.
+    ///
+    private func displayAppleMapsErrorNotice() {
+        let notice = Notice(title: Localization.appleMapsErrorNotice, feedbackType: .error, actionTitle: nil, actionHandler: nil)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -434,6 +456,8 @@ private extension ShippingLabelAddressFormViewController {
                                                     comment: "Error showed in Shipping Label Address Validation for the state field")
         static let missingCountry = NSLocalizedString("Country missing",
                                                       comment: "Error showed in Shipping Label Address Validation for the country field")
+        static let appleMapsErrorNotice = NSLocalizedString("Error in finding the address in Apple Maps",
+                                                            comment: "Error in finding the address in the Shipping Label Address Validation in Apple Maps")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -28,7 +28,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
                 }
             }
         } contactCustomerPressed: { [weak self] in
-            if !PhoneHelper.callPhoneNumber(phone: self?.viewModel.address?.phone) {
+            if PhoneHelper.callPhoneNumber(phone: self?.viewModel.address?.phone) == false {
                 self?.displayPhoneNumberErrorNotice()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
@@ -3,12 +3,21 @@ import UIKit
 /// Generates top banner view that is shown at the top of variation list screen when at least one variation is missing a price.
 ///
 final class ShippingLabelAddressTopBannerFactory {
-    static func addressErrorTopBannerView() -> TopBannerView {
+    static func addressErrorTopBannerView(openMapPressed: @escaping () -> Void,
+                                          contactCustomerPressed: @escaping () -> Void) -> TopBannerView {
+        let openMapAction = TopBannerViewModel.ActionButton(title: Localization.openMapAction) {
+            openMapPressed()
+        }
+        let contactCustomerAction = TopBannerViewModel.ActionButton(title: Localization.contactCustomerAction) {
+            contactCustomerPressed()
+        }
+        let actions = [openMapAction, contactCustomerAction]
         let viewModel = TopBannerViewModel(title: nil,
                                            infoText: Localization.info,
                                            icon: Constants.icon,
                                            isExpanded: true,
                                            topButton: .none,
+                                           actionButtons: actions,
                                            type: .warning)
         return TopBannerView(viewModel: viewModel)
     }
@@ -23,5 +32,7 @@ private extension ShippingLabelAddressTopBannerFactory {
         static let info = NSLocalizedString("We were unable to automatically verify the shipping address. " +
                                                 "View on Apple Maps or try contacting the customer to make sure the address is correct.",
                                             comment: "Banner caption in Shipping Label Address Validation when the address can't be verified.")
+        static let openMapAction = NSLocalizedString("Open Map", comment: "Open Map action in Shipping Label Address Validation.")
+        static let contactCustomerAction = NSLocalizedString("Contact Customer", comment: "Contact Customer action in Shipping Label Address Validation.")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596853E2540669900D17B90 /* DownloadableFileSource.swift */; };
 		45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */; };
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
+		45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EB92603F632006CDFB8 /* MapsHelper.swift */; };
 		45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */; };
 		45A0E4CC2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */; };
 		45A0E4D32566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */; };
@@ -1670,6 +1671,7 @@
 		4596853E2540669900D17B90 /* DownloadableFileSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileSource.swift; sourceTree = "<group>"; };
 		45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		45977EB92603F632006CDFB8 /* MapsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapsHelper.swift; sourceTree = "<group>"; };
 		45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfLinkedProductsTableViewCell.swift; sourceTree = "<group>"; };
 		45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberOfLinkedProductsTableViewCell.xib; sourceTree = "<group>"; };
 		45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4195,6 +4197,7 @@
 				0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */,
 				022F941D257F8E820011CD94 /* BoldableTextParser.swift */,
 				74460D3F22289B7600D7316A /* Coordinator.swift */,
+				45977EB92603F632006CDFB8 /* MapsHelper.swift */,
 				7459A6C521B0680300F83A78 /* RequirementsChecker.swift */,
 				B54FBE542111F70700390F57 /* ResultsController+UIKit.swift */,
 				74B5713521CD7604008F9B8E /* SharingHelper.swift */,
@@ -6433,6 +6436,7 @@
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
+				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,
 				0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */,
 				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,
 				0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */; };
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EB92603F632006CDFB8 /* MapsHelper.swift */; };
+		45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EBF2604C167006CDFB8 /* PhoneHelper.swift */; };
 		45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */; };
 		45A0E4CC2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */; };
 		45A0E4D32566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */; };
@@ -1672,6 +1673,7 @@
 		45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		45977EB92603F632006CDFB8 /* MapsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapsHelper.swift; sourceTree = "<group>"; };
+		45977EBF2604C167006CDFB8 /* PhoneHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneHelper.swift; sourceTree = "<group>"; };
 		45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfLinkedProductsTableViewCell.swift; sourceTree = "<group>"; };
 		45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberOfLinkedProductsTableViewCell.xib; sourceTree = "<group>"; };
 		45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4198,6 +4200,7 @@
 				022F941D257F8E820011CD94 /* BoldableTextParser.swift */,
 				74460D3F22289B7600D7316A /* Coordinator.swift */,
 				45977EB92603F632006CDFB8 /* MapsHelper.swift */,
+				45977EBF2604C167006CDFB8 /* PhoneHelper.swift */,
 				7459A6C521B0680300F83A78 /* RequirementsChecker.swift */,
 				B54FBE542111F70700390F57 /* ResultsController+UIKit.swift */,
 				74B5713521CD7604008F9B8E /* SharingHelper.swift */,
@@ -6240,6 +6243,7 @@
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
 				0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */,
 				452FE6522565849B00EB54A0 /* LinkedProductsViewModel.swift in Sources */,
+				45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */,
 				0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */,
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,


### PR DESCRIPTION
Closes #2973

## Description
The last part of the address validation form in Shipping Labels is to show the actions for opening the address in Apple Maps if not found to call the customer.
In this PR, I added the two actions in the top banner view, and I implemented two extensions for opening Apple Maps or for calling the user.

## Testing
Note: _It would be preferable to test on the device, as it will not be possible to call the customer's phone number from the simulator._
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the **Ship From** cell.
5. Go to the editing address screen and make sure the address is not valid remotely. -> You should see the top banner view with two buttons "Open Map" and "Contact Customer".
6. Tapping "Open Map" you should see that Apple Maps will be opened. If the address is not found on Apple Maps, you should see an error notice.
7. Tapping "Contact Customer" you should be able to call it. If the phone is not valid or the device doesn't support phone calls, you should see an error notice.

## Screenshots
<img src="https://user-images.githubusercontent.com/495617/111778099-74342f80-88b4-11eb-8446-4884f6758c13.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
