### PR TITLE
AddOns: Add i1 feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,6 +11,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .addOnsI1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -25,4 +25,8 @@ enum FeatureFlag: Int {
     /// Shipping labels - release 2
     ///
     case shippingLabelsRelease2
+
+    /// Product AddOns first iteration
+    ///
+    case addOnsI1
 }


### PR DESCRIPTION
close #3884 

# Why

As with every new project, this PR just adds the feature flag declaration to hide ongoing development in production builds.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
