### PR TITLE
[Mobile Payments] Support for card reader software updates (excluding UI)

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		D88303D525E44CD200C877F9 /* MockStripeCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303D425E44CD200C877F9 /* MockStripeCharge.swift */; };
 		D88303DB25E450E700C877F9 /* PaymentIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */; };
 		D88303DF25E4512400C877F9 /* MockStripePaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */; };
+		D88ECCD9262091CF0094398A /* CardReaderSoftwareUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */; };
+		D88ECCDF2620933D0094398A /* CardReaderSofware+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */; };
 		D88FDB0925DD216B00CB0DBD /* Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */; };
 		D88FDB1025DD216B00CB0DBD /* Hardware.h in Headers */ = {isa = PBXBuildFile; fileRef = D88FDB0225DD216B00CB0DBD /* Hardware.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB1F25DD21AF00CB0DBD /* CardReaderServiceDiscoveryStatus.swift */; };
@@ -84,6 +86,8 @@
 		D88303D425E44CD200C877F9 /* MockStripeCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripeCharge.swift; sourceTree = "<group>"; };
 		D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentTests.swift; sourceTree = "<group>"; };
 		D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripePaymentIntent.swift; sourceTree = "<group>"; };
+		D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSoftwareUpdate.swift; sourceTree = "<group>"; };
+		D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderSofware+Stripe.swift"; sourceTree = "<group>"; };
 		D88FDAFF25DD216B00CB0DBD /* Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D88FDB0225DD216B00CB0DBD /* Hardware.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Hardware.h; sourceTree = "<group>"; };
 		D88FDB0325DD216B00CB0DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -221,6 +225,7 @@
 				D80B464D260E18930092EDC0 /* Email.swift */,
 				D80B4655260E1B290092EDC0 /* CurrencyCode.swift */,
 				D80B4659260E1E160092EDC0 /* StatementDescriptor.swift */,
+				D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */,
 			);
 			path = CardReader;
 			sourceTree = "<group>";
@@ -240,6 +245,7 @@
 				D88FDB3825DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift */,
 				D81AE85925E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift */,
 				D854FC21260A34B000A219CD /* UnderlyingError+Stripe.swift */,
+				D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */,
 			);
 			path = StripeCardReader;
 			sourceTree = "<group>";
@@ -448,6 +454,7 @@
 				D88FDB2B25DD21B000CB0DBD /* CardReaderServiceStatus.swift in Sources */,
 				D80B464E260E18930092EDC0 /* Email.swift in Sources */,
 				D89B8F0225DDC7500001C726 /* PaymentIntentStatus.swift in Sources */,
+				D88ECCD9262091CF0094398A /* CardReaderSoftwareUpdate.swift in Sources */,
 				D89B8F1E25DDCD3D0001C726 /* PaymentIntent+Stripe.swift in Sources */,
 				D89B8F1625DDCC810001C726 /* ChargeStatus+Stripe.swift in Sources */,
 				D8DF5F4425DD9F36008AFE25 /* CardReaderType.swift in Sources */,
@@ -459,6 +466,7 @@
 				D88FDB2C25DD21B000CB0DBD /* CardReaderStatus.swift in Sources */,
 				D89B8F2425DDCD800001C726 /* PaymentIntentStatus+Stripe.swift in Sources */,
 				D88FDB3A25DD21D300CB0DBD /* DefaultConnectionTokenProvider.swift in Sources */,
+				D88ECCDF2620933D0094398A /* CardReaderSofware+Stripe.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		D88303DF25E4512400C877F9 /* MockStripePaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */; };
 		D88ECCD9262091CF0094398A /* CardReaderSoftwareUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */; };
 		D88ECCDF2620933D0094398A /* CardReaderSofware+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */; };
+		D88ECCE3262095A10094398A /* UpdateTimeEstimate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCE2262095A10094398A /* UpdateTimeEstimate.swift */; };
+		D88ECCE7262096BD0094398A /* UpdateTimeEstimate+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88ECCE6262096BD0094398A /* UpdateTimeEstimate+Stripe.swift */; };
 		D88FDB0925DD216B00CB0DBD /* Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */; };
 		D88FDB1025DD216B00CB0DBD /* Hardware.h in Headers */ = {isa = PBXBuildFile; fileRef = D88FDB0225DD216B00CB0DBD /* Hardware.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDB1F25DD21AF00CB0DBD /* CardReaderServiceDiscoveryStatus.swift */; };
