### PR TITLE
Shipping Labels: endpoint to fetch list of default and custom packages for a store

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Custom package/ShippingLabelCustomPackage.swift
@@ -16,11 +16,11 @@ public struct ShippingLabelCustomPackage: Equatable, GeneratedFakeable {
     /// Will be a string formatted like this: `2 x 3 x 4`
     public let dimensions: String
 
-    public let boxWeight: Int
+    public let boxWeight: Double
 
-    public let maxWeight: Int
+    public let maxWeight: Double
 
-    public init(isUserDefined: Bool, title: String, isLetter: Bool, dimensions: String, boxWeight: Int, maxWeight: Int) {
+    public init(isUserDefined: Bool, title: String, isLetter: Bool, dimensions: String, boxWeight: Double, maxWeight: Double) {
         self.isUserDefined = isUserDefined
         self.title = title
         self.isLetter = isLetter
@@ -39,8 +39,8 @@ extension ShippingLabelCustomPackage: Decodable {
         let title = try container.decode(String.self, forKey: .title)
         let isLetter = try container.decodeIfPresent(Bool.self, forKey: .isLetter) ?? false
         let dimensions = try container.decode(String.self, forKey: .innerDimensions)
-        let boxWeight = try container.decode(Int.self, forKey: .boxWeight)
-        let maxWeight = try container.decode(Int.self, forKey: .maxWeight)
+        let boxWeight = try container.decode(Double.self, forKey: .boxWeight)
+        let maxWeight = try container.decode(Double.self, forKey: .maxWeight)
 
         self.init(isUserDefined: isUserDefined, title: title, isLetter: isLetter, dimensions: dimensions, boxWeight: boxWeight, maxWeight: maxWeight)
     }

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -93,7 +93,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     ///   - completion: Closure to be executed upon completion.
     public func packagesDetails(siteID: Int64,
                                 completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
-        let path = "\(Path.packages)"
+        let path = Path.packages
         let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ShippingLabelPackagesMapper()
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -94,7 +94,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     public func packagesDetails(siteID: Int64,
                                 completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
         let path = "\(Path.packages)"
-        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .post, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ShippingLabelPackagesMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -14,6 +14,8 @@ public protocol ShippingLabelRemoteProtocol {
     func addressValidation(siteID: Int64,
                            address: ShippingLabelAddressVerification,
                            completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void)
+    func packagesDetails(siteID: Int64,
+                         completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -84,6 +86,18 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Requests all the details for the packages (custom and predefined).
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the shipping label.
+    ///   - completion: Closure to be executed upon completion.
+    public func packagesDetails(siteID: Int64,
+                                completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
+        let path = "\(Path.packages)"
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .post, siteID: siteID, path: path, parameters: nil)
+        let mapper = ShippingLabelPackagesMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: Constant
@@ -91,6 +105,7 @@ private extension ShippingLabelRemote {
     enum Path {
         static let shippingLabels = "label"
         static let normalizeAddress = "normalize-address"
+        static let packages = "packages"
     }
 
     enum ParameterKey {

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -139,6 +139,38 @@ final class ShippingLabelRemoteTests: XCTestCase {
         XCTAssertEqual(errors.addressError, "House number is missing")
         XCTAssertEqual(errors.generalError, "Address not found")
     }
+
+    func test_packagesDetails_returns_packages_on_success() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "shipping-label-packages-success")
+
+        // When
+        let result: Result<ShippingLabelPackagesResponse, Error> = waitFor { promise in
+            remote.packagesDetails(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(try result.get())
+    }
+
+    func test_packagesDetails_returns_errors_on_failure() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "generic_error")
+
+        // When
+        let result: Result<ShippingLabelPackagesResponse, Error> = waitFor { promise in
+            remote.packagesDetails(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension ShippingLabelRemoteTests {

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -27,6 +27,11 @@ public enum ShippingLabelAction: Action {
                          address: ShippingLabelAddressVerification,
                          completion: (Result<ShippingLabelAddressValidationResponse, Error>) -> Void)
 
+    /// Requests all the details for the packages (custom and predefined).
+    ///
+    case packagesDetails(siteID: Int64,
+                         completion: (Result<ShippingLabelPackagesResponse, Error>) -> Void)
+
     /// Checks whether an order is eligible for shipping label creation.
     ///
     case checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: (_ isEligible: Bool) -> Void)

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -72,6 +72,7 @@ public typealias ShipmentTrackingProviderGroup = Networking.ShipmentTrackingProv
 public typealias ShippingLabel = Networking.ShippingLabel
 public typealias ShippingLabelAddress = Networking.ShippingLabelAddress
 public typealias ShippingLabelAddressVerification = Networking.ShippingLabelAddressVerification
+public typealias ShippingLabelPackagesResponse = Networking.ShippingLabelPackagesResponse
 public typealias ShipType = Networking.ShippingLabelAddressVerification.ShipType
 public typealias ShippingLabelAddressValidationResponse = Networking.ShippingLabelAddressValidationResponse
 public typealias ShippingLabelAddressValidationError = Networking.ShippingLabelAddressValidationError

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -47,6 +47,8 @@ public final class ShippingLabelStore: Store {
             loadShippingLabelSettings(shippingLabel: shippingLabel, completion: completion)
         case .validateAddress(let siteID, let address, let completion):
             validateAddress(siteID: siteID, address: address, completion: completion)
+        case .packagesDetails(let siteID, let completion):
+            packagesDetails(siteID: siteID, completion: completion)
         case .checkCreationEligibility(let siteID, let orderID, let isFeatureFlagEnabled, let onCompletion):
             checkCreationEligibility(siteID: siteID, orderID: orderID, isFeatureFlagEnabled: isFeatureFlagEnabled, onCompletion: onCompletion)
         }
@@ -105,6 +107,11 @@ private extension ShippingLabelStore {
                          address: ShippingLabelAddressVerification,
                          completion: @escaping (Result<ShippingLabelAddressValidationResponse, Error>) -> Void) {
         remote.addressValidation(siteID: siteID, address: address, completion: completion)
+    }
+
+    func packagesDetails(siteID: Int64,
+                         completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
+        remote.packagesDetails(siteID: siteID, completion: completion)
     }
 
     func checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: @escaping (_ isEligible: Bool) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -27,6 +27,10 @@ final class MockShippingLabelRemote {
         let siteID: Int64
     }
 
+    private struct PackagesDetailsResultKey: Hashable {
+        let siteID: Int64
+    }
+
     /// The results to return based on the given arguments in `loadShippingLabels`
     private var loadAllResults = [LoadAllResultKey: Result<OrderShippingLabelListResponse, Error>]()
 
@@ -38,6 +42,9 @@ final class MockShippingLabelRemote {
 
     /// The results to return based on the given arguments in `addressValidation`
     private var addressValidationResults = [AddressValidationResultKey: Result<ShippingLabelAddressValidationResponse, Error>]()
+
+    /// The results to return based on the given arguments in `packagesDetails`
+    private var packagesDetailsResults = [PackagesDetailsResultKey: Result<ShippingLabelPackagesResponse, Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -124,6 +131,19 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = AddressValidationResultKey(siteID: siteID)
             if let result = self.addressValidationResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func packagesDetails(siteID: Int64, completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = PackagesDetailsResultKey(siteID: siteID)
+            if let result = self.packagesDetailsResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -78,6 +78,13 @@ final class MockShippingLabelRemote {
         let key = AddressValidationResultKey(siteID: siteID)
         addressValidationResults[key] = result
     }
+
+    /// Set the value passed to the `completion` block if `packagesDetails` is called.
+    func whenPackagesDetails(siteID: Int64,
+                             thenReturn result: Result<ShippingLabelPackagesResponse, Error>) {
+        let key = PackagesDetailsResultKey(siteID: siteID)
+        packagesDetailsResults[key] = result
+    }
 }
 
 // MARK: - ShippingLabelRemoteProtocol


### PR DESCRIPTION
Closes #2970 

**Important**: before merging this PR in `develop`, we should make sure that the previous PR https://github.com/woocommerce/woocommerce-ios/pull/3862 was merged.

## Description
As part of Shipping Labels M2, in this PR I implemented the endpoint for fetching a list of default and custom packages for a store editing the Networking and the Yosemite layers. The endpoint implemented here will be used in future PRs.

## Testing
- Just CI, since the endpoint is still not used.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
