### PR TITLE
[Mobile Payments] Card Reader Settings Screen: UI Styles, Tab Bar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
@@ -98,7 +98,7 @@ final class CardReaderSettingsConnectView: NSObject {
 
     private func configureButton(cell: ButtonTableViewCell) {
         let buttonTitle = NSLocalizedString(
-            "Connect card reader",
+            "Connect Card Reader",
             comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
         )
         cell.configure(title: buttonTitle) { [weak self] in
@@ -147,10 +147,9 @@ private enum Row: CaseIterable {
     var height: CGFloat {
         switch self {
         case .connectHeader,
-             .connectButton:
+             .connectButton,
+             .connectImage:
             return UITableView.automaticDimension
-        case .connectImage:
-            return 250
         case .connectHelpHintChargeReader,
              .connectHelpHintTurnOnReader,
              .connectHelpHintEnableBluetooth,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
@@ -51,10 +51,7 @@ final class CardReaderSettingsConnectView: NSObject {
     }
 
     private func configureHeader(cell: TitleTableViewCell) {
-        cell.titleLabel?.text = NSLocalizedString(
-            "Connect your card reader",
-            comment: "Settings > Manage Card Reader > Prompt user to connect their first reader"
-        )
+        cell.titleLabel?.text = Localization.connectYourCardReaderTitle
         cell.selectionStyle = .none
     }
 
@@ -64,43 +61,25 @@ final class CardReaderSettingsConnectView: NSObject {
     }
 
     private func configureHelpHintChargeReader(cell: NumberedListItemTableViewCell) {
-        cell.numberLabel?.text = NSLocalizedString(
-            "1",
-            comment: "Settings > Manage Card Reader > Connect > Help hint number 1"
-        )
-        cell.itemTextLabel?.text = NSLocalizedString(
-            "Make sure card reader is charged",
-            comment: "Settings > Manage Card Reader > Connect > Hint to charge card reader")
+        cell.numberLabel?.text = Localization.hintOneTitle
+        cell.itemTextLabel?.text = Localization.hintOne
         cell.selectionStyle = .none
     }
 
     private func configureHelpHintTurnOnReader(cell: NumberedListItemTableViewCell) {
-        cell.numberLabel?.text = NSLocalizedString(
-            "2",
-            comment: "Settings > Manage Card Reader > Connect > Help hint number 2"
-        )
-        cell.itemTextLabel?.text = NSLocalizedString(
-            "Turn card reader on and place it next to mobile device",
-            comment: "Settings > Manage Card Reader > Connect > Hint to power on reader")
+        cell.numberLabel?.text = Localization.hintTwoTitle
+        cell.itemTextLabel?.text = Localization.hintTwo
         cell.selectionStyle = .none
     }
 
     private func configureHelpHintEnableBluetooth(cell: NumberedListItemTableViewCell) {
-        cell.numberLabel?.text = NSLocalizedString(
-            "3",
-            comment: "Settings > Manage Card Reader > Connect > Help hint number 3"
-        )
-        cell.itemTextLabel?.text = NSLocalizedString(
-            "Turn mobile device Bluetooth on",
-            comment: "Settings > Manage Card Reader > Connect > Hint to enable Bluetooth")
+        cell.numberLabel?.text = Localization.hintThreeTitle
+        cell.itemTextLabel?.text = Localization.hintThree
         cell.selectionStyle = .none
    }
 
     private func configureButton(cell: ButtonTableViewCell) {
-        let buttonTitle = NSLocalizedString(
-            "Connect Card Reader",
-            comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
-        )
+        let buttonTitle = Localization.connectButton
         cell.configure(title: buttonTitle) { [weak self] in
             self?.onPressedConnect?()
         }
@@ -108,10 +87,7 @@ final class CardReaderSettingsConnectView: NSObject {
     }
 
     private func configureLearnMore(cell: LearnMoreTableViewCell) {
-        cell.learnMoreLabel.text = NSLocalizedString(
-            "Learn more about accepting payments with your mobile device and ordering card readers",
-            comment: "Settings > Manage Card Reader > Connect > A prompt for new users to start accepting mobile payments"
-        )
+        cell.learnMoreLabel.text = Localization.learnMore
         cell.selectionStyle = .none
     }
 }
@@ -207,4 +183,51 @@ extension CardReaderSettingsConnectView: UITableViewDelegate {
             UIApplication.shared.open(url)
         }
     }
+}
+
+private enum Localization {
+    static let connectYourCardReaderTitle = NSLocalizedString(
+        "Connect your card reader",
+        comment: "Settings > Manage Card Reader > Prompt user to connect their first reader"
+    )
+
+    static let hintOneTitle = NSLocalizedString(
+        "1",
+        comment: "Settings > Manage Card Reader > Connect > Help hint number 1"
+    )
+
+    static let hintOne = NSLocalizedString(
+        "Make sure card reader is charged",
+        comment: "Settings > Manage Card Reader > Connect > Hint to charge card reader"
+    )
+
+    static let hintTwoTitle = NSLocalizedString(
+        "2",
+        comment: "Settings > Manage Card Reader > Connect > Help hint number 2"
+    )
+
+    static let hintTwo = NSLocalizedString(
+        "Turn card reader on and place it next to mobile device",
+        comment: "Settings > Manage Card Reader > Connect > Hint to power on reader"
+    )
+
+    static let hintThreeTitle = NSLocalizedString(
+        "3",
+        comment: "Settings > Manage Card Reader > Connect > Help hint number 3"
+    )
+
+    static let hintThree = NSLocalizedString(
+        "Turn mobile device Bluetooth on",
+        comment: "Settings > Manage Card Reader > Connect > Hint to enable Bluetooth"
+    )
+
+    static let connectButton = NSLocalizedString(
+        "Connect Card Reader",
+        comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
+    )
+
+    static let learnMore = NSLocalizedString(
+        "Learn more about accepting payments with your mobile device and ordering card readers",
+        comment: "Settings > Manage Card Reader > Connect > A prompt for new users to start accepting mobile payments"
+    )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -13,8 +13,16 @@ final class CardReaderSettingsViewController: UIViewController {
     private lazy var connectView = CardReaderSettingsConnectView()
     private lazy var connectedView = CardReaderSettingsConnectedReaderView()
 
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        /// We do not want to show the tabs on card reader settings screens
+        hidesBottomBarWhenPushed = true
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        /// Needed to avoid incorrect background appearing near bottom of view, especially on dark mode
+        view.backgroundColor = .systemBackground
         configureNavigation()
         setTableSource()
         setTableFooter()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -21,8 +21,7 @@ final class CardReaderSettingsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        /// Needed to avoid incorrect background appearing near bottom of view, especially on dark mode
-        view.backgroundColor = .systemBackground
+        configureView()
         configureNavigation()
         setTableSource()
         setTableFooter()
@@ -47,6 +46,11 @@ final class CardReaderSettingsViewController: UIViewController {
                 self?.tableView.reloadData()
             }
             .store(in: &subscriptions)
+    }
+
+    private func configureView() {
+        /// Needed to avoid incorrect background appearing near bottom of view, especially on dark mode
+        view.backgroundColor = .systemBackground
     }
 
     private func setTableSource() {
@@ -179,6 +183,13 @@ final class CardReaderSettingsViewController: UIViewController {
 private extension CardReaderSettingsViewController {
 
     func configureNavigation() {
-        title = NSLocalizedString("Manage Card Reader", comment: "Card reader settings screen title")
+        title = Localization.screenTitle
     }
+}
+
+private enum Localization {
+    static let screenTitle = NSLocalizedString(
+        "Manage Card Reader",
+        comment: "Card reader settings screen title"
+    )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewController.swift
@@ -171,6 +171,6 @@ final class CardReaderSettingsViewController: UIViewController {
 private extension CardReaderSettingsViewController {
 
     func configureNavigation() {
-        title = NSLocalizedString("Card Readers", comment: "Card reader settings screen title")
+        title = NSLocalizedString("Manage Card Reader", comment: "Card reader settings screen title")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -376,7 +376,6 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsViewController` from Dashboard storyboard")
         }
-        viewController.hidesBottomBarWhenPushed = true
         show(viewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -376,6 +376,7 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsViewController` from Dashboard storyboard")
         }
+        viewController.hidesBottomBarWhenPushed = true
         show(viewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleTableViewCell.xib
@@ -21,7 +21,7 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="90" id="H3J-Po-Bo0"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>


### PR DESCRIPTION
Partially addresses #3745 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

Changes:

- Change screen title to “Manage Card Reader”
- Use Headline font for “Connect your card reader”
- Image too big - should be 206 x 180px
- Title case on Button (should be “Connect Card Reader”)
- Hide Bottom Nav (Tab) Bar

Not included:
- Pink Learn more link

To test:
- Enter Settings and then Manage Card Reader
- Make sure you see all the changes above
- Repeat for light mode or dark mode:

After:

<img src="https://user-images.githubusercontent.com/1595739/114224844-7410d800-9926-11eb-90e7-4f8784e49f62.png" width=40%/>
<img src="https://user-images.githubusercontent.com/1595739/114224848-75420500-9926-11eb-9cb7-61be2bfe1add.png" width=40%/>

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
