### PR TITLE
Shipping Labels: Networking layer for account settings endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -366,6 +366,9 @@
 		CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */; };
 		CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */; };
 		CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */; };
+		CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */; };
+		CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */; };
+		CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -825,6 +828,9 @@
 		CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethod.swift; sourceTree = "<group>"; };
 		CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentCardType.swift; sourceTree = "<group>"; };
 		CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapper.swift; sourceTree = "<group>"; };
+		CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-account-settings.json"; sourceTree = "<group>"; };
+		CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-account-settings-no-payment-methods.json"; sourceTree = "<group>"; };
+		CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapperTests.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -1450,6 +1456,8 @@
 				45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */,
 				45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */,
 				CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */,
+				CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */,
+				CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */,
 				B56C1EB920EA7D2C00D749F9 /* sites.json */,
 				7426CA1221AF34A3004E9FFC /* site-api.json */,
 				74AB5B4E21AF3F0D00859C12 /* site-api-no-woo.json */,
@@ -1631,6 +1639,7 @@
 				02698CF724C183A5005337C4 /* ProductVariationListMapperTests.swift */,
 				020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */,
 				451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */,
+				CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 			);
 			path = Mapper;
@@ -1793,6 +1802,7 @@
 				74C8F07020EEC3A800B6EDC9 /* broken-notes.json in Resources */,
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
+				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */,
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
@@ -1805,6 +1815,7 @@
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
+				CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
@@ -2247,6 +2258,7 @@
 				262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
+				CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */,
 				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,
 				4599FC5A24A626B70056157A /* ProductTagListMapperTests.swift in Sources */,
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -362,6 +362,9 @@
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
+		CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */; };
+		CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */; };
+		CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -817,6 +820,9 @@
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
+		CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
+		CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethod.swift; sourceTree = "<group>"; };
+		CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentCardType.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -938,10 +944,12 @@
 				02C254B525637A8300A04423 /* Enums */,
 				029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */,
 				02C254A7256373AB00A04423 /* ShippingLabel.swift */,
+				CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */,
 				02C2549925636E1500A04423 /* ShippingLabelAddress.swift */,
 				457A573F25D1817E000797AD /* ShippingLabelAddressVerification.swift */,
 				45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */,
 				45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */,
+				CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 				451A97C72609FDE50059D135 /* Packages */,
@@ -955,6 +963,7 @@
 				02C2548325635BD000A04423 /* ShippingLabelPaperSize.swift */,
 				02C254AB2563781800A04423 /* ShippingLabelStatus.swift */,
 				02C254AF256378D000A04423 /* ShippingLabelRefundStatus.swift */,
+				CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2031,6 +2040,7 @@
 				26E83A022554683A00390DD9 /* GeneratedFakeable.swift in Sources */,
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
+				CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
 				57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */,
@@ -2127,6 +2137,7 @@
 				B5C6FCCF20A3592900A4F8E4 /* OrderItem.swift in Sources */,
 				02C254A025636F6900A04423 /* ShippingLabelRefund.swift in Sources */,
 				26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */,
+				CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */,
 				26455E2725F669EA008A1D32 /* ProductAttributeTermListMapper.swift in Sources */,
 				B524193F21AC5FE400D6FC0A /* DotcomDeviceMapper.swift in Sources */,
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
@@ -2172,6 +2183,7 @@
 				45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
+				CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */; };
 		CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */; };
 		CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */; };
+		CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -823,6 +824,7 @@
 		CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethod.swift; sourceTree = "<group>"; };
 		CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentCardType.swift; sourceTree = "<group>"; };
+		CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapper.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -1530,6 +1532,7 @@
 				029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */,
 				021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationResponseMapper.swift */,
+				CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2150,6 +2153,7 @@
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
+				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Mapper: Shipping Label Account Settings
+///
+struct ShippingLabelAccountSettingsMapper: Mapper {
+    /// (Attempts) to convert a dictionary into ShippingLabelAccountSettings.
+    ///
+    func map(response: Data) throws -> ShippingLabelAccountSettings {
+        let decoder = JSONDecoder()
+        return try decoder.decode(ShippingLabelAccountSettingsMapperEnvelope.self, from: response).data
+    }
+}
+
+/// ShippingLabelAccountSettingsMapperEnvelope Disposable Entity:
+/// `Shipping Label Account Settings` endpoint returns the shipping label account settings in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct ShippingLabelAccountSettingsMapperEnvelope: Decodable {
+    let data: ShippingLabelAccountSettings
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}

