### PR TITLE
Shipping Labels M2: Show different address verification banner text and actions based on address type

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -18,7 +18,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
     /// Top banner that shows a warning in case there is an error in the address validation.
     ///
     private lazy var topBannerView: TopBannerView = {
-        let topBanner = ShippingLabelAddressTopBannerFactory.addressErrorTopBannerView { [weak self] in
+        let topBanner = ShippingLabelAddressTopBannerFactory.addressErrorTopBannerView(shipType: viewModel.type) { [weak self] in
             MapsHelper.openAppleMaps(address: self?.viewModel.address?.formattedPostalAddress) { [weak self] (result) in
                 switch result {
                 case .success:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
@@ -35,7 +35,7 @@ private extension ShippingLabelAddressTopBannerFactory {
 
     enum Localization {
         static let infoShipFrom = NSLocalizedString("We were unable to automatically verify the origin address.",
-                                                        comment: "Banner caption in Shipping Label Address Validation when the origin address can't be verified.")
+                                                    comment: "Banner caption in Shipping Label Address Validation when the origin address can't be verified.")
         static let infoShipTo = NSLocalizedString("We were unable to automatically verify the shipping address. " +
                                                 "View on Apple Maps or try contacting the customer to make sure the address is correct.",
                                             comment: "Banner caption in Shipping Label Address Validation when the destination address can't be verified.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressTopBannerFactory.swift
@@ -1,19 +1,24 @@
 import UIKit
+import Yosemite
 
-/// Generates top banner view that is shown at the top of variation list screen when at least one variation is missing a price.
+/// Generates top banner view that is shown at the top of Shipping Label address form screen when there is an error in the address validation.
 ///
 final class ShippingLabelAddressTopBannerFactory {
-    static func addressErrorTopBannerView(openMapPressed: @escaping () -> Void,
+    static func addressErrorTopBannerView(shipType: ShipType,
+                                          openMapPressed: @escaping () -> Void,
                                           contactCustomerPressed: @escaping () -> Void) -> TopBannerView {
+        // Set banner text and action buttons based on shipping address type (origin or destination).
+        let infoText = shipType == .destination ? Localization.infoShipTo : Localization.infoShipFrom
         let openMapAction = TopBannerViewModel.ActionButton(title: Localization.openMapAction) {
             openMapPressed()
         }
         let contactCustomerAction = TopBannerViewModel.ActionButton(title: Localization.contactCustomerAction) {
             contactCustomerPressed()
         }
-        let actions = [openMapAction, contactCustomerAction]
+        let actions = shipType == .destination ? [openMapAction, contactCustomerAction] : []
+
         let viewModel = TopBannerViewModel(title: nil,
-                                           infoText: Localization.info,
+                                           infoText: infoText,
                                            icon: Constants.icon,
                                            isExpanded: true,
                                            topButton: .none,
@@ -29,9 +34,11 @@ private extension ShippingLabelAddressTopBannerFactory {
     }
 
     enum Localization {
-        static let info = NSLocalizedString("We were unable to automatically verify the shipping address. " +
+        static let infoShipFrom = NSLocalizedString("We were unable to automatically verify the origin address.",
+                                                        comment: "Banner caption in Shipping Label Address Validation when the origin address can't be verified.")
+        static let infoShipTo = NSLocalizedString("We were unable to automatically verify the shipping address. " +
                                                 "View on Apple Maps or try contacting the customer to make sure the address is correct.",
-                                            comment: "Banner caption in Shipping Label Address Validation when the address can't be verified.")
+                                            comment: "Banner caption in Shipping Label Address Validation when the destination address can't be verified.")
         static let openMapAction = NSLocalizedString("Open Map", comment: "Open Map action in Shipping Label Address Validation.")
         static let contactCustomerAction = NSLocalizedString("Contact Customer", comment: "Contact Customer action in Shipping Label Address Validation.")
     }


### PR DESCRIPTION
Fixes: #3918 

## Description

When an origin or destination address can't be verified while creating a shipping label, we display a banner at the top of the edit shipping address screen explaining the problem. Previously, we showed the same text and actions regardless of the address type (origin or destination).

This PR updates the banner so it shows different text and actions depending on whether it's for the origin or destination address.

## Changes

This updates `ShippingLabelAddressTopBannerFactory` to take `ShippingLabelAddressVerification.ShipType` (origin or destination) as a parameter and use it to determine what text and actions to display in the banner:

* The origin banner is a simple text banner (no actions) with relevant message.
* The destination includes text and actions prompting the user to view the address on Apple Maps or contact the customer to verify the address.

Origin|Destination
-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-04-19 at 11 32 39](https://user-images.githubusercontent.com/8658164/115230354-26595400-a10c-11eb-82da-0f72c5100c29.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-04-19 at 11 40 30](https://user-images.githubusercontent.com/8658164/115230380-2ce7cb80-a10c-11eb-993c-6b7fdd11fe0f.png)

## Testing

1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the Ship From cell.
5. Go to the editing address screen and make sure the address is not valid remotely. -> You should see the top banner view with the message "We were unable to automatically verify the origin address." and no action buttons.
6. Fix the address and tap "Done" to return to the "Create Shipping Label" screen.
7. Press the button "Continue" under the Ship To cell.
8. Go to the editing address screen and make sure the address is not valid remotely. -> You should see the top banner view with the message "We were unable to automatically verify the shipping address. View on Apple Maps or try contacting the customer to make sure the address is correct." and two buttons "Open Map" and "Contact Customer".

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
