### PR TITLE
Update CircleCI script to fix wrong iOS sim usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ workflows:
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
-          name: UI Tests (iPhone 11)
+          name: UI Tests (iPhone)
           <<: *iphone_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
@@ -220,7 +220,7 @@ workflows:
                 - develop
                 - /^release.*/
       - UI Tests:
-          name: UI Tests (iPad Air 4th generation)
+          name: UI Tests (iPad)
           <<: *ipad_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
@@ -243,11 +243,11 @@ workflows:
           <<: *iphone_test_device
           requires: [ "Hold" ]
       - UI Tests:
-          name: Optional UI Tests (iPhone 11)
+          name: Optional UI Tests (iPhone)
           <<: *iphone_test_device
           requires: [ "Build Tests" ]
       - UI Tests:
-          name: Optional UI Tests (iPad Air 4th generation)
+          name: Optional UI Tests (iPad)
           <<: *ipad_test_device
           requires: [ "Build Tests" ]
   Installable Build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,17 @@ orbs:
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 
+xcode_version: &xcode_version
+  xcode-version: "12.0.0"
+
+iphone_test_device: &iphone_test_device
+  device: iPhone 11
+  ios-version: "14.0"
+
+ipad_test_device: &ipad_test_device
+  device: iPad Air (4th generation)
+  ios-version: "14.0"
+
 commands:
   fix-image:
     steps:
@@ -30,9 +41,16 @@ commands:
 
 jobs:
   Build Tests:
+    parameters:
+      device:
+        type: string
+        description: The device (e.g. "iPhone 11") to use when running unit tests.
+      ios-version:
+        type: string
+        description: The iOS version (e.g. "14.0") of the device used to run tests.
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - git/shallow-checkout
       - fix-image
@@ -44,7 +62,7 @@ jobs:
           command: bundle exec fastlane run configure_apply
       - run:
           name: Build for Testing
-          command: bundle exec fastlane build_for_testing
+          command: bundle exec fastlane build_for_testing device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - persist_to_workspace:
           root: ./
           paths:
@@ -52,43 +70,47 @@ jobs:
             - vendor/bundle
   
   Unit Tests:
+    parameters:
+      device:
+        type: string
+        description: The device (e.g. "iPhone 11") to use when running unit tests.
+      ios-version:
+        type: string
+        description: The iOS version (e.g. "14.0") of the device used to run tests.
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - git/shallow-checkout
       - fix-image
-      - ios/boot-simulator:
-          xcode-version: "12.0.0"
-          device: iPhone 11
       - attach_workspace:
           at: ./
       - run:
           name: Prepare Bundle
           command: bundle --path vendor/bundle
-      - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
-          command: bundle exec fastlane test_without_building name:UnitTests try_count:3
+          command: bundle exec fastlane test_without_building name:UnitTests try_count:3 device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
     parameters:
       device:
         type: string
+        description: The device (e.g. "iPhone 11") to use when running unit tests.
+      ios-version:
+        type: string
+        description: The iOS version (e.g. "14.0") of the device used to run tests.
       post-to-slack:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - git/shallow-checkout
       - fix-image
-      - ios/boot-simulator:
-          xcode-version: "12.0.0"
-          device: << parameters.device >>
       - attach_workspace:
           at: ./
       - run:
@@ -98,10 +120,9 @@ jobs:
           name: Run mocks
           command: ./WooCommerce/WooCommerceUITests/Mocks/scripts/start.sh 8282
           background: true
-      - ios/wait-for-simulator
       - run:
           name: Run UI Tests
-          command: bundle exec fastlane test_without_building name:UITests
+          command: bundle exec fastlane test_without_building name:UITests device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:
@@ -111,9 +132,8 @@ jobs:
                 name: Prepare Slack message
                 when: always
                 command: |