--- a/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
@@ -3,11 +3,19 @@ import Foundation
 /// Mapper: Shipping Label Account Settings
 ///
 struct ShippingLabelAccountSettingsMapper: Mapper {
+    /// Site Identifier associated to the stats that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID.
+    ///
+    let siteID: Int64
+
     /// (Attempts) to convert a dictionary into ShippingLabelAccountSettings.
     ///
     func map(response: Data) throws -> ShippingLabelAccountSettings {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.yearMonthDayDateFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
 
         return try decoder.decode(ShippingLabelAccountSettingsMapperEnvelope.self, from: response).data
     }

--- a/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelAccountSettingsMapper.swift
@@ -7,6 +7,8 @@ struct ShippingLabelAccountSettingsMapper: Mapper {
     ///
     func map(response: Data) throws -> ShippingLabelAccountSettings {
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.yearMonthDayDateFormatter)
+
         return try decoder.decode(ShippingLabelAccountSettingsMapperEnvelope.self, from: response).data
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaymentCardType.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaymentCardType.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// The supported card types for Shipping Label Payment Methods.
+///
+public enum ShippingLabelPaymentCardType: GeneratedFakeable {
+    case amex
+    case discover
+    case mastercard
+    case visa
+    case paypal
+}
+
+/// RawRepresentable Conformance
+extension ShippingLabelPaymentCardType: RawRepresentable {
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.amex:
+            self = .amex
+        case Keys.discover:
+            self = .discover
+        case Keys.mastercard:
+            self = .mastercard
+        case Keys.visa:
+            self = .visa
+        case Keys.paypal:
+            self = .paypal
+        default:
+            assertionFailure("Unexpected value for `ShippingLabelPaymentCardType`: \(rawValue)")
+            self = .amex
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .amex:
+            return Keys.amex
+        case .discover:
+            return Keys.discover
+        case .mastercard:
+            return Keys.mastercard
+        case .visa:
+            return Keys.visa
+        case .paypal:
+            return Keys.paypal
+        }
+    }
+}
+
+/// Contains the supported ShippingLabelPaymentCardType values.
+private enum Keys {
+    static let amex = "amex"
+    static let discover = "discover"
+    static let mastercard = "mastercard"
+    static let visa = "visa"
+    static let paypal = "paypal"
+}

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaymentCardType.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelPaymentCardType.swift
@@ -2,59 +2,10 @@ import Foundation
 
 /// The supported card types for Shipping Label Payment Methods.
 ///