@@ -88,6 +90,8 @@
 		D88303DE25E4512400C877F9 /* MockStripePaymentIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStripePaymentIntent.swift; sourceTree = "<group>"; };
 		D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSoftwareUpdate.swift; sourceTree = "<group>"; };
 		D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderSofware+Stripe.swift"; sourceTree = "<group>"; };
+		D88ECCE2262095A10094398A /* UpdateTimeEstimate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateTimeEstimate.swift; sourceTree = "<group>"; };
+		D88ECCE6262096BD0094398A /* UpdateTimeEstimate+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdateTimeEstimate+Stripe.swift"; sourceTree = "<group>"; };
 		D88FDAFF25DD216B00CB0DBD /* Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D88FDB0225DD216B00CB0DBD /* Hardware.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Hardware.h; sourceTree = "<group>"; };
 		D88FDB0325DD216B00CB0DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -225,6 +229,7 @@
 				D80B464D260E18930092EDC0 /* Email.swift */,
 				D80B4655260E1B290092EDC0 /* CurrencyCode.swift */,
 				D80B4659260E1E160092EDC0 /* StatementDescriptor.swift */,
+				D88ECCE2262095A10094398A /* UpdateTimeEstimate.swift */,
 				D88ECCD8262091CF0094398A /* CardReaderSoftwareUpdate.swift */,
 			);
 			path = CardReader;
@@ -246,6 +251,7 @@
 				D81AE85925E6A62800D9CFD3 /* StripeCardReaderDiscoveryCache.swift */,
 				D854FC21260A34B000A219CD /* UnderlyingError+Stripe.swift */,
 				D88ECCDE2620933D0094398A /* CardReaderSofware+Stripe.swift */,
+				D88ECCE6262096BD0094398A /* UpdateTimeEstimate+Stripe.swift */,
 			);
 			path = StripeCardReader;
 			sourceTree = "<group>";
@@ -458,6 +464,8 @@
 				D89B8F1E25DDCD3D0001C726 /* PaymentIntent+Stripe.swift in Sources */,
 				D89B8F1625DDCC810001C726 /* ChargeStatus+Stripe.swift in Sources */,
 				D8DF5F4425DD9F36008AFE25 /* CardReaderType.swift in Sources */,
