### PR TITLE
Unify navigation bar back button styles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.4
 -----
-
+- [*] Enhancement/fix: Unify back button style across the app. [https://github.com/woocommerce/woocommerce-ios/pull/3872]
 
 6.3
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -306,7 +306,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         supportViewController.displaysDismissAction = true
 
-        let navController = UINavigationController(rootViewController: supportViewController)
+        let navController = WooNavigationController(rootViewController: supportViewController)
         navController.modalPresentationStyle = .formSheet
 
         sourceViewController.present(navController, animated: true, completion: nil)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -74,11 +74,11 @@ private extension StorePickerCoordinator {
     func showStorePicker() {
         switch selectedConfiguration {
         case .standard:
-            let wrapper = UINavigationController(rootViewController: storePicker)
+            let wrapper = WooNavigationController(rootViewController: storePicker)
             wrapper.modalPresentationStyle = .fullScreen
             navigationController.present(wrapper, animated: false)
         case .switchingStores:
-            let wrapper = UINavigationController(rootViewController: storePicker)
+            let wrapper = WooNavigationController(rootViewController: storePicker)
             navigationController.present(wrapper, animated: true)
         default:
             navigationController.pushViewController(storePicker, animated: true)

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -15,7 +15,11 @@ extension UIViewController {
     /// Removes the text of the navigation bar back button in the next view controller of the navigation stack.
     ///
     func removeNavigationBackBarButtonText() {
-        navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        if #available(iOS 14.0, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+        } else {
+            navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        }
     }
 
     /// Show the X close button or a custom close button with title on the left bar button item position

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -5,7 +5,7 @@ import UIKit
 ///
 class WooNavigationController: UINavigationController {
 
-    weak open override var delegate: UINavigationControllerDelegate? {
+    weak override var delegate: UINavigationControllerDelegate? {
         get {
             return navigationDelegate.forwardDelegate
         }

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -61,7 +61,7 @@ private class WooNavigationControllerDelegate: NSObject, UINavigationControllerD
     /// Forwards the event to the children delegate.
     ///
     func navigationControllerPreferredInterfaceOrientationForPresentation(_ navigationController: UINavigationController) -> UIInterfaceOrientation {
-        forwardDelegate?.navigationControllerPreferredInterfaceOrientationForPresentation?(navigationController) ?? .unknown
+        forwardDelegate?.navigationControllerPreferredInterfaceOrientationForPresentation?(navigationController) ?? .portrait
     }
 
     /// Forwards the event to the children delegate.

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -1,13 +1,96 @@
 import UIKit
 
-/// Subclass to set Woo styling.
+/// Subclass to set Woo styling. Removes back button text on managed view controllers.
 /// Use this when presenting modals.
 ///
 class WooNavigationController: UINavigationController {
+
+    weak open override var delegate: UINavigationControllerDelegate? {
+        get {
+            return navigationDelegate.forwardDelegate
+        }
+        set {
+            navigationDelegate.forwardDelegate = newValue
+        }
+    }
+
+    /// Private object that listens, acts upon, and forwards events from `UINavigationControllerDelegate`
+    ///
+    private let navigationDelegate = WooNavigationControllerDelegate()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        super.delegate = navigationDelegate
+    }
 
     /// Sets the status bar of the pushed view to white.
     ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return StyleManager.statusBarLight
+    }
+}
+
+/// Class that listens and forwards events from `UINavigationControllerDelegate`
+/// Needed to configure the managed `ViewController` back button while providing a `delegate` to children classes.
+///
+private class WooNavigationControllerDelegate: NSObject, UINavigationControllerDelegate {
+
+    /// Children delegate, all events will be forwarded to this object
+    ///
+    weak var forwardDelegate: UINavigationControllerDelegate?
+
+    /// Configures the back button for the managed `ViewController` and forwards the event to the children delegate.
+    ///
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        configureBackButton(for: viewController)
+        forwardDelegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
+    }
+
+    /// Forwards the event to the children delegate.
+    ///
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        forwardDelegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
+    }
+
+    /// Forwards the event to the children delegate.
+    ///
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        forwardDelegate?.navigationControllerSupportedInterfaceOrientations?(navigationController) ?? .allButUpsideDown
+    }
+
+    /// Forwards the event to the children delegate.
+    ///
+    func navigationControllerPreferredInterfaceOrientationForPresentation(_ navigationController: UINavigationController) -> UIInterfaceOrientation {
+        forwardDelegate?.navigationControllerPreferredInterfaceOrientationForPresentation?(navigationController) ?? .unknown
+    }
+
+    /// Forwards the event to the children delegate.
+    ///
+    func navigationController(
+        _ navigationController: UINavigationController,
+        interactionControllerFor animationController: UIViewControllerAnimatedTransitioning
+    ) -> UIViewControllerInteractiveTransitioning? {
+        forwardDelegate?.navigationController?(navigationController, interactionControllerFor: animationController)
+    }
+
+    /// Forwards the event to the children delegate.
+    ///
+    func navigationController(_ navigationController: UINavigationController,
+                              animationControllerFor operation: UINavigationController.Operation,
+                              from fromVC: UIViewController,
+                              to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        forwardDelegate?.navigationController?(navigationController,
+                                               animationControllerFor: operation,
+                                               from: fromVC,
+                                               to: toVC)
+    }
+}
+
+// MARK: Back button configuration
+private extension WooNavigationControllerDelegate {
+    /// Removes the back button text for the provided `ViewController`
+    ///
+    func configureBackButton(for viewController: UIViewController) {
+        viewController.removeNavigationBackBarButtonText()
     }
 }

--- a/WooCommerce/Classes/System/WooTabNavigationController.swift
+++ b/WooCommerce/Classes/System/WooTabNavigationController.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Navigation controller for a Woo tab, shown as the root view controller of one of the tab bar.
 /// The first view controller always has large title, while the following view controllers in the navigation stack do not have large title by default.
 /// The following view controllers can override `preferredLargeTitleDisplayMode` function to change the large title display mode.
-final class WooTabNavigationController: UINavigationController {
+final class WooTabNavigationController: WooNavigationController {
     init() {
         super.init(nibName: nil, bundle: nil)
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -467,7 +467,7 @@ private extension ZendeskManager {
 
         // If the controller is a UIViewController, set the modal display for iPad.
         if !controller.isKind(of: UINavigationController.self) && UIDevice.current.userInterfaceIdiom == .pad {
-            let navController = UINavigationController(rootViewController: zendeskView)
+            let navController = WooNavigationController(rootViewController: zendeskView)
             navController.modalPresentationStyle = .fullScreen
             navController.modalTransitionStyle = .crossDissolve
             controller.present(navController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -79,7 +79,7 @@ private extension AppCoordinator {
         }
 
         DDLogInfo("💬 Authenticated user does not have a Woo store selected — launching store picker.")
-        let navigationController = UINavigationController()
+        let navigationController = WooNavigationController()
         setWindowRootViewControllerAndAnimateIfNeeded(navigationController)
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .standard)
         storePickerCoordinator?.start()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -94,8 +94,6 @@ private extension DashboardViewController {
         )
         rightBarButton.accessibilityIdentifier = "dashboard-settings-button"
         navigationItem.setRightBarButton(rightBarButton, animated: false)
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureDashboardUIContainer() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -64,7 +64,6 @@ private extension AboutViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("About", comment: "About this app (information page title)")
-        removeNavigationBackBarButtonText()
     }
 
     /// Apply Woo styles.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -35,7 +35,6 @@ private extension LicensesViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("Licenses", comment: "Licenses (information page title)")
-        removeNavigationBackBarButtonText()
     }
 
     /// Setup the main view

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -13,13 +13,5 @@ private extension CardReaderSettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Card Readers", comment: "Card reader settings screen title")
-
-        // Don't show the Settings title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -46,8 +46,6 @@ class ApplicationLogDetailViewController: UIViewController {
     func configureNavigation() {
         title = logDate
 
-        removeNavigationBackBarButtonText()
-
         let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(showShareActivity))
         navigationItem.rightBarButtonItem = shareButton
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -54,8 +54,6 @@ class ApplicationLogViewController: UIViewController {
             "Application Logs",
             comment: "Application Logs navigation bar title - this screen is where users view the list of application logs available to them."
         )
-
-        removeNavigationBackBarButtonText()
     }
 
     /// Apply Woo styles.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -58,7 +58,6 @@ private extension HelpAndSupportViewController {
     ///
     func configureNavigation() {
         title = NSLocalizedString("Help", comment: "Help and Support navigation title")
-        removeNavigationBackBarButtonText()
 
         // Dismiss
         navigationItem.leftBarButtonItem = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -97,8 +97,6 @@ private extension PrivacySettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Privacy Settings", comment: "Privacy settings screen title")
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -83,7 +83,6 @@ private extension SettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Settings", comment: "Settings navigation title")
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
@@ -66,7 +66,7 @@ private extension AztecLinkFormatBarCommand {
             }
         })
 
-        let navigationController = UINavigationController(rootViewController: linkController)
+        let navigationController = WooNavigationController(rootViewController: linkController)
         navigationController.modalPresentationStyle = .popover
         navigationController.popoverPresentationController?.sourceView = richTextView
         if richTextView.selectedRange.length > 0,

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -116,7 +116,7 @@ private extension FancyAlertViewController {
 
             supportViewController.displaysDismissAction = true
 
-            let navController = UINavigationController(rootViewController: supportViewController)
+            let navController = WooNavigationController(rootViewController: supportViewController)
             navController.modalPresentationStyle = .formSheet
 
             controller.present(navController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -194,8 +194,6 @@ private extension FilterListViewController {
 
         // Disables interactive dismiss action so that we can prompt the discard changes alert.
         isModalInPresentation = true
-
-        listSelector.removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -234,7 +234,7 @@ private extension FilterListViewController {
     }
 
     func configureChildNavigationController() {
-        let navigationController = UINavigationController(rootViewController: listSelector)
+        let navigationController = WooNavigationController(rootViewController: listSelector)
         addChild(navigationController)
         navigationControllerContainerView.addSubview(navigationController.view)
         navigationController.didMove(toParent: self)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -114,7 +114,6 @@ private extension OrderDetailsViewController {
     func configureNavigation() {
         let titleFormat = NSLocalizedString("Order #%1$@", comment: "Order number title. Parameters: %1$@ - order number")
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
-        removeNavigationBackBarButtonText()
     }
 
     /// Setup: EntityListener

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -622,7 +622,7 @@ private extension OrderDetailsViewController {
             }
         }
 
-        let navigationController = UINavigationController(rootViewController: statusList)
+        let navigationController = WooNavigationController(rootViewController: statusList)
 
         present(navigationController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -120,7 +120,6 @@ private extension OrderLoaderViewController {
     ///
     func configureNavigationItem() {
         title = NSLocalizedString("Loading Order", comment: "Displayed when an Order is being retrieved")
-        removeNavigationBackBarButtonText()
     }
 
     /// Setup: Main View

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -38,8 +38,6 @@ private extension ProductListViewController {
         let titleFormat = NSLocalizedString("Details Order #%1$@", comment: "Screen title: Details Order number. Parameters: %1$@ - order number")
         title = String.localizedStringWithFormat(titleFormat, viewModel.order.number)
         view.backgroundColor = .listBackground
-
-        removeNavigationBackBarButtonText()
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -66,7 +66,6 @@ private extension ManualTrackingViewController {
     func configureNavigation() {
         configureTitle()
         configureDismissButton()
-        configureBackButton()
         configureAddButton()
     }
 
@@ -82,10 +81,6 @@ private extension ManualTrackingViewController {
                                             target: self,
                                             action: #selector(dismissButtonTapped))
         navigationItem.setLeftBarButton(leftBarButton, animated: false)
-    }
-
-    func configureBackButton() {
-        removeNavigationBackBarButtonText()
     }
 
     func removeProgressIndicator() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -78,7 +78,6 @@ private extension ShippingLabelSuggestedAddressViewController {
 
     func configureNavigationBar() {
         title = type == .origin ? Localization.titleViewShipFrom : Localization.titleViewShipTo
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -84,7 +84,6 @@ private extension ShippingLabelAddressFormViewController {
 
     func configureNavigationBar() {
         title = viewModel.type == .origin ? Localization.titleViewShipFrom : Localization.titleViewShipTo
-        removeNavigationBackBarButtonText()
         if viewModel.showLoadingIndicator {
             configureRightButtonItemAsLoader()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -36,7 +36,6 @@ private extension ShippingLabelFormViewController {
 
     func configureNavigationBar() {
         title = Localization.titleView
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -90,8 +90,6 @@ private extension OrdersRootViewController {
     ///
     func configureNavigationButtons() {
         navigationItem.rightBarButtonItem = ordersViewController.createSearchBarButtonItem()
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureContainerView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
@@ -220,7 +220,6 @@ private extension ProductDownloadFileViewController {
 
         navigationItem.rightBarButtonItems = rightBarButtonItems
 
-        removeNavigationBackBarButtonText()
         enableDoneButton(viewModel.hasUnsavedChanges())
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
@@ -182,7 +182,6 @@ private extension ProductDownloadSettingsViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
                                                             target: self,
                                                             action: #selector(completeUpdating))
-        removeNavigationBackBarButtonText()
         enableDoneButton(false)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -69,7 +69,6 @@ private extension AddProductCategoryViewController {
 
         addCloseNavigationBarButton(title: Strings.cancelButton)
         configureRightBarButtomitemAsSave()
-        removeNavigationBackBarButtonText()
     }
 
     func configureRightBarButtomitemAsSave() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -86,7 +86,6 @@ private extension ProductPriceSettingsViewController {
         title = NSLocalizedString("Price", comment: "Product Price Settings navigation title")
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -94,7 +94,6 @@ private extension ProductTagsViewController {
     func configureNavigationBar() {
         title = Strings.title
 
-        removeNavigationBackBarButtonText()
         configureRightBarButtonItemAsSave()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
@@ -146,7 +146,6 @@ private extension LinkedProductsListSelectorViewController {
     func configureNavigation() {
         title = viewConfiguration.title
         updateNavigationRightBarButtonItem()
-        removeNavigationBackBarButtonText()
     }
 
     func configureAddButton() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelectorViewController.swift
@@ -146,7 +146,6 @@ private extension ProductListSelectorViewController {
     func configureNavigation() {
         updateNavigationTitle(productIDs: productIDs)
         updateNavigationRightBarButtonItem(productIDs: productIDs)
-        removeNavigationBackBarButtonText()
     }
 
     func configurePaginatedProductListSelectorChildViewController() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products/LinkedProductsViewController.swift
@@ -47,7 +47,6 @@ private extension LinkedProductsViewController {
         title = Localization.titleView
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Catalog Visibility/ProductCatalogVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Catalog Visibility/ProductCatalogVisibilityViewController.swift
@@ -51,8 +51,6 @@ private extension ProductCatalogVisibilityViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Catalog Visibility", comment: "Product Catalog Visibility navigation title")
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
@@ -56,7 +56,6 @@ private extension ProductMenuOrderViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Menu Order", comment: "Product Menu Order navigation title")
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -62,7 +62,6 @@ private extension ProductSettingsViewController {
         title = NSLocalizedString("Product Settings", comment: "Product Settings navigation title")
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -63,8 +63,6 @@ private extension ProductPurchaseNoteViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Purchase Note", comment: "Product Note navigation title")
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -53,8 +53,6 @@ private extension ProductSlugViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Slug", comment: "Product Slug navigation title")
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -92,8 +92,6 @@ private extension ProductVisibilityViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Visibility", comment: "Product Visibility navigation title")
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -398,7 +398,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar()
-        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -111,8 +111,6 @@ private extension ProductImagesViewController {
         title = NSLocalizedString("Photos", comment: "Product images (Product images page title)")
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
-
-        removeNavigationBackBarButtonText()
     }
 
     func configureAddButton() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -57,7 +57,6 @@ final class AddAttributeOptionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNavigationBar()
         configureMainView()
         configureTableView()
         configureGhostTableView()
@@ -72,10 +71,6 @@ final class AddAttributeOptionsViewController: UIViewController {
 // MARK: - View Configuration
 //
 private extension AddAttributeOptionsViewController {
-
-    func configureNavigationBar() {
-        removeNavigationBackBarButtonText()
-    }
 
     func configureRightButtonItem() {
         // The update indicator has precedence over the next button

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -54,7 +54,6 @@ private extension AddAttributeViewController {
 
     func configureNavigationBar() {
         title = Localization.titleView
-        removeNavigationBackBarButtonText()
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.nextNavBarButton,
                                                            style: .plain,
                                                            target: self,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -73,7 +73,6 @@ private extension EditAttributesViewController {
     func configureNavigationBar() {
         configureTitle()
         configureRightButton()
-        removeNavigationBackBarButtonText()
     }
 
     func configureTitle() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
@@ -44,7 +44,6 @@ final class RenameAttributesViewController: UIViewController {
 private extension RenameAttributesViewController {
 
     func configureNavigationBar() {
-        removeNavigationBackBarButtonText()
         title = Localization.title
 
         let rightBarButton = UIBarButtonItem(barButtonSystemItem: .done,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -175,7 +175,6 @@ private extension ProductVariationsViewController {
     /// Set the title and navigation buttons.
     ///
     func configureNavigationBar() {
-        removeNavigationBackBarButtonText()
         title = NSLocalizedString(
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -64,7 +64,6 @@ final class ReviewDetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureNavigationItem()
         configureMainView()
         configureTableView()
         configureEntityListener()
@@ -84,12 +83,6 @@ final class ReviewDetailsViewController: UIViewController {
 // MARK: - User Interface Initialization
 //
 private extension ReviewDetailsViewController {
-
-    /// Setup: Navigation
-    ///
-    func configureNavigationItem() {
-        removeNavigationBackBarButtonText()
-    }
 
     /// Setup: Main View
     ///

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -110,7 +110,6 @@ final class ReviewsViewController: UIViewController {
         refreshTitle()
 
         configureSyncingCoordinator()
-        configureNavigationItem()
         configureNavigationBarButtons()
         configureTableView()
         configureTableViewCells()
@@ -152,12 +151,6 @@ private extension ReviewsViewController {
         tabBarItem.title = NSLocalizedString("Reviews", comment: "Title of the Reviews tab — plural form of Review")
         tabBarItem.image = .starOutlineImage()
         tabBarItem.accessibilityIdentifier = "tab-bar-reviews-item"
-    }
-
-    /// Setup: Navigation
-    ///
-    func configureNavigationItem() {
-        removeNavigationBackBarButtonText()
     }
 
     /// Setup: NavigationBar Buttons


### PR DESCRIPTION
fix #3760 

# Why

We have spotted that the back button style was not consistent across the app. This happens because the back button configuration is handled in each view controller, which makes it easy for the dev to forget.

 Title Text  | No Text | Placeholder Text
--- | --- | ---
<img width="393" alt="Screen Shot 2021-02-26 at 2 46 46 PM" src="https://user-images.githubusercontent.com/562080/109347678-884eb900-7841-11eb-9075-c8d0e5dc56cd.png"> | <img width="392" alt="Screen Shot 2021-02-26 at 2 47 04 PM" src="https://user-images.githubusercontent.com/562080/109347683-88e74f80-7841-11eb-8a1f-4a2ab7ea3d7d.png"> | <img width="387" alt="Screen Shot 2021-02-26 at 2 46 21 PM" src="https://user-images.githubusercontent.com/562080/109347675-871d8c00-7841-11eb-8c81-d0c473ec692f.png">

This PR fixes that by placing the back button style management in our `WooNavigationController` so any view controller managed by it gets configured with the correct back button.

# How
- Update our `removeNavigationBackBarButtonText()` method to use the new iOS14+ API for back buttons.
- Replace usages of `UINavigationController` in favor of `WooNavigationController`
- Update `WooNavigationController` to configure the back button of managed VCs.
- Update `WooNavigationController` to forward the navigation delegate events(as it captures the navigation delegate), for cases where this class is used as a parent class. EG: `WooTabNavigationController`
- Remove the usage of `removeNavigationBackBarButtonText()` throughout VCs

# Testing Steps
- Smoketest the app on IOS 14 and make sure the back button does not have any text and is consistent across the app.
- Smoketest the app on IOS 13 and make sure the back button does not have any text and is consistent across the app.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
