### PR TITLE
Networking models for parsing default and custom packages in Shipping Labels

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -895,6 +895,20 @@ extension ShippingLabelAddressVerification.ShipType {
         .origin
     }
 }
+extension ShippingLabelCustomPackage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomPackage {
+        .init(
+            isUserDefined: .fake(),
+            title: .fake(),
+            isLetter: .fake(),
+            dimensions: .fake(),
+            boxWeight: .fake(),
+            maxWeight: .fake()
+        )
+    }
+}
 extension ShippingLabelPackagesResponse {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -911,6 +925,28 @@ extension ShippingLabelPaperSize {
     ///
     public static func fake() -> ShippingLabelPaperSize {
         .a4
+    }
+}
+extension ShippingLabelPredefinedOption {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPredefinedOption {
+        .init(
+            title: .fake(),
+            predefinedPackages: .fake()
+        )
+    }
+}
+extension ShippingLabelPredefinedPackage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPredefinedPackage {
+        .init(
+            id: .fake(),
+            title: .fake(),
+            isLetter: .fake(),
+            dimensions: .fake()
+        )
     }
 }
 extension ShippingLabelPrintData {
@@ -956,6 +992,18 @@ extension ShippingLabelStatus {
     ///
     public static func fake() -> ShippingLabelStatus {
         .purchased
+    }
+}
+extension ShippingLabelStoreOptions {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelStoreOptions {
+        .init(
+            currencySymbol: .fake(),
+            dimensionUnit: .fake(),
+            weightUnit: .fake(),
+            originCountry: .fake()
+        )
     }
 }
 extension ShippingLine {

--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -895,6 +895,17 @@ extension ShippingLabelAddressVerification.ShipType {
         .origin
     }
 }
+extension ShippingLabelPackagesResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPackagesResponse {
+        .init(
+            storeOptions: .fake(),
+            customPackages: .fake(),
+            predefinedOptions: .fake()
+        )
+    }
+}
 extension ShippingLabelPaperSize {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1007,6 +1018,35 @@ extension SitePlan {
             siteID: .fake(),
             shortName: .fake()
         )
+    }
+}
+extension SitePlugin {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SitePlugin {
+        .init(
+            siteID: .fake(),
+            plugin: .fake(),
+            status: .fake(),
+            name: .fake(),
+            pluginUri: .fake(),
+            author: .fake(),
+            authorUri: .fake(),
+            descriptionRaw: .fake(),
+            descriptionRendered: .fake(),
+            version: .fake(),
+            networkOnly: .fake(),
+            requiresWPVersion: .fake(),
+            requiresPHPVersion: .fake(),
+            textDomain: .fake()
+        )
+    }
+}
+extension SitePluginStatusEnum {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SitePluginStatusEnum {
+        .active
     }
 }
 extension SiteSetting {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -128,6 +128,14 @@
 		4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 4515282A257A8C010076B03C /* product-attribute-delete.json */; };
 		45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */; };
 		45152835257A8F490076B03C /* ProductAttributeListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */; };
+		451A97C92609FF050059D135 /* ShippingLabelPackagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */; };
+		451A97CD260A01A40059D135 /* ShippingLabelStoreOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */; };
+		451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A97D0260A03900059D135 /* ShippingLabelCustomPackage.swift */; };
+		451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 451A97DD260B59870059D135 /* shipping-label-packages-success.json */; };
+		451A97E5260B631E0059D135 /* ShippingLabelPredefinedPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A97E4260B631E0059D135 /* ShippingLabelPredefinedPackage.swift */; };
+		451A97E9260B657D0059D135 /* ShippingLabelPredefinedOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A97E8260B657D0059D135 /* ShippingLabelPredefinedOption.swift */; };
+		451A9832260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A9831260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift */; };
+		451A9836260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */; };
 		4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */; };
 		453305E92459DF2100264E50 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305E82459DF2100264E50 /* PostMapper.swift */; };
 		453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EA2459E01A00264E50 /* PostMapperTests.swift */; };
@@ -562,6 +570,14 @@
 		4515282A257A8C010076B03C /* product-attribute-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-attribute-delete.json"; sourceTree = "<group>"; };
 		45152830257A8E1A0076B03C /* ProductAttributeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapperTests.swift; sourceTree = "<group>"; };
 		45152834257A8F490076B03C /* ProductAttributeListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeListMapperTests.swift; sourceTree = "<group>"; };
+		451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesResponse.swift; sourceTree = "<group>"; };
+		451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStoreOptions.swift; sourceTree = "<group>"; };
+		451A97D0260A03900059D135 /* ShippingLabelCustomPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackage.swift; sourceTree = "<group>"; };
+		451A97DD260B59870059D135 /* shipping-label-packages-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-packages-success.json"; sourceTree = "<group>"; };
+		451A97E4260B631E0059D135 /* ShippingLabelPredefinedPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPredefinedPackage.swift; sourceTree = "<group>"; };
+		451A97E8260B657D0059D135 /* ShippingLabelPredefinedOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPredefinedOption.swift; sourceTree = "<group>"; };
+		451A9831260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesMapper.swift; sourceTree = "<group>"; };
+		451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesMapperTests.swift; sourceTree = "<group>"; };
 		4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-on-sale-with-empty-sale-price.json"; sourceTree = "<group>"; };
 		453305E82459DF2100264E50 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		453305EA2459E01A00264E50 /* PostMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapperTests.swift; sourceTree = "<group>"; };
@@ -916,6 +932,7 @@
 				45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
+				451A97C72609FDE50059D135 /* Packages */,
 			);
 			path = ShippingLabel;
 			sourceTree = "<group>";
@@ -946,6 +963,34 @@
 				69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		451A97C72609FDE50059D135 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				451A97C82609FF050059D135 /* ShippingLabelPackagesResponse.swift */,
+				451A97CC260A01A40059D135 /* ShippingLabelStoreOptions.swift */,
+				451A97D4260A069B0059D135 /* Custom package */,
+				451A97E3260B63030059D135 /* Predefined package */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
+		451A97D4260A069B0059D135 /* Custom package */ = {
+			isa = PBXGroup;
+			children = (
+				451A97D0260A03900059D135 /* ShippingLabelCustomPackage.swift */,
+			);
+			path = "Custom package";
+			sourceTree = "<group>";
+		};
+		451A97E3260B63030059D135 /* Predefined package */ = {
+			isa = PBXGroup;
+			children = (
+				451A97E8260B657D0059D135 /* ShippingLabelPredefinedOption.swift */,
+				451A97E4260B631E0059D135 /* ShippingLabelPredefinedPackage.swift */,
+			);
+			path = "Predefined package";
 			sourceTree = "<group>";
 		};
 		45AE58142306ADA8001901E3 /* Refund */ = {
@@ -1273,7 +1318,6 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
-				02E7FFCE25621C7900C53030 /* shipping-label-print.json */,
 				CECC759D23D6231900486676 /* order-560-all-refunds.json */,
 				74C8F06F20EEC3A800B6EDC9 /* broken-notes.json */,
 				B5A2417A217F98FC00595DEF /* broken-notifications.json */,
@@ -1375,6 +1419,8 @@
 				D823D90622376B4800C90817 /* shipment_tracking_new_custom_provider.json */,
 				D823D90A22376EFE00C90817 /* shipment_tracking_delete.json */,
 				D823D91322377EE600C90817 /* shipment_tracking_providers.json */,
+				451A97DD260B59870059D135 /* shipping-label-packages-success.json */,
+				02E7FFCE25621C7900C53030 /* shipping-label-print.json */,
 				028FA471257E110700F88A48 /* shipping-label-refund-error.json */,
 				028FA472257E110700F88A48 /* shipping-label-refund-success.json */,
 				45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */,
@@ -1456,6 +1502,7 @@
 				74ABA1D2213F25AE00FFAD30 /* TopEarnerStatsMapper.swift */,
 				026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */,
 				02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */,
+				451A9831260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift */,
 				029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */,
 				021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */,
@@ -1556,6 +1603,7 @@
 				D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */,
 				02698CF724C183A5005337C4 /* ProductVariationListMapperTests.swift */,
 				020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */,
+				451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 			);
 			path = Mapper;
@@ -1818,6 +1866,7 @@
 				02698CFA24C188E9005337C4 /* product-variations-load-all-alternative-types.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
+				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,
 				31D27C8F2602B553002EDB1D /* plugins.json in Resources */,
 				261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */,
 				268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */,
@@ -1910,6 +1959,7 @@
 				B50A583921AD861700617455 /* APNSDevice.swift in Sources */,
 				26455E2425F66982008A1D32 /* ProductAttributeTermRemote.swift in Sources */,
 				7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */,
+				451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */,
 				D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */,
 				B59325D4217E4206000B0E8E /* NoteBlock.swift in Sources */,
 				D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */,
@@ -1924,6 +1974,7 @@
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
 				26731337255ACA850026F7EF /* PaymentGatewayListMapper.swift in Sources */,
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
+				451A97E9260B657D0059D135 /* ShippingLabelPredefinedOption.swift in Sources */,
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
@@ -1936,6 +1987,7 @@
 				020D07B823D852BB00FD9580 /* Media.swift in Sources */,
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
 				743E84EE2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift in Sources */,
+				451A97E5260B631E0059D135 /* ShippingLabelPredefinedPackage.swift in Sources */,
 				B567AF2520A0CCA300AB6C62 /* AuthenticatedRequest.swift in Sources */,
 				453305E92459DF2100264E50 /* PostMapper.swift in Sources */,
 				456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */,
@@ -1991,6 +2043,7 @@
 				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
+				451A97CD260A01A40059D135 /* ShippingLabelStoreOptions.swift in Sources */,
 				5726F72E2460A2820031CAAC /* Copiable.swift in Sources */,
 				02C254A8256373AB00A04423 /* ShippingLabel.swift in Sources */,
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
@@ -2071,6 +2124,7 @@
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
 				24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */,
+				451A9832260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift in Sources */,
 				4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */,
 				B53EF5342180F646003E146F /* DotcomValidator.swift in Sources */,
 				74046E1D217A6989007DD7BF /* SiteSetting.swift in Sources */,
@@ -2088,6 +2142,7 @@
 				CE43066C2347C5F90073CBFF /* OrderItemRefund.swift in Sources */,
 				B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */,
 				D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */,
+				451A97C92609FF050059D135 /* ShippingLabelPackagesResponse.swift in Sources */,
 				029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */,
 				B557DA0F20975E07005962F4 /* DotcomRequest.swift in Sources */,
 				740211E321939C84002248DA /* CommentResultMapper.swift in Sources */,
@@ -2121,6 +2176,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
+				451A9836260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift in Sources */,
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelPackagesMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelPackagesMapper.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+
+/// Mapper: Shipping Label Packages
+///
+struct ShippingLabelPackagesMapper: Mapper {
+    /// (Attempts) to convert a dictionary into ShippingLabelPackagesResponse.
+    ///
+    func map(response: Data) throws -> ShippingLabelPackagesResponse {
+        let decoder = JSONDecoder()
+        return try decoder.decode(ShippingLabelPackagesMapperEnvelope.self, from: response).data
+    }
+}
+
+/// ShippingLabelPackagesMapperEnvelope Disposable Entity:
+/// `Shipping Label Packages` endpoint returns the shipping label packages in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ShippingLabelPackagesMapperEnvelope: Decodable {
+    let data: ShippingLabelPackagesResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a custom package in Shipping Labels.
 ///
