### PR TITLE
Update illustrations and design for login error screen, orders empty state, and reviews empty state

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -191,7 +191,7 @@ private extension AppDelegate {
         appearance.topDividerColor = appearance.bodyBackgroundColor
 
         appearance.titleTextColor = .text
-        appearance.titleFont = UIFont.title2
+        appearance.titleFont = UIFont.title2SemiBold
 
         appearance.bodyTextColor = .text
         appearance.bodyFont = UIFont.body

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.xib
@@ -62,7 +62,7 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="166.5" width="346" height="533"/>
+                    <rect key="frame" x="34" y="190" width="346" height="486"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Np4-PU-IRZ" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="143" y="0.0" width="60" height="60"/>
@@ -104,17 +104,21 @@
                             </subviews>
                         </stackView>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="202.5" width="281" height="150"/>
+                            <rect key="frame" x="114" y="202.5" width="118" height="103"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="118" id="HJ8-h9-jF9"/>
+                                <constraint firstAttribute="height" constant="103" id="t8b-QG-26e"/>
+                            </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="384.5" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="337.5" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="503" width="228" height="30"/>
+                            <rect key="frame" x="59" y="456" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>
@@ -138,7 +142,7 @@
         </view>
     </objects>
     <resources>
-        <image name="woo-no-jetpack-error" width="281" height="150"/>
+        <image name="woo-no-jetpack-error" width="236" height="206"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -54,7 +54,7 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
     let logOutButtonTitle: String = Localization.logOutButtonTitle
 
-    let image: UIImage = .errorImage
+    let image: UIImage = .productErrorImage
 
     var text: NSAttributedString {
         let font: UIFont = .body

--- a/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
@@ -13,6 +13,10 @@ extension UIFont {
     }
 
     static var title2: UIFont {
+        return .preferredFont(forTextStyle: .title2)
+    }
+
+    static var title2SemiBold: UIFont {
         return font(forStyle: .title2, weight: .semibold)
     }
 

--- a/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
@@ -57,6 +57,12 @@ extension UILabel {
         textColor = .text
     }
 
+    func applySecondaryTitleStyle() {
+        adjustsFontForContentSizeCategory = true
+        font = .title2
+        textColor = .text
+    }
+
     func applyPaddedLabelDefaultStyles() {
         adjustsFontForContentSizeCategory = true
         layer.borderWidth = 1.0

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -316,7 +316,7 @@ extension UIColor {
     /// List BackGround.
     ///
     static var listBackground: UIColor {
-        return .systemGroupedBackground
+        return UIColor(light: .gray(.shade0), dark: .black)
     }
 
     /// List ForeGround.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -95,6 +95,10 @@ extension WooConstants {
         ///
         case shippingLabelCreationInfo = "https://woocommerce.com/products/shipping"
 
+        /// URL for product review information
+        ///
+        case productReviewInfo = "https://woocommerce.com/posts/reviews-woocommerce-best-practices/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -255,7 +255,7 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     func configureView() {
-        view.backgroundColor = .systemColor(.systemGroupedBackground)
+        view.backgroundColor = .listBackground
         configureButtonBarBottomBorder()
 
         // Disables any content inset adjustment since `XLPagerTabStrip` doesn't seem to support safe area insets.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -230,7 +230,7 @@ private extension OrdersTabbedViewController {
             NSLocalizedString("Waiting for your first order",
                               comment: "The message shown in the Orders → All Orders tab if the list is empty.")
         static let allOrdersEmptyStateDetail =
-            NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
+            NSLocalizedString("Explore how you can increase your store sales",
                               comment: "The detailed message shown in the Orders → All Orders tab if the list is empty.")
         static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -36,6 +36,10 @@ final class ProductReviewsViewController: UIViewController {
         return viewModel.isEmpty
     }
 
+    /// The view shown if the list is empty.
+    ///
+    private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
+
     /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
     ///
     private let syncingCoordinator = SyncingCoordinator()
@@ -84,10 +88,7 @@ private extension ProductReviewsViewController {
     /// Setup: View properties
     ///
     func configureView() {
-        navigationItem.title = NSLocalizedString(
-            "Reviews",
-            comment: "Title that appears on top of the Product Reviews screen."
-        )
+        navigationItem.title = Localization.reviewsTitle
         view.backgroundColor = .listBackground
     }
 
@@ -178,37 +179,43 @@ private extension ProductReviewsViewController {
         viewModel.removePlaceholderReviews(tableView: tableView)
     }
 
-    /// Displays the Empty State Overlay.
+    /// Displays the EmptyStateViewController.
     ///
-    func displayEmptyOverlay() {
-        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
-        overlayView.messageImage = .emptyReviewsImage
-        overlayView.messageText = NSLocalizedString("No Reviews Yet for this Product!", comment: "Empty Product Reviews List Message")
-        overlayView.actionText = NSLocalizedString("Share your Store", comment: "Action: Opens the Store in a browser")
-        overlayView.onAction = { [weak self] in
-            guard let self = self else {
-                return
-            }
-            guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
-                return
-            }
-            guard let url = URL(string: site.url) else {
-                return
-            }
+    func displayEmptyViewController() {
+        let childController = emptyStateViewController
+        let emptyStateConfig = EmptyStateViewController.Config.withLink(message: NSAttributedString(string: Localization.emptyStateMessage),
+                                                              image: .emptyReviewsImage,
+                                                              details: Localization.emptyStateDetail,
+                                                              linkTitle: Localization.emptyStateAction,
+                                                              linkURL: WooConstants.URLs.productReviewInfo.asURL())
 
-            ServiceLocator.analytics.track(.reviewsShareStoreButtonTapped)
-            SharingHelper.shareURL(url: url, title: site.name, from: overlayView.actionButtonView, in: self)
+        // Abort if we are already displaying this childController
+        guard childController.parent == nil,
+              let childView = childController.view else {
+            return
         }
 
-        overlayView.attach(to: view)
+        childController.configure(emptyStateConfig)
+
+        childView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(childController)
+        view.addSubview(childView)
+        tableView.pinSubviewToAllEdges(childView)
+        childController.didMove(toParent: self)
     }
 
-    /// Removes all of the the OverlayMessageView instances in the view hierarchy.
-    ///
-    func removeAllOverlays() {
-        for subview in view.subviews where subview is OverlayMessageView {
-            subview.removeFromSuperview()
+    func removeEmptyViewController() {
+        let childController = emptyStateViewController
+
+        guard childController.parent == self,
+            let childView = childController.view else {
+            return
         }
+
+        childController.willMove(toParent: nil)
+        childView.removeFromSuperview()
+        childController.removeFromParent()
     }
 }
 
@@ -230,7 +237,7 @@ private extension ProductReviewsViewController {
         switch state {
         case .empty:
             if isEmpty == true {
-                displayEmptyOverlay()
+                displayEmptyViewController()
             }
         case .results:
             break
@@ -246,7 +253,7 @@ private extension ProductReviewsViewController {
     func didLeave(state: State) {
         switch state {
         case .empty:
-            removeAllOverlays()
+            removeEmptyViewController()
         case .results:
             break
         case .placeholder:
@@ -330,5 +337,17 @@ private extension ProductReviewsViewController {
         case empty
         case results
         case syncing
+    }
+}
+
+// MARK: - Localization
+//
+private extension ProductReviewsViewController {
+    enum Localization {
+        static let reviewsTitle = NSLocalizedString("Reviews", comment: "Title that appears on top of the Product Reviews screen.")
+        static let emptyStateMessage = NSLocalizedString("Get your first reviews", comment: "Message shown on the Product Reviews screen if the list is empty")
+        static let emptyStateDetail = NSLocalizedString("Capture high-quality product reviews for your store.",
+                                                         comment: "Detailed message shown on the Product Reviews screen if the list is empty")
+        static let emptyStateAction = NSLocalizedString("Learn more", comment: "Title of button shown on the Product Reviews screen if the list is empty")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -105,7 +105,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
         view.backgroundColor = style.backgroundColor
         contentView.backgroundColor = style.backgroundColor
 
-        messageLabel.applyBodyStyle()
+        messageLabel.applySecondaryTitleStyle()
         detailsLabel.applySecondaryBodyStyle()
 
         keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
@@ -298,9 +298,9 @@ extension EmptyStateViewController {
         /// This is exposed so that consumers can build `NSAttributedString` instances using the same
         /// font. The `NSAttributedString` instance can then be used in `configure(message:`).
         ///
-        /// This must match the `applyBodyStyle()` call in `viewDidLoad`.
+        /// This must match the `messageLabel` style applied in `viewDidLoad`.
         ///
-        static let messageFont: UIFont = .body
+        static let messageFont: UIFont = .title2
 
         fileprivate var message: NSAttributedString {
             switch self {

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -52,7 +52,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 private extension WrongAccountErrorViewModelTests {
     private enum Expectations {
         static let url = "https://woocommerce.com"
-        static let image = UIImage.errorImage
+        static let image = UIImage.productErrorImage
 
         static let primaryButtonTitle = NSLocalizedString("See Connected Stores",
                                                           comment: "Action button linking to a list of connected stores."

--- a/WooCommerce/WooCommerceTests/ViewRelated/EmptyListMessageWithActionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/EmptyListMessageWithActionTests.swift
@@ -33,7 +33,7 @@ final class EmptyListMessageWithActionTests: XCTestCase {
     }
 
     func testBackgroundStyle() {
-        XCTAssertEqual(subject?.backgroundColor, UIColor.listBackground)
+        XCTAssertEqual(subject?.backgroundColor?.cgColor, UIColor.listBackground.cgColor)
     }
 
     func testMessageLabelStyle() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/ManualTrackingViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ManualTrackingViewControllerTests.swift
@@ -61,6 +61,6 @@ final class ManualTrackingViewControllerTests: XCTestCase {
     }
 
     func testVCBackgroundColorIsSet() {
-        XCTAssertEqual(subject?.view.backgroundColor, UIColor.listBackground)
+        XCTAssertEqual(subject?.view.backgroundColor?.cgColor, UIColor.listBackground.cgColor)
     }
 }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/3786

## Description

We're ready to update the illustrations in the app to the latest design from core! This PR contains the remaining changes for the All Orders tab empty state, Reviews empty state CTA and message, and Login wrong account error screen, as well as design updates for all Empty State screens.

## Changes

Updated illustration:

* Login - Wrong account error screen

Updated empty state text:

* Orders - All Orders tab empty state message
* Reviews - Empty state message and CTA
* Product details - Product reviews empty state message and CTA

Updated designs:

* All empty state screens - Message text now uses iOS Title 2 font
   * Previously, `UIFont.title2` was defined as a semibold weight. This changes `UIFont.title2` to regular weight and introduces a separate `UIFont.title2SemiBold` that can be used for those cases where semibold weight is needed.
* Multiple screens - `listBackground` color is updated to Gray 0 (light mode) or Black (dark mode). This provides the correct background color for the new illustrations but also updates other screens with this background color, for consistency.

## Testing

### Login - Wrong account

1. Log out if needed.
2. Tap "Enter Your Store Address."
3. Enter the site address for a Jetpack-connected WooCommerce store.
4. Enter an email that is associated with a WordPress.com account but **not** connected to this site.
5. Enter your password to finish logging in --> the error screen illustration should look as expected.

### Orders

For easier testing, you can hard code to show the empty orders state by updating the siteID to a different value (e.g. 123):

https://github.com/woocommerce/woocommerce-ios/blob/876b67c9a4dac7f5c46de995995d213fd4e17fde/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift#L150

1. Launch the app and log in if needed.
2. Go to the Orders tab where the All Orders tab has no data --> the empty state text should have the expected strings and styles, and the background should be the expected color, as noted in https://github.com/woocommerce/woocommerce-ios/pull/3806#issuecomment-795041561.
3. Tap the search icon
4. Tap into an order status row that has 0 orders --> the empty state text should look as expected, with all the text in the same font size
5. Navigate back to the search screen, and enter some query that renders no results --> the empty state text should look as expected, with all the text in the same font size

### Reviews

For easier testing, you can hard code to show the empty reviews state by updating the siteID to a different value (e.g. 123):

https://github.com/woocommerce/woocommerce-ios/blob/eeee79ebafb171a64eeae3a9a78afa38b0403efc/WooCommerce/Classes/ViewRelated/Reviews/DefaultReviewsDataSource.swift#L126

1. Launch the app and log in if needed.
2. Go to the Reviews tab --> the empty state should have the expected text and button.
3. Tap the "Learn more" button --> it should open a WooCommerce.com blog post titled "Best practices for reviews with WooCommerce."

### Product details - product reviews

1. Launch the app and log in if needed.
2. Select a product with no reviews (create a new product, if needed).
3. In the product details, select the Reviews section --> the empty state should look the same as the Reviews tab empty state (text, illustration, and button).

## Screenshots

### Dark mode

/|Login|Orders|Reviews|Product details (reviews)
-|-|-|-|-
Before|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 59 55](https://user-images.githubusercontent.com/8658164/113169541-9d05de80-923d-11eb-9fed-2a5ab94b2dbd.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 56 14](https://user-images.githubusercontent.com/8658164/113169573-a55e1980-923d-11eb-849d-3d8a83638acc.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 56 21](https://user-images.githubusercontent.com/8658164/113169577-a68f4680-923d-11eb-9bee-403991ad0ba3.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 56 35](https://user-images.githubusercontent.com/8658164/113169585-a8590a00-923d-11eb-807e-4f433240ba65.png)
After|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 15 24](https://user-images.githubusercontent.com/8658164/113169671-bd359d80-923d-11eb-9aac-1a77efcd68bd.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 16 35](https://user-images.githubusercontent.com/8658164/113169676-beff6100-923d-11eb-8829-7237a27091bf.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 16 40](https://user-images.githubusercontent.com/8658164/113169679-c0308e00-923d-11eb-8118-2114c2091981.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 16 45](https://user-images.githubusercontent.com/8658164/113169685-c161bb00-923d-11eb-8505-1f565567fb61.png)

### Light mode

/|Login|Orders|Reviews|Product details (reviews)
-|-|-|-|-
Before|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 59 44](https://user-images.githubusercontent.com/8658164/113169601-abec9100-923d-11eb-8155-6e503962ebef.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 56 53](https://user-images.githubusercontent.com/8658164/113169603-ac852780-923d-11eb-99a2-ae1e94ed283b.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 56 56](https://user-images.githubusercontent.com/8658164/113169605-ae4eeb00-923d-11eb-8ee1-9d9fbeadfbd3.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 15 57 01](https://user-images.githubusercontent.com/8658164/113169614-af801800-923d-11eb-9fb6-44b4dd706739.png)
After|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 15 33](https://user-images.githubusercontent.com/8658164/113169745-cf174080-923d-11eb-8c92-325e03be6cd0.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 16 57](https://user-images.githubusercontent.com/8658164/113169749-d0486d80-923d-11eb-883b-b459b0c17797.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 16 59](https://user-images.githubusercontent.com/8658164/113169755-d1799a80-923d-11eb-842a-ae9d6140475c.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-03-31 at 16 17 05](https://user-images.githubusercontent.com/8658164/113169758-d2123100-923d-11eb-9caa-9b0c77af5832.png)





## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