-public enum ShippingLabelPaymentCardType: GeneratedFakeable {
+public enum ShippingLabelPaymentCardType: String, Decodable, GeneratedFakeable {
     case amex
     case discover
     case mastercard
     case visa
     case paypal
-}
-
-/// RawRepresentable Conformance
-extension ShippingLabelPaymentCardType: RawRepresentable {
-    /// Designated Initializer.
-    ///
-    public init(rawValue: String) {
-        switch rawValue {
-        case Keys.amex:
-            self = .amex
-        case Keys.discover:
-            self = .discover
-        case Keys.mastercard:
-            self = .mastercard
-        case Keys.visa:
-            self = .visa
-        case Keys.paypal:
-            self = .paypal
-        default:
-            assertionFailure("Unexpected value for `ShippingLabelPaymentCardType`: \(rawValue)")
-            self = .amex
-        }
-    }
-
-    /// Returns the current Enum Case's Raw Value
-    ///
-    public var rawValue: String {
-        switch self {
-        case .amex:
-            return Keys.amex
-        case .discover:
-            return Keys.discover
-        case .mastercard:
-            return Keys.mastercard
-        case .visa:
-            return Keys.visa
-        case .paypal:
-            return Keys.paypal
-        }
-    }
-}
-
-/// Contains the supported ShippingLabelPaymentCardType values.
-private enum Keys {
-    static let amex = "amex"
-    static let discover = "discover"
-    static let mastercard = "mastercard"
-    static let visa = "visa"
-    static let paypal = "paypal"
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Represents Account Settings for Shipping Labels.
+///
+public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
+    /// Whether the current user can make changes to the payments section.
+    public let canManagePayments: Bool
+
+    /// Whether the current user can edit non-payment settings.
+    public let canEditSettings: Bool
+
+    /// Store owner's display name.
+    public let storeOwnerDisplayName: String
+
+    /// Store owner's username.
+    public let storeOwnerUsername: String
+
+    /// Store owner's WordPress.com username.
+    public let storeOwnerWpcomUsername: String
+
+    /// Store owner's WordPress.com email.
+    public let storeOwnerWpcomEmail: String
+
+    /// Available payment methods for the store.
+    /// This is an empty array if there are no payment methods available.
+    public let paymentMethods: [ShippingLabelPaymentMethod]
+
+    /// Selected payment method.
+    /// This is `0` if no payment method is available.
+    public let selectedPaymentMethodID: Int64
+
+    /// Whether receipts for shipping label purchases should be emailed to the store owner.
+    public let isEmailReceiptsEnabled: Bool
+
+    /// Default paper size for shipping labels.
+    public let paperSize: ShippingLabelPaperSize
+
+    /// The last selected package for shipping labels.
+    /// Uses the `id` for predefined packages or `name` for custom packages.
+    public let lastSelectedPackageID: String
+
+    public init(canManagePayments: Bool,
+                canEditSettings: Bool,
+                storeOwnerDisplayName: String,
+                storeOwnerUsername: String,
+                storeOwnerWpcomUsername: String,
+                storeOwnerWpcomEmail: String,
+                paymentMethods: [ShippingLabelPaymentMethod],
+                selectedPaymentMethodID: Int64,
+                isEmailReceiptsEnabled: Bool,
+                paperSize: ShippingLabelPaperSize,
+                lastSelectedPackageID: String) {
+        self.canManagePayments = canManagePayments
+        self.canEditSettings = canEditSettings
+        self.storeOwnerDisplayName = storeOwnerDisplayName
+        self.storeOwnerUsername = storeOwnerUsername
+        self.storeOwnerWpcomUsername = storeOwnerWpcomUsername
+        self.storeOwnerWpcomEmail = storeOwnerWpcomEmail
+        self.paymentMethods = paymentMethods
+        self.selectedPaymentMethodID = selectedPaymentMethodID
+        self.isEmailReceiptsEnabled = isEmailReceiptsEnabled
+        self.paperSize = paperSize
+        self.lastSelectedPackageID = lastSelectedPackageID
+    }
+}
+
+extension ShippingLabelAccountSettings: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let formMetaContainer = try container.nestedContainer(keyedBy: FormMetaKeys.self, forKey: .formMeta)
+        let canManagePayments = try formMetaContainer.decode(Bool.self, forKey: .canManagePayments)
+        let canEditSettings = try formMetaContainer.decode(Bool.self, forKey: .canEditSettings)
+        let storeOwnerDisplayName = try formMetaContainer.decode(String.self, forKey: .storeOwnerDisplayName)
+        let storeOwnerUsername = try formMetaContainer.decode(String.self, forKey: .storeOwnerUsername)
+        let storeOwnerWpcomUsername = try formMetaContainer.decode(String.self, forKey: .storeOwnerWpcomUsername)
+        let storeOwnerWpcomEmail = try formMetaContainer.decode(String.self, forKey: .storeOwnerWpcomEmail)
+        let paymentMethods = try formMetaContainer.decodeIfPresent([ShippingLabelPaymentMethod].self, forKey: .paymentMethods) ?? []
+
+        let formDataContainer = try container.nestedContainer(keyedBy: FormDataKeys.self, forKey: .formData)
+        let selectedPaymentMethodID = try formDataContainer.decode(Int64.self, forKey: .selectedPaymentMethodID)
+        let isEmailReceiptsEnabled = try formDataContainer.decode(Bool.self, forKey: .isEmailReceiptsEnabled)
+        let paperSizeRawValue = try formDataContainer.decode(String.self, forKey: .paperSize)
+        let paperSize = ShippingLabelPaperSize(rawValue: paperSizeRawValue)
+
+        let userMetaContainer = try container.nestedContainer(keyedBy: UserMetaKeys.self, forKey: .userMeta)
+        let lastSelectedPackageID = try userMetaContainer.decode(String.self, forKey: .lastSelectedPackageID)
+
+        self.init(canManagePayments: canManagePayments,
+                  canEditSettings: canEditSettings,
+                  storeOwnerDisplayName: storeOwnerDisplayName,
+                  storeOwnerUsername: storeOwnerUsername,
+                  storeOwnerWpcomUsername: storeOwnerWpcomUsername,
+                  storeOwnerWpcomEmail: storeOwnerWpcomEmail,
+                  paymentMethods: paymentMethods,
+                  selectedPaymentMethodID: selectedPaymentMethodID,
+                  isEmailReceiptsEnabled: isEmailReceiptsEnabled,
+                  paperSize: paperSize,
+                  lastSelectedPackageID: lastSelectedPackageID)
+    }
+}
+
+/// Defines all of the ShippingLabelAccountSettings CodingKeys
+///
+private extension ShippingLabelAccountSettings {
+    private enum CodingKeys: String, CodingKey {
+        case formData
+        case formMeta
+        case userMeta
+    }
+
+    private enum FormDataKeys: String, CodingKey {
+        case selectedPaymentMethodID = "selected_payment_method_id"
+        case isEmailReceiptsEnabled = "email_receipts"
+        case paperSize = "paper_size"
+    }
+
+    private enum FormMetaKeys: String, CodingKey {
+        case canManagePayments = "can_manage_payments"
+        case canEditSettings = "can_edit_settings"
+        case storeOwnerDisplayName = "master_user_name"
+        case storeOwnerUsername = "master_user_login"
+        case storeOwnerWpcomUsername = "master_user_wpcom_login"
+        case storeOwnerWpcomEmail = "master_user_email"
+        case paymentMethods = "payment_methods"
+    }
+
+    private enum UserMetaKeys: String, CodingKey {
+        case lastSelectedPackageID = "last_box_id"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Represents Account Settings for Shipping Labels.
 ///
 public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
+    /// Remote Site ID.
+    public let siteID: Int64
+
     /// Whether the current user can make changes to the payments section.
     public let canManagePayments: Bool
 
@@ -39,7 +42,8 @@ public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
     /// Uses the `id` for predefined packages or `name` for custom packages.
     public let lastSelectedPackageID: String
 
-    public init(canManagePayments: Bool,
+    public init(siteID: Int64,
+                canManagePayments: Bool,
                 canEditSettings: Bool,
                 storeOwnerDisplayName: String,
                 storeOwnerUsername: String,
@@ -50,6 +54,7 @@ public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
                 isEmailReceiptsEnabled: Bool,
                 paperSize: ShippingLabelPaperSize,
                 lastSelectedPackageID: String) {
+        self.siteID = siteID
         self.canManagePayments = canManagePayments
         self.canEditSettings = canEditSettings
         self.storeOwnerDisplayName = storeOwnerDisplayName
@@ -66,6 +71,10 @@ public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
 
 extension ShippingLabelAccountSettings: Decodable {
     public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ShippingLabelAccountSettingsDecodingError.missingSiteID
+        }
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let formMetaContainer = try container.nestedContainer(keyedBy: FormMetaKeys.self, forKey: .formMeta)
@@ -86,7 +95,8 @@ extension ShippingLabelAccountSettings: Decodable {
         let userMetaContainer = try container.nestedContainer(keyedBy: UserMetaKeys.self, forKey: .userMeta)
         let lastSelectedPackageID = try userMetaContainer.decode(String.self, forKey: .lastSelectedPackageID)
 
-        self.init(canManagePayments: canManagePayments,
+        self.init(siteID: siteID,
+                  canManagePayments: canManagePayments,
                   canEditSettings: canEditSettings,
                   storeOwnerDisplayName: storeOwnerDisplayName,
                   storeOwnerUsername: storeOwnerUsername,
@@ -128,4 +138,10 @@ private extension ShippingLabelAccountSettings {
     private enum UserMetaKeys: String, CodingKey {
         case lastSelectedPackageID = "last_box_id"
     }
+}
+
+// MARK: - Decoding Errors
+//
+enum ShippingLabelAccountSettingsDecodingError: Error {
+    case missingSiteID
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
@@ -16,13 +16,13 @@ public struct ShippingLabelPaymentMethod: Equatable, GeneratedFakeable {
     public let cardDigits: String
 
     /// The expiry date for the payment method.
-    public let expiry: String
+    public let expiry: Date?
 
     public init(paymentMethodID: Int64,
                 name: String,
                 cardType: ShippingLabelPaymentCardType,
                 cardDigits: String,
-                expiry: String) {
+                expiry: Date?) {
         self.paymentMethodID = paymentMethodID
         self.name = name
         self.cardType = cardType
@@ -40,7 +40,7 @@ extension ShippingLabelPaymentMethod: Decodable {
         let cardTypeRawValue = try container.decode(String.self, forKey: .cardType)
         let cardType = ShippingLabelPaymentCardType(rawValue: cardTypeRawValue)
         let cardDigits = try container.decode(String.self, forKey: .cardDigits)
-        let expiry = try container.decode(String.self, forKey: .expiry)
+        let expiry = try container.decode(Date.self, forKey: .expiry)
 
         self.init(paymentMethodID: paymentMethodID, name: name, cardType: cardType, cardDigits: cardDigits, expiry: expiry)
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
@@ -37,8 +37,7 @@ extension ShippingLabelPaymentMethod: Decodable {
 
         let paymentMethodID = try container.decode(Int64.self, forKey: .paymentMethodID)
         let name = try container.decode(String.self, forKey: .name)
-        let cardTypeRawValue = try container.decode(String.self, forKey: .cardType)
-        let cardType = ShippingLabelPaymentCardType(rawValue: cardTypeRawValue)
+        let cardType = try container.decode(ShippingLabelPaymentCardType.self, forKey: .cardType)
         let cardDigits = try container.decode(String.self, forKey: .cardDigits)
         let expiry = try container.decode(Date.self, forKey: .expiry)
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a Shipping Label Payment Method.
+///
+public struct ShippingLabelPaymentMethod: Equatable, GeneratedFakeable {
+    /// The remote ID for the payment method.
+    public let paymentMethodID: Int64
+
+    /// The billing name for the payment method.
+    public let name: String
+
+    /// The card type for the payment method.
+    public let cardType: ShippingLabelPaymentCardType
+
+    /// The last card digits for the payment method.
+    public let cardDigits: Int64
+
+    /// The expiry date for the payment method.
+    public let expiry: Date
+
+    public init(paymentMethodID: Int64,
+                name: String,
+                cardType: ShippingLabelPaymentCardType,
+                cardDigits: Int64,
+                expiry: Date) {
+        self.paymentMethodID = paymentMethodID
+        self.name = name
+        self.cardType = cardType
+        self.cardDigits = cardDigits
+        self.expiry = expiry
+    }
+}
+
+extension ShippingLabelPaymentMethod: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let paymentMethodID = try container.decode(Int64.self, forKey: .paymentMethodID)
+        let name = try container.decode(String.self, forKey: .name)
+        let cardTypeRawValue = try container.decode(String.self, forKey: .cardType)
+        let cardType = ShippingLabelPaymentCardType(rawValue: cardTypeRawValue)
+        let cardDigits = try container.decode(Int64.self, forKey: .cardDigits)
+        let expiry = try container.decode(Date.self, forKey: .expiry)
+
+        self.init(paymentMethodID: paymentMethodID, name: name, cardType: cardType, cardDigits: cardDigits, expiry: expiry)
+    }
+}
+
+/// Defines all of the ShippingLabelPaymentMethod CodingKeys
+///
+private extension ShippingLabelPaymentMethod {
+    private enum CodingKeys: String, CodingKey {
+        case paymentMethodID = "payment_method_id"
+        case name
+        case cardType = "card_type"
+        case cardDigits = "card_digits"
+        case expiry
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPaymentMethod.swift
@@ -13,16 +13,16 @@ public struct ShippingLabelPaymentMethod: Equatable, GeneratedFakeable {
     public let cardType: ShippingLabelPaymentCardType
 
     /// The last card digits for the payment method.
-    public let cardDigits: Int64
+    public let cardDigits: String
 
     /// The expiry date for the payment method.
-    public let expiry: Date
+    public let expiry: String
 
     public init(paymentMethodID: Int64,
                 name: String,
                 cardType: ShippingLabelPaymentCardType,
-                cardDigits: Int64,
-                expiry: Date) {
+                cardDigits: String,
+                expiry: String) {
         self.paymentMethodID = paymentMethodID
         self.name = name
         self.cardType = cardType
@@ -39,8 +39,8 @@ extension ShippingLabelPaymentMethod: Decodable {
         let name = try container.decode(String.self, forKey: .name)
         let cardTypeRawValue = try container.decode(String.self, forKey: .cardType)
         let cardType = ShippingLabelPaymentCardType(rawValue: cardTypeRawValue)
-        let cardDigits = try container.decode(Int64.self, forKey: .cardDigits)
-        let expiry = try container.decode(Date.self, forKey: .expiry)
+        let cardDigits = try container.decode(String.self, forKey: .cardDigits)
+        let expiry = try container.decode(String.self, forKey: .expiry)
 
         self.init(paymentMethodID: paymentMethodID, name: name, cardType: cardType, cardDigits: cardDigits, expiry: expiry)
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Represents Shipping Label Settings.
+/// Represents Shipping Label Settings for an order.
 ///
 public struct ShippingLabelSettings: Equatable, GeneratedFakeable {
     public let siteID: Int64

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -132,7 +132,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     public func loadShippingLabelAccountSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
         let path = Path.accountSettings
         let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path)
-        let mapper = ShippingLabelAccountSettingsMapper()
+        let mapper = ShippingLabelAccountSettingsMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
 }

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -19,7 +19,7 @@ public protocol ShippingLabelRemoteProtocol {
     func createPackage(siteID: Int64,
                        customPackage: ShippingLabelCustomPackage,
                        completion: @escaping (Result<Bool, Error>) -> Void)
-    func loadShippingLabelSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void)
+    func loadShippingLabelAccountSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -129,7 +129,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     /// - Parameters:
     ///   - siteID: Remote ID of the site.
     ///   - completion: Closure to be executed upon completion.
-    public func loadShippingLabelSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
+    public func loadShippingLabelAccountSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
         let path = Path.accountSettings
         let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path)
         let mapper = ShippingLabelAccountSettingsMapper()

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -19,6 +19,7 @@ public protocol ShippingLabelRemoteProtocol {
     func createPackage(siteID: Int64,
                        customPackage: ShippingLabelCustomPackage,
                        completion: @escaping (Result<Bool, Error>) -> Void)
+    func loadShippingLabelSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -123,6 +124,17 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Loads account-level shipping label settings for a store.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadShippingLabelSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
+        let path = Path.accountSettings
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path)
+        let mapper = ShippingLabelAccountSettingsMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: Constant
@@ -131,6 +143,7 @@ private extension ShippingLabelRemote {
         static let shippingLabels = "label"
         static let normalizeAddress = "normalize-address"
         static let packages = "packages"
+        static let accountSettings = "account/settings"
     }
 
     enum ParameterKey {

--- a/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
@@ -6,6 +6,9 @@ import XCTest
 ///
 class ShippingLabelAccountSettingsMapperTests: XCTestCase {
 
+    /// Sample Site ID
+    private let sampleSiteID: Int64 = 123456
+
     /// Verifies that the Shipping Label Account Settings are parsed correctly.
     ///
     func test_Account_Settings_are_properly_parsed() {
@@ -14,6 +17,7 @@ class ShippingLabelAccountSettingsMapperTests: XCTestCase {
             return
         }
 
+        XCTAssertEqual(settings.siteID, sampleSiteID)
         XCTAssertEqual(settings.canEditSettings, true)
         XCTAssertEqual(settings.canManagePayments, true)
         XCTAssertEqual(settings.isEmailReceiptsEnabled, true)
@@ -35,6 +39,7 @@ class ShippingLabelAccountSettingsMapperTests: XCTestCase {
             return
         }
 
+        XCTAssertEqual(settings.siteID, sampleSiteID)
         XCTAssertEqual(settings.canEditSettings, true)
         XCTAssertEqual(settings.canManagePayments, false)
         XCTAssertEqual(settings.isEmailReceiptsEnabled, true)
@@ -61,7 +66,7 @@ private extension ShippingLabelAccountSettingsMapperTests {
             return nil
         }
 
-        return try! ShippingLabelAccountSettingsMapper().map(response: response)
+        return try! ShippingLabelAccountSettingsMapper(siteID: sampleSiteID).map(response: response)
     }
 
     /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings`

--- a/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
@@ -83,6 +83,6 @@ private extension ShippingLabelAccountSettingsMapperTests {
                                           name: "Example User",
                                           cardType: .visa,
                                           cardDigits: "4242",
-                                          expiry: "2030-12-31")
+                                          expiry: DateFormatter.Defaults.yearMonthDayDateFormatter.date(from: "2030-12-31"))
     }
 }

--- a/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelAccountSettingsMapperTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ShippingLabelAccountSettingsMapper`
+///
+class ShippingLabelAccountSettingsMapperTests: XCTestCase {
+
+    /// Verifies that the Shipping Label Account Settings are parsed correctly.
+    ///
+    func test_Account_Settings_are_properly_parsed() {
+        guard let settings = mapLoadShippingLabelAccountSettings() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(settings.canEditSettings, true)
+        XCTAssertEqual(settings.canManagePayments, true)
+        XCTAssertEqual(settings.isEmailReceiptsEnabled, true)
+        XCTAssertEqual(settings.lastSelectedPackageID, "small_flat_box")
+        XCTAssertEqual(settings.paperSize, .label)
+        XCTAssertEqual(settings.paymentMethods, [sampleShippingLabelPaymentMethod()])
+        XCTAssertEqual(settings.selectedPaymentMethodID, 11743265)
+        XCTAssertEqual(settings.storeOwnerDisplayName, "Example User")
+        XCTAssertEqual(settings.storeOwnerUsername, "admin")
+        XCTAssertEqual(settings.storeOwnerWpcomEmail, "example@example.com")
+        XCTAssertEqual(settings.storeOwnerWpcomUsername, "apiexamples")
+    }
+
+    /// Verifies that the Shipping Label Account Settings without any payment methods are parsed correctly.
+    ///
+    func test_Account_Settings_without_payment_methods_are_properly_parsed() {
+        guard let settings = mapLoadIncompleteShippingLabelAccountSettings() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(settings.canEditSettings, true)
+        XCTAssertEqual(settings.canManagePayments, false)
+        XCTAssertEqual(settings.isEmailReceiptsEnabled, true)
+        XCTAssertEqual(settings.lastSelectedPackageID, "")
+        XCTAssertEqual(settings.paperSize, .label)
+        XCTAssertEqual(settings.paymentMethods, [])
+        XCTAssertEqual(settings.selectedPaymentMethodID, 0)
+        XCTAssertEqual(settings.storeOwnerDisplayName, "Example User")
+        XCTAssertEqual(settings.storeOwnerUsername, "admin")
+        XCTAssertEqual(settings.storeOwnerWpcomEmail, "example@example.com")
+        XCTAssertEqual(settings.storeOwnerWpcomUsername, "apiexamples")
+    }
+
+}
+
+/// Private Helpers
+///
+private extension ShippingLabelAccountSettingsMapperTests {
+
+    /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapAccountSettings(from filename: String) -> ShippingLabelAccountSettings? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! ShippingLabelAccountSettingsMapper().map(response: response)
+    }
+
+    /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings`
+    ///
+    func mapLoadShippingLabelAccountSettings() -> ShippingLabelAccountSettings? {
+        return mapAccountSettings(from: "shipping-label-account-settings")
+    }
+
+    /// Returns the ShippingLabelAccountSettingsMapper output upon receiving `shipping-label-account-settings-no-payment-methods`
+    ///
+    func mapLoadIncompleteShippingLabelAccountSettings() -> ShippingLabelAccountSettings? {
+        return mapAccountSettings(from: "shipping-label-account-settings-no-payment-methods")
+    }
+}
+
+private extension ShippingLabelAccountSettingsMapperTests {
+    func sampleShippingLabelPaymentMethod() -> ShippingLabelPaymentMethod {
+        return ShippingLabelPaymentMethod(paymentMethodID: 11743265,
+                                          name: "Example User",
+                                          cardType: .visa,
+                                          cardDigits: "4242",
+                                          expiry: "2030-12-31")
+    }
+}

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -207,6 +207,38 @@ final class ShippingLabelRemoteTests: XCTestCase {
                      message: "At least one of the new custom packages has the same name as existing packages.")
         XCTAssertEqual(result.failure as? DotcomError, expectedError)
     }
+
+    func test_loadShippingLabelAccountSettings_returns_settings_on_success() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "account/settings", filename: "shipping-label-account-settings")
+
+        // When
+        let result: Result<ShippingLabelAccountSettings, Error> = waitFor { promise in
+            remote.loadShippingLabelAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(try result.get())
+    }
+
+    func test_loadShippingLabelAccountSettings_returns_error_on_failure() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "account/settings", filename: "generic_error")
+
+        // When
+        let result: Result<ShippingLabelAccountSettings, Error> = waitFor { promise in
+            remote.loadShippingLabelAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension ShippingLabelRemoteTests {

--- a/Networking/NetworkingTests/Responses/shipping-label-account-settings-no-payment-methods.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-account-settings-no-payment-methods.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "success": true,
+        "storeOptions": {
+            "currency_symbol": "$",
+            "dimension_unit": "in",
+            "weight_unit": "lbs",
+            "origin_country": "US"
+        },
+        "formData": {
+            "selected_payment_method_id": 0,
+            "enabled": true,
+            "email_receipts": true,
+            "paper_size": "label"
+        },
+        "formMeta": {
+            "can_manage_payments": false,
+            "can_edit_settings": true,
+            "master_user_name": "Example User",
+            "master_user_login": "admin",
+            "master_user_wpcom_login": "apiexamples",
+            "master_user_email": "example@example.com",
+            "payment_methods": [],
+            "warnings": {
+                "payment_methods": false
+            }
+        },
+        "userMeta": {
+            "last_box_id": ""
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-account-settings.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-account-settings.json
@@ -1,0 +1,40 @@
+{
+    "data": {
+        "success": true,
+        "storeOptions": {
+            "currency_symbol": "$",
+            "dimension_unit": "in",
+            "weight_unit": "lbs",
+            "origin_country": "US"
+        },
+        "formData": {
+            "selected_payment_method_id": 11743265,
+            "enabled": true,
+            "email_receipts": true,
+            "paper_size": "label"
+        },
+        "formMeta": {
+            "can_manage_payments": true,
+            "can_edit_settings": true,
+            "master_user_name": "Example User",
+            "master_user_login": "admin",
+            "master_user_wpcom_login": "apiexamples",
+            "master_user_email": "example@example.com",
+            "payment_methods": [
+                {
+                    "payment_method_id": 11743265,
+                    "name": "Example User",
+                    "card_type": "visa",
+                    "card_digits": "4242",
+                    "expiry": "2030-12-31"
+                }
+            ],
+            "warnings": {
+                "payment_methods": false
+            }
+        },
+        "userMeta": {
+            "last_box_id": "small_flat_box"
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -35,6 +35,10 @@ final class MockShippingLabelRemote {
         let siteID: Int64
     }
 
+    private struct LoadAccountSettingsResultKey: Hashable {
+        let siteID: Int64
+    }
+
     /// The results to return based on the given arguments in `loadShippingLabels`
     private var loadAllResults = [LoadAllResultKey: Result<OrderShippingLabelListResponse, Error>]()
 
@@ -52,6 +56,9 @@ final class MockShippingLabelRemote {
 
     /// The results to return based on the given arguments in `createPackage`
     private var createPackageResults = [CreatePackageResultKey: Result<Bool, Error>]()
+
+    /// The results to return based on the given arguments in `loadShippingLabelAccountSettings`
+    private var loadAccountSettings = [LoadAccountSettingsResultKey: Result<ShippingLabelAccountSettings, Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -98,6 +105,13 @@ final class MockShippingLabelRemote {
                            thenReturn result: Result<Bool, Error>) {
         let key = CreatePackageResultKey(siteID: siteID)
         createPackageResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `createPackage` is called.
+    func whenLoadShippingLabelAccountSettings(siteID: Int64,
+                                       thenReturn result: Result<ShippingLabelAccountSettings, Error>) {
+        let key = LoadAccountSettingsResultKey(siteID: siteID)
+        loadAccountSettings[key] = result
     }
 }
 
@@ -178,6 +192,19 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = CreatePackageResultKey(siteID: siteID)
             if let result = self.createPackageResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func loadShippingLabelAccountSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = LoadAccountSettingsResultKey(siteID: siteID)
+            if let result = self.loadAccountSettings[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
Part of: #3940 

## Description

This PR adds support in the Networking layer for the Shipping Label account settings endpoint (`/wc/v1/connect/account/settings`). We currently need this endpoint to fetch the last selected package for shipping labels, and it will also be used in the future for handling payment methods.

Note: The settings returned in this endpoint are different from other Shipping Label settings we already support. Our existing support is for shipping labels linked to specific orders. The settings in this endpoint are account-level (such as user capabilities for editing payment settings and methods) and store-level (such as store owner details and payment methods).

Future PRs will add support in the Yosemite and Storage layers.

## Changes

* Adds `ShippingLabelRemote.loadShippingLabelAccountSettings` to make the API request to fetch the account settings.
* Adds the mapper `ShippingLabelAccountSettingsMapper` to handle the API response.
* Adds two new models `ShippingLabelAccountSettings` and `ShippingLabelPaymentMethod` and an enum `ShippingLabelPaymentCardType`.
   * **Question:** Should we also inject `userID` into the `ShippingLabelAccountSettings` model, since it includes account-specific settings?
* Adds mocks and unit tests for remote success/failure responses in `ShippingLabelRemoteTests`, and unit tests for the mapper parsing in `ShippingLabelAccountSettingsMapperTests`.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