+				D88ECCE3262095A10094398A /* UpdateTimeEstimate.swift in Sources */,
+				D88ECCE7262096BD0094398A /* UpdateTimeEstimate+Stripe.swift in Sources */,
 				D88FDB2925DD21B000CB0DBD /* CardReaderServiceDiscoveryStatus.swift in Sources */,
 				D88FDB3925DD21D300CB0DBD /* StripeCardReaderService.swift in Sources */,
 				D8EDFE2A25EED21D003D2213 /* CardReaderConfigProvider.swift in Sources */,

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -58,5 +58,5 @@ public protocol CardReaderService {
 
     /// Triggers a software update. This method requires that checkForUpdates
     /// has been completed successfully
-    func installUpdate() -> Future <Void, Error>
+    func installUpdate() -> Future<Void, Error>
 }

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -22,6 +22,9 @@ public protocol CardReaderService {
     /// The Publisher that emits reader events
     var readerEvents: AnyPublisher<CardReaderEvent, Never> { get }
 
+    /// The Publisher that emits software update progress. Values are in the range [0, 1]
+    var softwareUpdateEvents: AnyPublisher<Float, Never> { get }
+
     // MARK: - Commands
 
     /// Starts the service.
@@ -52,4 +55,8 @@ public protocol CardReaderService {
 
     /// Checks for firmware updates.
     func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error>
+
+    /// Triggers a software update. This method requires that checkForUpdates
+    /// has been completed successfully
+    func installUpdate() -> Future <Void, Error>
 }

--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -49,4 +49,7 @@ public protocol CardReaderService {
     /// Cancels a a PaymentIntent
     /// If the cancel request succeeds, the promise will be called with the updated PaymentIntent object with status Canceled
     func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error>
+
+    /// Checks for firmware updates.
+    func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error>
 }

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -20,6 +20,9 @@ public enum CardReaderServiceError: Error {
 
     /// Error thrown while capturing a payment
     case paymentCapture(underlyingError: UnderlyingError = .internalServiceError)
+
+    /// Error thrown while updating the reader firmware
+    case softwareUpdate(underlyingError: UnderlyingError = .internalServiceError)
 }
 
 

--- a/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
+++ b/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
@@ -1,0 +1,4 @@
+/// A struct representing a reader update.
+public struct CardReaderSoftwareUpdate {
+
+}

--- a/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
+++ b/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
@@ -1,4 +1,8 @@
 /// A struct representing a reader update.
 public struct CardReaderSoftwareUpdate {
+    /// The estimated amount of time for the update.
+    public let estimatedUpdateTime: UpdateTimeEstimate
 
+    /// The target version for the update.
+    public let deviceSoftwareVersion: String
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
@@ -2,6 +2,7 @@ import StripeTerminal
 
 extension CardReaderSoftwareUpdate {
     init(update: ReaderSoftwareUpdate) {
-   
+        self.estimatedUpdateTime = UpdateTimeEstimate(update.estimatedUpdateTime)
+        self.deviceSoftwareVersion = update.deviceSoftwareVersion
     }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
@@ -1,6 +1,10 @@
 import StripeTerminal
 
 extension CardReaderSoftwareUpdate {
+
+    /// Convenience initializer
+    /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPReaderSoftwareUpdate.html
+    /// - Parameter update: StripeTerminal.ReaderSoftwareUpdate
     init(update: ReaderSoftwareUpdate) {
         self.estimatedUpdateTime = UpdateTimeEstimate(update.estimatedUpdateTime)
         self.deviceSoftwareVersion = update.deviceSoftwareVersion

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderSofware+Stripe.swift
@@ -1,0 +1,7 @@
+import StripeTerminal
+
+extension CardReaderSoftwareUpdate {
+    init(update: ReaderSoftwareUpdate) {
+   
+    }
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -10,7 +10,7 @@ extension Hardware.PaymentIntentParameters {
         }
 
         /// The amount of the payment needs to be provided in the currency’s smallest unit.
-        ///https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
+        /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPPaymentIntentParameters.html#/c:objc(cs)SCPPaymentIntentParameters(py)amount
         let amountInSmallestUnit = amount * 100
 
         let amountForStripe = NSDecimalNumber(decimal: amountInSmallestUnit).uintValue

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -214,8 +214,9 @@ extension StripeCardReaderService: CardReaderService {
 
             // If the update succeeds the completion block is called with nil
             // https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)installUpdate:delegate:completion:
-            Terminal.shared.installUpdate(pendingUpdate, delegate: self) { error in
+            Terminal.shared.installUpdate(pendingUpdate, delegate: self) { [weak self] error in
                 if error == nil {
+                    self?.pendingSoftwareUpdate = nil
                     promise(.success(()))
                 }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/UpdateTimeEstimate+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UpdateTimeEstimate+Stripe.swift
@@ -1,0 +1,18 @@
+import StripeTerminal
+
+extension Hardware.UpdateTimeEstimate {
+    init(_ estimate: StripeTerminal.UpdateTimeEstimate) {
+        switch estimate {
+        case .estimateLessThan1Minute:
+            self = .lessThanOneMinute
+        case .estimate1To2Minutes:
+            self = .betweenOneAndTwoMinutes
+        case .estimate2To5Minutes:
+            self = .betweenTwoAndFiveMinutes
+        case .estimate5To15Minutes:
+            self = .betweenFiveAndFifteenMinutes
+        default:
+            self = .indeterminate
+        }
+    }
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/UpdateTimeEstimate+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UpdateTimeEstimate+Stripe.swift
@@ -1,6 +1,10 @@
 import StripeTerminal
 
 extension Hardware.UpdateTimeEstimate {
+
+    /// Convenience initializer
+    /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPUpdateTimeEstimate.html
+    /// - Parameter estimate: StripeTerminal.UpdateTimeEstimate
     init(_ estimate: StripeTerminal.UpdateTimeEstimate) {
         switch estimate {
         case .estimateLessThan1Minute:

--- a/Hardware/Hardware/CardReader/UpdateTimeEstimate.swift
+++ b/Hardware/Hardware/CardReader/UpdateTimeEstimate.swift
@@ -1,0 +1,18 @@
+/// The estimated amount of time for an update.
+/// Note that these times are estimates; actual times may vary depending on your network connection.
+public enum UpdateTimeEstimate {
+    /// The update should take less than 1 minute to complete.
+    case lessThanOneMinute
+
+    /// The update should take 1-2 minutes to complete.
+    case betweenOneAndTwoMinutes
+
+    /// The update should take 2-5 minutes to complete.
+    case betweenTwoAndFiveMinutes
+
+    /// The update should take 5-15 minutes to complete.
+    case betweenFiveAndFifteenMinutes
+
+    /// Call 911. We don't know how long this will take.
+    case indeterminate
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -172,12 +172,18 @@ private extension CardReaderSettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Card Readers", comment: "Card reader settings screen title")
-        // Adding this button just for testing
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "🌀", style: .plain, target: self, action: #selector(checkForUpdate))
+        // Adding these button just for testing
+        let checkForUpdates = UIBarButtonItem(title: "🌀", style: .plain, target: self, action: #selector(checkForUpdate))
+        let updateReader = UIBarButtonItem(title: "🚀", style: .plain, target: self, action: #selector(startUpdate))
+        navigationItem.rightBarButtonItems = [checkForUpdates, updateReader]
 
     }
 
     @objc func checkForUpdate() {
         viewModel.checkForUpdate()
+    }
+
+    @objc func startUpdate() {
+        viewModel.startUpdate()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -172,5 +172,12 @@ private extension CardReaderSettingsViewController {
 
     func configureNavigation() {
         title = NSLocalizedString("Card Readers", comment: "Card reader settings screen title")
+        // Adding this button just for testing
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "🌀", style: .plain, target: self, action: #selector(checkForUpdate))
+
+    }
+
+    @objc func checkForUpdate() {
+        viewModel.checkForUpdate()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -173,7 +173,7 @@ private extension CardReaderSettingsViewController {
     func configureNavigation() {
         title = NSLocalizedString("Card Readers", comment: "Card reader settings screen title")
         // Adding these button just for testing
-        let checkForUpdates = UIBarButtonItem(title: "🌀", style: .plain, target: self, action: #selector(checkForUpdate))
+        let checkForUpdates = UIBarButtonItem(title: "🕵️‍♀️", style: .plain, target: self, action: #selector(checkForUpdate))
         let updateReader = UIBarButtonItem(title: "🚀", style: .plain, target: self, action: #selector(startUpdate))
         navigationItem.rightBarButtonItems = [checkForUpdates, updateReader]
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -181,7 +181,20 @@ final class CardReaderSettingsViewModel: ObservableObject {
     }
 
     /// Views can call this method to initiate a software update on the connected reader.
-    func updateSoftware() {
-        // TODO dispatch an action to update software on the connected reader
+    func checkForUpdate() {
+        let action = CardPresentPaymentAction.checkForUpdate { result in
+            switch result {
+            case .failure(let error):
+                print("===== error checking for updates ", error)
+            case .success(let update):
+                print("=== there is an update available")
+                print("=== version ", update.deviceSoftwareVersion)
+                print("=== estimated time ", update.estimatedUpdateTime)
+            }
+        } onCompletion: {
+            print("=== check for updates completed")
+        }
+
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -197,4 +197,8 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         ServiceLocator.stores.dispatch(action)
     }
+
+    func startUpdate() {
+        print("=== hitting start update in viewmodel")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -182,7 +182,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
     /// Views can call this method to initiate a software update on the connected reader.
     func checkForUpdate() {
-        let action = CardPresentPaymentAction.checkForUpdate { result in
+        let action = CardPresentPaymentAction.checkForCardReaderUpdate { result in
             switch result {
             case .failure(let error):
                 print("===== error checking for updates ", error)
@@ -199,7 +199,7 @@ final class CardReaderSettingsViewModel: ObservableObject {
     }
 
     func startUpdate() {
-        let action = CardPresentPaymentAction.update { progress in
+        let action = CardPresentPaymentAction.startCardReaderUpdate { progress in
             print("==== progress ", progress)
         } onCompletion: { result in
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -199,6 +199,17 @@ final class CardReaderSettingsViewModel: ObservableObject {
     }
 
     func startUpdate() {
-        print("=== hitting start update in viewmodel")
+        let action = CardPresentPaymentAction.update { progress in
+            print("==== progress ", progress)
+        } onCompletion: { result in
+            switch result {
+            case .failure(let error):
+                print("===== error instaling updates ", error)
+            case .success:
+                print("=== the update has been completed. Moving on!")
+            }
+        }
+
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -22,5 +22,6 @@ public enum CardPresentPaymentAction: Action {
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onCompletion: (Result<Void, Error>) -> Void )
 
-    case checkForUpdate(onCompletion: (Result<CardReaderSoftwareUpdate?, Error>) -> Void)
+    case checkForUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
+                        onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -21,4 +21,6 @@ public enum CardPresentPaymentAction: Action {
                         parameters: PaymentParameters,
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onCompletion: (Result<Void, Error>) -> Void )
+
+    case checkForUpdate(onCompletion: (Result<CardReaderSoftwareUpdate?, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -22,10 +22,10 @@ public enum CardPresentPaymentAction: Action {
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onCompletion: (Result<Void, Error>) -> Void )
 
-    case checkForUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
+    case checkForCardReaderUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
                         onCompletion: () -> Void)
 
-    case update(onProgress: (Float) -> Void,
+    case startCardReaderUpdate(onProgress: (Float) -> Void,
                         onCompletion: (Result<Void, Error>) -> Void)
 
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -24,4 +24,8 @@ public enum CardPresentPaymentAction: Action {
 
     case checkForUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
                         onCompletion: () -> Void)
+
+    case update(onProgress: (Float) -> Void,
+                        onCompletion: (Result<Void, Error>) -> Void)
+
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -97,6 +97,7 @@ public typealias WooAPIVersion = Networking.WooAPIVersion
 public typealias StoredProductSettings = Networking.StoredProductSettings
 public typealias CardReader = Hardware.CardReader
 public typealias CardReaderEvent = Hardware.CardReaderEvent
+public typealias CardReaderSoftwareUpdate = Hardware.CardReaderSoftwareUpdate
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -48,8 +48,8 @@ public final class CardPresentPaymentStore: Store {
                            parameters: parameters,
                            onCardReaderMessage: event,
                            onCompletion: completion)
-        case .checkForUpdate(onCompletion: let completion):
-            checkForUpdate(onCompletion: completion)
+        case .checkForUpdate(onData: let data, onCompletion: let completion):
+            checkForUpdate(onData: data, onCompletion: completion)
         }
     }
 }
@@ -117,16 +117,17 @@ private extension CardPresentPaymentStore {
         }.store(in: &cancellables)
     }
 
-    func checkForUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
+    func checkForUpdate(onData: @escaping (Result<CardReaderSoftwareUpdate, Error>) -> Void,
+                        onCompletion: @escaping () -> Void) {
         cardReaderService.checkForUpdate().sink(receiveCompletion: { value in
             switch value {
             case .failure(let error):
-                onCompletion(.failure(error))
+                onData(.failure(error))
             case .finished:
-                onCompletion(.success(nil))
+                onCompletion()
             }
         }, receiveValue: {softwareUpdate in
-            onCompletion(.success(softwareUpdate))
+            onData(.success(softwareUpdate))
         }).store(in: &cancellables)
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -48,10 +48,10 @@ public final class CardPresentPaymentStore: Store {
                            parameters: parameters,
                            onCardReaderMessage: event,
                            onCompletion: completion)
-        case .checkForUpdate(onData: let data, onCompletion: let completion):
-            checkForUpdate(onData: data, onCompletion: completion)
-        case .update(onProgress: let progress, onCompletion: let completion):
-            update(onProgress: progress, onCompletion: completion)
+        case .checkForCardReaderUpdate(onData: let data, onCompletion: let completion):
+            checkForCardReaderUpdate(onData: data, onCompletion: completion)
+        case .startCardReaderUpdate(onProgress: let progress, onCompletion: let completion):
+            startCardReaderUpdate(onProgress: progress, onCompletion: completion)
         }
     }
 }
@@ -119,7 +119,7 @@ private extension CardPresentPaymentStore {
         }.store(in: &cancellables)
     }
 
-    func checkForUpdate(onData: @escaping (Result<CardReaderSoftwareUpdate, Error>) -> Void,
+    func checkForCardReaderUpdate(onData: @escaping (Result<CardReaderSoftwareUpdate, Error>) -> Void,
                         onCompletion: @escaping () -> Void) {
         cardReaderService.checkForUpdate().sink(receiveCompletion: { value in
             switch value {
@@ -133,7 +133,7 @@ private extension CardPresentPaymentStore {
         }).store(in: &cancellables)
     }
 
-    func update(onProgress: @escaping (Float) -> Void,
+    func startCardReaderUpdate(onProgress: @escaping (Float) -> Void,
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
         cardReaderService.installUpdate().sink(receiveCompletion: { value in
             switch value {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -48,6 +48,8 @@ public final class CardPresentPaymentStore: Store {
                            parameters: parameters,
                            onCardReaderMessage: event,
                            onCompletion: completion)
+        case .checkForUpdate(onCompletion: let completion):
+            checkForUpdate(onCompletion: completion)
         }
     }
 }
@@ -114,6 +116,19 @@ private extension CardPresentPaymentStore {
         cardReaderService.readerEvents.sink { event in
             onCardReaderMessage(event)
         }.store(in: &cancellables)
+    }
+
+    func checkForUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
+        cardReaderService.checkForUpdate().sink(receiveCompletion: { value in
+            switch value {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .finished:
+                onCompletion(.success(nil))
+            }
+        }, receiveValue: {softwareUpdate in
+            onCompletion(.success(softwareUpdate))
+        }).store(in: &cancellables)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -29,7 +29,7 @@ final class MockCardReaderService: CardReaderService {
     }
 
     var softwareUpdateEvents: AnyPublisher<Float, Never> {
-        CurrentValueSubject<Float, Never>(.notReady).eraseToAnyPublisher()
+        CurrentValueSubject<Float, Never>(0).eraseToAnyPublisher()
     }
 
     /// Boolean flag Indicates that clients have called the start method
@@ -101,10 +101,14 @@ final class MockCardReaderService: CardReaderService {
     }
 
     func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error> {
-        <#code#>
+        Future() { promise in
+            // To be implemented
+        }
     }
 
     func installUpdate() -> Future<Void, Error> {
-        <#code#>
+        Future() { promise in
+            // To be implemented
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -28,6 +28,10 @@ final class MockCardReaderService: CardReaderService {
         PassthroughSubject<CardReaderEvent, Never>().eraseToAnyPublisher()
     }
 
+    var softwareUpdateEvents: AnyPublisher<Float, Never> {
+        CurrentValueSubject<Float, Never>(.notReady).eraseToAnyPublisher()
+    }
+
     /// Boolean flag Indicates that clients have called the start method
     var didHitStart = false
 
@@ -94,5 +98,13 @@ final class MockCardReaderService: CardReaderService {
         Future() { promise in
             // To be implemented
         }
+    }
+
+    func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error> {
+        <#code#>
+    }
+
+    func installUpdate() -> Future<Void, Error> {
+        <#code#>
     }
 }


### PR DESCRIPTION
Closes #3947 

⚠️⚠️⚠️⚠️ ONCE UPGRADED A HARDWARE READER CANNOT BE DOWNGRADED ⚠️⚠️⚠️⚠️
⚠️⚠️⚠️⚠️ BEST TO TEST WITH SIMULATORS MOSTLY - THEY CAN BE REPEATEDLY UPGRADED ⚠️⚠️⚠️⚠️

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Please note there are several parts of the implementation that are not production ready.⚠️

We continue building our prototype (for reference, p91TBi-4q4-p2), this time, by adding support for updating the reader software.

## Changes
* Add support in CardReaderService for updating the reader software. That means, adding two public methods (to check for updates and to trigger the actual update) and one publisher to be notified of the progress of the update)
* Add support in CardPresentPaymentStore for checking for updates and for triggering the update.

The PR also contains a couple of temporary updates to the UI, but those are only for testing this PR and will removed later.

## How to test
Testing is a bit complicated because:
1. Requires setting up a store for [Card Present Payment Testing](https://github.com/woocommerce/woocommerce-ios/blob/issue/3748-intent-service/docs/stripe-tests.md#integration-tests) (also P91TBi-4BH-p2 for more specific instructions)  
2. Requires an external hardware reader.

Once the store is setup and there is a hardware reader available:
1. Checkout the branch. Run `bundle exec pod install`. 
2. Build and run on a device. 
3. Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
4. Log in to an account that matches a store that has been configured for testing.
5. Navigate to Settings in the app. (Tap the gear button in the top right)
6. In the "Store Settings" section, tap "Manage Card Reader".
7. Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
8. Tap "Connect card reader"
9. Wait until the app suggests one reader to connect to.
10. Tap "Connect to reader"
11. Make sure the reader light turns solid blue.
12. Tap the detective icon in the top right toolbar. That should trigger the check for an update. Look at the logs in the console.
13. After checking for an update, tap the rocket icon. That will trigger the actual update. Look at the console. 

<img src="https://user-images.githubusercontent.com/2722505/114220382-eccd5f80-9939-11eb-8a7b-436ce3b9714d.png" width="350"/>


The console traces should look similar to this:
```
=== there is an update available
=== version  1.00.03.32-SZZZ_Generic_v37-300001
=== estimated time  betweenOneAndTwoMinutes
=== check for updates completed
==== progress  0.0
==== progress  0.0
==== progress  0.01
==== progress  0.02
==== progress  0.03
==== progress  0.04
==== progress  0.05
==== progress  0.06
==== progress  0.07
==== progress  0.08
==== progress  0.09
==== progress  0.1
==== progress  0.11
==== progress  0.12
==== progress  0.13
==== progress  0.14
==== progress  0.15
==== progress  0.16
==== progress  0.17
==== progress  0.18
==== progress  0.19
==== progress  0.2
==== progress  0.21
==== progress  0.22
==== progress  0.23
==== progress  0.24
==== progress  0.25
==== progress  0.26
==== progress  0.27
==== progress  0.28
==== progress  0.29
==== progress  0.3
==== progress  0.31
==== progress  0.32
==== progress  0.33
==== progress  0.34
==== progress  0.35
==== progress  0.36
==== progress  0.37
==== progress  0.38
==== progress  0.39
==== progress  0.4
==== progress  0.41
==== progress  0.42
==== progress  0.43
==== progress  0.44
==== progress  0.45
==== progress  0.46
==== progress  0.47
==== progress  0.48
==== progress  0.49
==== progress  0.5
==== progress  0.51
==== progress  0.52
==== progress  0.53
==== progress  0.54
==== progress  0.55
==== progress  0.56
==== progress  0.57
==== progress  0.58
==== progress  0.59
==== progress  0.6
==== progress  0.61
==== progress  0.62
==== progress  0.63
==== progress  0.64
==== progress  0.65
==== progress  0.66
==== progress  0.67
==== progress  0.68
==== progress  0.69
==== progress  0.7
==== progress  0.71
==== progress  0.72
==== progress  0.73
==== progress  0.74
==== progress  0.75
==== progress  0.76
==== progress  0.77
==== progress  0.78
==== progress  0.79
==== progress  0.8
==== progress  0.81
==== progress  0.82
==== progress  0.83
==== progress  0.84
==== progress  0.85
==== progress  0.86
==== progress  0.87
==== progress  0.88
==== progress  0.89
==== progress  0.9
==== progress  0.91
==== progress  0.92
==== progress  0.93
==== progress  0.94
==== progress  0.95
==== progress  0.96
==== progress  0.97
==== progress  0.98
==== progress  0.99
=== the update has been completed. Moving on!
```


* To test on the simulator, in StripeCardReaderService, change, on line 72, from: 
```
        let config = DiscoveryConfiguration(
            discoveryMethod: .bluetoothProximity,
            simulated: false
        )
```

to 
```
        let config = DiscoveryConfiguration(
            discoveryMethod: .bluetoothProximity,
            simulated: true
        )
```


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
