### PR TITLE
[Mobile Payments] Bring PaymentIntent back and hide implementation details of payment collection

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		D865C61E261CE001006717B8 /* CardReaderEvent+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D865C61D261CE001006717B8 /* CardReaderEvent+Stripe.swift */; };
 		D88303D125E44B2500C877F9 /* ChargeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303D025E44B2500C877F9 /* ChargeTests.swift */; };
 		D88303D525E44CD200C877F9 /* MockStripeCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303D425E44CD200C877F9 /* MockStripeCharge.swift */; };
+		D88303DB25E450E700C877F9 /* PaymentIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */; };
+		D88303DF25E4512400C877F9 /* MockStripePaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */; };
 		D88FDB0925DD216B00CB0DBD /* Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */; };
 		D88FDB1025DD216B00CB0DBD /* Hardware.h in Headers */ = {isa = PBXBuildFile; fileRef = D88FDB0225DD216B00CB0DBD /* Hardware.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB1F25DD21AF00CB0DBD /* CardReaderServiceDiscoveryStatus.swift */; };
@@ -30,16 +32,20 @@
 		D88FDB2C25DD21B000CB0DBD /* CardReaderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2225DD21AF00CB0DBD /* CardReaderStatus.swift */; };
 		D88FDB2D25DD21B000CB0DBD /* PaymentIntentParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2325DD21B000CB0DBD /* PaymentIntentParameters.swift */; };
 		D88FDB2E25DD21B000CB0DBD /* CardReaderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2425DD21B000CB0DBD /* CardReaderEvent.swift */; };
+		D88FDB2F25DD21B000CB0DBD /* PaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2525DD21B000CB0DBD /* PaymentIntent.swift */; };
 		D88FDB3025DD21B000CB0DBD /* CardReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2625DD21B000CB0DBD /* CardReaderService.swift */; };
 		D88FDB3125DD21B000CB0DBD /* CardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB2725DD21B000CB0DBD /* CardReader.swift */; };
 		D88FDB3925DD21D300CB0DBD /* StripeCardReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB3725DD21D200CB0DBD /* StripeCardReaderService.swift */; };
 		D88FDB3A25DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB3825DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift */; };
 		D892F21025E3F4C0001D7134 /* MockStripeCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D892F20F25E3F4C0001D7134 /* MockStripeCardReader.swift */; };
 		D892F21425E3F67A001D7134 /* CardReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D892F21325E3F67A001D7134 /* CardReaderTests.swift */; };
+		D89B8F0225DDC7500001C726 /* PaymentIntentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F0125DDC7500001C726 /* PaymentIntentStatus.swift */; };
 		D89B8F0825DDC8F60001C726 /* Charge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F0725DDC8F60001C726 /* Charge.swift */; };
 		D89B8F0C25DDC9D30001C726 /* ChargeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F0B25DDC9D30001C726 /* ChargeStatus.swift */; };
 		D89B8F1225DDCBCD0001C726 /* Charge+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F1125DDCBCD0001C726 /* Charge+Stripe.swift */; };
 		D89B8F1625DDCC810001C726 /* ChargeStatus+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F1525DDCC810001C726 /* ChargeStatus+Stripe.swift */; };
+		D89B8F1E25DDCD3D0001C726 /* PaymentIntent+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F1D25DDCD3D0001C726 /* PaymentIntent+Stripe.swift */; };
+		D89B8F2425DDCD800001C726 /* PaymentIntentStatus+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B8F2325DDCD800001C726 /* PaymentIntentStatus+Stripe.swift */; };
 		D8DF5F4425DD9F36008AFE25 /* CardReaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DF5F4325DD9F36008AFE25 /* CardReaderType.swift */; };
 		D8DF5F4A25DD9F7A008AFE25 /* CardReader+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DF5F4925DD9F7A008AFE25 /* CardReader+Stripe.swift */; };
 		D8DF5F4E25DD9F91008AFE25 /* CardReaderType+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DF5F4D25DD9F91008AFE25 /* CardReaderType+Stripe.swift */; };
