### PR TITLE
Add-Ons: Parse attributes for all order items

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -72,12 +72,8 @@ public struct OrderItem: Decodable, Hashable, GeneratedFakeable {
         if isVariation {
             name = try ((container.decodeIfPresent(String.self, forKey: .variationParentName))
                         ?? container.decode(String.self, forKey: .name)).strippedHTML
-            let allAttributes = (try? container.decodeIfPresent([OrderItemAttribute].self, forKey: .attributes)) ?? []
-            // Skips any attribute if the name is `_reduced_stock` because this is a known attribute added by core.
-            attributes = allAttributes.filter { !$0.name.hasPrefix("_") }
         } else {
             name = try container.decode(String.self, forKey: .name).strippedHTML
-            attributes = []
         }
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
@@ -91,6 +87,10 @@ public struct OrderItem: Decodable, Hashable, GeneratedFakeable {
         let taxes = try container.decode([OrderItemTax].self, forKey: .taxes)
         let total = try container.decode(String.self, forKey: .total)
         let totalTax = try container.decode(String.self, forKey: .totalTax)
+
+        // Do not throw errors in case new metadata is introduced with a different format
+        let allAttributes = (try? container.decodeIfPresent([OrderItemAttribute].self, forKey: .attributes)) ?? []
+        attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 
         // initialize the struct
         self.init(itemID: itemID,

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -1,5 +1,7 @@
 /// Represents an attribute of an `OrderItem` in its `attributes` property.
-/// Currently, the use case is when an order item is a variation and the attributes are its variation attributes.
+/// Currently, the use case is
+/// 1.When an order item is a variation and the attributes are its variation attributes.
+/// 2. Product Add-Ons are stored as attributes.
 public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable {
     public let metaID: Int64
     public let name: String

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -1,6 +1,6 @@
 /// Represents an attribute of an `OrderItem` in its `attributes` property.
 /// Currently, the use case is
-/// 1.When an order item is a variation and the attributes are its variation attributes.
+/// 1. When an order item is a variation and the attributes are its variation attributes.
 /// 2. Product Add-Ons are stored as attributes.
 public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable {
     public let metaID: Int64


### PR DESCRIPTION
close #3885 

# Why

In order to display product add-ons, we need to parse the metadata from each line item of the order. 
Previously, we were parsing metadata (called attributes in the code) only for variable products, as variation information came there.

This PR updates the code to parse attributes(metadata) for all types of products. 

# How

- Update `OrderItem` decoding function to parse attributes for all the types of products
- Added a bit more comments as documentation.

# Testing steps

**Prerequisites:** Have your site with the [add ons plugin](https://woocommerce.com/products/product-add-ons/) installed, configured, and with at least one order with items with add-ons. 

Add the following code in `OrderDetailsViewModel`'s `init` function.
```swift
print("********** Begin attributes ***********")
for item in order.items {
    print(item.attributes)
}
print("********** End attributes ***********")
```

- Launch the app.
- Navigate to an order with items with add-ons.
- See that add-ons info is being printed in the console. 🤷 



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
