### PR TITLE
Fix Unable to Delete Variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -67,9 +67,9 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     var actionButtons: [ActionButtonType] {
         switch (formType, hasUnsavedChanges()) {
         case (.edit, true):
-            return [.save]
+            return [.save, .more]
         default:
-            return []
+            return [.more]
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -65,12 +65,20 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     /// The action buttons that should be rendered in the navigation bar.
     var actionButtons: [ActionButtonType] {
-        switch (formType, hasUnsavedChanges()) {
-        case (.edit, true):
-            return [.save, .more]
-        default:
-            return [.more]
+        var buttons: [ActionButtonType] = {
+            switch (formType, hasUnsavedChanges()) {
+            case (.edit, true):
+                return [.save]
+            default:
+                return []
+            }
+        }()
+
+        if shouldShowMoreOptionsMenu() {
+            buttons.append(.more)
         }
+
+        return buttons
     }
 
     /// Assign this closure to get notified when the variation is deleted.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -162,7 +162,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.save])
+        XCTAssertEqual(actionButtons, [.save, .more])
     }
 
     func test_action_buttons_for_existing_product_and_no_pending_changes() {
@@ -176,7 +176,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [])
+        XCTAssertEqual(actionButtons, [.more])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -8,7 +8,7 @@ import Yosemite
 final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
 
-    func testProductVariationHasNoChangesFromEditActionsOfTheSameData() {
+    func test_product_variation_has_no_changes_from_edit_actions_of_the_same_data() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -36,7 +36,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertFalse(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromUploadingAnImage() {
+    func test_product_variation_has_unsaved_changes_from_uploading_an_image() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -57,7 +57,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromEditingImages() {
+    func test_product_variation_has_unsaved_changes_from_editing_images() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -77,7 +77,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromEditingDescription() {
+    func test_product_variation_has_unsaved_changes_from_editing_description() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -91,7 +91,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromEditingPriceSettings() {
+    func test_product_variation_has_unsaved_changes_from_editing_price_settings() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -105,7 +105,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromEditingInventorySettings() {
+    func test_product_variation_has_unsaved_changes_from_editing_inventory_settings() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -119,7 +119,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testProductVariationHasUnsavedChangesFromEditingShippingSettings() {
+    func test_product_variation_has_unsaved_changes_from_editing_shipping_settings() {
         // Arrange
         let productVariation = MockProductVariation().productVariation()
         let model = EditableProductVariationModel(productVariation: productVariation)


### PR DESCRIPTION
It looks like this is a regression caused by #3846. The changes in there did not include the `.more` as an option for the action buttons. 

## Code Changes

### Before 

https://github.com/woocommerce/woocommerce-ios/blob/3bd504763609fa37b60e16d78c45674f5b7ef2df/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/ProductVariationFormViewModel.swift#L66-L74

### After

https://github.com/woocommerce/woocommerce-ios/blob/f07b64f15a27e4e7b18aea206ce7d5c7ff004c70/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/ProductVariationFormViewModel.swift#L66-L82

## Visuals

### Before Ants Existed

<img src="https://user-images.githubusercontent.com/198826/112392301-c3b49a00-8cbe-11eb-9088-ef1176280c35.png" width="300">

### After Ants Existed 🐜 🐜 🐜 


https://user-images.githubusercontent.com/198826/112392090-7c2e0e00-8cbe-11eb-8e0b-45f6c7d50bcf.mp4




## Assumptions

Based on 6.2, we always show the Delete button. So I kept the same behavior here. 

## Testing

1. Navigate to a variation. 
2. Confirm the ants button is visible. 
3. Tap ants. 🐜 🐜 🐜 
4. Tap Delete. Confirm deletion still works. It should! If not, OMG!

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