@@ -76,6 +82,8 @@
 		D865C61D261CE001006717B8 /* CardReaderEvent+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderEvent+Stripe.swift"; sourceTree = "<group>"; };
 		D88303D025E44B2500C877F9 /* ChargeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeTests.swift; sourceTree = "<group>"; };
 		D88303D425E44CD200C877F9 /* MockStripeCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripeCharge.swift; sourceTree = "<group>"; };
+		D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentTests.swift; sourceTree = "<group>"; };
+		D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripePaymentIntent.swift; sourceTree = "<group>"; };
 		D88FDAFF25DD216B00CB0DBD /* Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D88FDB0225DD216B00CB0DBD /* Hardware.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Hardware.h; sourceTree = "<group>"; };
 		D88FDB0325DD216B00CB0DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -87,16 +95,20 @@
 		D88FDB2225DD21AF00CB0DBD /* CardReaderStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderStatus.swift; sourceTree = "<group>"; };
 		D88FDB2325DD21B000CB0DBD /* PaymentIntentParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentIntentParameters.swift; sourceTree = "<group>"; };
 		D88FDB2425DD21B000CB0DBD /* CardReaderEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderEvent.swift; sourceTree = "<group>"; };
+		D88FDB2525DD21B000CB0DBD /* PaymentIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentIntent.swift; sourceTree = "<group>"; };
 		D88FDB2625DD21B000CB0DBD /* CardReaderService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderService.swift; sourceTree = "<group>"; };
 		D88FDB2725DD21B000CB0DBD /* CardReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReader.swift; sourceTree = "<group>"; };
 		D88FDB3725DD21D200CB0DBD /* StripeCardReaderService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StripeCardReaderService.swift; sourceTree = "<group>"; };
 		D88FDB3825DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectionTokenProvider.swift; sourceTree = "<group>"; };
 		D892F20F25E3F4C0001D7134 /* MockStripeCardReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripeCardReader.swift; sourceTree = "<group>"; };
 		D892F21325E3F67A001D7134 /* CardReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderTests.swift; sourceTree = "<group>"; };
+		D89B8F0125DDC7500001C726 /* PaymentIntentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentStatus.swift; sourceTree = "<group>"; };
 		D89B8F0725DDC8F60001C726 /* Charge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Charge.swift; sourceTree = "<group>"; };
 		D89B8F0B25DDC9D30001C726 /* ChargeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeStatus.swift; sourceTree = "<group>"; };
 		D89B8F1125DDCBCD0001C726 /* Charge+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Charge+Stripe.swift"; sourceTree = "<group>"; };
 		D89B8F1525DDCC810001C726 /* ChargeStatus+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChargeStatus+Stripe.swift"; sourceTree = "<group>"; };
+		D89B8F1D25DDCD3D0001C726 /* PaymentIntent+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIntent+Stripe.swift"; sourceTree = "<group>"; };
+		D89B8F2325DDCD800001C726 /* PaymentIntentStatus+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIntentStatus+Stripe.swift"; sourceTree = "<group>"; };
 		D8DF5F4325DD9F36008AFE25 /* CardReaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderType.swift; sourceTree = "<group>"; };
 		D8DF5F4925DD9F7A008AFE25 /* CardReader+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReader+Stripe.swift"; sourceTree = "<group>"; };
 		D8DF5F4D25DD9F91008AFE25 /* CardReaderType+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Stripe.swift"; sourceTree = "<group>"; };
@@ -176,8 +188,10 @@
 				D88FDB0F25DD216B00CB0DBD /* Info.plist */,
 				D892F20F25E3F4C0001D7134 /* MockStripeCardReader.swift */,
 				D88303D425E44CD200C877F9 /* MockStripeCharge.swift */,
+				D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */,
 				D892F21325E3F67A001D7134 /* CardReaderTests.swift */,
 				D88303D025E44B2500C877F9 /* ChargeTests.swift */,
+				D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */,
 				D81AE85D25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift */,
 				D854FC25260A6B5800A219CD /* ErrorCodesTests.swift */,
 				D80B4651260E19590092EDC0 /* PaymentIntentParametersTests.swift */,
@@ -198,6 +212,8 @@
 				D8DF5F4325DD9F36008AFE25 /* CardReaderType.swift */,
 				D89B8F0725DDC8F60001C726 /* Charge.swift */,
 				D89B8F0B25DDC9D30001C726 /* ChargeStatus.swift */,
