### PR TITLE
[Mobile Payments] Capture Payment Intent

### DIFF
--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -118,18 +118,17 @@ private extension CardPresentPaymentStore {
             self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
                 switch result {
                 case .success(let intent):
-                    if intent.status == .succeeded {
-                        onCompletion(.success(()))
-                    } else {
+                    guard intent.status == .succeeded else {
                         DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
                         onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+                        return
                     }
+                    onCompletion(.success(()))
                 case .failure(let error):
                     onCompletion(.failure(error))
+                    return
                 }
             }
-
-            onCompletion(.success(()))
         }.store(in: &cancellables)
 
         // Observe status events fired by the card reader


### PR DESCRIPTION
Closes #3971 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader ⚠️

This PR leverages the remote added for #3970 to capture the payment intent created by the Stripe Terminal SDK.

⚠️ As the WCPay endpoint does not actually exist yet, this capture will, for now, always fail ⚠️

## How to Test

- Ensure all automated tests continue to pass

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
