### PR TITLE
AddOns: Cross-reference order attributes with product add-ons

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -27,9 +27,8 @@ struct AddOnCrossreferenceUseCase {
     }
 
     /// Tries to extract the `addOn` name from an attribute where it's format it's `"add-on-title (add-on-price)"`
-    /// Returns `nil` if the attribute does not have that format.
     ///
-    private func extractAddOnName(from attribute: OrderItemAttribute) -> String? {
+    private func extractAddOnName(from attribute: OrderItemAttribute) -> String {
         let splitToken = " ("
         let components = attribute.name.components(separatedBy: splitToken)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -1,1 +1,36 @@
 import Foundation
+import Yosemite
+
+/// Use case to cross-reference an order's items's attributes with a product's addOns list, to figure out which attributes of the order are real add ons.
+///
+struct AddOnCrossreferenceUseCase {
+
+    /// Order item with unknown attributes
+    ///
+    private let orderItem: AggregateOrderItem
+
+    /// Product entity with known addOns that matches the order item.
+    ///
+    private let product: Product
+
+    init(orderItem: AggregateOrderItem, product: Product) {
+        self.orderItem = orderItem
+        self.product = product
+    }
+
+    /// Returns the attributes of an `orderItem` that are `addOns` by cross-referencing the attribute name with the addOn name.
+    ///
+    func addOnsAttributes() -> [OrderItemAttribute] {
+        let addOnsAttributes = orderItem.attributes.filter { attribute in
+            product.addOns.contains { $0.name == extractAddOnName(from: attribute) }
+        }
+        return addOnsAttributes
+    }
+
+    /// Tries to extract the `addOn` name from an attribute where it's format it's `"add-on-title (add-on-price)"`
+    /// Returns `nil` if the attribute does not have that format.
+    ///
+    private func extractAddOnName(from attribute: OrderItemAttribute) -> String? {
+        attribute.name.components(separatedBy: " (").first
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -21,10 +21,9 @@ struct AddOnCrossreferenceUseCase {
     /// Returns the attributes of an `orderItem` that are `addOns` by cross-referencing the attribute name with the addOn name.
     ///
     func addOnsAttributes() -> [OrderItemAttribute] {
-        let addOnsAttributes = orderItem.attributes.filter { attribute in
+        orderItem.attributes.filter { attribute in
             product.addOns.contains { $0.name == extractAddOnName(from: attribute) }
         }
-        return addOnsAttributes
     }
 
     /// Tries to extract the `addOn` name from an attribute where it's format it's `"add-on-title (add-on-price)"`

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -31,6 +31,11 @@ struct AddOnCrossreferenceUseCase {
     /// Returns `nil` if the attribute does not have that format.
     ///
     private func extractAddOnName(from attribute: OrderItemAttribute) -> String? {
-        attribute.name.components(separatedBy: " (").first
+        let splitToken = " ("
+        let components = attribute.name.components(separatedBy: splitToken)
+
+        // In case there are more `" ("` occurrences in the string, drop the last one assuming its the add-on price,
+        // and join the remaining components to keep the original name integrity
+        return components.dropLast().joined(separator: splitToken)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
+		265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */; };
 		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
 		265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */; };
 		265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
@@ -1552,6 +1553,7 @@
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
+		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
 		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryListViewController.xib; sourceTree = "<group>"; };
 		265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModel.swift; sourceTree = "<group>"; };
@@ -3273,6 +3275,15 @@
 			path = AddOns;
 			sourceTree = "<group>";
 		};
+		265284072624ACAF00F91BA1 /* AddOns */ = {
+			isa = PBXGroup;
+			children = (
+				265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */,
+			);
+			name = AddOns;
+			path = "Order Details/AddOns";
+			sourceTree = "<group>";
+		};
 		265BCA032430E5EA004E53EE /* Edit Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -3882,6 +3893,7 @@
 		57F34A9F2423D44000E38AFB /* Orders */ = {
 			isa = PBXGroup;
 			children = (
+				265284072624ACAF00F91BA1 /* AddOns */,
 				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
@@ -6627,6 +6639,7 @@
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				0215C6FC2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift in Sources */,
+				265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */,
 				265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift in Sources */,
 				4590B652261C8D1E00A6FCE0 /* WeightFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
+		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
 		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
 		265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */; };
 		265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
@@ -1550,6 +1551,7 @@
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
+		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryListViewController.xib; sourceTree = "<group>"; };
 		265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModel.swift; sourceTree = "<group>"; };
@@ -3261,6 +3263,14 @@
 			);
 			name = "Add Attributes";
 			path = "Variations/Add Attributes";
+			sourceTree = "<group>";
+		};
+		265284002624933B00F91BA1 /* AddOns */ = {
+			isa = PBXGroup;
+			children = (
+				265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */,
+			);
+			path = AddOns;
 			sourceTree = "<group>";
 		};
 		265BCA032430E5EA004E53EE /* Edit Categories */ = {
@@ -5298,6 +5308,7 @@
 		D817585C22BB5E6900289CFE /* Order Details */ = {
 			isa = PBXGroup;
 			children = (
+				265284002624933B00F91BA1 /* AddOns */,
 				CECC758F23D226AC00486676 /* Aggregate Order Items */,
 				CECC758E23D2266300486676 /* Refund Details */,
 				CECC758D23D2260E00486676 /* Refunded Products */,
@@ -6012,6 +6023,7 @@
 				57C503DC23E8C70C00EC0790 /* OrdersTabbedViewController.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
+				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,
 				451A9963260E31480059D135 /* ShippingLabelPackageDetailsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
@@ -7,13 +7,13 @@ import Fakes
 
 class AddOnCrossreferenceTests: XCTestCase {
 
-    func tests_addOn_attributes_are_correctly_filtered_agains_product_addOns() {
+    func tests_addOn_attributes_are_correctly_filtered_against_product_addOns() {
         // Given
         let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
             OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
-            OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
-            OrderItemAttribute(metaID: 4, name: "NotOnProduct (%7.00)", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
+            OrderItemAttribute(metaID: 4, name: "NotOnProduct ($7.00)", value: ""),
         ])
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Fast Delivery"),
@@ -28,7 +28,26 @@ class AddOnCrossreferenceTests: XCTestCase {
         // Then
         XCTAssertEqual(addOnsAttributes, [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
-            OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
+        ])
+    }
+
+    func tests_addOn_attributes_with_special_characters_in_name_are_correctly_filtered_against_product_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 3, name: "Fast (really) Delivery (fast) ($7.00)", value: ""),
+        ])
+        let product = Product.fake().copy(addOns: [
+            ProductAddOn.fake().copy(name: "Fast (really) Delivery (fast)"),
+        ])
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertEqual(addOnsAttributes, [
+            OrderItemAttribute(metaID: 3, name: "Fast (really) Delivery (fast) ($7.00)", value: ""),
         ])
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Fakes
+
+@testable import WooCommerce
+@testable import Yosemite
+@testable import Networking
+
+class AddOnCrossreferenceTests: XCTestCase {
+
+    func tests_addOn_attributes_are_correctly_filtered_agains_product_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
+            OrderItemAttribute(metaID: 4, name: "NotOnProduct (%7.00)", value: ""),
+        ])
+        let product = Product.fake().copy(addOns: [
+            ProductAddOn.fake().copy(name: "Fast Delivery"),
+            ProductAddOn.fake().copy(name: "Topping"),
+            ProductAddOn.fake().copy(name: "Schedule"),
+        ])
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertEqual(addOnsAttributes, [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
+        ])
+    }
+
+    func tests_addOnAttributes_is_empty_when_product_does_not_have_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
+            OrderItemAttribute(metaID: 4, name: "NotOnProduct (%7.00)", value: ""),
+        ])
+        let product = Product.fake()
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertTrue(addOnsAttributes.isEmpty)
+    }
+
+    func tests_addOnAttributes_is_empty_when_orderItem_does_not_have_attributes() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem()
+        let product = Product.fake().copy(addOns: [
+            ProductAddOn.fake().copy(name: "Fast Delivery"),
+            ProductAddOn.fake().copy(name: "Topping"),
+            ProductAddOn.fake().copy(name: "Schedule"),
+        ])
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertTrue(addOnsAttributes.isEmpty)
+    }
+}


### PR DESCRIPTION
closes #3887 

# Why

As you may know(p91TBi-4MK-p2), add-on information for orders is disguised as raw order item attributes. In order to know which attribute from an order is an add-on, we need to cross-reference the attribute name with the add-on name.

This PR creates a `UseCase` whose responsibility is to filter order item's attributes that are real add-on attributes. 

# How

- Added `AddOnCrossreferenceUseCase` that receives an `AggregatedorderItem` and a `Product`. This use case has an `addOnsAttributes()` method that infers the `AggregatedorderItem.attributes` names and checks if they exist on the product add-on's list.

- The method that infers the `AggregatedorderItem.attributes` names is a simple heuristic that takes a string with the format `"add-on-title (add-on-price)"` and takes out the last part of the string by splitting it via the `" ("` token.

# Testing Steps
- I've added new tests, so make sure the CI is green!


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