+				D88FDB2525DD21B000CB0DBD /* PaymentIntent.swift */,
+				D89B8F0125DDC7500001C726 /* PaymentIntentStatus.swift */,
 				D88FDB2325DD21B000CB0DBD /* PaymentIntentParameters.swift */,
 				D88FDB2025DD21AF00CB0DBD /* PaymentStatus.swift */,
 				D81AE86325E6B77F00D9CFD3 /* CardReaderServiceError.swift */,
@@ -217,7 +233,9 @@
 				D8DF5F4D25DD9F91008AFE25 /* CardReaderType+Stripe.swift */,
 				D89B8F1125DDCBCD0001C726 /* Charge+Stripe.swift */,
 				D89B8F1525DDCC810001C726 /* ChargeStatus+Stripe.swift */,
+				D89B8F1D25DDCD3D0001C726 /* PaymentIntent+Stripe.swift */,
 				D80409A525FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift */,
+				D89B8F2325DDCD800001C726 /* PaymentIntentStatus+Stripe.swift */,
 				D88FDB3725DD21D200CB0DBD /* StripeCardReaderService.swift */,
 				D88FDB3825DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift */,
 				D81AE85925E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift */,
@@ -429,13 +447,17 @@
 				D854FC22260A34B000A219CD /* UnderlyingError+Stripe.swift in Sources */,
 				D88FDB2B25DD21B000CB0DBD /* CardReaderServiceStatus.swift in Sources */,
 				D80B464E260E18930092EDC0 /* Email.swift in Sources */,
+				D89B8F0225DDC7500001C726 /* PaymentIntentStatus.swift in Sources */,
+				D89B8F1E25DDCD3D0001C726 /* PaymentIntent+Stripe.swift in Sources */,
 				D89B8F1625DDCC810001C726 /* ChargeStatus+Stripe.swift in Sources */,
 				D8DF5F4425DD9F36008AFE25 /* CardReaderType.swift in Sources */,
 				D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */,
 				D88FDB3925DD21D300CB0DBD /* StripeCardReaderService.swift in Sources */,
 				D8EDFE2A25EED21D003D2213 /* CardReaderConfigProvider.swift in Sources */,
+				D88FDB2F25DD21B000CB0DBD /* PaymentIntent.swift in Sources */,
 				D88FDB3025DD21B000CB0DBD /* CardReaderService.swift in Sources */,
 				D88FDB2C25DD21B000CB0DBD /* CardReaderStatus.swift in Sources */,
+				D89B8F2425DDCD800001C726 /* PaymentIntentStatus+Stripe.swift in Sources */,
 				D88FDB3A25DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -445,10 +467,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				D88303D525E44CD200C877F9 /* MockStripeCharge.swift in Sources */,
+				D88303DF25E4512400C877F9 /* MockStripePaymentIntent.swift in Sources */,
 				D81AE85E25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift in Sources */,
 				D892F21425E3F67A001D7134 /* CardReaderTests.swift in Sources */,
 				D854FC26260A6B5800A219CD /* ErrorCodesTests.swift in Sources */,
 				D892F21025E3F4C0001D7134 /* MockStripeCardReader.swift in Sources */,