-public struct ShippingLabelCustomPackage: Equatable {
+public struct ShippingLabelCustomPackage: Equatable, GeneratedFakeable {
 
     /// Usually is always `true` for custom packages
     public let isUserDefined: Bool

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a custom package in Shipping Labels.
 ///
-public struct ShippingLabelCustomPackage: Equatable, GeneratedFakeable {
+public struct ShippingLabelCustomPackage: Equatable {
 
     /// Usually is always `true` for custom packages
     public let isUserDefined: Bool

--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Represents a custom package in Shipping Labels.
+///
+public struct ShippingLabelCustomPackage: Equatable, GeneratedFakeable {
+
+    /// Usually is always `true` for custom packages
+    public let isUserDefined: Bool
+
+    /// The name of the custom package, like `Krabica`
+    public let title: String
+
+    /// Defines if package is a box or a letter. By default is a box, so it's equal to `false`
+    public let isLetter: Bool
+
+    /// Will be a string formatted like this: `2 x 3 x 4`
+    public let dimensions: String
+
+    public let boxWeight: Int
+
+    public let maxWeight: Int
+
+    public init(isUserDefined: Bool, title: String, isLetter: Bool, dimensions: String, boxWeight: Int, maxWeight: Int) {
+        self.isUserDefined = isUserDefined
+        self.title = title
+        self.isLetter = isLetter
+        self.dimensions = dimensions
+        self.boxWeight = boxWeight
+        self.maxWeight = maxWeight
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelCustomPackage: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let isUserDefined = try container.decode(Bool.self, forKey: .isUserDefined)
+        let title = try container.decode(String.self, forKey: .title)
+        let isLetter = try container.decodeIfPresent(Bool.self, forKey: .isLetter) ?? false
+        let dimensions = try container.decode(String.self, forKey: .innerDimensions)
+        let boxWeight = try container.decode(Int.self, forKey: .boxWeight)
+        let maxWeight = try container.decode(Int.self, forKey: .maxWeight)
+
+        self.init(isUserDefined: isUserDefined, title: title, isLetter: isLetter, dimensions: dimensions, boxWeight: boxWeight, maxWeight: maxWeight)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isUserDefined = "is_user_defined"
+        case title = "name"
+        case isLetter = "is_letter"
+        case innerDimensions = "inner_dimensions"
+        case boxWeight = "box_weight"
+        case maxWeight = "max_weight"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Represents a predefined option in Shipping Labels.
+///
+public struct ShippingLabelPredefinedOption: Equatable, GeneratedFakeable {
+
+    /// The title of the predefined option
+    public let title: String
+
+    /// List of predefined packages
+    public let predefinedPackages: [ShippingLabelPredefinedPackage]
+
+
+    public init(title: String, predefinedPackages: [ShippingLabelPredefinedPackage]) {
+        self.title = title
+        self.predefinedPackages = predefinedPackages
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelPredefinedOption: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let title = try container.decode(String.self, forKey: .title)
+        let predefinedPackages = try container.decodeIfPresent([ShippingLabelPredefinedPackage].self, forKey: .predefinedPackages) ?? []
+
+        self.init(title: title, predefinedPackages: predefinedPackages)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case predefinedPackages
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a predefined option in Shipping Labels.
 ///
-public struct ShippingLabelPredefinedOption: Equatable {
+public struct ShippingLabelPredefinedOption: Equatable, GeneratedFakeable {
 
     /// The title of the predefined option
     public let title: String

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a predefined option in Shipping Labels.
 ///
-public struct ShippingLabelPredefinedOption: Equatable, GeneratedFakeable {
+public struct ShippingLabelPredefinedOption: Equatable {
 
     /// The title of the predefined option
     public let title: String

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Represents a predefined package in Shipping Labels.
+///
+public struct ShippingLabelPredefinedPackage: Equatable, GeneratedFakeable {
+
+    /// The id of the predefined package
+    public let id: String
+
+    /// The name of the package, like `USPS Priority Mail Boxes`
+    public let title: String
+
+    /// Defines if package is a box or a letter. By default is a box, so it's equal to `false`
+    public let isLetter: Bool
+
+    /// Will be a string formatted like this: ` 21.91 x 13.65 x 4.13`
+    public let dimensions: String
+
+    public init(id: String, title: String, isLetter: Bool, dimensions: String) {
+        self.id = id
+        self.title = title
+        self.isLetter = isLetter
+        self.dimensions = dimensions
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelPredefinedPackage: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let id = try container.decode(String.self, forKey: .id)
+        let title = try container.decode(String.self, forKey: .title)
+        let isLetter = try container.decodeIfPresent(Bool.self, forKey: .isLetter) ?? false
+        let dimensions = try container.decode(String.self, forKey: .dimensions)
+
+        self.init(id: id, title: title, isLetter: isLetter, dimensions: dimensions)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title = "name"
+        case isLetter = "is_letter"
+        case dimensions = "outer_dimensions"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a predefined package in Shipping Labels.
 ///
-public struct ShippingLabelPredefinedPackage: Equatable {
+public struct ShippingLabelPredefinedPackage: Equatable, GeneratedFakeable {
 
     /// The id of the predefined package
     public let id: String

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedPackage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a predefined package in Shipping Labels.
 ///
-public struct ShippingLabelPredefinedPackage: Equatable, GeneratedFakeable {
+public struct ShippingLabelPredefinedPackage: Equatable {
 
     /// The id of the predefined package
     public let id: String

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -44,6 +44,8 @@ extension ShippingLabelPackagesResponse: Decodable {
 
         var predefinedOptions: [ShippingLabelPredefinedOption] = []
 
+        // Iterate around keys of `formSchema` and `formData` for creating the predefined options available for this website.
+        //
         rawPredefinedFormSchema.forEach { (key, value) in
 
             let provider: [String: Any]? = try? value.toDictionary()

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Represents a list of Shipping Label Packages (custom and predefined).
+///
+public struct ShippingLabelPackagesResponse: Equatable, GeneratedFakeable {
+
+    /// The options of the store, like currency symbol and origin country.
+    public let storeOptions: ShippingLabelStoreOptions
+
+    public let customPackages: [ShippingLabelCustomPackage]
+
+    public let predefinedOptions: [ShippingLabelPredefinedOption]
+
+    public init(storeOptions: ShippingLabelStoreOptions,
+                customPackages: [ShippingLabelCustomPackage],
+                predefinedOptions: [ShippingLabelPredefinedOption]) {
+        self.storeOptions = storeOptions
+        self.customPackages = customPackages
+        self.predefinedOptions = predefinedOptions
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelPackagesResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let mainContainer = try decoder.container(keyedBy: CodingKeys.self)
+
+        let storeOptions = try mainContainer.decode(ShippingLabelStoreOptions.self, forKey: .storeOptions)
+        let formDataContainer = try mainContainer.nestedContainer(keyedBy: FormDataKeys.self, forKey: .formData)
+        let customPackages = try formDataContainer.decodeIfPresent([ShippingLabelCustomPackage].self, forKey: .custom) ?? []
+
+        let formSchemaContainer = try mainContainer.nestedContainer(keyedBy: FormSchemaKeys.self, forKey: .formSchema)
+
+
+
+        // We assume that rows will always be of type `Dictionary<String:<Array<String>>>`
+        //
+        let rawPredefinedFormData: [String: AnyCodable] = try formDataContainer.decodeIfPresent([String: AnyCodable].self, forKey: .predefined) ?? [:]
+
+        // We assume that rows will always be of type `Dictionary<String:<Dictionary<String: Dictionary<different values>>>`
+        //
+        let rawPredefinedFormSchema: [String: AnyCodable] = try formSchemaContainer.decodeIfPresent([String: AnyCodable].self, forKey: .predefined) ?? [:]
+
+
+        var predefinedOptions: [ShippingLabelPredefinedOption] = []
+
+        rawPredefinedFormSchema.forEach { (key, value) in
+
+            let provider: [String: Any]? = try? value.toDictionary()
+            provider?.forEach({ (providerKey, providerValue) in
+
+                let packageIDs: [String] = rawPredefinedFormData[key]?.value as? [String] ?? []
+
+                let providerValueDict = providerValue as? [String: Any]
+                let predefinedPackages = ShippingLabelPackagesResponse.getPredefinedPackages(packageIDs: packageIDs,
+                                                                                             packageDefinitions: providerValueDict)
+                if !predefinedPackages.isEmpty {
+                    let titleOption: String = providerValueDict?["title"] as? String ?? ""
+                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: predefinedPackages)
+                    predefinedOptions.append(option)
+                }
+            })
+        }
+
+        self.init(storeOptions: storeOptions, customPackages: customPackages, predefinedOptions: predefinedOptions)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case storeOptions
+        case formData
+        case formSchema
+    }
+
+    private enum FormDataKeys: String, CodingKey {
+        case custom
+        case predefined
+    }
+
+    private enum FormSchemaKeys: String, CodingKey {
+        case predefined
+    }
+}
+
+private extension ShippingLabelPackagesResponse {
+    static func getPredefinedPackages(packageIDs: [String], packageDefinitions: [String: Any]?) -> [ShippingLabelPredefinedPackage] {
+        var predefinedPackages: [ShippingLabelPredefinedPackage] = []
+        guard let definitions = packageDefinitions?["definitions"], let jsonData = try? JSONSerialization.data(withJSONObject: definitions, options: []) else {
+            return []
+        }
+        let packages = (try? JSONDecoder().decode([ShippingLabelPredefinedPackage].self, from: jsonData)) ?? []
+
+        packageIDs.forEach { (packageID) in
+            packages.forEach { (package) in
+                if packageID == package.id {
+                    predefinedPackages.append(package)
+                }
+            }
+        }
+        return predefinedPackages
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -49,8 +49,7 @@ extension ShippingLabelPackagesResponse: Decodable {
             let provider: [String: Any]? = try? value.toDictionary()
             provider?.forEach({ (providerKey, providerValue) in
 
-                let packageIDs: [String] = rawPredefinedFormData[key]?.value as? [String] ?? []
-
+                let packageIDs: [Any?] = rawPredefinedFormData[key]?.value as? [Any?] ?? []
                 let providerValueDict = providerValue as? [String: Any]
                 let predefinedPackages = ShippingLabelPackagesResponse.getPredefinedPackages(packageIDs: packageIDs,
                                                                                              packageDefinitions: providerValueDict)
@@ -82,16 +81,16 @@ extension ShippingLabelPackagesResponse: Decodable {
 }
 
 private extension ShippingLabelPackagesResponse {
-    static func getPredefinedPackages(packageIDs: [String], packageDefinitions: [String: Any]?) -> [ShippingLabelPredefinedPackage] {
+    static func getPredefinedPackages(packageIDs: [Any?], packageDefinitions: [String: Any]?) -> [ShippingLabelPredefinedPackage] {
         var predefinedPackages: [ShippingLabelPredefinedPackage] = []
         guard let definitions = packageDefinitions?["definitions"], let jsonData = try? JSONSerialization.data(withJSONObject: definitions, options: []) else {
             return []
         }
         let packages = (try? JSONDecoder().decode([ShippingLabelPredefinedPackage].self, from: jsonData)) ?? []
 
-        packageIDs.forEach { (packageID) in
+        packageIDs.compactMap { $0 }.forEach { (packageID) in
             packages.forEach { (package) in
-                if packageID == package.id {
+                if packageID as? String == package.id {
                     predefinedPackages.append(package)
                 }
             }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Represents the store options returned in the packages details.
+///
+public struct ShippingLabelStoreOptions: Equatable, GeneratedFakeable {
+
+    public let currencySymbol: String // eg. `$`
+    public let dimensionUnit: String // eg. `in`
+    public let weightUnit: String // eg. `oz`
+    public let originCountry: String // eg. `US`
+
+
+    public init(currencySymbol: String, dimensionUnit: String, weightUnit: String, originCountry: String) {
+        self.currencySymbol = currencySymbol
+        self.dimensionUnit = dimensionUnit
+        self.weightUnit = weightUnit
+        self.originCountry = originCountry
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelStoreOptions: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let currencySymbol = try container.decode(String.self, forKey: .currencySymbol)
+        let dimensionUnit = try container.decode(String.self, forKey: .dimensionUnit)
+        let weightUnit = try container.decode(String.self, forKey: .weightUnit)
+        let originCountry = try container.decode(String.self, forKey: .originCountry)
+
+        self.init(currencySymbol: currencySymbol, dimensionUnit: dimensionUnit, weightUnit: weightUnit, originCountry: originCountry)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case currencySymbol = "currency_symbol"
+        case dimensionUnit = "dimension_unit"
+        case weightUnit = "weight_unit"
+        case originCountry = "origin_country"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the store options returned in the packages details.
 ///
-public struct ShippingLabelStoreOptions: Equatable {
+public struct ShippingLabelStoreOptions: Equatable, GeneratedFakeable {
 
     public let currencySymbol: String // eg. `$`
     public let dimensionUnit: String // eg. `in`

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelStoreOptions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents the store options returned in the packages details.
 ///
-public struct ShippingLabelStoreOptions: Equatable, GeneratedFakeable {
+public struct ShippingLabelStoreOptions: Equatable {
 
     public let currencySymbol: String // eg. `$`
     public let dimensionUnit: String // eg. `in`

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -1,104 +1,54 @@
-//import Foundation
-//
-//import XCTest
-//@testable import Networking
-//
-///// Unit Tests for `ShippingLabelPackagesMapper`
-/////
-//final class ShippingLabelPackagesMapperTests: XCTestCase {
-//    /// Dummy Site ID.
-//    ///
-//    private let dummySiteID: Int64 = 33334444
-//
-//    /// Verifies that all of the ProductVariation Fields are parsed correctly.
-//    ///
-//    func test_ShippingLabelPackages_fields_are_properly_parsed() throws {
-//        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
-//
-//        XCTAssertEqual(productVariation, sampleProductVariation(siteID: dummySiteID, productID: dummyProductID, id: 2783))
-//    }
-//}
-//
-///// Private Helpers
-/////
-//private extension ShippingLabelPackagesMapperTests {
-//    /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
-//    ///
-//    func mapProductVariation(from filename: String) -> ProductVariation? {
-//        guard let response = Loader.contentsOf(filename) else {
-//            return nil
-//        }
-//
-//        return try? ProductVariationMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
-//    }
-//
-//    /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
-//    ///
-//    func mapLoadProductVariationResponse() -> ProductVariation? {
-//        return mapProductVariation(from: "product-variation-update")
-//    }
-//}
-//
-//private extension ShippingLabelPackagesMapperTests {
-//    func sampleProductVariation(siteID: Int64,
-//                                productID: Int64,
-//                                id: Int64) -> ProductVariation {
-//        let imageSource = "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1"
-//        return ProductVariation(siteID: siteID,
-//                                productID: productID,
-//                                productVariationID: id,
-//                                attributes: sampleProductVariationAttributes(),
-//                                image: ProductImage(imageID: 2432,
-//                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
-//                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
-//                                                    src: imageSource,
-//                                                    name: "DSC_0010",
-//                                                    alt: ""),
-//                                permalink: "https://chocolate.com/marble",
-//                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
-//                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
-//                                dateOnSaleStart: nil,
-//                                dateOnSaleEnd: nil,
-//                                status: .publish,
-//                                description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
-//                                sku: "87%-strawberry-marble",
-//                                price: "14.99",
-//                                regularPrice: "14.99",
-//                                salePrice: "",
-//                                onSale: false,
-//                                purchasable: true,
-//                                virtual: false,
-//                                downloadable: true,
-//                                downloads: [],
-//                                downloadLimit: -1,
-//                                downloadExpiry: 0,
-//                                taxStatusKey: "taxable",
-//                                taxClass: "",
-//                                manageStock: false,
-//                                stockQuantity: 16,
-//                                stockStatus: .inStock,
-//                                backordersKey: "notify",
-//                                backordersAllowed: true,
-//                                backordered: false,
-//                                weight: "2.5",
-//                                dimensions: ProductDimensions(length: "10",
-//                                                              width: "2.5",
-//                                                              height: ""),
-//                                shippingClass: "",
-//                                shippingClassID: 0,
-//                                menuOrder: 1)
-//    }
-//
-//    func sampleProductVariationAttributes() -> [ProductVariationAttribute] {
-//        return [
-//            ProductVariationAttribute(id: 0, name: "Darkness", option: "87%"),
-//            ProductVariationAttribute(id: 0, name: "Flavor", option: "strawberry"),
-//            ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
-//        ]
-//    }
-//
-//    func dateFromGMT(_ dateStringInGMT: String) -> Date {
-//        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-//        return dateFormatter.date(from: dateStringInGMT)!
-//    }
-//}
+import Foundation
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ShippingLabelPackagesMapper`
+///
+final class ShippingLabelPackagesMapperTests: XCTestCase {
+
+    /// Verifies that all of the ShippingLabelPackagesResponse Fields are parsed correctly.
+    ///
+    func test_ShippingLabelPackages_fields_are_properly_parsed() throws {
+        let shippingLabelPackages = try XCTUnwrap(mapLoadShippingLabelPackagesResponse())
+
+        XCTAssertEqual(shippingLabelPackages.storeOptions, sampleShippingLabelStoreOptions())
+        XCTAssertEqual(shippingLabelPackages.customPackages, sampleShippingLabelCustomPackages())
+    }
+}
+
+/// Private Helpers
+///
+private extension ShippingLabelPackagesMapperTests {
+    /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapShippingLabelPackages(from filename: String) -> ShippingLabelPackagesResponse? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ShippingLabelPackagesMapper().map(response: response)
+    }
+
+    /// Returns the ShippingLabelPackagesMapper output upon receiving `filename`
+    ///
+    func mapLoadShippingLabelPackagesResponse() -> ShippingLabelPackagesResponse? {
+        return mapShippingLabelPackages(from: "shipping-label-packages-success")
+    }
+}
+
+private extension ShippingLabelPackagesMapperTests {
+    func sampleShippingLabelStoreOptions() -> ShippingLabelStoreOptions {
+        return ShippingLabelStoreOptions(currencySymbol: "$", dimensionUnit: "cm", weightUnit: "kg", originCountry: "US")
+    }
+
+    func sampleShippingLabelCustomPackages() -> [ShippingLabelCustomPackage] {
+        let customPackage1 = ShippingLabelCustomPackage(isUserDefined: true, title: "Krabica", isLetter: false, dimensions: "1 x 2 x 3", boxWeight: 1, maxWeight: 0)
+        let customPackage2 = ShippingLabelCustomPackage(isUserDefined: true, title: "Obalka", isLetter: true, dimensions: "2 x 3 x 4", boxWeight: 5, maxWeight: 0)
+        
+        return [customPackage1, customPackage2]
+    }
+    
+    func sampleShippingLabelPredefinedOptions() -> [ShippingLabelPredefinedOption] {
+        return []
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -1,0 +1,104 @@
+//import Foundation
+//
+//import XCTest
+//@testable import Networking
+//
+///// Unit Tests for `ShippingLabelPackagesMapper`
+/////
+//final class ShippingLabelPackagesMapperTests: XCTestCase {
+//    /// Dummy Site ID.
+//    ///
+//    private let dummySiteID: Int64 = 33334444
+//
+//    /// Verifies that all of the ProductVariation Fields are parsed correctly.
+//    ///
+//    func test_ShippingLabelPackages_fields_are_properly_parsed() throws {
+//        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
+//
+//        XCTAssertEqual(productVariation, sampleProductVariation(siteID: dummySiteID, productID: dummyProductID, id: 2783))
+//    }
+//}
+//
+///// Private Helpers
+/////
+//private extension ShippingLabelPackagesMapperTests {
+//    /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
+//    ///
+//    func mapProductVariation(from filename: String) -> ProductVariation? {
+//        guard let response = Loader.contentsOf(filename) else {
+//            return nil
+//        }
+//
+//        return try? ProductVariationMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
+//    }
+//
+//    /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
+//    ///
+//    func mapLoadProductVariationResponse() -> ProductVariation? {
+//        return mapProductVariation(from: "product-variation-update")
+//    }
+//}
+//
+//private extension ShippingLabelPackagesMapperTests {
+//    func sampleProductVariation(siteID: Int64,
+//                                productID: Int64,
+//                                id: Int64) -> ProductVariation {
+//        let imageSource = "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1"
+//        return ProductVariation(siteID: siteID,
+//                                productID: productID,
+//                                productVariationID: id,
+//                                attributes: sampleProductVariationAttributes(),
+//                                image: ProductImage(imageID: 2432,
+//                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
+//                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+//                                                    src: imageSource,
+//                                                    name: "DSC_0010",
+//                                                    alt: ""),
+//                                permalink: "https://chocolate.com/marble",
+//                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
+//                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+//                                dateOnSaleStart: nil,
+//                                dateOnSaleEnd: nil,
+//                                status: .publish,
+//                                description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+//                                sku: "87%-strawberry-marble",
+//                                price: "14.99",
+//                                regularPrice: "14.99",
+//                                salePrice: "",
+//                                onSale: false,
+//                                purchasable: true,
+//                                virtual: false,
+//                                downloadable: true,
+//                                downloads: [],
+//                                downloadLimit: -1,
+//                                downloadExpiry: 0,
+//                                taxStatusKey: "taxable",
+//                                taxClass: "",
+//                                manageStock: false,
+//                                stockQuantity: 16,
+//                                stockStatus: .inStock,
+//                                backordersKey: "notify",
+//                                backordersAllowed: true,
+//                                backordered: false,
+//                                weight: "2.5",
+//                                dimensions: ProductDimensions(length: "10",
+//                                                              width: "2.5",
+//                                                              height: ""),
+//                                shippingClass: "",
+//                                shippingClassID: 0,
+//                                menuOrder: 1)
+//    }
+//
+//    func sampleProductVariationAttributes() -> [ProductVariationAttribute] {
+//        return [
+//            ProductVariationAttribute(id: 0, name: "Darkness", option: "87%"),
+//            ProductVariationAttribute(id: 0, name: "Flavor", option: "strawberry"),
+//            ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
+//        ]
+//    }
+//
+//    func dateFromGMT(_ dateStringInGMT: String) -> Date {
+//        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+//        return dateFormatter.date(from: dateStringInGMT)!
+//    }
+//}

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -13,6 +13,7 @@ final class ShippingLabelPackagesMapperTests: XCTestCase {
 
         XCTAssertEqual(shippingLabelPackages.storeOptions, sampleShippingLabelStoreOptions())
         XCTAssertEqual(shippingLabelPackages.customPackages, sampleShippingLabelCustomPackages())
+        XCTAssertEqual(shippingLabelPackages.predefinedOptions, sampleShippingLabelPredefinedOptions())
     }
 }
 
@@ -42,13 +43,41 @@ private extension ShippingLabelPackagesMapperTests {
     }
 
     func sampleShippingLabelCustomPackages() -> [ShippingLabelCustomPackage] {
-        let customPackage1 = ShippingLabelCustomPackage(isUserDefined: true, title: "Krabica", isLetter: false, dimensions: "1 x 2 x 3", boxWeight: 1, maxWeight: 0)
-        let customPackage2 = ShippingLabelCustomPackage(isUserDefined: true, title: "Obalka", isLetter: true, dimensions: "2 x 3 x 4", boxWeight: 5, maxWeight: 0)
-        
+        let customPackage1 = ShippingLabelCustomPackage(isUserDefined: true,
+                                                        title: "Krabica",
+                                                        isLetter: false,
+                                                        dimensions: "1 x 2 x 3",
+                                                        boxWeight: 1,
+                                                        maxWeight: 0)
+        let customPackage2 = ShippingLabelCustomPackage(isUserDefined: true,
+                                                        title: "Obalka",
+                                                        isLetter: true,
+                                                        dimensions: "2 x 3 x 4",
+                                                        boxWeight: 5,
+                                                        maxWeight: 0)
+
         return [customPackage1, customPackage2]
     }
-    
+
     func sampleShippingLabelPredefinedOptions() -> [ShippingLabelPredefinedOption] {
-        return []
+        let predefinedPackages1 = [ShippingLabelPredefinedPackage(id: "small_flat_box",
+                                                                  title: "Small Flat Rate Box",
+                                                                  isLetter: false,
+                                                                  dimensions: "21.91 x 13.65 x 4.13"),
+                                  ShippingLabelPredefinedPackage(id: "medium_flat_box_top",
+                                                                 title: "Medium Flat Rate Box 1, Top Loading",
+                                                                 isLetter: false,
+                                                                 dimensions: "28.57 x 22.22 x 15.24")]
+        let predefinedOption1 = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                              predefinedPackages: predefinedPackages1)
+
+        let predefinedPackages2 = [ShippingLabelPredefinedPackage(id: "LargePaddedPouch",
+                                                                  title: "Large Padded Pouch",
+                                                                  isLetter: true,
+                                                                  dimensions: "30.22 x 35.56 x 2.54")]
+        let predefinedOption2 = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              predefinedPackages: predefinedPackages2)
+
+        return [predefinedOption1, predefinedOption2]
     }
 }

--- a/Networking/NetworkingTests/Responses/shipping-label-packages-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-packages-success.json
@@ -1,0 +1,983 @@
+{
+    "data": {
+        {
+            "success": true,
+            "storeOptions": {
+                "currency_symbol": "$",
+                "dimension_unit": "cm",
+                "weight_unit": "kg",
+                "origin_country": "US"
+            },
+            "formSchema": {
+                "custom": {
+                    "type": "array",
+                    "title": "Box Sizes",
+                    "description": "Items will be packed into these boxes based on item dimensions and volume. Outer dimensions will be passed to the delivery service, whereas inner dimensions will be used for packing. Items not fitting into boxes will be packed individually.",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "title": "Box",
+                        "required": [
+                            "name",
+                            "inner_dimensions",
+                            "box_weight",
+                            "max_weight"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "Name"
+                            },
+                            "is_user_defined": {
+                                "type": "boolean"
+                            },
+                            "inner_dimensions": {
+                                "type": "string",
+                                "title": "Inner Dimensions (L x W x H)",
+                                "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
+                            },
+                            "outer_dimensions": {
+                                "type": "string",
+                                "title": "Outer Dimensions (L x W x H)",
+                                "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
+                            },
+                            "box_weight": {
+                                "type": "number",
+                                "title": "Weight of Box (lbs)"
+                            },
+                            "max_weight": {
+                                "type": "number",
+                                "title": "Max Weight (lbs)"
+                            },
+                            "is_letter": {
+                                "type": "boolean",
+                                "title": "Letter"
+                            }
+                        }
+                    }
+                },
+                "predefined": {
+                    "usps": {
+                        "pri_flat_boxes": {
+                            "title": "USPS Priority Mail Flat Rate Boxes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "21.91 x 13.65 x 4.13",
+                                    "outer_dimensions": "21.91 x 13.65 x 4.13",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "small_flat_box",
+                                    "name": "Small Flat Rate Box",
+                                    "dimensions": "21.91 x 13.65 x 4.13",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "27.94 x 21.59 x 13.97",
+                                    "outer_dimensions": "28.57 x 22.22 x 15.24",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "medium_flat_box_top",
+                                    "name": "Medium Flat Rate Box 1, Top Loading",
+                                    "dimensions": {
+                                        "inner": "27.94 x 21.59 x 13.97",
+                                        "outer": "28.57 x 22.22 x 15.24"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "34.61 x 30.16 x 8.57",
+                                    "outer_dimensions": "35.56 x 30.48 x 8.89",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "medium_flat_box_side",
+                                    "name": "Medium Flat Rate Box 2, Side Loading",
+                                    "dimensions": {
+                                        "inner": "34.61 x 30.16 x 8.57",
+                                        "outer": "35.56 x 30.48 x 8.89"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "30.48 x 30.48 x 13.97",
+                                    "outer_dimensions": "31.11 x 31.11 x 15.24",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "large_flat_box",
+                                    "name": "Large Flat Rate Box",
+                                    "dimensions": {
+                                        "inner": "30.48 x 30.48 x 13.97",
+                                        "outer": "31.11 x 31.11 x 15.24"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "60.16 x 29.84 x 7.62",
+                                    "outer_dimensions": "61.12 x 30.16 x 7.94",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "large_flat_box_2",
+                                    "name": "Large Flat Rate Board Game Box",
+                                    "dimensions": {
+                                        "inner": "60.16 x 29.84 x 7.62",
+                                        "outer": "61.12 x 30.16 x 7.94"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "19.21 x 13.81 x 1.59",
+                                    "outer_dimensions": "19.21 x 13.81 x 1.59",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "dvd_flat",
+                                    "name": "DVD Flat Rate (International Only)",
+                                    "dimensions": "19.21 x 13.81 x 1.59",
+                                    "max_weight": 1.81,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "23.49 x 15.87 x 5.08",
+                                    "outer_dimensions": "23.49 x 15.87 x 5.08",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "large_video_flat",
+                                    "name": "1096L - Large Video Flat Rate (International Only)",
+                                    "dimensions": "23.49 x 15.87 x 5.08",
+                                    "max_weight": 1.81,
+                                    "is_letter": false,
+                                    "group_id": "pri_flat_boxes",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        },
+                        "pri_envelopes": {
+                            "title": "USPS Priority Mail Flat Rate Envelopes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "flat_envelope",
+                                    "name": "Flat Rate Envelope",
+                                    "dimensions": [
+                                        "31.75 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "38.1 x 24.13 x 1.27",
+                                    "outer_dimensions": "38.1 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "legal_flat_envelope",
+                                    "name": "Legal Flat Rate Envelope",
+                                    "dimensions": [
+                                        "38.1 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "padded_flat_envelope",
+                                    "name": "Padded Flat Rate Envelope",
+                                    "dimensions": [
+                                        "31.75 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "window_flat_envelope",
+                                    "name": "Window Flat Rate Envelope (12.5\" x 9.5\")",
+                                    "dimensions": [
+                                        "31.75 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "25.4 x 15.24 x 1.27",
+                                    "outer_dimensions": "25.4 x 15.24 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "small_flat_envelope",
+                                    "name": "Small Flat Rate Envelope",
+                                    "dimensions": [
+                                        "25.4 x 15.24 x 1.27",
+                                        "25.4 x 10.16 x 3.81",
+                                        "25.4 x 6.35 x 5.71"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_envelopes",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        },
+                        "pri_boxes": {
+                            "title": "USPS Priority Mail Boxes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "95.72 x 15.56 x 12.86",
+                                    "outer_dimensions": "95.72 x 15.56 x 12.86",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "medium_tube",
+                                    "name": "Priority Mail Medium Tube",
+                                    "dimensions": "95.72 x 15.56 x 12.86",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "63.5 x 15.24 x 14.92",
+                                    "outer_dimensions": "63.5 x 15.24 x 14.92",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "small_tube",
+                                    "name": "Priority Mail Small Tube",
+                                    "dimensions": "63.5 x 15.24 x 14.92",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "19.05 x 13.02 x 36.51",
+                                    "outer_dimensions": "19.05 x 13.02 x 36.51",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "shoe_box",
+                                    "name": "Priority Mail Shoe Box",
+                                    "dimensions": "19.05 x 13.02 x 36.51",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "17.78 x 17.78 x 15.24",
+                                    "outer_dimensions": "17.78 x 17.78 x 15.24",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_4",
+                                    "name": "Priority Mail Box - 4",
+                                    "dimensions": "17.78 x 17.78 x 15.24",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "30.48 x 30.48 x 20.32",
+                                    "outer_dimensions": "30.48 x 30.48 x 20.32",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_7",
+                                    "name": "Priority Mail Box - 7",
+                                    "dimensions": "30.48 x 30.48 x 20.32",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "38.73 x 31.43 x 7.62",
+                                    "outer_dimensions": "39.69 x 31.59 x 7.94",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_1095",
+                                    "name": "Priority Mail Box - 1095",
+                                    "dimensions": {
+                                        "inner": "38.73 x 31.43 x 7.62",
+                                        "outer": "39.69 x 31.59 x 7.94"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "23.49 x 15.87 x 5.08",
+                                    "outer_dimensions": "24.29 x 16.35 x 5.56",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_1096L",
+                                    "name": "Priority Mail Box - 1096L",
+                                    "dimensions": {
+                                        "inner": "23.49 x 15.87 x 5.08",
+                                        "outer": "24.29 x 16.35 x 5.56"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "29.21 x 33.34 x 6.03",
+                                    "outer_dimensions": "29.53 x 34.13 x 6.35",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_1097",
+                                    "name": "Priority Mail Box - 1097",
+                                    "dimensions": {
+                                        "inner": "29.21 x 33.34 x 6.03",
+                                        "outer": "29.53 x 34.13 x 6.35"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "19.21 x 13.81 x 1.59",
+                                    "outer_dimensions": "19.21 x 13.81 x 1.59",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_dvd",
+                                    "name": "Priority Mail DVD Box",
+                                    "dimensions": "19.21 x 13.81 x 1.59",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "29.53 x 38.42 x 1.27",
+                                    "outer_dimensions": "29.53 x 38.42 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "priority_tyvek_envelope",
+                                    "name": "Priority Mail Tyvek Envelope",
+                                    "dimensions": "29.53 x 38.42 x 1.27",
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "service_group_ids": [
+                                        "priority",
+                                        "priority_international"
+                                    ],
+                                    "group_id": "pri_boxes",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        },
+                        "pri_express_envelopes": {
+                            "title": "USPS Priority Mail Express Flat Rate Envelopes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "express_flat_envelope",
+                                    "name": "Flat Rate Envelope",
+                                    "dimensions": [
+                                        "31.75 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_express_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "38.1 x 24.13 x 1.27",
+                                    "outer_dimensions": "38.1 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "express_legal_flat_envelope",
+                                    "name": "Legal Flat Rate Envelope",
+                                    "dimensions": [
+                                        "38.1 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_express_envelopes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "express_padded_flat_envelope",
+                                    "name": "Padded Flat Rate Envelope",
+                                    "dimensions": [
+                                        "31.75 x 24.13 x 1.27",
+                                        "31.75 x 19.05 x 3.81",
+                                        "31.75 x 13.97 x 6.35",
+                                        "31.75 x 8.89 x 8.89"
+                                    ],
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "group_id": "pri_express_envelopes",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        },
+                        "pri_express_boxes": {
+                            "title": "USPS Priority Mail Express Boxes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "38.73 x 31.43 x 7.62",
+                                    "outer_dimensions": "39.69 x 31.59 x 7.94",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_box",
+                                    "name": "Priority Mail Express Box",
+                                    "dimensions": {
+                                        "inner": "38.73 x 31.43 x 7.62",
+                                        "outer": "39.69 x 31.59 x 7.94"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "27.94 x 21.59 x 13.97",
+                                    "outer_dimensions": "28.57 x 22.22 x 15.24",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_box_1",
+                                    "name": "Priority Mail Express Box 1",
+                                    "dimensions": {
+                                        "inner": "27.94 x 21.59 x 13.97",
+                                        "outer": "28.57 x 22.22 x 15.24"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "30.16 x 8.57 x 34.61",
+                                    "outer_dimensions": "30.48 x 8.89 x 35.56",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_box_2",
+                                    "name": "Priority Mail Express Box 2",
+                                    "dimensions": {
+                                        "inner": "30.16 x 8.57 x 34.61",
+                                        "outer": "30.48 x 8.89 x 35.56"
+                                    },
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "95.72 x 15.56 x 12.86",
+                                    "outer_dimensions": "95.72 x 15.56 x 12.86",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_medium_tube",
+                                    "name": "Priority Mail Express Medium Tube",
+                                    "dimensions": "95.72 x 15.56 x 12.86",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "63.5 x 15.24 x 14.92",
+                                    "outer_dimensions": "63.5 x 15.24 x 14.92",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_small_tube",
+                                    "name": "Priority Mail Express Small Tube",
+                                    "dimensions": "63.5 x 15.24 x 14.92",
+                                    "max_weight": 31.75,
+                                    "is_letter": false,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "29.53 x 38.42 x 1.27",
+                                    "outer_dimensions": "29.53 x 38.42 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_tyvek_envelope",
+                                    "name": "Priority Mail Express Tyvek Envelope",
+                                    "dimensions": "29.53 x 38.42 x 1.27",
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "14.92 x 25.4 x 1.27",
+                                    "outer_dimensions": "14.92 x 25.4 x 1.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "express_window_envelope",
+                                    "name": "Priority Mail Express Window Envelope",
+                                    "dimensions": "14.92 x 25.4 x 1.27",
+                                    "max_weight": 31.75,
+                                    "is_letter": true,
+                                    "service_group_ids": [
+                                        "priority_exp",
+                                        "priority_express_international"
+                                    ],
+                                    "group_id": "pri_express_boxes",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        },
+                        "pri_regional_boxes": {
+                            "title": "USPS Priority Mail Regional Rate Boxes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "25.72 x 18.1 x 12.7",
+                                    "outer_dimensions": "25.72 x 18.1 x 12.7",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "regional_a1",
+                                    "name": "Regional Rate Box A1",
+                                    "dimensions": "25.72 x 18.1 x 12.7",
+                                    "max_weight": 6.8,
+                                    "is_letter": false,
+                                    "group_id": "pri_regional_boxes",
+                                    "can_ship_international": false
+                                },
+                                {
+                                    "inner_dimensions": "28.1 x 6.35 x 33.18",
+                                    "outer_dimensions": "28.1 x 6.35 x 33.18",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "regional_a2",
+                                    "name": "Regional Rate Box A2",
+                                    "dimensions": "28.1 x 6.35 x 33.18",
+                                    "max_weight": 6.8,
+                                    "is_letter": false,
+                                    "group_id": "pri_regional_boxes",
+                                    "can_ship_international": false
+                                },
+                                {
+                                    "inner_dimensions": "31.11 x 26.67 x 13.97",
+                                    "outer_dimensions": "31.11 x 26.67 x 13.97",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "regional_b1",
+                                    "name": "Regional Rate Box B1",
+                                    "dimensions": "31.11 x 26.67 x 13.97",
+                                    "max_weight": 9.07,
+                                    "is_letter": false,
+                                    "group_id": "pri_regional_boxes",
+                                    "can_ship_international": false
+                                },
+                                {
+                                    "inner_dimensions": "36.83 x 7.62 x 41.27",
+                                    "outer_dimensions": "36.83 x 7.62 x 41.27",
+                                    "box_weight": 0,
+                                    "is_flat_rate": true,
+                                    "id": "regional_b2",
+                                    "name": "Regional Rate Box B2",
+                                    "dimensions": "36.83 x 7.62 x 41.27",
+                                    "max_weight": 9.07,
+                                    "is_letter": false,
+                                    "group_id": "pri_regional_boxes",
+                                    "can_ship_international": false
+                                }
+                            ]
+                        }
+                    },
+                    "fedex": {
+                        "express": {
+                            "title": "FedEx Express Packages",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "33.5 x 23.49 x 1.9",
+                                    "outer_dimensions": "33.5 x 23.49 x 1.9",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExEnvelope",
+                                    "name": "Envelope",
+                                    "dimensions": "33.5 x 23.49 x 1.9",
+                                    "max_weight": 4.54,
+                                    "is_letter": true,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "39.37 x 30.48 x 1.9",
+                                    "outer_dimensions": "39.37 x 30.48 x 1.9",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExPak",
+                                    "name": "Large Pak",
+                                    "dimensions": "39.37 x 30.48 x 1.9",
+                                    "max_weight": 9.07,
+                                    "is_letter": true,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "31.11 x 27.68 x 3.81",
+                                    "outer_dimensions": "31.11 x 27.68 x 3.81",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExSmallBox1",
+                                    "name": "Small Box (S1)",
+                                    "dimensions": "31.11 x 27.68 x 3.81",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "28.57 x 22.22 x 6.68",
+                                    "outer_dimensions": "28.57 x 22.22 x 6.68",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExSmallBox2",
+                                    "name": "Small Box (S2)",
+                                    "dimensions": "28.57 x 22.22 x 6.68",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "33.65 x 29.21 x 6.04",
+                                    "outer_dimensions": "33.65 x 29.21 x 6.04",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExMediumBox1",
+                                    "name": "Medium Box (M1)",
+                                    "dimensions": "33.65 x 29.21 x 6.04",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "28.57 x 22.22 x 11.12",
+                                    "outer_dimensions": "28.57 x 22.22 x 11.12",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExMediumBox2",
+                                    "name": "Medium Box (M2)",
+                                    "dimensions": "28.57 x 22.22 x 11.12",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "45.41 x 31.44 x 1.9",
+                                    "outer_dimensions": "45.41 x 31.44 x 1.9",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExLargeBox1",
+                                    "name": "Large Box (L1)",
+                                    "dimensions": "45.41 x 31.44 x 1.9",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "28.57 x 22.22 x 19.68",
+                                    "outer_dimensions": "28.57 x 22.22 x 19.68",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExLargeBox2",
+                                    "name": "Large Box (L2)",
+                                    "dimensions": "28.57 x 22.22 x 19.68",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "30.17 x 27.94 x 27.3",
+                                    "outer_dimensions": "30.17 x 27.94 x 27.3",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExExtraLargeBox1",
+                                    "name": "Extra Large Box (X1)",
+                                    "dimensions": "30.17 x 27.94 x 27.3",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "38.73 x 35.89 x 15.24",
+                                    "outer_dimensions": "38.73 x 35.89 x 15.24",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExExtraLargeBox2",
+                                    "name": "Extra Large Box (X2)",
+                                    "dimensions": "38.73 x 35.89 x 15.24",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                },
+                                {
+                                    "inner_dimensions": "96.52 x 15.24 x 12.7",
+                                    "outer_dimensions": "96.52 x 15.24 x 12.7",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedExTube",
+                                    "name": "Tube",
+                                    "dimensions": "96.52 x 15.24 x 12.7",
+                                    "max_weight": 22.68,
+                                    "is_letter": false,
+                                    "group_id": "express"
+                                }
+                            ]
+                        },
+                        "international": {
+                            "title": "FedEx International Boxes",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "40.16 x 32.87 x 25.88",
+                                    "outer_dimensions": "40.16 x 32.87 x 25.88",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedEx10kgBox",
+                                    "name": "10kg Box",
+                                    "dimensions": "40.16 x 32.87 x 25.88",
+                                    "max_weight": 9.98,
+                                    "is_letter": false,
+                                    "group_id": "international"
+                                },
+                                {
+                                    "inner_dimensions": "54.76 x 42.06 x 33.5",
+                                    "outer_dimensions": "54.76 x 42.06 x 33.5",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "FedEx25kgBox",
+                                    "name": "25kg Box",
+                                    "dimensions": "54.76 x 42.06 x 33.5",
+                                    "max_weight": 24.95,
+                                    "is_letter": false,
+                                    "group_id": "international"
+                                }
+                            ]
+                        }
+                    },
+                    "dhlexpress": {
+                        "domestic_and_international": {
+                            "title": "DHL Express",
+                            "definitions": [
+                                {
+                                    "inner_dimensions": "24.89 x 30.48 x 2.54",
+                                    "outer_dimensions": "24.89 x 30.48 x 2.54",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "SmallPaddedPouch",
+                                    "name": "Small Padded Pouch",
+                                    "dimensions": "24.89 x 30.48 x 2.54",
+                                    "max_weight": 45.36,
+                                    "is_letter": true,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "30.22 x 35.56 x 2.54",
+                                    "outer_dimensions": "30.22 x 35.56 x 2.54",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "LargePaddedPouch",
+                                    "name": "Large Padded Pouch",
+                                    "dimensions": "30.22 x 35.56 x 2.54",
+                                    "max_weight": 45.36,
+                                    "is_letter": true,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "25.65 x 14.73 x 14.99",
+                                    "outer_dimensions": "25.65 x 14.73 x 14.99",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "Box2Cube",
+                                    "name": "Box #2 Cube",
+                                    "dimensions": "25.65 x 14.73 x 14.99",
+                                    "max_weight": 45.36,
+                                    "is_letter": false,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "31.75 x 28.19 x 3.81",
+                                    "outer_dimensions": "31.75 x 28.19 x 3.81",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "Box2Small",
+                                    "name": "Box #2 Small",
+                                    "dimensions": "31.75 x 28.19 x 3.81",
+                                    "max_weight": 45.36,
+                                    "is_letter": false,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "33.53 x 32 x 5.08",
+                                    "outer_dimensions": "33.53 x 32 x 5.08",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "Box2Medium",
+                                    "name": "Box #2 Medium",
+                                    "dimensions": "33.53 x 32 x 5.08",
+                                    "max_weight": 45.36,
+                                    "is_letter": false,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                },
+                                {
+                                    "inner_dimensions": "44.45 x 31.75 x 7.62",
+                                    "outer_dimensions": "44.45 x 31.75 x 7.62",
+                                    "box_weight": 0,
+                                    "is_flat_rate": false,
+                                    "id": "Box3Large",
+                                    "name": "Box #3 Large",
+                                    "dimensions": "44.45 x 31.75 x 7.62",
+                                    "max_weight": 45.36,
+                                    "is_letter": false,
+                                    "group_id": "domestic_and_international",
+                                    "can_ship_international": true
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "formData": {
+                "custom": [
+                    {
+                        "is_user_defined": true,
+                        "name": "Krabica",
+                        "inner_dimensions": "1 x 2 x 3",
+                        "box_weight": 1,
+                        "max_weight": 0
+                    },
+                    {
+                        "is_user_defined": true,
+                        "is_letter": true,
+                        "name": "Obalka",
+                        "inner_dimensions": "2 x 3 x 4",
+                        "box_weight": 5,
+                        "max_weight": 0
+                    }
+                ],
+                "predefined": {
+                    "usps": [
+                        null,
+                        "small_flat_box",
+                        "medium_flat_box_top"
+                    ],
+                    "dhlexpress": [
+                        "LargePaddedPouch"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-packages-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-packages-success.json
@@ -1,982 +1,980 @@
 {
     "data": {
-        {
-            "success": true,
-            "storeOptions": {
-                "currency_symbol": "$",
-                "dimension_unit": "cm",
-                "weight_unit": "kg",
-                "origin_country": "US"
-            },
-            "formSchema": {
-                "custom": {
-                    "type": "array",
-                    "title": "Box Sizes",
-                    "description": "Items will be packed into these boxes based on item dimensions and volume. Outer dimensions will be passed to the delivery service, whereas inner dimensions will be used for packing. Items not fitting into boxes will be packed individually.",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "title": "Box",
-                        "required": [
-                            "name",
-                            "inner_dimensions",
-                            "box_weight",
-                            "max_weight"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "title": "Name"
-                            },
-                            "is_user_defined": {
-                                "type": "boolean"
-                            },
-                            "inner_dimensions": {
-                                "type": "string",
-                                "title": "Inner Dimensions (L x W x H)",
-                                "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
-                            },
-                            "outer_dimensions": {
-                                "type": "string",
-                                "title": "Outer Dimensions (L x W x H)",
-                                "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
-                            },
-                            "box_weight": {
-                                "type": "number",
-                                "title": "Weight of Box (lbs)"
-                            },
-                            "max_weight": {
-                                "type": "number",
-                                "title": "Max Weight (lbs)"
-                            },
-                            "is_letter": {
-                                "type": "boolean",
-                                "title": "Letter"
-                            }
+        "success": true,
+        "storeOptions": {
+            "currency_symbol": "$",
+            "dimension_unit": "cm",
+            "weight_unit": "kg",
+            "origin_country": "US"
+        },
+        "formSchema": {
+            "custom": {
+                "type": "array",
+                "title": "Box Sizes",
+                "description": "Items will be packed into these boxes based on item dimensions and volume. Outer dimensions will be passed to the delivery service, whereas inner dimensions will be used for packing. Items not fitting into boxes will be packed individually.",
+                "default": [],
+                "items": {
+                    "type": "object",
+                    "title": "Box",
+                    "required": [
+                        "name",
+                        "inner_dimensions",
+                        "box_weight",
+                        "max_weight"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name"
+                        },
+                        "is_user_defined": {
+                            "type": "boolean"
+                        },
+                        "inner_dimensions": {
+                            "type": "string",
+                            "title": "Inner Dimensions (L x W x H)",
+                            "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
+                        },
+                        "outer_dimensions": {
+                            "type": "string",
+                            "title": "Outer Dimensions (L x W x H)",
+                            "pattern": "^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$"
+                        },
+                        "box_weight": {
+                            "type": "number",
+                            "title": "Weight of Box (lbs)"
+                        },
+                        "max_weight": {
+                            "type": "number",
+                            "title": "Max Weight (lbs)"
+                        },
+                        "is_letter": {
+                            "type": "boolean",
+                            "title": "Letter"
                         }
+                    }
+                }
+            },
+            "predefined": {
+                "usps": {
+                    "pri_flat_boxes": {
+                        "title": "USPS Priority Mail Flat Rate Boxes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "21.91 x 13.65 x 4.13",
+                                "outer_dimensions": "21.91 x 13.65 x 4.13",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "small_flat_box",
+                                "name": "Small Flat Rate Box",
+                                "dimensions": "21.91 x 13.65 x 4.13",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "27.94 x 21.59 x 13.97",
+                                "outer_dimensions": "28.57 x 22.22 x 15.24",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "medium_flat_box_top",
+                                "name": "Medium Flat Rate Box 1, Top Loading",
+                                "dimensions": {
+                                    "inner": "27.94 x 21.59 x 13.97",
+                                    "outer": "28.57 x 22.22 x 15.24"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "34.61 x 30.16 x 8.57",
+                                "outer_dimensions": "35.56 x 30.48 x 8.89",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "medium_flat_box_side",
+                                "name": "Medium Flat Rate Box 2, Side Loading",
+                                "dimensions": {
+                                    "inner": "34.61 x 30.16 x 8.57",
+                                    "outer": "35.56 x 30.48 x 8.89"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "30.48 x 30.48 x 13.97",
+                                "outer_dimensions": "31.11 x 31.11 x 15.24",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "large_flat_box",
+                                "name": "Large Flat Rate Box",
+                                "dimensions": {
+                                    "inner": "30.48 x 30.48 x 13.97",
+                                    "outer": "31.11 x 31.11 x 15.24"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "60.16 x 29.84 x 7.62",
+                                "outer_dimensions": "61.12 x 30.16 x 7.94",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "large_flat_box_2",
+                                "name": "Large Flat Rate Board Game Box",
+                                "dimensions": {
+                                    "inner": "60.16 x 29.84 x 7.62",
+                                    "outer": "61.12 x 30.16 x 7.94"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "19.21 x 13.81 x 1.59",
+                                "outer_dimensions": "19.21 x 13.81 x 1.59",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "dvd_flat",
+                                "name": "DVD Flat Rate (International Only)",
+                                "dimensions": "19.21 x 13.81 x 1.59",
+                                "max_weight": 1.81,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "23.49 x 15.87 x 5.08",
+                                "outer_dimensions": "23.49 x 15.87 x 5.08",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "large_video_flat",
+                                "name": "1096L - Large Video Flat Rate (International Only)",
+                                "dimensions": "23.49 x 15.87 x 5.08",
+                                "max_weight": 1.81,
+                                "is_letter": false,
+                                "group_id": "pri_flat_boxes",
+                                "can_ship_international": true
+                            }
+                        ]
+                    },
+                    "pri_envelopes": {
+                        "title": "USPS Priority Mail Flat Rate Envelopes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "flat_envelope",
+                                "name": "Flat Rate Envelope",
+                                "dimensions": [
+                                    "31.75 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "38.1 x 24.13 x 1.27",
+                                "outer_dimensions": "38.1 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "legal_flat_envelope",
+                                "name": "Legal Flat Rate Envelope",
+                                "dimensions": [
+                                    "38.1 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "padded_flat_envelope",
+                                "name": "Padded Flat Rate Envelope",
+                                "dimensions": [
+                                    "31.75 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "window_flat_envelope",
+                                "name": "Window Flat Rate Envelope (12.5\" x 9.5\")",
+                                "dimensions": [
+                                    "31.75 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "25.4 x 15.24 x 1.27",
+                                "outer_dimensions": "25.4 x 15.24 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "small_flat_envelope",
+                                "name": "Small Flat Rate Envelope",
+                                "dimensions": [
+                                    "25.4 x 15.24 x 1.27",
+                                    "25.4 x 10.16 x 3.81",
+                                    "25.4 x 6.35 x 5.71"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_envelopes",
+                                "can_ship_international": true
+                            }
+                        ]
+                    },
+                    "pri_boxes": {
+                        "title": "USPS Priority Mail Boxes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "95.72 x 15.56 x 12.86",
+                                "outer_dimensions": "95.72 x 15.56 x 12.86",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "medium_tube",
+                                "name": "Priority Mail Medium Tube",
+                                "dimensions": "95.72 x 15.56 x 12.86",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "63.5 x 15.24 x 14.92",
+                                "outer_dimensions": "63.5 x 15.24 x 14.92",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "small_tube",
+                                "name": "Priority Mail Small Tube",
+                                "dimensions": "63.5 x 15.24 x 14.92",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "19.05 x 13.02 x 36.51",
+                                "outer_dimensions": "19.05 x 13.02 x 36.51",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "shoe_box",
+                                "name": "Priority Mail Shoe Box",
+                                "dimensions": "19.05 x 13.02 x 36.51",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "17.78 x 17.78 x 15.24",
+                                "outer_dimensions": "17.78 x 17.78 x 15.24",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_4",
+                                "name": "Priority Mail Box - 4",
+                                "dimensions": "17.78 x 17.78 x 15.24",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "30.48 x 30.48 x 20.32",
+                                "outer_dimensions": "30.48 x 30.48 x 20.32",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_7",
+                                "name": "Priority Mail Box - 7",
+                                "dimensions": "30.48 x 30.48 x 20.32",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "38.73 x 31.43 x 7.62",
+                                "outer_dimensions": "39.69 x 31.59 x 7.94",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_1095",
+                                "name": "Priority Mail Box - 1095",
+                                "dimensions": {
+                                    "inner": "38.73 x 31.43 x 7.62",
+                                    "outer": "39.69 x 31.59 x 7.94"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "23.49 x 15.87 x 5.08",
+                                "outer_dimensions": "24.29 x 16.35 x 5.56",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_1096L",
+                                "name": "Priority Mail Box - 1096L",
+                                "dimensions": {
+                                    "inner": "23.49 x 15.87 x 5.08",
+                                    "outer": "24.29 x 16.35 x 5.56"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "29.21 x 33.34 x 6.03",
+                                "outer_dimensions": "29.53 x 34.13 x 6.35",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_1097",
+                                "name": "Priority Mail Box - 1097",
+                                "dimensions": {
+                                    "inner": "29.21 x 33.34 x 6.03",
+                                    "outer": "29.53 x 34.13 x 6.35"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "19.21 x 13.81 x 1.59",
+                                "outer_dimensions": "19.21 x 13.81 x 1.59",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_dvd",
+                                "name": "Priority Mail DVD Box",
+                                "dimensions": "19.21 x 13.81 x 1.59",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "29.53 x 38.42 x 1.27",
+                                "outer_dimensions": "29.53 x 38.42 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "priority_tyvek_envelope",
+                                "name": "Priority Mail Tyvek Envelope",
+                                "dimensions": "29.53 x 38.42 x 1.27",
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "service_group_ids": [
+                                    "priority",
+                                    "priority_international"
+                                ],
+                                "group_id": "pri_boxes",
+                                "can_ship_international": true
+                            }
+                        ]
+                    },
+                    "pri_express_envelopes": {
+                        "title": "USPS Priority Mail Express Flat Rate Envelopes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "express_flat_envelope",
+                                "name": "Flat Rate Envelope",
+                                "dimensions": [
+                                    "31.75 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_express_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "38.1 x 24.13 x 1.27",
+                                "outer_dimensions": "38.1 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "express_legal_flat_envelope",
+                                "name": "Legal Flat Rate Envelope",
+                                "dimensions": [
+                                    "38.1 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_express_envelopes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "31.75 x 24.13 x 1.27",
+                                "outer_dimensions": "31.75 x 24.13 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "express_padded_flat_envelope",
+                                "name": "Padded Flat Rate Envelope",
+                                "dimensions": [
+                                    "31.75 x 24.13 x 1.27",
+                                    "31.75 x 19.05 x 3.81",
+                                    "31.75 x 13.97 x 6.35",
+                                    "31.75 x 8.89 x 8.89"
+                                ],
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "group_id": "pri_express_envelopes",
+                                "can_ship_international": true
+                            }
+                        ]
+                    },
+                    "pri_express_boxes": {
+                        "title": "USPS Priority Mail Express Boxes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "38.73 x 31.43 x 7.62",
+                                "outer_dimensions": "39.69 x 31.59 x 7.94",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_box",
+                                "name": "Priority Mail Express Box",
+                                "dimensions": {
+                                    "inner": "38.73 x 31.43 x 7.62",
+                                    "outer": "39.69 x 31.59 x 7.94"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "27.94 x 21.59 x 13.97",
+                                "outer_dimensions": "28.57 x 22.22 x 15.24",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_box_1",
+                                "name": "Priority Mail Express Box 1",
+                                "dimensions": {
+                                    "inner": "27.94 x 21.59 x 13.97",
+                                    "outer": "28.57 x 22.22 x 15.24"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "30.16 x 8.57 x 34.61",
+                                "outer_dimensions": "30.48 x 8.89 x 35.56",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_box_2",
+                                "name": "Priority Mail Express Box 2",
+                                "dimensions": {
+                                    "inner": "30.16 x 8.57 x 34.61",
+                                    "outer": "30.48 x 8.89 x 35.56"
+                                },
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "95.72 x 15.56 x 12.86",
+                                "outer_dimensions": "95.72 x 15.56 x 12.86",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_medium_tube",
+                                "name": "Priority Mail Express Medium Tube",
+                                "dimensions": "95.72 x 15.56 x 12.86",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "63.5 x 15.24 x 14.92",
+                                "outer_dimensions": "63.5 x 15.24 x 14.92",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_small_tube",
+                                "name": "Priority Mail Express Small Tube",
+                                "dimensions": "63.5 x 15.24 x 14.92",
+                                "max_weight": 31.75,
+                                "is_letter": false,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "29.53 x 38.42 x 1.27",
+                                "outer_dimensions": "29.53 x 38.42 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_tyvek_envelope",
+                                "name": "Priority Mail Express Tyvek Envelope",
+                                "dimensions": "29.53 x 38.42 x 1.27",
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "14.92 x 25.4 x 1.27",
+                                "outer_dimensions": "14.92 x 25.4 x 1.27",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "express_window_envelope",
+                                "name": "Priority Mail Express Window Envelope",
+                                "dimensions": "14.92 x 25.4 x 1.27",
+                                "max_weight": 31.75,
+                                "is_letter": true,
+                                "service_group_ids": [
+                                    "priority_exp",
+                                    "priority_express_international"
+                                ],
+                                "group_id": "pri_express_boxes",
+                                "can_ship_international": true
+                            }
+                        ]
+                    },
+                    "pri_regional_boxes": {
+                        "title": "USPS Priority Mail Regional Rate Boxes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "25.72 x 18.1 x 12.7",
+                                "outer_dimensions": "25.72 x 18.1 x 12.7",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "regional_a1",
+                                "name": "Regional Rate Box A1",
+                                "dimensions": "25.72 x 18.1 x 12.7",
+                                "max_weight": 6.8,
+                                "is_letter": false,
+                                "group_id": "pri_regional_boxes",
+                                "can_ship_international": false
+                            },
+                            {
+                                "inner_dimensions": "28.1 x 6.35 x 33.18",
+                                "outer_dimensions": "28.1 x 6.35 x 33.18",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "regional_a2",
+                                "name": "Regional Rate Box A2",
+                                "dimensions": "28.1 x 6.35 x 33.18",
+                                "max_weight": 6.8,
+                                "is_letter": false,
+                                "group_id": "pri_regional_boxes",
+                                "can_ship_international": false
+                            },
+                            {
+                                "inner_dimensions": "31.11 x 26.67 x 13.97",
+                                "outer_dimensions": "31.11 x 26.67 x 13.97",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "regional_b1",
+                                "name": "Regional Rate Box B1",
+                                "dimensions": "31.11 x 26.67 x 13.97",
+                                "max_weight": 9.07,
+                                "is_letter": false,
+                                "group_id": "pri_regional_boxes",
+                                "can_ship_international": false
+                            },
+                            {
+                                "inner_dimensions": "36.83 x 7.62 x 41.27",
+                                "outer_dimensions": "36.83 x 7.62 x 41.27",
+                                "box_weight": 0,
+                                "is_flat_rate": true,
+                                "id": "regional_b2",
+                                "name": "Regional Rate Box B2",
+                                "dimensions": "36.83 x 7.62 x 41.27",
+                                "max_weight": 9.07,
+                                "is_letter": false,
+                                "group_id": "pri_regional_boxes",
+                                "can_ship_international": false
+                            }
+                        ]
                     }
                 },
-                "predefined": {
-                    "usps": {
-                        "pri_flat_boxes": {
-                            "title": "USPS Priority Mail Flat Rate Boxes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "21.91 x 13.65 x 4.13",
-                                    "outer_dimensions": "21.91 x 13.65 x 4.13",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "small_flat_box",
-                                    "name": "Small Flat Rate Box",
-                                    "dimensions": "21.91 x 13.65 x 4.13",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "27.94 x 21.59 x 13.97",
-                                    "outer_dimensions": "28.57 x 22.22 x 15.24",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "medium_flat_box_top",
-                                    "name": "Medium Flat Rate Box 1, Top Loading",
-                                    "dimensions": {
-                                        "inner": "27.94 x 21.59 x 13.97",
-                                        "outer": "28.57 x 22.22 x 15.24"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "34.61 x 30.16 x 8.57",
-                                    "outer_dimensions": "35.56 x 30.48 x 8.89",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "medium_flat_box_side",
-                                    "name": "Medium Flat Rate Box 2, Side Loading",
-                                    "dimensions": {
-                                        "inner": "34.61 x 30.16 x 8.57",
-                                        "outer": "35.56 x 30.48 x 8.89"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "30.48 x 30.48 x 13.97",
-                                    "outer_dimensions": "31.11 x 31.11 x 15.24",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "large_flat_box",
-                                    "name": "Large Flat Rate Box",
-                                    "dimensions": {
-                                        "inner": "30.48 x 30.48 x 13.97",
-                                        "outer": "31.11 x 31.11 x 15.24"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "60.16 x 29.84 x 7.62",
-                                    "outer_dimensions": "61.12 x 30.16 x 7.94",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "large_flat_box_2",
-                                    "name": "Large Flat Rate Board Game Box",
-                                    "dimensions": {
-                                        "inner": "60.16 x 29.84 x 7.62",
-                                        "outer": "61.12 x 30.16 x 7.94"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "19.21 x 13.81 x 1.59",
-                                    "outer_dimensions": "19.21 x 13.81 x 1.59",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "dvd_flat",
-                                    "name": "DVD Flat Rate (International Only)",
-                                    "dimensions": "19.21 x 13.81 x 1.59",
-                                    "max_weight": 1.81,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "23.49 x 15.87 x 5.08",
-                                    "outer_dimensions": "23.49 x 15.87 x 5.08",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "large_video_flat",
-                                    "name": "1096L - Large Video Flat Rate (International Only)",
-                                    "dimensions": "23.49 x 15.87 x 5.08",
-                                    "max_weight": 1.81,
-                                    "is_letter": false,
-                                    "group_id": "pri_flat_boxes",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        },
-                        "pri_envelopes": {
-                            "title": "USPS Priority Mail Flat Rate Envelopes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
-                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "flat_envelope",
-                                    "name": "Flat Rate Envelope",
-                                    "dimensions": [
-                                        "31.75 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "38.1 x 24.13 x 1.27",
-                                    "outer_dimensions": "38.1 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "legal_flat_envelope",
-                                    "name": "Legal Flat Rate Envelope",
-                                    "dimensions": [
-                                        "38.1 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
-                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "padded_flat_envelope",
-                                    "name": "Padded Flat Rate Envelope",
-                                    "dimensions": [
-                                        "31.75 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
-                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "window_flat_envelope",
-                                    "name": "Window Flat Rate Envelope (12.5\" x 9.5\")",
-                                    "dimensions": [
-                                        "31.75 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "25.4 x 15.24 x 1.27",
-                                    "outer_dimensions": "25.4 x 15.24 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "small_flat_envelope",
-                                    "name": "Small Flat Rate Envelope",
-                                    "dimensions": [
-                                        "25.4 x 15.24 x 1.27",
-                                        "25.4 x 10.16 x 3.81",
-                                        "25.4 x 6.35 x 5.71"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_envelopes",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        },
-                        "pri_boxes": {
-                            "title": "USPS Priority Mail Boxes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "95.72 x 15.56 x 12.86",
-                                    "outer_dimensions": "95.72 x 15.56 x 12.86",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "medium_tube",
-                                    "name": "Priority Mail Medium Tube",
-                                    "dimensions": "95.72 x 15.56 x 12.86",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "63.5 x 15.24 x 14.92",
-                                    "outer_dimensions": "63.5 x 15.24 x 14.92",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "small_tube",
-                                    "name": "Priority Mail Small Tube",
-                                    "dimensions": "63.5 x 15.24 x 14.92",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "19.05 x 13.02 x 36.51",
-                                    "outer_dimensions": "19.05 x 13.02 x 36.51",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "shoe_box",
-                                    "name": "Priority Mail Shoe Box",
-                                    "dimensions": "19.05 x 13.02 x 36.51",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "17.78 x 17.78 x 15.24",
-                                    "outer_dimensions": "17.78 x 17.78 x 15.24",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_4",
-                                    "name": "Priority Mail Box - 4",
-                                    "dimensions": "17.78 x 17.78 x 15.24",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "30.48 x 30.48 x 20.32",
-                                    "outer_dimensions": "30.48 x 30.48 x 20.32",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_7",
-                                    "name": "Priority Mail Box - 7",
-                                    "dimensions": "30.48 x 30.48 x 20.32",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "38.73 x 31.43 x 7.62",
-                                    "outer_dimensions": "39.69 x 31.59 x 7.94",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_1095",
-                                    "name": "Priority Mail Box - 1095",
-                                    "dimensions": {
-                                        "inner": "38.73 x 31.43 x 7.62",
-                                        "outer": "39.69 x 31.59 x 7.94"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "23.49 x 15.87 x 5.08",
-                                    "outer_dimensions": "24.29 x 16.35 x 5.56",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_1096L",
-                                    "name": "Priority Mail Box - 1096L",
-                                    "dimensions": {
-                                        "inner": "23.49 x 15.87 x 5.08",
-                                        "outer": "24.29 x 16.35 x 5.56"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "29.21 x 33.34 x 6.03",
-                                    "outer_dimensions": "29.53 x 34.13 x 6.35",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_1097",
-                                    "name": "Priority Mail Box - 1097",
-                                    "dimensions": {
-                                        "inner": "29.21 x 33.34 x 6.03",
-                                        "outer": "29.53 x 34.13 x 6.35"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "19.21 x 13.81 x 1.59",
-                                    "outer_dimensions": "19.21 x 13.81 x 1.59",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_dvd",
-                                    "name": "Priority Mail DVD Box",
-                                    "dimensions": "19.21 x 13.81 x 1.59",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "29.53 x 38.42 x 1.27",
-                                    "outer_dimensions": "29.53 x 38.42 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "priority_tyvek_envelope",
-                                    "name": "Priority Mail Tyvek Envelope",
-                                    "dimensions": "29.53 x 38.42 x 1.27",
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "service_group_ids": [
-                                        "priority",
-                                        "priority_international"
-                                    ],
-                                    "group_id": "pri_boxes",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        },
-                        "pri_express_envelopes": {
-                            "title": "USPS Priority Mail Express Flat Rate Envelopes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
-                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "express_flat_envelope",
-                                    "name": "Flat Rate Envelope",
-                                    "dimensions": [
-                                        "31.75 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_express_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "38.1 x 24.13 x 1.27",
-                                    "outer_dimensions": "38.1 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "express_legal_flat_envelope",
-                                    "name": "Legal Flat Rate Envelope",
-                                    "dimensions": [
-                                        "38.1 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_express_envelopes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "31.75 x 24.13 x 1.27",
-                                    "outer_dimensions": "31.75 x 24.13 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "express_padded_flat_envelope",
-                                    "name": "Padded Flat Rate Envelope",
-                                    "dimensions": [
-                                        "31.75 x 24.13 x 1.27",
-                                        "31.75 x 19.05 x 3.81",
-                                        "31.75 x 13.97 x 6.35",
-                                        "31.75 x 8.89 x 8.89"
-                                    ],
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "group_id": "pri_express_envelopes",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        },
-                        "pri_express_boxes": {
-                            "title": "USPS Priority Mail Express Boxes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "38.73 x 31.43 x 7.62",
-                                    "outer_dimensions": "39.69 x 31.59 x 7.94",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_box",
-                                    "name": "Priority Mail Express Box",
-                                    "dimensions": {
-                                        "inner": "38.73 x 31.43 x 7.62",
-                                        "outer": "39.69 x 31.59 x 7.94"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "27.94 x 21.59 x 13.97",
-                                    "outer_dimensions": "28.57 x 22.22 x 15.24",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_box_1",
-                                    "name": "Priority Mail Express Box 1",
-                                    "dimensions": {
-                                        "inner": "27.94 x 21.59 x 13.97",
-                                        "outer": "28.57 x 22.22 x 15.24"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "30.16 x 8.57 x 34.61",
-                                    "outer_dimensions": "30.48 x 8.89 x 35.56",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_box_2",
-                                    "name": "Priority Mail Express Box 2",
-                                    "dimensions": {
-                                        "inner": "30.16 x 8.57 x 34.61",
-                                        "outer": "30.48 x 8.89 x 35.56"
-                                    },
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "95.72 x 15.56 x 12.86",
-                                    "outer_dimensions": "95.72 x 15.56 x 12.86",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_medium_tube",
-                                    "name": "Priority Mail Express Medium Tube",
-                                    "dimensions": "95.72 x 15.56 x 12.86",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "63.5 x 15.24 x 14.92",
-                                    "outer_dimensions": "63.5 x 15.24 x 14.92",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_small_tube",
-                                    "name": "Priority Mail Express Small Tube",
-                                    "dimensions": "63.5 x 15.24 x 14.92",
-                                    "max_weight": 31.75,
-                                    "is_letter": false,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "29.53 x 38.42 x 1.27",
-                                    "outer_dimensions": "29.53 x 38.42 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_tyvek_envelope",
-                                    "name": "Priority Mail Express Tyvek Envelope",
-                                    "dimensions": "29.53 x 38.42 x 1.27",
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "14.92 x 25.4 x 1.27",
-                                    "outer_dimensions": "14.92 x 25.4 x 1.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "express_window_envelope",
-                                    "name": "Priority Mail Express Window Envelope",
-                                    "dimensions": "14.92 x 25.4 x 1.27",
-                                    "max_weight": 31.75,
-                                    "is_letter": true,
-                                    "service_group_ids": [
-                                        "priority_exp",
-                                        "priority_express_international"
-                                    ],
-                                    "group_id": "pri_express_boxes",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        },
-                        "pri_regional_boxes": {
-                            "title": "USPS Priority Mail Regional Rate Boxes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "25.72 x 18.1 x 12.7",
-                                    "outer_dimensions": "25.72 x 18.1 x 12.7",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "regional_a1",
-                                    "name": "Regional Rate Box A1",
-                                    "dimensions": "25.72 x 18.1 x 12.7",
-                                    "max_weight": 6.8,
-                                    "is_letter": false,
-                                    "group_id": "pri_regional_boxes",
-                                    "can_ship_international": false
-                                },
-                                {
-                                    "inner_dimensions": "28.1 x 6.35 x 33.18",
-                                    "outer_dimensions": "28.1 x 6.35 x 33.18",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "regional_a2",
-                                    "name": "Regional Rate Box A2",
-                                    "dimensions": "28.1 x 6.35 x 33.18",
-                                    "max_weight": 6.8,
-                                    "is_letter": false,
-                                    "group_id": "pri_regional_boxes",
-                                    "can_ship_international": false
-                                },
-                                {
-                                    "inner_dimensions": "31.11 x 26.67 x 13.97",
-                                    "outer_dimensions": "31.11 x 26.67 x 13.97",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "regional_b1",
-                                    "name": "Regional Rate Box B1",
-                                    "dimensions": "31.11 x 26.67 x 13.97",
-                                    "max_weight": 9.07,
-                                    "is_letter": false,
-                                    "group_id": "pri_regional_boxes",
-                                    "can_ship_international": false
-                                },
-                                {
-                                    "inner_dimensions": "36.83 x 7.62 x 41.27",
-                                    "outer_dimensions": "36.83 x 7.62 x 41.27",
-                                    "box_weight": 0,
-                                    "is_flat_rate": true,
-                                    "id": "regional_b2",
-                                    "name": "Regional Rate Box B2",
-                                    "dimensions": "36.83 x 7.62 x 41.27",
-                                    "max_weight": 9.07,
-                                    "is_letter": false,
-                                    "group_id": "pri_regional_boxes",
-                                    "can_ship_international": false
-                                }
-                            ]
-                        }
+                "fedex": {
+                    "express": {
+                        "title": "FedEx Express Packages",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "33.5 x 23.49 x 1.9",
+                                "outer_dimensions": "33.5 x 23.49 x 1.9",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExEnvelope",
+                                "name": "Envelope",
+                                "dimensions": "33.5 x 23.49 x 1.9",
+                                "max_weight": 4.54,
+                                "is_letter": true,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "39.37 x 30.48 x 1.9",
+                                "outer_dimensions": "39.37 x 30.48 x 1.9",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExPak",
+                                "name": "Large Pak",
+                                "dimensions": "39.37 x 30.48 x 1.9",
+                                "max_weight": 9.07,
+                                "is_letter": true,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "31.11 x 27.68 x 3.81",
+                                "outer_dimensions": "31.11 x 27.68 x 3.81",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExSmallBox1",
+                                "name": "Small Box (S1)",
+                                "dimensions": "31.11 x 27.68 x 3.81",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "28.57 x 22.22 x 6.68",
+                                "outer_dimensions": "28.57 x 22.22 x 6.68",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExSmallBox2",
+                                "name": "Small Box (S2)",
+                                "dimensions": "28.57 x 22.22 x 6.68",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "33.65 x 29.21 x 6.04",
+                                "outer_dimensions": "33.65 x 29.21 x 6.04",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExMediumBox1",
+                                "name": "Medium Box (M1)",
+                                "dimensions": "33.65 x 29.21 x 6.04",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "28.57 x 22.22 x 11.12",
+                                "outer_dimensions": "28.57 x 22.22 x 11.12",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExMediumBox2",
+                                "name": "Medium Box (M2)",
+                                "dimensions": "28.57 x 22.22 x 11.12",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "45.41 x 31.44 x 1.9",
+                                "outer_dimensions": "45.41 x 31.44 x 1.9",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExLargeBox1",
+                                "name": "Large Box (L1)",
+                                "dimensions": "45.41 x 31.44 x 1.9",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "28.57 x 22.22 x 19.68",
+                                "outer_dimensions": "28.57 x 22.22 x 19.68",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExLargeBox2",
+                                "name": "Large Box (L2)",
+                                "dimensions": "28.57 x 22.22 x 19.68",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "30.17 x 27.94 x 27.3",
+                                "outer_dimensions": "30.17 x 27.94 x 27.3",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExExtraLargeBox1",
+                                "name": "Extra Large Box (X1)",
+                                "dimensions": "30.17 x 27.94 x 27.3",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "38.73 x 35.89 x 15.24",
+                                "outer_dimensions": "38.73 x 35.89 x 15.24",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExExtraLargeBox2",
+                                "name": "Extra Large Box (X2)",
+                                "dimensions": "38.73 x 35.89 x 15.24",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            },
+                            {
+                                "inner_dimensions": "96.52 x 15.24 x 12.7",
+                                "outer_dimensions": "96.52 x 15.24 x 12.7",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedExTube",
+                                "name": "Tube",
+                                "dimensions": "96.52 x 15.24 x 12.7",
+                                "max_weight": 22.68,
+                                "is_letter": false,
+                                "group_id": "express"
+                            }
+                        ]
                     },
-                    "fedex": {
-                        "express": {
-                            "title": "FedEx Express Packages",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "33.5 x 23.49 x 1.9",
-                                    "outer_dimensions": "33.5 x 23.49 x 1.9",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExEnvelope",
-                                    "name": "Envelope",
-                                    "dimensions": "33.5 x 23.49 x 1.9",
-                                    "max_weight": 4.54,
-                                    "is_letter": true,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "39.37 x 30.48 x 1.9",
-                                    "outer_dimensions": "39.37 x 30.48 x 1.9",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExPak",
-                                    "name": "Large Pak",
-                                    "dimensions": "39.37 x 30.48 x 1.9",
-                                    "max_weight": 9.07,
-                                    "is_letter": true,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "31.11 x 27.68 x 3.81",
-                                    "outer_dimensions": "31.11 x 27.68 x 3.81",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExSmallBox1",
-                                    "name": "Small Box (S1)",
-                                    "dimensions": "31.11 x 27.68 x 3.81",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "28.57 x 22.22 x 6.68",
-                                    "outer_dimensions": "28.57 x 22.22 x 6.68",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExSmallBox2",
-                                    "name": "Small Box (S2)",
-                                    "dimensions": "28.57 x 22.22 x 6.68",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "33.65 x 29.21 x 6.04",
-                                    "outer_dimensions": "33.65 x 29.21 x 6.04",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExMediumBox1",
-                                    "name": "Medium Box (M1)",
-                                    "dimensions": "33.65 x 29.21 x 6.04",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "28.57 x 22.22 x 11.12",
-                                    "outer_dimensions": "28.57 x 22.22 x 11.12",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExMediumBox2",
-                                    "name": "Medium Box (M2)",
-                                    "dimensions": "28.57 x 22.22 x 11.12",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "45.41 x 31.44 x 1.9",
-                                    "outer_dimensions": "45.41 x 31.44 x 1.9",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExLargeBox1",
-                                    "name": "Large Box (L1)",
-                                    "dimensions": "45.41 x 31.44 x 1.9",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "28.57 x 22.22 x 19.68",
-                                    "outer_dimensions": "28.57 x 22.22 x 19.68",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExLargeBox2",
-                                    "name": "Large Box (L2)",
-                                    "dimensions": "28.57 x 22.22 x 19.68",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "30.17 x 27.94 x 27.3",
-                                    "outer_dimensions": "30.17 x 27.94 x 27.3",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExExtraLargeBox1",
-                                    "name": "Extra Large Box (X1)",
-                                    "dimensions": "30.17 x 27.94 x 27.3",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "38.73 x 35.89 x 15.24",
-                                    "outer_dimensions": "38.73 x 35.89 x 15.24",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExExtraLargeBox2",
-                                    "name": "Extra Large Box (X2)",
-                                    "dimensions": "38.73 x 35.89 x 15.24",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                },
-                                {
-                                    "inner_dimensions": "96.52 x 15.24 x 12.7",
-                                    "outer_dimensions": "96.52 x 15.24 x 12.7",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedExTube",
-                                    "name": "Tube",
-                                    "dimensions": "96.52 x 15.24 x 12.7",
-                                    "max_weight": 22.68,
-                                    "is_letter": false,
-                                    "group_id": "express"
-                                }
-                            ]
-                        },
-                        "international": {
-                            "title": "FedEx International Boxes",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "40.16 x 32.87 x 25.88",
-                                    "outer_dimensions": "40.16 x 32.87 x 25.88",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedEx10kgBox",
-                                    "name": "10kg Box",
-                                    "dimensions": "40.16 x 32.87 x 25.88",
-                                    "max_weight": 9.98,
-                                    "is_letter": false,
-                                    "group_id": "international"
-                                },
-                                {
-                                    "inner_dimensions": "54.76 x 42.06 x 33.5",
-                                    "outer_dimensions": "54.76 x 42.06 x 33.5",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "FedEx25kgBox",
-                                    "name": "25kg Box",
-                                    "dimensions": "54.76 x 42.06 x 33.5",
-                                    "max_weight": 24.95,
-                                    "is_letter": false,
-                                    "group_id": "international"
-                                }
-                            ]
-                        }
-                    },
-                    "dhlexpress": {
-                        "domestic_and_international": {
-                            "title": "DHL Express",
-                            "definitions": [
-                                {
-                                    "inner_dimensions": "24.89 x 30.48 x 2.54",
-                                    "outer_dimensions": "24.89 x 30.48 x 2.54",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "SmallPaddedPouch",
-                                    "name": "Small Padded Pouch",
-                                    "dimensions": "24.89 x 30.48 x 2.54",
-                                    "max_weight": 45.36,
-                                    "is_letter": true,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "30.22 x 35.56 x 2.54",
-                                    "outer_dimensions": "30.22 x 35.56 x 2.54",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "LargePaddedPouch",
-                                    "name": "Large Padded Pouch",
-                                    "dimensions": "30.22 x 35.56 x 2.54",
-                                    "max_weight": 45.36,
-                                    "is_letter": true,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "25.65 x 14.73 x 14.99",
-                                    "outer_dimensions": "25.65 x 14.73 x 14.99",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "Box2Cube",
-                                    "name": "Box #2 Cube",
-                                    "dimensions": "25.65 x 14.73 x 14.99",
-                                    "max_weight": 45.36,
-                                    "is_letter": false,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "31.75 x 28.19 x 3.81",
-                                    "outer_dimensions": "31.75 x 28.19 x 3.81",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "Box2Small",
-                                    "name": "Box #2 Small",
-                                    "dimensions": "31.75 x 28.19 x 3.81",
-                                    "max_weight": 45.36,
-                                    "is_letter": false,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "33.53 x 32 x 5.08",
-                                    "outer_dimensions": "33.53 x 32 x 5.08",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "Box2Medium",
-                                    "name": "Box #2 Medium",
-                                    "dimensions": "33.53 x 32 x 5.08",
-                                    "max_weight": 45.36,
-                                    "is_letter": false,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                },
-                                {
-                                    "inner_dimensions": "44.45 x 31.75 x 7.62",
-                                    "outer_dimensions": "44.45 x 31.75 x 7.62",
-                                    "box_weight": 0,
-                                    "is_flat_rate": false,
-                                    "id": "Box3Large",
-                                    "name": "Box #3 Large",
-                                    "dimensions": "44.45 x 31.75 x 7.62",
-                                    "max_weight": 45.36,
-                                    "is_letter": false,
-                                    "group_id": "domestic_and_international",
-                                    "can_ship_international": true
-                                }
-                            ]
-                        }
+                    "international": {
+                        "title": "FedEx International Boxes",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "40.16 x 32.87 x 25.88",
+                                "outer_dimensions": "40.16 x 32.87 x 25.88",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedEx10kgBox",
+                                "name": "10kg Box",
+                                "dimensions": "40.16 x 32.87 x 25.88",
+                                "max_weight": 9.98,
+                                "is_letter": false,
+                                "group_id": "international"
+                            },
+                            {
+                                "inner_dimensions": "54.76 x 42.06 x 33.5",
+                                "outer_dimensions": "54.76 x 42.06 x 33.5",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "FedEx25kgBox",
+                                "name": "25kg Box",
+                                "dimensions": "54.76 x 42.06 x 33.5",
+                                "max_weight": 24.95,
+                                "is_letter": false,
+                                "group_id": "international"
+                            }
+                        ]
+                    }
+                },
+                "dhlexpress": {
+                    "domestic_and_international": {
+                        "title": "DHL Express",
+                        "definitions": [
+                            {
+                                "inner_dimensions": "24.89 x 30.48 x 2.54",
+                                "outer_dimensions": "24.89 x 30.48 x 2.54",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "SmallPaddedPouch",
+                                "name": "Small Padded Pouch",
+                                "dimensions": "24.89 x 30.48 x 2.54",
+                                "max_weight": 45.36,
+                                "is_letter": true,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "30.22 x 35.56 x 2.54",
+                                "outer_dimensions": "30.22 x 35.56 x 2.54",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "LargePaddedPouch",
+                                "name": "Large Padded Pouch",
+                                "dimensions": "30.22 x 35.56 x 2.54",
+                                "max_weight": 45.36,
+                                "is_letter": true,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "25.65 x 14.73 x 14.99",
+                                "outer_dimensions": "25.65 x 14.73 x 14.99",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "Box2Cube",
+                                "name": "Box #2 Cube",
+                                "dimensions": "25.65 x 14.73 x 14.99",
+                                "max_weight": 45.36,
+                                "is_letter": false,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "31.75 x 28.19 x 3.81",
+                                "outer_dimensions": "31.75 x 28.19 x 3.81",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "Box2Small",
+                                "name": "Box #2 Small",
+                                "dimensions": "31.75 x 28.19 x 3.81",
+                                "max_weight": 45.36,
+                                "is_letter": false,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "33.53 x 32 x 5.08",
+                                "outer_dimensions": "33.53 x 32 x 5.08",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "Box2Medium",
+                                "name": "Box #2 Medium",
+                                "dimensions": "33.53 x 32 x 5.08",
+                                "max_weight": 45.36,
+                                "is_letter": false,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            },
+                            {
+                                "inner_dimensions": "44.45 x 31.75 x 7.62",
+                                "outer_dimensions": "44.45 x 31.75 x 7.62",
+                                "box_weight": 0,
+                                "is_flat_rate": false,
+                                "id": "Box3Large",
+                                "name": "Box #3 Large",
+                                "dimensions": "44.45 x 31.75 x 7.62",
+                                "max_weight": 45.36,
+                                "is_letter": false,
+                                "group_id": "domestic_and_international",
+                                "can_ship_international": true
+                            }
+                        ]
                     }
                 }
-            },
-            "formData": {
-                "custom": [
-                    {
-                        "is_user_defined": true,
-                        "name": "Krabica",
-                        "inner_dimensions": "1 x 2 x 3",
-                        "box_weight": 1,
-                        "max_weight": 0
-                    },
-                    {
-                        "is_user_defined": true,
-                        "is_letter": true,
-                        "name": "Obalka",
-                        "inner_dimensions": "2 x 3 x 4",
-                        "box_weight": 5,
-                        "max_weight": 0
-                    }
+            }
+        },
+        "formData": {
+            "custom": [
+                {
+                    "is_user_defined": true,
+                    "name": "Krabica",
+                    "inner_dimensions": "1 x 2 x 3",
+                    "box_weight": 1,
+                    "max_weight": 0
+                },
+                {
+                    "is_user_defined": true,
+                    "is_letter": true,
+                    "name": "Obalka",
+                    "inner_dimensions": "2 x 3 x 4",
+                    "box_weight": 5,
+                    "max_weight": 0
+                }
+            ],
+            "predefined": {
+                "usps": [
+                    null,
+                    "small_flat_box",
+                    "medium_flat_box_top"
                 ],
-                "predefined": {
-                    "usps": [
-                        null,
-                        "small_flat_box",
-                        "medium_flat_box_top"
-                    ],
-                    "dhlexpress": [
-                        "LargePaddedPouch"
-                    ]
-                }
+                "dhlexpress": [
+                    "LargePaddedPouch"
+                ]
             }
         }
     }


### PR DESCRIPTION
Part of #2970

## Description
This is the first PR for managing default and custom packages in Shipping Labels M2. In particular, in this PR I focused on implementing the networking models that are needed in future PRs for parsing the response of the endpoint `GET: wc/v1/connect/packages` for getting all the packages. The parsing was tricky because certain attributes contain (JSON) objects instead of arrays and it added complexity to the deserialization. Also, it’s a source of bugs because it’s not documented anywhere. This applies to the `formData.predefined` and `formSchema.predefined` attributes. I added a unit test for the `ShippingLabelPackagesMapper` for testing that all the fields are parsed correctly.

**The code is over 1500 lines of code just because the JSON example is more than 1000 LOC. Don't be scared.** :octocat: 

## Testing
Just CI, because the code of this PR will be useful for future PRs.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
