### PR TITLE
Fix image loading for some filenames/urls

### DIFF
--- a/Networking/Networking/Model/Media/Media.swift
+++ b/Networking/Networking/Model/Media/Media.swift
@@ -47,6 +47,7 @@ extension Media: Decodable {
         let date = try container.decodeIfPresent(Date.self, forKey: .date) ?? Date()
         let fileExtension = try container.decodeIfPresent(String.self, forKey: .fileExtension) ?? ""
         let mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
+        // Decoding String instead of URL for `src`, since it may have non-Latin chars and URL init can fail without prior percent encoding
         let src = try container.decodeIfPresent(String.self, forKey: .src) ?? ""
         let name = try container.decode(String.self, forKey: .name)
         let alt = try container.decodeIfPresent(String.self, forKey: .alt)

--- a/Networking/Networking/Model/Media/Media.swift
+++ b/Networking/Networking/Model/Media/Media.swift
@@ -47,7 +47,7 @@ extension Media: Decodable {
         let date = try container.decodeIfPresent(Date.self, forKey: .date) ?? Date()
         let fileExtension = try container.decodeIfPresent(String.self, forKey: .fileExtension) ?? ""
         let mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
-        let src = try container.decodeIfPresent(URL.self, forKey: .src)?.absoluteString ?? ""
+        let src = try container.decodeIfPresent(String.self, forKey: .src) ?? ""
         let name = try container.decode(String.self, forKey: .name)
         let alt = try container.decodeIfPresent(String.self, forKey: .alt)
         let height = try container.decodeIfPresent(Double.self, forKey: .height)

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -34,7 +34,7 @@ final class MediaRemoteTests: XCTestCase {
         remote.loadMediaLibrary(for: sampleSiteID) { mediaItems, error in
             XCTAssertNil(error)
             XCTAssertNotNil(mediaItems)
-            XCTAssertEqual(mediaItems!.count, 5)
+            XCTAssertEqual(mediaItems?.count, 5)
             expectation.fulfill()
         }
 

--- a/Networking/NetworkingTests/Responses/media-library.json
+++ b/Networking/NetworkingTests/Responses/media-library.json
@@ -94,25 +94,25 @@
         },
         {
             "ID": 2348,
-            "URL": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12.jpeg",
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест.jpeg",
             "date": "2020-02-21T11:58:24+08:00",
             "mime_type": "image/jpeg",
             "extension": "jpeg",
             "title": "img_0111-1",
             "alt": "",
             "thumbnails": {
-                "medium": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-300x225.jpeg",
-                "large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-1024x768.jpeg",
-                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-150x150.jpeg",
-                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-768x576.jpeg",
-                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-1536x1152.jpeg",
-                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-2048x1536.jpeg",
-                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-350x350.jpeg",
-                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-685x514.jpeg",
-                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-100x100.jpeg",
-                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-350x350.jpeg",
-                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-685x514.jpeg",
-                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-100x100.jpeg"
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-300x225.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-1024x768.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-768x576.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-1536x1152.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-2048x1536.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-685x514.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-685x514.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-100x100.jpeg"
             }
         }
     ],

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.5
 -----
-
+- [*] Fix: Product images with non-latin characters in filenames now will load correctly and won't break Media Library. [https://github.com/woocommerce/woocommerce-ios/pull/3935]
 
 6.4
 -----

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -58,7 +58,8 @@ struct DefaultImageService: ImageService {
                                            placeholder: UIImage? = nil,
                                            progressBlock: ImageDownloadProgressBlock? = nil,
                                            completion: ImageDownloadCompletion? = nil) {
-        let url = URL(string: url ?? "")
+        let encodedString = url?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let url = URL(string: encodedString ?? "")
         imageView.kf.setImage(with: url,
                               placeholder: placeholder,
                               options: defaultOptions,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -600,10 +600,11 @@ private extension OrderDetailsDataSource {
         let imageURL: URL? = {
             guard let imageURLString = aggregateItem.variationID != 0 ?
                     lookUpProductVariation(productID: aggregateItem.productID, variationID: aggregateItem.variationID)?.image?.src:
-                    lookUpProduct(by: aggregateItem.productID)?.images.first?.src else {
+                    lookUpProduct(by: aggregateItem.productID)?.images.first?.src,
+                  let encodedImageURLString = imageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
                 return nil
             }
-            return URL(string: imageURLString)
+            return URL(string: encodedImageURLString)
         }()
         let itemViewModel = ProductDetailsCellViewModel(aggregateItem: aggregateItem.copy(imageURL: imageURL),
                                                         currency: order.currency)

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -180,14 +180,3 @@ private extension AggregatedShippingLabelOrderItems {
         case productVariation(productVariation: ProductVariation, orderItem: OrderItem?, name: String)
     }
 }
-
-private extension Product {
-    /// Returns the URL of the first image, if available. Otherwise, nil is returned.
-    var imageURL: URL? {
-        guard let productImageURLString = images.first?.src,
-              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            return nil
-        }
-        return URL(string: encodedProductImageURLString)
-    }
-}

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -119,6 +119,12 @@ private extension AggregatedShippingLabelOrderItems {
             let price = orderItem?.price ??
                 currencyFormatter.convertToDecimal(from: product.price) ?? 0
             let totalPrice = price.multiplying(by: .init(decimal: Decimal(quantity)))
+            let imageURL: URL?
+            if let encodedImageURLString = product.images.first?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                imageURL = URL(string: encodedImageURLString)
+            } else {
+                imageURL = nil
+            }
             return .init(productID: product.productID,
                          variationID: 0,
                          name: productName,
@@ -126,13 +132,19 @@ private extension AggregatedShippingLabelOrderItems {
                          quantity: Decimal(quantity),
                          sku: orderItem?.sku ?? product.sku,
                          total: totalPrice,
-                         imageURL: URL(string: product.images.first?.src ?? ""),
+                         imageURL: imageURL,
                          attributes: orderItem?.attributes ?? [])
         case .productVariation(let variation, let orderItem, let name):
             let productName = orderItem?.name ?? name
             let price = orderItem?.price ??
                 currencyFormatter.convertToDecimal(from: variation.price) ?? 0
             let totalPrice = price.multiplying(by: .init(decimal: Decimal(quantity)))
+            let imageURL: URL?
+            if let encodedImageURLString = variation.image?.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                imageURL = URL(string: encodedImageURLString)
+            } else {
+                imageURL = nil
+            }
             return .init(productID: variation.productID,
                          variationID: variation.productVariationID,
                          name: productName,
@@ -140,7 +152,7 @@ private extension AggregatedShippingLabelOrderItems {
                          quantity: Decimal(quantity),
                          sku: orderItem?.sku ?? variation.sku,
                          total: totalPrice,
-                         imageURL: URL(string: variation.image?.src ?? ""),
+                         imageURL: imageURL,
                          attributes: orderItem?.attributes ?? [])
         }
     }
@@ -166,5 +178,16 @@ private extension AggregatedShippingLabelOrderItems {
         case productName(name: String)
         case product(product: Product, orderItem: OrderItem?, name: String)
         case productVariation(productVariation: ProductVariation, orderItem: OrderItem?, name: String)
+    }
+}
+
+private extension Product {
+    /// Returns the URL of the first image, if available. Otherwise, nil is returned.
+    var imageURL: URL? {
+        guard let productImageURLString = images.first?.src,
+              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return nil
+        }
+        return URL(string: encodedProductImageURLString)
     }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -192,9 +192,10 @@ private extension ProductDetailsCellViewModel {
 private extension Product {
     /// Returns the URL of the first image, if available. Otherwise, nil is returned.
     var imageURL: URL? {
-        guard let productImageURLString = images.first?.src else {
+        guard let productImageURLString = images.first?.src,
+              let encodedProductImageURLString = productImageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             return nil
         }
-        return URL(string: productImageURLString)
+        return URL(string: encodedProductImageURLString)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -54,7 +54,8 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
             completion(image)
             return nil
         }
-        guard let url = URL(string: productImage.src) else {
+        guard let encodedString = productImage.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: encodedString) else {
             return nil
         }
         let task = imageService.downloadImage(with: url, shouldCacheImage: true) { [weak self] (image, error) in

--- a/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
@@ -5,7 +5,8 @@ import Yosemite
 extension CancellableMedia: WPMediaAsset {
     public func image(with size: CGSize, completionHandler: @escaping WPMediaImageBlock) -> WPMediaRequestID {
         let imageURL = media.thumbnailURL ?? media.src
-        guard let url = URL(string: imageURL) else {
+        guard let encodedString = imageURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: encodedString) else {
             return 0
         }
 

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -86,7 +86,7 @@ final class DefaultImageServiceTests: XCTestCase {
         let mockPlaceholder = UIImage.shippingImage
 
         let mockCache = MockImageCache(name: "Testing")
-        // `MockKingfisherImageDownloader` is used only in this test because only `downloadAndCacheImageForImageView` depends on a Kingfisher `ImageDownloader`.
+        // `MockKingfisherImageDownloader` is used in this test because it depends on a Kingfisher `ImageDownloader`.
         let mockDownloader = MockKingfisherImageDownloader(imagesByKey: [url.absoluteString: testImage])
         imageService = DefaultImageService(imageCache: mockCache, imageDownloader: mockDownloader)
 
@@ -102,6 +102,42 @@ final class DefaultImageServiceTests: XCTestCase {
                                                 waitForDownloadingAndCachingAnImage.fulfill()
 
                                                 self.imageService.retrieveImageFromCache(with: self.url) { image in
+                                                    XCTAssertNotNil(image)
+                                                    waitForRetrievingImageAfterDownload.fulfill()
+                                                }
+        }
+        XCTAssertNotNil(mockImageView.image)
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    func testDownloadingAndCachingAndRetrievingAnImageForImageViewFromURLWithSpecialChars() {
+        let mockImageView = UIImageView()
+        let mockPlaceholder = UIImage.shippingImage
+
+        let mockCache = MockImageCache(name: "Testing")
+
+        let urlStringWithSpecialChars = "https://woo.com/тест-图像"
+        let encodedURLStringWithSpecialChars = urlStringWithSpecialChars.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        let encodedURL = URL(string: encodedURLStringWithSpecialChars)!
+
+        // `MockKingfisherImageDownloader` is used in this test because it depends on a Kingfisher `ImageDownloader`.
+        let imagesMapping = [encodedURLStringWithSpecialChars: testImage]
+        let mockDownloader = MockKingfisherImageDownloader(imagesByKey: imagesMapping)
+        imageService = DefaultImageService(imageCache: mockCache, imageDownloader: mockDownloader)
+
+        // Downloads the image and retrieves it again.
+        let waitForDownloadingAndCachingAnImage = expectation(description: "Wait for downloading and caching an image")
+        let waitForRetrievingImageAfterDownload = expectation(description: "Wait for retrieving image after the previous download")
+        imageService
+            .downloadAndCacheImageForImageView(mockImageView,
+                                               with: urlStringWithSpecialChars,
+                                               placeholder: mockPlaceholder,
+                                               progressBlock: nil) { (image, error) in
+                                                XCTAssertNotNil(image)
+                                                waitForDownloadingAndCachingAnImage.fulfill()
+
+                                                self.imageService.retrieveImageFromCache(with: encodedURL) { image in
                                                     XCTAssertNotNil(image)
                                                     waitForRetrievingImageAfterDownload.fulfill()
                                                 }

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -134,14 +134,14 @@ final class DefaultImageServiceTests: XCTestCase {
                                                with: urlStringWithSpecialChars,
                                                placeholder: mockPlaceholder,
                                                progressBlock: nil) { (image, error) in
-                                                XCTAssertNotNil(image)
-                                                waitForDownloadingAndCachingAnImage.fulfill()
+                XCTAssertNotNil(image)
+                waitForDownloadingAndCachingAnImage.fulfill()
 
-                                                self.imageService.retrieveImageFromCache(with: encodedURL) { image in
-                                                    XCTAssertNotNil(image)
-                                                    waitForRetrievingImageAfterDownload.fulfill()
-                                                }
-        }
+                self.imageService.retrieveImageFromCache(with: encodedURL) { image in
+                    XCTAssertNotNil(image)
+                    waitForRetrievingImageAfterDownload.fulfill()
+                }
+            }
         XCTAssertNotNil(mockImageView.image)
 
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -71,6 +71,41 @@ final class MediaStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response for cases where URLs contain special chars.
+    ///
+    func testRetrieveMediaLibraryUponSuccessfulResponseWhereURLsContainSpecialChars() {
+        let expectation = self.expectation(description: "Retrieve media library")
+
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library")
+
+        let expectedMedia = Media(mediaID: 2348,
+                                  date: date(with: "2020-02-21T11:58:24+08:00"),
+                                  fileExtension: "jpeg",
+                                  mimeType: "image/jpeg",
+                                  src: "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест.jpeg",
+                                  thumbnailURL: "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-тест-150x150.jpeg",
+                                  name: "img_0111-1",
+                                  alt: "",
+                                  height: nil,
+                                  width: nil)
+
+        let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
+                                                      pageNumber: 1,
+                                                      pageSize: 20) { mediaItems, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(mediaItems.count, 5)
+            XCTAssertTrue(mediaItems.contains(expectedMedia))
+
+            expectation.fulfill()
+        }
+
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+        mediaStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is an error response from the backend.
     ///
     func testRetrieveMediaLibraryReturnsErrorUponReponseError() {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/2789, https://github.com/woocommerce/woocommerce-ios/issues/3928.

## Description

iOS app fails to preview and map product image URLs with non-encoded special characters - like Chinese or Cyrillic.
This PR adds percent encoding on all URL inits related to product images.

## Test

1. Create an image with non-latin characters in name, like `test-图像.png` or `тест.png`
2. Upload it to Media Library
3. Create a new product and assign test image to it
4. Open mobile app, switch to products tab
5. Check product icon in the list
6. Open product details
7. Check product image in the header
8. Tap "Add Image" icon -> "Add Photos" -> "WP Media Library"
9. Check that media library loads all data and displays test image from step 1

## Screenshots

|Example image in web admin media library|
|---|
|<img width="1118" src="https://user-images.githubusercontent.com/3132438/114044947-52fda800-9890-11eb-950b-c6710aeb28dd.png">|

/ | before | after
--|--|--
Products list |![Simulator](https://user-images.githubusercontent.com/3132438/114044301-c81cad80-988f-11eb-80bd-851a1b9f2aaf.png)|![Simulator](https://user-images.githubusercontent.com/3132438/114044363-d9fe5080-988f-11eb-802d-fed0b8ac5313.png)
Product details|![Simulator](https://user-images.githubusercontent.com/3132438/114044326-cf43bb80-988f-11eb-860f-e87240ae43b9.png)|![Simulator](https://user-images.githubusercontent.com/3132438/114044393-dff43180-988f-11eb-8b45-b107229f24c7.png)
Media Library |![Simulator](https://user-images.githubusercontent.com/3132438/114044333-d1a61580-988f-11eb-9e88-68da17b5fd09.png)|![Simulator](https://user-images.githubusercontent.com/3132438/114044418-e5517c00-988f-11eb-8869-157db695bb30.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
