### PR TITLE
[Tooling] Mute fastlane's CHANGELOG and update check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ commands:
             # Add support for fetching SPM packages from GitHub
             for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
 
+            # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
+            echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
+
 jobs:
   Build Tests:
     executor:


### PR DESCRIPTION
This adds a magic env var that will prevent fastlane from checking for an update at the end of every invocation, and thus remove the quite verbose fastlane changelog output that gets printed at the end of every fastlane step.

Similar to https://github.com/woocommerce/woocommerce-android/pull/3729.

## To test

Check on CI that the steps invoking `fastlane` don't print the fastlane changelog at the end anymore.

**Before:** ([example here on latest run on develop](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/10841/workflows/5c63e7ce-4354-4c45-9d5a-dab6f357e8c4/jobs/19540))
```
[18:12:55]: fastlane.tools finished successfully 🎉

#######################################################################
# fastlane 2.178.0 is available. You are on 2.170.0.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.178.0 Improvements

…[a quite long fastlane changelog here]…

To see all new releases, open https://github.com/fastlane/fastlane/releases

Please update using `bundle update fastlane`
CircleCI received exit code 0
```

**After:** (see [CI on this PR](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/10844/workflows/2320db41-1f74-41a3-8c8a-feea1f6f68a8/jobs/19547))
```
[12:30:55]: fastlane.tools finished successfully 🎉
CircleCI received exit code 0
```