### PR TITLE
Coupon Management: Networking - Remote with loadAllCoupons endpoint method

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -72,7 +72,6 @@
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
-		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
 		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
 		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -72,6 +72,9 @@
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
+		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
+		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
+		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -522,6 +525,8 @@
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
 		03DCB7512624B3BE00C8953D /* coupons-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all.json"; sourceTree = "<group>"; };
+		03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemoteTests.swift; sourceTree = "<group>"; };
+		03DCB771262591D900C8953D /* CouponsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemote.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1108,6 +1113,7 @@
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
+				03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
@@ -1229,6 +1235,7 @@
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
+				03DCB771262591D900C8953D /* CouponsRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
@@ -2030,6 +2037,7 @@
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
+				03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,
 				7452387221124B7700A973CD /* AnyEncodable.swift in Sources */,
@@ -2284,6 +2292,7 @@
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Coupons: Remote endpoints
+///
+public final class CouponsRemote: Remote {
+    // MARK: - Coupons
+
+    /// Retrieves all of the `Coupon`s from the API.
+    ///
+    /// - Parameters:
+    ///     - siteID
+    ///     - pageNumber:
+    ///     - pageSize:
+    ///     - completion:
+    ///
+    public func loadAllCoupons(for siteID: Int64,
+                               pageNumber: Int = Default.pageNumber,
+                               pageSize: Int = Default.pageSize,
+                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize)
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.coupons,
+                                     parameters: parameters)
+
+        let mapper = CouponListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - Constants
+//
+public extension CouponsRemote {
+    enum Default {
+        public static let pageSize: Int = 25
+        public static let pageNumber: Int = 1
+    }
+
+    private enum Path {
+        static let coupons = "coupons"
+    }
+
+    private enum ParameterKey {
+        static let page: String = "page"
+        static let perPage: String = "per_page"
+    }
+}

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Coupons: Remote endpoints
 ///
 public final class CouponsRemote: Remote {
-    // MARK: - Coupons
+    // MARK: - Get Coupons
 
     /// Retrieves all of the `Coupon`s from the API.
     ///
@@ -16,7 +16,7 @@ public final class CouponsRemote: Remote {
     public func loadAllCoupons(for siteID: Int64,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
-                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+                               completion: @escaping (Result<[Coupon], Error>) -> ()) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize)
@@ -38,8 +38,8 @@ public final class CouponsRemote: Remote {
 //
 public extension CouponsRemote {
     enum Default {
-        public static let pageSize: Int = 25
-        public static let pageNumber: Int = 1
+        public static let pageSize = 25
+        public static let pageNumber = 1
     }
 
     private enum Path {
@@ -47,7 +47,7 @@ public extension CouponsRemote {
     }
 
     private enum ParameterKey {
-        static let page: String = "page"
-        static let perPage: String = "per_page"
+        static let page = "page"
+        static let perPage = "per_page"
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import Networking
+import Alamofire
+
+class CouponsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all coupons tests
+
+    /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
+    /// 
+    func test_loadAllCoupons_returns_parsed_coupons() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.coupons)
+        XCTAssertEqual(result.coupons?.count, 3)
+    }
+
+    /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
+    ///
+    func test_loadAllCoupons_uses_passed_pagination_parameters() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        guard let page = request.parameters["page"] as? String,
+              let pageSize = request.parameters["per_page"] as? String else {
+            XCTFail("Pagination parameters not found")
+            return
+        }
+        XCTAssertEqual(page, "2")
+        XCTAssertEqual(pageSize, "17")
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in for the request.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_request() {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        XCTAssertEqual(request.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+    }
+}

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -22,11 +22,11 @@ class CouponsRemoteTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Load all coupons tests
+    // MARK: - Load all Coupons tests
 
     /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
     /// 
-    func test_loadAllCoupons_returns_parsed_coupons() {
+    func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -34,18 +34,19 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertNil(result.error)
-        XCTAssertNotNil(result.coupons)
-        XCTAssertEqual(result.coupons?.count, 3)
+        XCTAssertFalse(try XCTUnwrap(result).isFailure)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertNotNil(coupons)
+        XCTAssertEqual(coupons.count, 3)
     }
 
     /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
@@ -55,7 +56,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -78,7 +79,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -90,7 +91,7 @@ class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
     ///
-    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -98,15 +99,16 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -105,7 +105,7 @@ class CouponsRemoteTests: XCTestCase {
 
         // Then
         let coupons = try result.get()
-        XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
+        XCTAssertEqual(coupons.first?.siteID, sampleSiteID)
     }
 
     /// Verifies that loadAllCoupons properly relays Networking Layer errors.

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -29,23 +29,22 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertFalse(try XCTUnwrap(result).isFailure)
-        let coupons = try XCTUnwrap(result).get()
-        XCTAssertNotNil(coupons)
+        XCTAssert(result.isSuccess)
+        guard let coupons = try? result.get() else {
+            XCTFail("Expected parsed Coupons not found in response")
+            return
+        }
         XCTAssertEqual(coupons.count, 3)
     }
 
@@ -94,21 +93,18 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let coupons = try XCTUnwrap(result).get()
+        let coupons = try result.get()
         XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -1,8 +1,7 @@
 import XCTest
 @testable import Networking
-import Alamofire
 
-class CouponsRemoteTests: XCTestCase {
+final class CouponsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///


### PR DESCRIPTION
Part of #3912
Please ensure #3987 is merged before this PR

## Description
This PR adds `CouponsRemote`, with a single endpoint method for the time being: `loadAllCoupons`, which makes `GET` requests to `/coupons/` and supports pagination parameters. This method will required by the coupon list screens, to list the coupons available for a site.

The implementation here follows the existing pattern, but some further improvement to allow injection of the mapper to the remote would be helpful. This would let us test for what the siteID passed to the mapper is independently of the results of parsing coupons. I did attempt to improve on this while working on the code, but it turned out to have a bit too much complexity to do in the scope of this work. I'd be interested to improve on this in future though.

## Testing
The endpoint is not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
