### PR TITLE
Coupon Management: Networking - Add deleteCoupon endpoint method to Remote

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -32,6 +32,29 @@ public final class CouponsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    // MARK: - Delete Coupon
+
+    /// Delete a `Coupon`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll delete the product attribute.
+    ///     - couponID: ID of the Coupon that will be deleted.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func deleteCoupon(for siteID: Int64,
+                             couponID: Int64,
+                             completion: @escaping (Result<Coupon, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .delete,
+                                     siteID: siteID,
+                                     path: Path.coupons + "/\(couponID)",
+                                     parameters: [ParameterKey.force: true])
+
+        let mapper = CouponMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: - Constants
@@ -49,5 +72,6 @@ public extension CouponsRemote {
     private enum ParameterKey {
         static let page = "page"
         static let perPage = "per_page"
+        static let force = "force"
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -132,4 +132,32 @@ final class CouponsRemoteTests: XCTestCase {
         }
         XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 403))
     }
+
+    // MARK: - Delete Coupon tests
+
+    /// Verifies that deleteCoupon properly parses the `coupon` sample response.
+    ///
+    func test_deleteCoupon_properly_returns_parsed_Coupon() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let sampleCouponID: Int64 = 720
+        let expectation = self.expectation(description: "Delete Coupon")
+
+        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+
+        // When
+        var result: Swift.Result<Coupon, Error>?
+        remote.deleteCoupon(for: sampleSiteID, couponID: sampleCouponID) { response in
+            result = response
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+
+        let coupon = try XCTUnwrap(result).get()
+        XCTAssertEqual(coupon.couponId, sampleCouponID)
+    }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -157,7 +157,7 @@ final class CouponsRemoteTests: XCTestCase {
             XCTFail("Expected parsed Coupon not found in response")
             return
         }
-        XCTAssertEqual(coupon.couponId, sampleCouponID)
+        XCTAssertEqual(coupon.couponID, sampleCouponID)
     }
 
     /// Verifies that deleteCoupon properly relays Networking Layer errors.

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -141,23 +141,22 @@ final class CouponsRemoteTests: XCTestCase {
         // Given
         let remote = CouponsRemote(network: network)
         let sampleCouponID: Int64 = 720
-        let expectation = self.expectation(description: "Delete Coupon")
 
         network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
 
         // When
-        var result: Swift.Result<Coupon, Error>?
-        remote.deleteCoupon(for: sampleSiteID, couponID: sampleCouponID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.deleteCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
-
-        let coupon = try XCTUnwrap(result).get()
+        XCTAssert(result.isSuccess)
+        guard let coupon = try? result.get() else {
+            XCTFail("Expected parsed Coupon not found in response")
+            return
+        }
         XCTAssertEqual(coupon.couponId, sampleCouponID)
     }
 


### PR DESCRIPTION
Part of issue #3912 
Please ensure #3989 is merged before this PR

## Description
This PR adds the `deleteCoupon` endpoint method to `CouponsRemote`, which will required by the coupon list management screen to enable swipe to delete, and/or the coupon edit screen to include a delete button. This makes `DELETE` requests to `/coupons/{id}`, and returns the deleted coupon. 

The requests made by the endpoint always set `force=true` as a parameter, which is required as there is no bin functionality for Coupons. If this parameter is not set, the deletion will not do anything, and an error will be returned by the API.

## Testing
The endpoint is not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
