### PR TITLE
Update API mock to expect new query syntax on /rest-api/

### DIFF
--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/rest_api.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/rest_api.json
@@ -7,7 +7,10 @@
                 "equalTo": "true"
             },
             "path": {
-                "equalTo": "/&_method=get&_fields=authentication,namespaces"
+                "equalTo": "/&_method=get"
+            },
+            "query": {
+                "equalTo": "{\"_fields\":\"authentication,namespaces\"}"
             }
         }
     },


### PR DESCRIPTION
## Description

Fixes UI tests ([failed run here](https://circleci.com/gh/woocommerce/woocommerce-ios/19636)) after a change introduced in https://github.com/woocommerce/woocommerce-ios/pull/3860.
Just moves expected request parameters from `path` to `query`.

Actual networking for login flow works well, `_fields` in query also works - response has only required fields.

## Test

1. Run `rake mocks` to start local server
2. Run UI tests
3. Try logout and login on live network

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
