### PR TITLE
Experiment with reusable StaticList

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -28,18 +28,11 @@ struct OrderAddOnListI1View: View {
     /// A future improvement can be to use a `LazyVStack` when iOS-14 becomes our minimum target.
     ///
     var body: some View {
-        ScrollView {
-            VStack {
-                ForEach(viewModel.addOns) { addOn in
-                    OrderAddOnI1View(viewModel: addOn)
-                        .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
-                }
-
-                OrderAddOnNoticeView(updateText: viewModel.updateNotice)
-                    .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
-            }
+        StaticList(viewModel.addOns) { addOn in
+            OrderAddOnI1View(viewModel: addOn)
+        } footer: {
+            OrderAddOnNoticeView(updateText: viewModel.updateNotice)
         }
-        .background(Color(.listBackground))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/StaticList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/StaticList.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct StaticList<Data, Content, FooterContent>: View where Data: RandomAccessCollection, Content: View, FooterContent: View, Data.Element: Identifiable {
+    let data: Data
+    let rowContent: (Data.Element) -> Content
+    let footerContent: (() -> FooterContent)?
+
+    init(_ data: Data, rowContent: @escaping (Data.Element) -> Content, footer footerContent: (() -> FooterContent)? = nil) {
+        self.data = data
+        self.rowContent = rowContent
+        self.footerContent = footerContent
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                ForEach(data) { item in
+                    rowContent(item)
+                        .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
+                }
+                footerContent.map { $0() }
+                    .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
+            }
+        }
+        .background(Color(.listBackground))
+    }
+}
+
+#if DEBUG
+
+struct StaticList_PreviewItem: Identifiable {
+    let id = UUID()
+    let title: String
+}
+
+struct StaticList_Previews: PreviewProvider {
+    static var previews: some View {
+        let data = ["One", "Two", "Three"].map { StaticList_PreviewItem(title: $0) }
+        StaticList(data) { (item) in
+            VStack(alignment: .leading, spacing: 10) {
+                Divider()
+                Text(item.title)
+                    .padding([.leading, .trailing])
+                Divider()
+            }
+        } footer: {
+            Text("The footer")
+        }
+        .environment(\.colorScheme, .light)
+    }
+}
+
+#endif

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1112,6 +1112,7 @@
 		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
+		E191249326304AEA003BB3A5 /* StaticList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E191249226304AEA003BB3A5 /* StaticList.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2303,6 +2304,7 @@
 		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
+		E191249226304AEA003BB3A5 /* StaticList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticList.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -3773,6 +3775,7 @@
 				45DB705926124C710064A6CF /* TitleAndTextFieldRow.swift */,
 				45CE2D842625D7ED00E3CA00 /* SelectableItemRow.swift */,
 				4590B6A7261F0F8300A6FCE0 /* SegmentedView.swift */,
+				E191249226304AEA003BB3A5 /* StaticList.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -6604,6 +6607,7 @@
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
 				451B1747258BD7B600836277 /* AddAttributeOptionsViewModel.swift in Sources */,
+				E191249326304AEA003BB3A5 /* StaticList.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
 				CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */,
 				265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */,


### PR DESCRIPTION
I'm experimenting with the custom static list introduced in https://github.com/woocommerce/woocommerce-ios/pull/3968, trying to make it into a reusable component

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