-                  # Get the name of the device that is running. Using "<< parameters.device >>" can cause slack formatting errors.
-                  DEVICE_NAME=$(xcrun simctl list -j | jq -r --arg UDID $SIMULATOR_UDID '.devices[] | .[] | select(.udid == "\($UDID)") | .name')
-                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WooCommerce iOS UI tests failed on ${DEVICE_NAME} in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
+                  # Get the name of the device that is running.
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WooCommerce iOS UI tests failed on << parameters.device >> in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
             - slack/status:
                 fail_only: true
                 include_job_number_field: false
@@ -122,7 +142,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - git/shallow-checkout
       - fix-image
@@ -144,9 +164,9 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Release Build:
-    executor: 
+    executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -183,13 +203,15 @@ jobs:
 workflows:
   woocommerce_ios:
     jobs:
-      - Build Tests
+      - Build Tests:
+          <<: *iphone_test_device
       - Unit Tests:
+          <<: *iphone_test_device
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
           name: UI Tests (iPhone 11)
-          device: iPhone 11
+          <<: *iphone_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -199,7 +221,7 @@ workflows:
                 - /^release.*/
       - UI Tests:
           name: UI Tests (iPad Air 4th generation)
-          device: iPad Air \\(4th generation\\)
+          <<: *ipad_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -218,14 +240,15 @@ workflows:
                 - develop
                 - /^release.*/
       - Build Tests:
+          <<: *iphone_test_device
           requires: [ "Hold" ]
       - UI Tests:
           name: Optional UI Tests (iPhone 11)
-          device: iPhone 11
+          <<: *iphone_test_device
           requires: [ "Build Tests" ]
       - UI Tests:
           name: Optional UI Tests (iPad Air 4th generation)
-          device: iPad Air \\(4th generation\\)
+          <<: *ipad_test_device
           requires: [ "Build Tests" ]
   Installable Build:
     jobs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -387,6 +387,8 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       scheme: "WooCommerce",
       derived_data_path: "DerivedData",
       build_for_testing: true,
+      device: options[:device],
+      deployment_target_version: options[:ios_version],
     )
   end
 
@@ -754,6 +756,8 @@ end
     multi_scan(
       workspace: "WooCommerce.xcworkspace",
       scheme: "WooCommerce",
+      device: options[:device],
+      deployment_target_version: options[:ios_version],
       test_without_building: true,
       xctestrun: testPlanPath,
       try_count: options[:try_count],


### PR DESCRIPTION
## Description

I've noticed that our UI tests jobs (for "iPhone 11" and "iPad Air 4") both output ([example here](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/10897/workflows/e25833d5-4260-4506-98b0-f86ebc7bd617/jobs/19663/parallel-runs/0/steps/0-108)):
```
Found simulator "iPhone 8 (13.5)"
```
It's not even iOS 14! 

After a small investigation I found similar issue with a fix already applied in WordPress-iOS:  https://github.com/wordpress-mobile/WordPress-iOS/pull/15261. Check for additional details and discussion there, since this PR is almost exact duplicate. Thanks @guarani!

## Changes

- Removed `ios/boot-simulator` and `ios/wait-for-simulator` steps
- Instead added `device` and `deployment_target_version` arguments to fastlane actions `run_tests` and `multi_scan`
- Cleaned up parameters everywhere to keep Xcode version, devices and iOS versions list in single place on top

## Test

1. Open "Build Tests" job
  a. Check "Build for Testing" step -> "Summary for scan" section -> ensure that the `device` parameter is "iPhone 11"
  b. Ensure the job completes successfully
2. Open "Unit Tests" job
  a. Expect to no longer see "Boot simulator" or "Wait for simulator" steps
  b. Check "Run Unit Tests" step -> search for "SimDevice" -> ensure value is `iPhone 11 ... iOS 14.0`
  c. Ensure job completes successfully
3. Open "UI Tests" jobs for iPhone and iPad
  a. Expect to no longer see "Boot simulator" or "Wait for simulator" steps
  b. Check "Run UI Tests" step -> search for "SimDevice" -> ensure value is `iPhone 11 ... iOS 14.0` and `iPad Air (4th generation) ... iOS 14.0` according to job device
  c. Ensure job completes successfully
4. Open "Installable Build" job
  a. Ensure the job completes successfully

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
