### PR TITLE
Add-Ons: Add update disclaimer to order add-ons

### DIFF
--- a/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
+++ b/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
@@ -30,6 +30,14 @@ struct HeadlineStyle: ViewModifier {
     }
 }
 
+struct FootnoteStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.footnote)
+            .foregroundColor(Color(.textSubtle))
+    }
+}
+
 // MARK: View extensions
 extension View {
     func bodyStyle() -> some View {
@@ -42,5 +50,9 @@ extension View {
 
     func headlineStyle() -> some View {
         self.modifier(HeadlineStyle())
+    }
+
+    func footnoteStyle() -> some View {
+        self.modifier(FootnoteStyle())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
@@ -12,6 +12,10 @@ final class OrderAddOnListI1ViewModel {
     ///
     let title = Localization.title
 
+    /// Update add-ons notice
+    ///
+    let updateNotice = Localization.updateNotice
+
     /// Member-wise initializer, useful for `SwiftUI` previews
     ///
     init(addOns: [OrderAddOnI1ViewModel]) {
@@ -50,6 +54,8 @@ final class OrderAddOnListI1ViewModel {
 private extension OrderAddOnListI1ViewModel {
     enum Localization {
         static let title = NSLocalizedString("Product Add-ons", comment: "The title on the navigation bar when viewing an order item add-ons")
+        static let updateNotice = NSLocalizedString("You can edit product add-ons in the web dashboard.",
+                                                    comment: "The text below the order add-ons list indicating that edit can be done on the web.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -35,7 +35,7 @@ struct OrderAddOnListI1View: View {
                         .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                 }
 
-                OrderAddOnNotice(updateText: viewModel.updateNotice)
+                OrderAddOnNoticeView(updateText: viewModel.updateNotice)
                     .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
             }
         }
@@ -77,7 +77,7 @@ private struct OrderAddOnI1View: View {
 
 /// Renders a info notice with an icon
 ///
-private struct OrderAddOnNotice: View {
+private struct OrderAddOnNoticeView: View {
 
     /// Content to be rendered next to the info icon.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -32,7 +32,11 @@ struct OrderAddOnListI1View: View {
             VStack {
                 ForEach(viewModel.addOns) { addOn in
                     OrderAddOnI1View(viewModel: addOn)
+                        .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                 }
+
+                OrderAddOnNotice(updateText: viewModel.updateNotice)
+                    .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
             }
         }
         .background(Color(.listBackground))
@@ -41,7 +45,7 @@ struct OrderAddOnListI1View: View {
 
 /// Renders a single order add-on
 ///
-struct OrderAddOnI1View: View {
+private struct OrderAddOnI1View: View {
 
     /// Static view model to populate the view content
     ///
@@ -68,6 +72,24 @@ struct OrderAddOnI1View: View {
             Divider()
         }
         .background(Color(.basicBackground))
+    }
+}
+
+/// Renders a info notice with an icon
+///
+private struct OrderAddOnNotice: View {
+
+    /// Content to be rendered next to the info icon.
+    ///
+    let updateText: String
+
+    var body: some View {
+        HStack {
+            Image(uiImage: .infoOutlineImage)
+            Text(updateText)
+        }
+        .footnoteStyle()
+        .padding([.leading, .trailing])
     }
 }
 


### PR DESCRIPTION
part of #3894

# Why

As our add-ons screen won't have edit capabilities right now, this PR adds a small disclaimer informing the merchant that they can do any edit on the web dashboard.

# How

- Added a new `footnoteStyle()` modifier
- Updated VM to provide the "edit disclaimer"
- Updated view to render the disclaimer: Creates a new `OrderAddOnNoticeView` which is added in `OrderAddOnListI1View`

Note: There is a small workaround where texts inside a `ScrollView` do not have the ideal height. 
Adding the `fixedSize()` modifier, seems to fix the issue. Ref: paNNhX-d2-p2

# Screenshot
<img src="https://user-images.githubusercontent.com/562080/115341043-74eb0a80-a16d-11eb-92bf-df23bae5ad47.PNG" width="400"/>

# Testing Steps
**Prerequisites:** Have your site with the add-ons plugin installed and configured.

- Make an order with an item with add-ons
- Launch the app and navigate to that order
- Tap on the "View Add-Ons" button.
- See that a new screen is presented with the add-on's information with the info disclaimer.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
