### PR TITLE
Large Titles: Update navigation bar loading color

### DIFF
--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -266,7 +266,7 @@ extension UIColor {
     ///
     static var navigationBarLoadingIndicator: UIColor {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            return .gray(.shade60)
+            return .systemGray
         } else {
             return .white
         }

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -266,7 +266,7 @@ extension UIColor {
     ///
     static var navigationBarLoadingIndicator: UIColor {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.largeTitles) {
-            return .accent
+            return .gray(.shade60)
         } else {
             return .white
         }


### PR DESCRIPTION
fix #3803

# Why

[It was identified](https://github.com/woocommerce/woocommerce-ios/pull/3783#issuecomment-792733670) that the loading indicators in the large title navigation bar could appear as actionable due to its purple color.

This PR fixes that bu changing the color to a grey one.

# Demo

![loading](https://user-images.githubusercontent.com/562080/113054468-0ff45400-916f-11eb-94a3-14eecce73f5d.gif)

# Testing Steps
- Go to a variable product
- Try to add or edit an attribute option.
- See the gray loading indicator in the navigation bar while the remote operation happens.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