+				D88303DB25E450E700C877F9 /* PaymentIntentTests.swift in Sources */,
 				D88303D125E44B2500C877F9 /* ChargeTests.swift in Sources */,
 				D80B4652260E19590092EDC0 /* PaymentIntentParametersTests.swift in Sources */,
 			);

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -51,10 +51,10 @@ public protocol CardReaderService {
     func collectPaymentMethod() -> Future<Void, Error>
 
     /// Captures a payment after collecting a payment method succeeds.
-    /// In the success case, it returns the PaymentIntent id
-    func processPayment() -> Future<String, Error>
+    func processPayment() -> Future<PaymentIntent, Error>
 
 
     /// Cancels a a PaymentIntent
-    func cancelPaymentIntent() -> Future<Void, Error>
+    /// If the cancel request succeeds, the promise will be called with the updated PaymentIntent object with status Canceled
+    func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error>
 }

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -43,16 +43,8 @@ public protocol CardReaderService {
     /// We need to call this method when switching accounts or stores
     func clear()
 
-    /// Creates a PaymentIntent
-    /// - Parameter parameters: the intent's parameters
-    func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future <Void, Error>
-
-    /// Collects a payment method.
-    func collectPaymentMethod() -> Future<Void, Error>
-
     /// Captures a payment after collecting a payment method succeeds.
-    func processPayment() -> Future<PaymentIntent, Error>
-
+    func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error>
 
     /// Cancels a a PaymentIntent
     /// If the cancel request succeeds, the promise will be called with the updated PaymentIntent object with status Canceled

--- a/Hardware/Hardware/CardReader/CurrencyCode.swift
+++ b/Hardware/Hardware/CardReader/CurrencyCode.swift
@@ -14,7 +14,7 @@ public struct CurrencyCode {
 
     public var wrappedValue: String {
         get {
-            guard Locale.isoCurrencyCodes.contains(value) else {
+            guard Locale.isoCurrencyCodes.map({ $0.uppercased() }).contains(value.uppercased()) else {
                 return ""
             }
 

--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -9,7 +9,9 @@ public struct PaymentIntent: Identifiable {
 
     /// When the PaymentIntent was created
     public let created: Date
+
     ///The amount to be collected by this PaymentIntent, provided in the currency’s smallest unit.
+    /// e.g. USD$5.00 should have amount = 500 and currency = 'usd'
     /// - see: https://stripe.com/docs/currencies#zero-decimal
     public let amount: UInt
 

--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -1,0 +1,24 @@
+/// A PaymentIntent tracks the process of collecting a payment from your customer.
+/// We would create exactly one PaymentIntent for each order
+public struct PaymentIntent: Identifiable {
+    /// Unique identifier for the PaymentIntent
+    public let id: String
+
+    /// The status of the Payment Intent
+    public let status: PaymentIntentStatus
+
+    /// When the PaymentIntent was created
+    public let created: Date
+    ///The amount to be collected by this PaymentIntent, provided in the currency’s smallest unit.
+    /// - see: https://stripe.com/docs/currencies#zero-decimal
+    public let amount: UInt
+
+    /// The currency of the payment.
+    public let currency: String
+
+    /// Set of key-value pairs attached to the object.
+    public let metadata: [AnyHashable: Any]?
+
+    // Charges that were created by this PaymentIntent, if any.
+    public let charges: [Charge]
+}

--- a/Hardware/Hardware/CardReader/PaymentIntentStatus.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentStatus.swift
@@ -1,0 +1,9 @@
+///The possible statuses for a PaymentIntent.
+public enum PaymentIntentStatus {
+    case requiresPaymentMethod
+    case requiresConfirmation
+    case requiresCapture
+    case processing
+    case canceled
+    case succeeded
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
@@ -1,0 +1,35 @@
+import StripeTerminal
+
+extension PaymentIntent {
+
+    /// Convenience initializer
+    /// - Parameter intent: An instance of a StripeTerminal.PaymentIntent
+    init(intent: StripePaymentIntent) {
+        self.id = intent.stripeId
+        self.status = PaymentIntentStatus.with(status: intent.status)
+        self.created = intent.created
+        self.amount = intent.amount
+        self.currency = intent.currency
+        self.metadata = intent.metadata
+        self.charges = intent.charges.map { .init(charge: $0) }
+    }
+}
+
+
+/// The initializers of StripeTerminal.PaymentIntent are annotated as NS_UNAVAILABLE
+/// So we can not create instances of that class in our tests.
+/// A workaround is declaring this protocol, which matches the parts of
+/// SCPPaymentIntent that we are interested in, make Reader implement it,
+/// and initialize Harware.CardReader with a type conforming to it.
+protocol StripePaymentIntent {
+    var stripeId: String { get }
+    var created: Date { get }
+    var status: StripeTerminal.PaymentIntentStatus { get }
+    var amount: UInt { get }
+    var currency: String { get }
+    var metadata: [AnyHashable: Any]? { get }
+    var charges: [SCPCharge] { get }
+}
+
+
+extension StripeTerminal.PaymentIntent: StripePaymentIntent { }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentStatus+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentStatus+Stripe.swift
@@ -1,0 +1,25 @@
+import StripeTerminal
+
+extension PaymentIntentStatus {
+
+    /// Factory Method to initialize PaymentItemStatus with StripeTerminal's PaymentIntentStatus
+    /// - Parameter readerType: an instance of PaymentIntentStatus, declared in StripeTerminal
+    static func with(status: StripeTerminal.PaymentIntentStatus) -> PaymentIntentStatus {
+        switch status {
+        case .requiresPaymentMethod:
+            return .requiresPaymentMethod
+        case .requiresCapture:
+            return .requiresCapture
+        case .requiresConfirmation:
+            return .requiresConfirmation
+        case .processing:
+            return .processing
+        case .canceled:
+            return .canceled
+        case .succeeded:
+            return .succeeded
+        default:
+            return .canceled
+        }
+    }
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentStatus+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentStatus+Stripe.swift
@@ -3,7 +3,7 @@ import StripeTerminal
 extension PaymentIntentStatus {
 
     /// Factory Method to initialize PaymentItemStatus with StripeTerminal's PaymentIntentStatus
-    /// - Parameter readerType: an instance of PaymentIntentStatus, declared in StripeTerminal
+    /// - Parameter status: an instance of PaymentIntentStatus, declared in StripeTerminal
     static func with(status: StripeTerminal.PaymentIntentStatus) -> PaymentIntentStatus {
         switch status {
         case .requiresPaymentMethod:

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -178,7 +178,7 @@ extension StripeCardReaderService: CardReaderService {
         }
     }
 
-    public func processPayment() -> Future<String, Error> {
+    public func processPayment() -> Future<PaymentIntent, Error> {
         return Future() { [weak self] promise in
             guard let activeIntent = self?.activePaymentIntent else {
                 // There is no active payment intent.
@@ -195,13 +195,14 @@ extension StripeCardReaderService: CardReaderService {
 
                 if let intent = intent {
                     self?.activePaymentIntent = intent
-                    promise(.success(intent.stripeId))
+
+                    promise(.success(PaymentIntent(intent: intent)))
                 }
             }
         }
     }
 
-    public func cancelPaymentIntent() -> Future<Void, Error> {
+    public func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error> {
         return Future() { promise in
             // Attack the Stripe SDK and cancel a PaymentIntent.
             // To be implemented

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -17,8 +17,6 @@ public final class StripeCardReaderService: NSObject {
     /// see
     ///  https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPDiscoveryDelegate.html#/c:objc(pl)SCPDiscoveryDelegate(im)terminal:didUpdateDiscoveredReaders:
     private let discoveredStripeReadersCache = StripeCardReaderDiscoveryCache()
-
-    private var activePaymentIntent: StripeTerminal.PaymentIntent?
 }
 
 
@@ -125,81 +123,13 @@ extension StripeCardReaderService: CardReaderService {
         Terminal.shared.clearCachedCredentials()
     }
 
-    public func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<Void, Error> {
-        return Future() { promise in
-            // Shortcircuit if we have an inconsistent set of parameters
-            guard let parameters = parameters.toStripe() else {
-                promise(.failure(CardReaderServiceError.intentCreation()))
-                return
-            }
-
-            Terminal.shared.createPaymentIntent(parameters) { [weak self] (intent, error) in
-                guard let self = self else {
-                    promise(.failure(CardReaderServiceError.intentCreation()))
-                    return
-                }
-
-                if let error = error {
-                    let underlyingError = UnderlyingError(with: error)
-                    promise(.failure(CardReaderServiceError.intentCreation(underlyingError: underlyingError)))
-                }
-
-                if let intent = intent {
-                    self.activePaymentIntent = intent
-                    promise(.success(()))
-                }
-            }
-        }
-    }
-
-    public func collectPaymentMethod() -> Future<Void, Error> {
-        return Future() { [weak self] promise in
-            guard let activeIntent = self?.activePaymentIntent else {
-                // There is no active payment intent.
-                // Shortcircuit with an internal error
-                promise(.failure(CardReaderServiceError.paymentMethodCollection()))
-                return
-            }
-
-            Terminal.shared.collectPaymentMethod(activeIntent, delegate: self) { (intent, error) in
-                // Notify clients that the card, no matter it tapped or inserted, is not needed anymore.
-                self?.sendReaderEvent(.cardRemoved)
-
-                if let error = error {
-                    let underlyingError = UnderlyingError(with: error)
-                    promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
-                }
-
-                if let intent = intent {
-                    self?.activePaymentIntent = intent
-                    promise(.success(()))
-                }
-            }
-        }
-    }
-
-    public func processPayment() -> Future<PaymentIntent, Error> {
-        return Future() { [weak self] promise in
-            guard let activeIntent = self?.activePaymentIntent else {
-                // There is no active payment intent.
-                // Shortcircuit with an internal error
-                promise(.failure(CardReaderServiceError.paymentCapture()))
-                return
-            }
-
-            Terminal.shared.processPayment(activeIntent) { (intent, error) in
-                if let error = error {
-                    let underlyingError = UnderlyingError(with: error)
-                    promise(.failure(CardReaderServiceError.paymentCapture(underlyingError: underlyingError)))
-                }
-
-                if let intent = intent {
-                    self?.activePaymentIntent = intent
-
-                    promise(.success(PaymentIntent(intent: intent)))
-                }
-            }
-        }
+    public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+        return createPaymentIntent(parameters)
+            .flatMap { intent in
+                self.collectPaymentMethod(intent: intent)
+            }.flatMap { intent in
+                self.processPayment(intent: intent)
+            }.eraseToAnyPublisher()
     }
 
     public func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error> {
@@ -248,6 +178,62 @@ extension StripeCardReaderService: CardReaderService {
 }
 
 
+// MARK: - Payment collection
+private extension StripeCardReaderService {
+    func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<StripeTerminal.PaymentIntent, Error> {
+        return Future() { promise in
+            // Shortcircuit if we have an inconsistent set of parameters
+            guard let parameters = parameters.toStripe() else {
+                promise(.failure(CardReaderServiceError.intentCreation()))
+                return
+            }
+
+            Terminal.shared.createPaymentIntent(parameters) { (intent, error) in
+                if let error = error {
+                    let underlyingError = UnderlyingError(with: error)
+                    promise(.failure(CardReaderServiceError.intentCreation(underlyingError: underlyingError)))
+                }
+
+                if let intent = intent {
+                    promise(.success(intent))
+                }
+            }
+        }
+    }
+
+    func collectPaymentMethod(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
+        return Future() { [weak self] promise in
+            Terminal.shared.collectPaymentMethod(intent, delegate: self) { (intent, error) in
+                // Notify clients that the card, no matter it tapped or inserted, is not needed anymore.
+                self?.sendReaderEvent(.cardRemoved)
+
+                if let error = error {
+                    let underlyingError = UnderlyingError(with: error)
+                    promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
+                }
+
+                if let intent = intent {
+                    promise(.success(intent))
+                }
+            }
+        }
+    }
+
+    func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<PaymentIntent, Error> {
+        return Future() { promise in
+            Terminal.shared.processPayment(intent) { (intent, error) in
+                if let error = error {
+                    let underlyingError = UnderlyingError(with: error)
+                    promise(.failure(CardReaderServiceError.paymentCapture(underlyingError: underlyingError)))
+                }
+
+                if let intent = intent {
+                    promise(.success(PaymentIntent(intent: intent)))
+                }
+            }
+        }
+    }
+}
 
 // MARK: - DiscoveryDelegate.
 extension StripeCardReaderService: DiscoveryDelegate {

--- a/Hardware/HardwareTests/MockStripePaymentIntent.swift
+++ b/Hardware/HardwareTests/MockStripePaymentIntent.swift
@@ -1,0 +1,28 @@
+@testable import Hardware
+import StripeTerminal
+// This structs emulates the properties of SCPPaymentIntent
+// We can not mock SCPPaymentIntent directly, because its initializers
+// are annotated as NS_UNAVAILABLE
+struct MockStripePaymentIntent {
+    let stripeId: String
+    let created: Date
+    let status: StripeTerminal.PaymentIntentStatus
+    let amount: UInt
+    let currency: String
+    let metadata: [AnyHashable: Any]?
+    let charges: [SCPCharge]
+}
+
+extension MockStripePaymentIntent: StripePaymentIntent {}
+
+extension MockStripePaymentIntent {
+    static func mock() -> Self {
+        MockStripePaymentIntent(stripeId: "id",
+                                created: Date(),
+                                status: .succeeded,
+                                amount: 100,
+                                currency: "USD",
+                                metadata: nil,
+                                charges: [])
+    }
+}

--- a/Hardware/HardwareTests/PaymentIntentTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Hardware
+
+/// Tests the mapping between PaymentIntent and SCPPaymentIntent
+final class PaymentIntentTests: XCTestCase {
+    private let mockIntent = MockStripePaymentIntent.mock()
+
+    func test_intent_maps_id() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertEqual(intent.id, mockIntent.stripeId)
+    }
+
+    func test_intent_maps_status() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertEqual(intent.status, .succeeded)
+    }
+
+    func test_intent_maps_date_created() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertEqual(intent.created, mockIntent.created)
+    }
+
+    func test_intent_maps_amount() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertEqual(intent.amount, mockIntent.amount)
+    }
+
+    func test_intent_maps_currency() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertEqual(intent.currency, mockIntent.currency)
+    }
+
+    func test_intent_maps_metadata() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        XCTAssertNil(intent.metadata)
+    }
+
+    func test_intent_maps_charges() {
+        let intent = PaymentIntent(intent: mockIntent)
+
+        // Very indirect test, that doesn't really test much.
+        // It is not possible to instantiate a SCPCharge, which is what
+        // would be needed to instantiate a mock intent.
+        // For now, we will rely on counting charges as a way
+        // to chek that at least both SCPPaymentIntent and
+        // PaymentIntent reference the same number of charges 🤷
+        XCTAssertEqual(intent.charges.count, mockIntent.charges.count)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -108,56 +108,6 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
         readerService.start(MockTokenProvider())
         wait(for: [discoveredReaders, connectedToReader, connectedreaderIsPublished], timeout: Constants.expectationTimeout)
     }
-
-    func test_creating_intent_fails_while_discovery_is_in_progress() {
-        let intentCreation = expectation(description: "Creating a Payment Intent")
-
-        let readerService = ServiceLocator.cardReaderService
-        readerService.start(MockTokenProvider())
-
-        let parameters = PaymentIntentParameters(amount: 100, currency: "usd", receiptDescription: "receipt", statementDescription: "statement")
-
-        /// Payment intent creation completes with an error:
-        /// Could not execute createPaymentIntent because the SDK is busy with another command: discoverReaders
-        readerService.createPaymentIntent(parameters).sink { completion in
-            intentCreation.fulfill()
-        } receiveValue: { _ in
-        }.store(in: &cancellables)
-
-
-        wait(for: [intentCreation], timeout: Constants.expectationTimeout)
-    }
-
-    func test_creating_intent_succeedes_after_discovery_is_completed() {
-        let discoveredReaders = expectation(description: "Discovered readers")
-        let intentCreation = expectation(description: "Creating a Payment Intent")
-
-        let readerService = ServiceLocator.cardReaderService
-
-        let parameters = PaymentIntentParameters(amount: 100, currency: "usd", receiptDescription: "receipt", statementDescription: "statement")
-
-        readerService.discoveredReaders.dropFirst(1).sink { completion in
-            readerService.cancelDiscovery()
-            discoveredReaders.fulfill()
-        } receiveValue: { readers in
-            // There should be at least one non nil reader
-            readerService.cancelDiscovery()
-            guard let _ = readers.first else {
-                return
-            }
-            discoveredReaders.fulfill()
-            readerService.createPaymentIntent(parameters).sink { completion in
-                //
-                print("== = completion")
-            } receiveValue: {
-                intentCreation.fulfill()
-            }.store(in: &self.cancellables)
-
-        }.store(in: &cancellables)
-
-        readerService.start(MockTokenProvider())
-        wait(for: [discoveredReaders, intentCreation], timeout: Constants.expectationTimeout)
-    }
 }
 
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -86,22 +86,8 @@ final class MockCardReaderService: CardReaderService {
 
     func clear() { }
 
-    func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<Void, Error> {
-        Future() { promise in
-            // To be implemented
-        }
-    }
-
-    func collectPaymentMethod() -> Future<Void, Error> {
-        Future() { promise in
-            // To be implemented
-        }
-    }
-
-    func processPayment() -> Future<PaymentIntent, Error> {
-        Future() { promise in
-            // To be implemented
-        }
+    func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+        return Empty(completeImmediately: true).eraseToAnyPublisher()
     }
 
     func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error> {

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -98,13 +98,13 @@ final class MockCardReaderService: CardReaderService {
         }
     }
 
-    func processPayment() -> Future<String, Error> {
+    func processPayment() -> Future<PaymentIntent, Error> {
         Future() { promise in
             // To be implemented
         }
     }
 
-    func cancelPaymentIntent() -> Future<Void, Error> {
+    func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error> {
         Future() { promise in
             // To be implemented
         }

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -77,7 +77,7 @@ Collecting a payment is a three step process that needs to be performed in this 
 
 For more details, see [Stripe's documentation](https://stripe.com/docs/terminal/payments)
 
-This process is abstracted away by the CardrReaderService, meaning that clients of the service do not need to know that the process requires three steps. 
+This process is abstracted away by the CardReaderService, meaning that clients of the service do not need to know that the process requires three steps. 
 
 The status of the payment collection procress is notified to the UI via a `CardReaderEvent`. This model object wraps a `CardReaderEventType`, which will allow a view model or view controller to decide how it needs to react to said event, and a user facing message. This message is, in the integraton with the Stripe SDK, most likely being generated [by the Stripe SDK itself](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPReaderDisplayDelegate.html#/c:objc(pl)SCPReaderDisplayDelegate(im)terminal:didRequestReaderDisplayMessage:) so it might be wise to ignore it, as it can be a tad vague. But it is there anyway.
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -77,6 +77,8 @@ Collecting a payment is a three step process that needs to be performed in this 
 
 For more details, see [Stripe's documentation](https://stripe.com/docs/terminal/payments)
 
+This process is abstracted away by the CardrReaderService, meaning that clients of the service do not need to know that the process requires three steps. 
+
 The status of the payment collection procress is notified to the UI via a `CardReaderEvent`. This model object wraps a `CardReaderEventType`, which will allow a view model or view controller to decide how it needs to react to said event, and a user facing message. This message is, in the integraton with the Stripe SDK, most likely being generated [by the Stripe SDK itself](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPReaderDisplayDelegate.html#/c:objc(pl)SCPReaderDisplayDelegate(im)terminal:didRequestReaderDisplayMessage:) so it might be wise to ignore it, as it can be a tad vague. But it is there anyway.
 
 ### Error handling


### PR DESCRIPTION
Closes #3927, #3930

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Please note there are several parts of the implementation that are not production ready.⚠️

We continue building our prototype (for reference, p91TBi-4q4-p2), this time, by rolling back some changes we did [in previous PRs](https://github.com/woocommerce/woocommerce-ios/pull/3847/commits/47cd4acd4be6f6ca862c552630ac99746ba7067f) and doing a bit of cleanup in the service API.

This PR does not introduce any user facing changes.


## Changes
* Revert the removal of PaymentIntent, and associated objects and tests. A few weeks back we removed this object, but after looking into what is necessary to render receipts, it is clear that we need it back. (p91TBi-4Ob-p2 for reference)
* Avoid leaking some of the implementation details of the Stripe Terminal SDK, in particular, the fact that processing a payment requires creating an intent, then collecting a payment method for that intent, and finally capturing the payment. Now, all that is done by the service via a new public method that takes the intent parameters as a parameter and returns a publisher that will complete with the final PaymentIntent or an error. In a nutshell, we moved most of the implementation of CardPresentPaymentStore.collectPayment to a method in StripeCardReaderService. 
* Removed a few tests that are just not possible now. #3864 , which goes next, will open up testing again.

## How to test
Testing is a bit complicated because:
1. Requires setting up a store for [Card Present Payment Testing](https://github.com/woocommerce/woocommerce-ios/blob/issue/3748-intent-service/docs/stripe-tests.md#integration-tests) (also P91TBi-4BH-p2 for more specific instructions)  
2. Requires an external hardware reader.

Once the store is setup and there is a hardware reader available:
1. Checkout the branch. Run `bundle exec pod install`. 
2. Build and run on a device. 
3. Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
4. Log in to an account that matches a store that has been configured for testing.
5. Navigate to Settings in the app. (Tap the gear button in the top right)
6. In the "Store Settings" section, tap "Manage Card Reader".
7. Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
8. Tap "Connect card reader"
9. Wait until the app suggests one reader to connect to.
10. Tap "Connect to reader"
11. Make sure the reader light turns solid blue.
12. Navigate to an order (any order with payment method Cash On Delivery).
13. Scroll down to the "Collect Payment" button
14. Tap the button. Follow the instructions on screen

The result should look like this:

https://user-images.githubusercontent.com/2722505/114028174-2de44780-9846-11eb-9155-bab847453f3e.mov


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
