### PR TITLE
Improve Jetpack query parameters syntax

### DIFF
--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -91,8 +91,12 @@ private extension JetpackRequest {
     var dotcomParams: [String: String] {
         var output = [
             "json": "true",
-            "path": jetpackPath + "&_method=" + method.rawValue.lowercased() + jetpackQueryParams
+            "path": jetpackPath + "&_method=" + method.rawValue.lowercased()
         ]
+
+        if let jetpackQueryParams = jetpackQueryParams {
+            output["query"] = jetpackQueryParams
+        }
 
         if let jetpackBodyParams = jetpackBodyParams {
             output["body"] = jetpackBodyParams
@@ -121,14 +125,12 @@ private extension JetpackRequest {
 
     /// Returns the Jetpack-Tunneled-Request's Parameters
     ///
-    var jetpackQueryParams: String {
-        guard jetpackEncodesParametersInQuery else {
-            return String()
+    var jetpackQueryParams: String? {
+        guard jetpackEncodesParametersInQuery, parameters.isEmpty == false else {
+            return nil
         }
 
-        return parameters.reduce("") { (output, parameter) in
-            output + "&" + parameter.key + "=" + String(describing: parameter.value)
-        }
+        return parameters.toJSONEncoded()
     }
 
     /// Returns the Jetpack-Tunneled-Request's Body parameters

--- a/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
+++ b/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import Networking
 
 extension MockNetwork {
-    /// Returns the parameters ("\(key)=\(value)") for the WC API path in the first network request URL.
-    var pathComponents: [String]? {
+    /// Returns the parameters ("\(key)=\(value)") for the WC API query in the first network request URL.
+    var queryParameters: [String]? {
         guard let request = requestsForResponseData.first,
             let urlRequest = try? request.asURLRequest(),
             let url = urlRequest.url,
@@ -15,9 +15,11 @@ extension MockNetwork {
         }
         let parameters = urlComponents.queryItems
 
-        guard let path = parameters?.first(where: { $0.name == "path" })?.value else {
+        guard let queryString = parameters?.first(where: { $0.name == "query" })?.value,
+              let queryData = queryString.data(using: .utf8),
+              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: String] else {
             return nil
         }
-        return path.components(separatedBy: "&")
+        return queryDictionary.map({ $0.0 + "=" + $0.1 })
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -266,9 +266,9 @@ final class ProductsRemoteTests: XCTestCase {
         }
 
         // Assert
-        let pathComponents = try XCTUnwrap(network.pathComponents)
+        let queryParameters = try XCTUnwrap(network.queryParameters)
         let expectedParam = "exclude=17,671"
-        XCTAssertTrue(pathComponents.contains(expectedParam), "Expected to have param: \(expectedParam)")
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
 
     /// Verifies that loadAllProducts properly relays Networking Layer errors.

--- a/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import Networking
 
 extension MockNetwork {
-    /// Returns the parameters ("\(key)=\(value)") for the WC API path in the first network request URL.
-    var pathComponents: [String]? {
+    /// Returns the parameters ("\(key)=\(value)") for the WC API query in the first network request URL.
+    var queryParameters: [String]? {
         guard let request = requestsForResponseData.first,
             let urlRequest = try? request.asURLRequest(),
             let url = urlRequest.url,
@@ -15,9 +15,11 @@ extension MockNetwork {
         }
         let parameters = urlComponents.queryItems
 
-        guard let path = parameters?.first(where: { $0.name == "path" })?.value else {
+        guard let queryString = parameters?.first(where: { $0.name == "query" })?.value,
+              let queryData = queryString.data(using: .utf8),
+              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: String] else {
             return nil
         }
-        return path.components(separatedBy: "&")
+        return queryDictionary.map({ $0.0 + "=" + $0.1 })
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
@@ -156,33 +156,33 @@ final class ProductStore_FilterProductsTests: XCTestCase {
 
 private extension ProductStore_FilterProductsTests {
     func assertParamValues(stockStatusValue: String?, productStatusValue: String?, productTypeValue: String?) {
-        guard let pathComponents = network.pathComponents else {
-            XCTFail("Cannot parse path from the API request")
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
             return
         }
 
         let stockStatusParameter = "stock_status"
         if let stockStatusValue = stockStatusValue {
             let expectedParam = "\(stockStatusParameter)=\(stockStatusValue)"
-            XCTAssertTrue(pathComponents.contains(expectedParam), "Expected to have param: \(expectedParam)")
+            XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
-            XCTAssertFalse(pathComponents.contains(where: { $0.starts(with: stockStatusParameter) }))
+            XCTAssertFalse(queryParameters.contains(where: { $0.starts(with: stockStatusParameter) }))
         }
 
         let productStatusParameter = "status"
         if let productStatusValue = productStatusValue {
             let expectedParam = "\(productStatusParameter)=\(productStatusValue)"
-            XCTAssertTrue(pathComponents.contains(expectedParam), "Expected to have param: \(expectedParam)")
+            XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
-            XCTAssertFalse(pathComponents.contains(where: { $0.starts(with: productStatusParameter) }))
+            XCTAssertFalse(queryParameters.contains(where: { $0.starts(with: productStatusParameter) }))
         }
 
         let productTypeParameter = "type"
         if let productTypeValue = productTypeValue {
             let expectedParam = "\(productTypeParameter)=\(productTypeValue)"
-            XCTAssertTrue(pathComponents.contains(expectedParam), "Expected to have param: \(expectedParam)")
+            XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
-            XCTAssertFalse(pathComponents.contains(where: { $0.starts(with: productTypeParameter) }))
+            XCTAssertFalse(queryParameters.contains(where: { $0.starts(with: productTypeParameter) }))
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
@@ -142,15 +142,15 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
 
 private extension ProductStore_ProductsSortOrderTests {
     func assertSortOrderParamValues(orderByValue: String, orderValue: String) {
-        guard let pathComponents = network.pathComponents else {
-            XCTFail("Cannot parse path from the API request")
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
             return
         }
 
         let expectedOrderbyParam = "orderby=\(orderByValue)"
-        XCTAssertTrue(pathComponents.contains(expectedOrderbyParam), "Expected to have param: \(expectedOrderbyParam)")
+        XCTAssertTrue(queryParameters.contains(expectedOrderbyParam), "Expected to have param: \(expectedOrderbyParam)")
 
         let expectedOrderParam = "order=\(orderValue)"
-        XCTAssertTrue(pathComponents.contains(expectedOrderParam), "Expected to have param: \(expectedOrderParam)")
+        XCTAssertTrue(queryParameters.contains(expectedOrderParam), "Expected to have param: \(expectedOrderParam)")
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1374,16 +1374,16 @@ final class ProductStoreTests: XCTestCase {
         productStore.onAction(action)
 
         // Assert
-        guard let pathComponents = network.pathComponents else {
-            XCTFail("Cannot parse path from the API request")
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
             return
         }
 
         let expectedPageNumberParam = "page=\(pageNumber)"
-        XCTAssertTrue(pathComponents.contains(expectedPageNumberParam), "Expected to have param: \(expectedPageNumberParam)")
+        XCTAssertTrue(queryParameters.contains(expectedPageNumberParam), "Expected to have param: \(expectedPageNumberParam)")
 
         let expectedPageSizeParam = "per_page=\(pageSize)"
-        XCTAssertTrue(pathComponents.contains(expectedPageSizeParam), "Expected to have param: \(expectedPageSizeParam)")
+        XCTAssertTrue(queryParameters.contains(expectedPageSizeParam), "Expected to have param: \(expectedPageSizeParam)")
     }
 
     /// Verifies that ProductAction.retrieveProducts always returns an empty result for an empty array of product IDs.


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/1980.

## Description

This PR moves wrapped Jetpack proxy request parameters from `path` to JSON-formatted `query` item.
Related discussion: p91TBi-2wf-p2

## Test

1. Verify that networking works well in the app (like getting all pages of products list)
2. Try POST and DELETE actions - like product update and trash (should be unaffected by PR)
3. Open Wormholy debug and check `query` parameter in calls to `rest-api` endpoint

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.