### PR TITLE
Back button menu on product form screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -398,6 +398,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar()
+        updateBackButtonTitle()
     }
 
     func configureMainView() {
@@ -482,6 +483,7 @@ private extension ProductFormViewController {
     func observeProductName() {
         cancellableProductName = viewModel.productName?.subscribe { [weak self] _ in
             guard let self = self else { return }
+            self.updateBackButtonTitle()
             if self.view.window == nil { // If window is nil, this screen isn't the active screen.
                 self.onProductUpdated(product: self.product)
             }
@@ -764,6 +766,12 @@ private extension ProductFormViewController {
 // MARK: Navigation Bar Items
 //
 private extension ProductFormViewController {
+
+    /// Even if the back button don't show any text, we still need a back button title for the menu that is presented by long pressing the back button.
+    ///
+    func updateBackButtonTitle() {
+        navigationItem.backButtonTitle = viewModel.productModel.name.isNotEmpty ? viewModel.productModel.name : Localization.unnamedProduct
+    }
 
     func updateNavigationBar() {
         // Create action buttons based on view model
@@ -1329,6 +1337,8 @@ private enum Localization {
     static let saveTitle = NSLocalizedString("Save", comment: "Action for saving a Product remotely")
     static let groupedProductsViewTitle = NSLocalizedString("Grouped Products",
                                                             comment: "Navigation bar title for editing linked products for a grouped product")
+    static let unnamedProduct = NSLocalizedString("Unnamed product",
+                                                  comment: "Back button title when the product doesn't have a name")
 }
 
 private enum ActionSheetStrings {


### PR DESCRIPTION
fix #3762 

# Why

IOS 14 introduced a callout menu when long-pressing the back button to give the ability to navigate a specific view controller in the navigation stack.

Proper support for it was introduced in https://github.com/woocommerce/woocommerce-ios/pull/3632, except for the product 
detail screen, as that screen does not have a title, the callout menu just adds a "Back" text to it.

# How

This PR fixes that situation by setting the `navigationItem.backButtonTitle` in the `ProductFormViewController` to the product name or to a placeholder if the product name is empty.

# Screenshots
Before | After
--- | ---
<img width="463" alt="before" src="https://user-images.githubusercontent.com/562080/112534943-b4465700-8d79-11eb-9456-44f0fbf97d04.png"> | <img width="460" alt="after" src="https://user-images.githubusercontent.com/562080/112534937-b3152a00-8d79-11eb-9cfd-483e0fe40c59.png">

# Testing steps
- Launch the app on an iOS 14 device/simu
- Navigate all the way to edit a variation price
- Long-press the back button
- See that the callout menu has meaningful names for each screen.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
