### PR TITLE
Add variations announcement banner

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -9,6 +9,10 @@ public enum FeedbackType: String, Codable {
     ///
     case productsM5
 
+    /// Identifier for the Products Variations.
+    ///
+    case productsVariations
+
     /// identifier for the shipping labels m1 feedback survey
     ///
     case shippingLabelsRelease1

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -5,10 +5,6 @@ public enum FeedbackType: String, Codable {
     ///
     case general
 
-    /// Identifier for the Products M5: Linked Products, Downloadable Files, Trashing.
-    ///
-    case productsM5
-
     /// Identifier for the Products Variations.
     ///
     case productsVariations

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -61,6 +61,8 @@ extension WooAnalyticsEvent {
         /// Shown in products banner for Milestone 4 features. New product banners should have
         /// their own `FeedbackContext` option.
         case productsM4 = "products_m4"
+        /// Shown in products banner for Variations release.
+        case productsVariations = "products_variations"
         /// Shown in shipping labels banner for Milestone 1 features.
         case shippingLabelsRelease1 = "shipping_labels_m1"
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -58,9 +58,6 @@ extension WooAnalyticsEvent {
     public enum FeedbackContext: String {
         /// Shown in Stats but is for asking general feedback.
         case general
-        /// Shown in products banner for Milestone 4 features. New product banners should have
-        /// their own `FeedbackContext` option.
-        case productsM4 = "products_m4"
         /// Shown in products banner for Variations release.
         case productsVariations = "products_variations"
         /// Shown in shipping labels banner for Milestone 1 features.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -79,9 +79,9 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
-        /// URL for the products M4 feedback survey
+        /// URL for the products feedback survey
         ///
-        case productsM4Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
+        case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
         /// URL for the shipping labels M1 feedback survey
         ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -2,9 +2,38 @@ import UIKit
 import Yosemite
 
 struct ProductsTopBannerFactory {
+
+    enum BannerType {
+        case productsM4
+        case variations
+
+        var title: String {
+            Localization.title
+        }
+
+        var info: String {
+            switch self {
+            case .productsM4:
+                return Localization.infoFilesAndLinkedProducts
+            case .variations:
+                return Localization.infoVariations
+            }
+        }
+
+        var feedbackContext: WooAnalyticsEvent.FeedbackContext {
+            switch self {
+            case .productsM4:
+                return .productsM4
+            case .variations:
+                return .productsVariations
+            }
+        }
+    }
+
     /// Creates a products tab top banner asynchronously based on the app settings.
     /// - Parameters:
     ///   - isExpanded: whether the top banner is expanded by default.
+    ///   - type: sets banner content and related analytics events.
     ///   - expandedStateChangeHandler: called when the top banner expanded state changes.
     ///   - onGiveFeedbackButtonPressed: called the give feedback button is pressed.
     ///   - onDismissButtonPressed: called the dismiss button is pressed
@@ -12,19 +41,20 @@ struct ProductsTopBannerFactory {
     static func topBanner(isExpanded: Bool,
                           stores: StoresManager = ServiceLocator.stores,
                           analytics: Analytics = ServiceLocator.analytics,
+                          type: BannerType,
                           expandedStateChangeHandler: @escaping () -> Void,
                           onGiveFeedbackButtonPressed: @escaping () -> Void,
                           onDismissButtonPressed: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
-        let title = Localization.title
+        let title = type.title
+        let infoText = type.info
         let icon: UIImage = .megaphoneIcon
-        let infoText = Localization.info
         let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
-            analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .gaveFeedback))
+            analytics.track(event: .featureFeedbackBanner(context: type.feedbackContext, action: .gaveFeedback))
             onGiveFeedbackButtonPressed()
         }
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
-            analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .dismissed))
+            analytics.track(event: .featureFeedbackBanner(context: type.feedbackContext, action: .dismissed))
             onDismissButtonPressed()
         }
         let actions = [giveFeedbackAction, dismissAction]
@@ -42,13 +72,18 @@ struct ProductsTopBannerFactory {
 
 private extension ProductsTopBannerFactory {
     enum Localization {
-        static let title =
-            NSLocalizedString("New features available!",
-                              comment: "The title of the top banner on the Products tab.")
-        static let info =
+        static let title = NSLocalizedString("New features available!",
+                                             comment: "The title of the top banner on the Products tab.")
+
+        static let infoFilesAndLinkedProducts =
             NSLocalizedString(
                 "You can now add downloadable files to a product and link upsell & cross-sell products. No longer want a product? Trash it!",
                 comment: "The info of the top banner on the Products tab.")
+        static let infoVariations =
+            NSLocalizedString(
+                "When editing a product, you can now create, delete, and update product variations, product attributes, and product attribute options.",
+                comment: "The info of the top banner on the Products tab.")
+
         static let giveFeedback =
             NSLocalizedString("Give feedback",
                               comment: "The title of the button to give feedback about products beta features on the banner on the products tab")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -79,10 +79,8 @@ private extension ProductsTopBannerFactory {
             NSLocalizedString(
                 "You can now add downloadable files to a product and link upsell & cross-sell products. No longer want a product? Trash it!",
                 comment: "The info of the top banner on the Products tab.")
-        static let infoVariations =
-            NSLocalizedString(
-                "When editing a product, you can now create, delete, and update product variations, product attributes, and product attribute options.",
-                comment: "The info of the top banner on the Products tab.")
+        static let infoVariations = NSLocalizedString("You can now create and manage product variations!",
+                                                      comment: "The info of the top banner on the Products tab.")
 
         static let giveFeedback =
             NSLocalizedString("Give feedback",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -4,7 +4,6 @@ import Yosemite
 struct ProductsTopBannerFactory {
 
     enum BannerType {
-        case productsM4
         case variations
 
         var title: String {
@@ -13,8 +12,6 @@ struct ProductsTopBannerFactory {
 
         var info: String {
             switch self {
-            case .productsM4:
-                return Localization.infoFilesAndLinkedProducts
             case .variations:
                 return Localization.infoVariations
             }
@@ -22,8 +19,6 @@ struct ProductsTopBannerFactory {
 
         var feedbackContext: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .productsM4:
-                return .productsM4
             case .variations:
                 return .productsVariations
             }
@@ -75,10 +70,6 @@ private extension ProductsTopBannerFactory {
         static let title = NSLocalizedString("New features available!",
                                              comment: "The title of the top banner on the Products tab.")
 
-        static let infoFilesAndLinkedProducts =
-            NSLocalizedString(
-                "You can now add downloadable files to a product and link upsell & cross-sell products. No longer want a product? Trash it!",
-                comment: "The info of the top banner on the Products tab.")
         static let infoVariations = NSLocalizedString("You can now create and manage product variations!",
                                                       comment: "The info of the top banner on the Products tab.")
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -419,6 +419,7 @@ private extension ProductsViewController {
     func requestAndShowNewTopBannerView() {
         let isExpanded = topBannerView?.isExpanded ?? false
         ProductsTopBannerFactory.topBanner(isExpanded: isExpanded,
+                                           type: .productsM4,
                                            expandedStateChangeHandler: { [weak self] in
             self?.updateTableHeaderViewHeight()
         }, onGiveFeedbackButtonPressed: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -162,7 +162,7 @@ final class ProductsViewController: UIViewController {
         configureSyncingCoordinator()
         registerTableViewCells()
 
-        showTopBannerView(for: .productsM4)
+        showTopBannerViewIfNeeded(for: .productsM4)
 
         /// We sync the local product settings for configuring local sorting and filtering.
         /// If there are some info stored when this screen is loaded, the data will be updated using the stored sort/filters.
@@ -397,7 +397,7 @@ private extension ProductsViewController {
 private extension ProductsViewController {
     /// Fetches products feedback visibility from AppSettingsStore and update products top banner accordingly
     ///
-    func showTopBannerView(for bannerType: ProductsTopBannerFactory.BannerType) {
+    func showTopBannerViewIfNeeded(for bannerType: ProductsTopBannerFactory.BannerType) {
         let action = AppSettingsAction.loadFeedbackVisibility(type: bannerType == .productsM4 ? .productsM5 : .productsVariations) { [weak self] result in
             switch result {
             case .success(let visible):
@@ -405,7 +405,7 @@ private extension ProductsViewController {
                     self?.requestAndShowNewTopBannerView(for: bannerType)
                 } else {
                     if bannerType == .productsM4 {
-                        self?.showTopBannerView(for: .variations)
+                        self?.showTopBannerViewIfNeeded(for: .variations)
                     } else {
                         self?.hideTopBannerView()
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -162,7 +162,7 @@ final class ProductsViewController: UIViewController {
         configureSyncingCoordinator()
         registerTableViewCells()
 
-        showTopBannerViewIfNeeded(for: .productsM4)
+        showTopBannerViewIfNeeded()
 
         /// We sync the local product settings for configuring local sorting and filtering.
         /// If there are some info stored when this screen is loaded, the data will be updated using the stored sort/filters.
@@ -397,18 +397,14 @@ private extension ProductsViewController {
 private extension ProductsViewController {
     /// Fetches products feedback visibility from AppSettingsStore and update products top banner accordingly
     ///
-    func showTopBannerViewIfNeeded(for bannerType: ProductsTopBannerFactory.BannerType) {
-        let action = AppSettingsAction.loadFeedbackVisibility(type: bannerType == .productsM4 ? .productsM5 : .productsVariations) { [weak self] result in
+    func showTopBannerViewIfNeeded() {
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .productsVariations) { [weak self] result in
             switch result {
             case .success(let visible):
                 if visible {
-                    self?.requestAndShowNewTopBannerView(for: bannerType)
+                    self?.requestAndShowNewTopBannerView(for: .variations)
                 } else {
-                    if bannerType == .productsM4 {
-                        self?.showTopBannerViewIfNeeded(for: .variations)
-                    } else {
-                        self?.hideTopBannerView()
-                    }
+                    self?.hideTopBannerView()
                 }
             case.failure(let error):
                 self?.hideTopBannerView()
@@ -427,9 +423,9 @@ private extension ProductsViewController {
                                            expandedStateChangeHandler: { [weak self] in
             self?.updateTableHeaderViewHeight()
         }, onGiveFeedbackButtonPressed: { [weak self] in
-            self?.presentProductsFeedback(for: bannerType)
+            self?.presentProductsFeedback()
         }, onDismissButtonPressed: { [weak self] in
-            self?.dismissProductsBanner(for: bannerType)
+            self?.dismissProductsBanner()
         }, onCompletion: { [weak self] topBannerView in
             self?.topBannerContainerView.updateSubview(topBannerView)
             self?.topBannerView = topBannerView
@@ -596,16 +592,16 @@ private extension ProductsViewController {
 
     /// Presents products survey
     ///
-    func presentProductsFeedback(for bannerType: ProductsTopBannerFactory.BannerType) {
+    func presentProductsFeedback() {
         // Present survey
-        let navigationController = SurveyCoordinatingController(survey: bannerType == .productsM4 ? .productsM5Feedback : .productsVariationsFeedback)
+        let navigationController = SurveyCoordinatingController(survey: .productsVariationsFeedback)
         present(navigationController, animated: true, completion: nil)
     }
 
     /// Mark feedback request as dismissed and update banner visibility
     ///
-    func dismissProductsBanner(for bannerType: ProductsTopBannerFactory.BannerType) {
-        let action = AppSettingsAction.updateFeedbackStatus(type: bannerType == .productsM4 ? .productsM5 : .productsVariations,
+    func dismissProductsBanner() {
+        let action = AppSettingsAction.updateFeedbackStatus(type: .productsVariations,
                                                             status: .dismissed) { [weak self] result in
             if let error = result.failure {
                 CrashLogging.logError(error)

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -64,6 +64,7 @@ extension SurveyViewController {
     enum Source {
         case inAppFeedback
         case productsM5Feedback
+        case productsVariationsFeedback
         case shippingLabelsRelease1Feedback
 
         fileprivate var url: URL {
@@ -80,6 +81,11 @@ extension SurveyViewController {
                     .tagPlatform("ios")
                     .tagProductMilestone("5")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .productsVariationsFeedback:
+                return WooConstants.URLs.productsM4Feedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             case .shippingLabelsRelease1Feedback:
                 return WooConstants.URLs.shippingLabelsRelease1Feedback
                     .asURL()
@@ -93,7 +99,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsM5Feedback, .shippingLabelsRelease1Feedback:
+            case .productsM5Feedback, .productsVariationsFeedback, .shippingLabelsRelease1Feedback:
                 return Localization.giveFeedback
             }
         }
@@ -105,6 +111,8 @@ extension SurveyViewController {
                 return .general
             case .productsM5Feedback:
                 return .productsM4
+            case .productsVariationsFeedback:
+                return .productsVariations
             case .shippingLabelsRelease1Feedback:
                 return .shippingLabelsRelease1
             }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -151,10 +151,6 @@ extension URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestAppVersionTag, value: version))
     }
 
-    func tagProductMilestone(_ milestone: String) -> URL {
-        appendingQueryItem(URLQueryItem(name: Tags.surveyRequestProductMilestoneTag, value: milestone))
-    }
-
     func tagShippingLabelsMilestone(_ milestone: String) -> URL {
         appendingQueryItem(URLQueryItem(name: Tags.surveyRequestShippingLabelsMilestoneTag, value: milestone))
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -63,7 +63,6 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 extension SurveyViewController {
     enum Source {
         case inAppFeedback
-        case productsM5Feedback
         case productsVariationsFeedback
         case shippingLabelsRelease1Feedback
 
@@ -75,14 +74,8 @@ extension SurveyViewController {
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
 
-            case .productsM5Feedback:
-                return WooConstants.URLs.productsM4Feedback
-                    .asURL()
-                    .tagPlatform("ios")
-                    .tagProductMilestone("5")
-                    .tagAppVersion(Bundle.main.bundleVersion())
             case .productsVariationsFeedback:
-                return WooConstants.URLs.productsM4Feedback
+                return WooConstants.URLs.productsFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -99,7 +92,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsM5Feedback, .productsVariationsFeedback, .shippingLabelsRelease1Feedback:
+            case .productsVariationsFeedback, .shippingLabelsRelease1Feedback:
                 return Localization.giveFeedback
             }
         }
@@ -109,8 +102,6 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
-            case .productsM5Feedback:
-                return .productsM4
             case .productsVariationsFeedback:
                 return .productsVariations
             case .shippingLabelsRelease1Feedback:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -28,7 +28,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
 
     func test_it_tracks_featureFeedbackBanner_gaveFeedback_event_when_giveFeedback_button_is_pressed() throws {
         // Given
-        let bannerMirror = try makeBannerViewMirror()
+        let bannerMirror = try makeBannerViewMirror(for: .productsM4)
         let giveFeedbackButton = try XCTUnwrap(bannerMirror.actionButtons.first)
 
         assertEmpty(analyticsProvider.receivedEvents)
@@ -47,7 +47,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
 
     func test_it_tracks_featureFeedbackBanner_dismissed_event_when_dismiss_button_is_pressed() throws {
         // Given
-        let bannerMirror = try makeBannerViewMirror()
+        let bannerMirror = try makeBannerViewMirror(for: .variations)
         let dismissButton = try XCTUnwrap(bannerMirror.actionButtons.last)
 
         assertEmpty(analyticsProvider.receivedEvents)
@@ -60,13 +60,13 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_m4")
+        XCTAssertEqual(properties["context"] as? String, "products_variations")
         XCTAssertEqual(properties["action"] as? String, "dismissed")
     }
 }
 
 private extension ProductsTopBannerFactoryTests {
-    func makeBannerViewMirror() throws -> TopBannerViewMirror {
+    func makeBannerViewMirror(for bannerType: ProductsTopBannerFactory.BannerType) throws -> TopBannerViewMirror {
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let .loadProductsFeatureSwitch(onCompletion) = action {
                 onCompletion(true)
@@ -78,6 +78,7 @@ private extension ProductsTopBannerFactoryTests {
             ProductsTopBannerFactory.topBanner(isExpanded: false,
                                                stores: storesManager,
                                                analytics: analytics,
+                                               type: bannerType,
                                                expandedStateChangeHandler: {
 
             }, onGiveFeedbackButtonPressed: {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -28,7 +28,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
 
     func test_it_tracks_featureFeedbackBanner_gaveFeedback_event_when_giveFeedback_button_is_pressed() throws {
         // Given
-        let bannerMirror = try makeBannerViewMirror(for: .productsM4)
+        let bannerMirror = try makeBannerViewMirror(for: .variations)
         let giveFeedbackButton = try XCTUnwrap(bannerMirror.actionButtons.first)
 
         assertEmpty(analyticsProvider.receivedEvents)
@@ -41,7 +41,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_m4")
+        XCTAssertEqual(properties["context"] as? String, "products_variations")
         XCTAssertEqual(properties["action"] as? String, "gave_feedback")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -24,7 +24,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_loads_the_correct_product_feedback_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .productsM5Feedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .productsVariationsFeedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -32,9 +32,8 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsM4Feedback
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.productsFeedback
                         .asURL().tagPlatform("ios")
-                        .tagProductMilestone("5")
                         .tagAppVersion(Bundle.main.bundleVersion()))
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/URL+SurveyViewControllerTests.swift
@@ -23,14 +23,6 @@ final class URL_SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(expectedURL, actualURL)
     }
 
-    func test_tagging_product_milestone_appends_the_correct_tag_data() throws {
-        let expectedURL = "https://testurl.com?product-milestone=test"
-
-        let actualURL = URL(string: "https://testurl.com")?.tagProductMilestone("test").absoluteString
-
-        XCTAssertEqual(expectedURL, actualURL)
-    }
-
     func test_tagging_shipping_labels_milestone_appends_the_correct_tag_data() throws {
         let expectedURL = "https://testurl.com?shipping_label_milestone=test"
 
@@ -39,26 +31,14 @@ final class URL_SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(expectedURL, actualURL)
     }
 
-    func test_tagging_platform_and_tagging_product_milestone_does_stack() throws {
-            let actualURL =
-                URL(string: "https://testurl.com")?
-                .tagPlatform("ios")
-                .tagProductMilestone("123")
-                .absoluteString
-
-            let expectedURL = "https://testurl.com?woo-mobile-platform=ios&product-milestone=123"
-
-            XCTAssertEqual(expectedURL, actualURL)
-    }
-
-    func test_tagging_platform_and_tagging_product_milestone_does_stack_in_order() throws {
+    func test_tagging_platform_and_tagging_shipping_labels_milestone_does_stack_in_order() throws {
         let actualURL =
             URL(string: "https://testurl.com")?
-            .tagProductMilestone("123")
+            .tagShippingLabelsMilestone("123")
             .tagPlatform("ios")
             .absoluteString
 
-        let expectedURL = "https://testurl.com?product-milestone=123&woo-mobile-platform=ios"
+        let expectedURL = "https://testurl.com?shipping_label_milestone=123&woo-mobile-platform=ios"
 
         XCTAssertEqual(expectedURL, actualURL)
     }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .productsM5:
+        case .productsM5, .productsVariations:
             return shouldProductsFeedbackBeVisible()
         case .shippingLabelsRelease1:
             return shouldShippingLabelsRelease1FeedbackBeVisible()
@@ -66,7 +66,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         return true
     }
 
-    /// Returns whether the productsM4 feedback request should be displayed
+    /// Returns whether the products feedback request should be displayed
     ///
     private func shouldProductsFeedbackBeVisible() -> Bool {
         return settings.feedbackStatus(of: feedbackType) == .pending

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .productsM5, .productsVariations:
+        case .productsVariations:
             return shouldProductsFeedbackBeVisible()
         case .shippingLabelsRelease1:
             return shouldShippingLabelsRelease1FeedbackBeVisible()

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -158,7 +158,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
     func test_shouldBeVisible_for_productM5_is_true_if_no_settings_are_found() throws {
         // Given
         let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -169,8 +169,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_true_if_feedback_has_pending_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -181,8 +181,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_dismissed_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .dismissed)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .dismissed)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -193,8 +193,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_false_if_feedback_has_given_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM5, feedbackSatus: .given(Date()))
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM5)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsVariations, feedbackSatus: .given(Date()))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -355,12 +355,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM5_returns_true_after_marking_it_as_pending() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .pending) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsVariations, status: .pending) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsVariations) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -375,12 +375,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM5_returns_false_after_marking_it_as_dismissed() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .dismissed) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsVariations, status: .dismissed) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsVariations) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -395,12 +395,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM5_returns_false_after_marking_it_as_given() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM5, status: .given(Date())) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsVariations, status: .given(Date())) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM5) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsVariations) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)


### PR DESCRIPTION
## Description

This PR adds a banner on top of Products List asking user feedback about Product Variations feature.

Following beta test feedback from: p5T066-21p-p2#comment-7623

## Changes

- Updated `ProductsTopBannerFactory` to have different content depending on banner type
- Added `productsVariations` FeedbackType to be stored in settings
- Added `productsVariationsFeedback` source for `SurveyViewController`
- Added `products_variations` feedback context for analytics
- Updated `ProductsViewController` to show Variations banner only after ProductsM5

**Note:** in code there is a little confusion between M4 and M5 for products. Analytics context string is `products_m4` while some of the code refers to this feedback as M5. There was no change applied, M4 naming is just more exposed now out of banner code due to parameters injection. Maybe worth additional rename to M5?

## Test

1. Open products list
2. If products M5 feedback banner is displayed - dismiss it and restart the app
3. Observe request for variations feedback
4. Dismiss it and make sure it won't appear again

## Screenshot

<img src="https://user-images.githubusercontent.com/3132438/112015691-18c8a280-8b3d-11eb-8782-187cdf444246.png" width=350>

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.