### PR TITLE
[Mobile Payments] Simplify tests to handle expected results more directly; add networking error test

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		31054728262E2FEE00C5C02B /* wcpay-payment-intent-canceled.json in Resources */ = {isa = PBXBuildFile; fileRef = 31054727262E2FEE00C5C02B /* wcpay-payment-intent-canceled.json */; };
 		3105472C262E303400C5C02B /* wcpay-payment-intent-unknown-status.json in Resources */ = {isa = PBXBuildFile; fileRef = 3105472B262E303400C5C02B /* wcpay-payment-intent-unknown-status.json */; };
 		31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 31054733262E36AB00C5C02B /* wcpay-payment-intent-error.json */; };
+		31104E142630DDA700587C1E /* wcpay-account-wrong-json.json in Resources */ = {isa = PBXBuildFile; fileRef = 31104E132630DDA700587C1E /* wcpay-account-wrong-json.json */; };
 		311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */; };
 		3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE5F26129ADD00E566B9 /* wcpay-account-none.json */; };
 		3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE6326129B1300E566B9 /* wcpay-account-complete.json */; };
@@ -133,7 +134,6 @@
 		3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE7B26129E2100E566B9 /* wcpay-account-restricted-pending.json */; };
 		3158FE8026129EC300E566B9 /* wcpay-account-restricted-overdue.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE7F26129EC300E566B9 /* wcpay-account-restricted-overdue.json */; };
 		3158FE8426129F3A00E566B9 /* wcpay-account-unknown-status.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE8326129F3A00E566B9 /* wcpay-account-unknown-status.json */; };
-		3158FE882612A13F00E566B9 /* wcpay-account-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE872612A13F00E566B9 /* wcpay-account-error.json */; };
 		31884A3B2603F3C7003FE338 /* SitePluginStatusEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */; };
 		3192F21C260D32550067FEF9 /* WCPayAccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3192F21B260D32550067FEF9 /* WCPayAccountMapper.swift */; };
 		3192F220260D33BB0067FEF9 /* WCPayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */; };
@@ -609,6 +609,7 @@
 		31054727262E2FEE00C5C02B /* wcpay-payment-intent-canceled.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-payment-intent-canceled.json"; sourceTree = "<group>"; };
 		3105472B262E303400C5C02B /* wcpay-payment-intent-unknown-status.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-payment-intent-unknown-status.json"; sourceTree = "<group>"; };
 		31054733262E36AB00C5C02B /* wcpay-payment-intent-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-payment-intent-error.json"; sourceTree = "<group>"; };
+		31104E132630DDA700587C1E /* wcpay-account-wrong-json.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-wrong-json.json"; sourceTree = "<group>"; };
 		311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapperTests.swift; sourceTree = "<group>"; };
 		3158FE5F26129ADD00E566B9 /* wcpay-account-none.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-none.json"; sourceTree = "<group>"; };
 		3158FE6326129B1300E566B9 /* wcpay-account-complete.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-complete.json"; sourceTree = "<group>"; };
@@ -620,7 +621,6 @@
 		3158FE7B26129E2100E566B9 /* wcpay-account-restricted-pending.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-restricted-pending.json"; sourceTree = "<group>"; };
 		3158FE7F26129EC300E566B9 /* wcpay-account-restricted-overdue.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-restricted-overdue.json"; sourceTree = "<group>"; };
 		3158FE8326129F3A00E566B9 /* wcpay-account-unknown-status.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-unknown-status.json"; sourceTree = "<group>"; };
-		3158FE872612A13F00E566B9 /* wcpay-account-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-error.json"; sourceTree = "<group>"; };
 		31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStatusEnum.swift; sourceTree = "<group>"; };
 		3192F21B260D32550067FEF9 /* WCPayAccountMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayAccountMapper.swift; sourceTree = "<group>"; };
 		3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayAccount.swift; sourceTree = "<group>"; };
@@ -1560,7 +1560,7 @@
 				3158FE7B26129E2100E566B9 /* wcpay-account-restricted-pending.json */,
 				3158FE7F26129EC300E566B9 /* wcpay-account-restricted-overdue.json */,
 				3158FE8326129F3A00E566B9 /* wcpay-account-unknown-status.json */,
-				3158FE872612A13F00E566B9 /* wcpay-account-error.json */,
+				31104E132630DDA700587C1E /* wcpay-account-wrong-json.json */,
 				31054713262E2F3B00C5C02B /* wcpay-payment-intent-requires-payment-method.json */,
 				31054717262E2F5E00C5C02B /* wcpay-payment-intent-requires-confirmation.json */,
 				3105471B262E2F8000C5C02B /* wcpay-payment-intent-requires-action.json */,
@@ -1901,6 +1901,7 @@
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,
 				45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */,
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
+				31104E142630DDA700587C1E /* wcpay-account-wrong-json.json in Resources */,
 				3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
@@ -1971,7 +1972,6 @@
 				261CF2CB255C50010090D8D3 /* payment-gateway-list-half.json in Resources */,
 				02C254D72563999300A04423 /* order-shipping-labels.json in Resources */,
 				45B204BC24890B1200FE6526 /* category.json in Resources */,
-				3158FE882612A13F00E566B9 /* wcpay-account-error.json in Resources */,
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,
 				74046E21217A73D0007DD7BF /* settings-general.json in Resources */,

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -65,267 +65,232 @@ final class WCPayRemoteTests: XCTestCase {
     /// Verifies that loadAccount properly handles the nominal response. We'll also validate the
     /// statement descriptor, currencies and country here.
     ///
-    func test_loadAccount_properly_returns_account() {
+    func test_loadAccount_properly_returns_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-complete")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .complete)
-            XCTAssertEqual(account.statementDescriptor, "MY.FANCY.US.STORE")
-            XCTAssertEqual(account.defaultCurrency, "usd")
-            XCTAssertEqual(account.supportedCurrencies, ["usd"])
-            XCTAssertEqual(account.country, "US")
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .complete)
+        XCTAssertEqual(account.statementDescriptor, "MY.FANCY.US.STORE")
+        XCTAssertEqual(account.defaultCurrency, "usd")
+        XCTAssertEqual(account.supportedCurrencies, ["usd"])
+        XCTAssertEqual(account.country, "US")
     }
 
     /// Verifies that loadAccount properly handles the no account response
     ///
-    func test_loadAccount_properly_handles_no_account() {
+    func test_loadAccount_properly_handles_no_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-none")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .noAccount)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .noAccount)
     }
 
     /// Verifies that loadAccount properly handles the rejected - fraud response
     ///
-    func test_loadAccount_properly_handles_rejected_fraud_account() {
+    func test_loadAccount_properly_handles_rejected_fraud_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-rejected-fraud")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .rejectedFraud)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .rejectedFraud)
     }
 
     /// Verifies that loadAccount properly handles the rejected - terms of service response
     ///
-    func test_loadAccount_properly_handles_rejected_terms_of_service_account() {
+    func test_loadAccount_properly_handles_rejected_terms_of_service_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-rejected-terms-of-service")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .rejectedTermsOfService)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .rejectedTermsOfService)
     }
 
     /// Verifies that loadAccount properly handles the rejected - listed response
     ///
-    func test_loadAccount_properly_handles_rejected_listed_account() {
+    func test_loadAccount_properly_handles_rejected_listed_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-rejected-listed")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .rejectedListed)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .rejectedListed)
     }
 
     /// Verifies that loadAccount properly handles the rejected - other response
     ///
-    func test_loadAccount_properly_handles_rejected_other_account() {
+    func test_loadAccount_properly_handles_rejected_other_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-rejected-other")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .rejectedOther)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .rejectedOther)
     }
 
     /// Verifies that loadAccount properly handles the restricted (review) response
     ///
-    func test_loadAccount_properly_handles_restricted_review_account() {
+    func test_loadAccount_properly_handles_restricted_review_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-restricted")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .restricted)
-            XCTAssertFalse(account.hasPendingRequirements)
-            XCTAssertFalse(account.hasOverdueRequirements)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .restricted)
+        XCTAssertFalse(account.hasPendingRequirements)
+        XCTAssertFalse(account.hasOverdueRequirements)
     }
 
     /// Verifies that loadAccount properly handles the restricted - pending response
     ///
-    func test_loadAccount_properly_handles_restricted_pending_account() {
+    func test_loadAccount_properly_handles_restricted_pending_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-restricted-pending")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .restricted)
-            XCTAssertTrue(account.hasPendingRequirements)
-            XCTAssertFalse(account.hasOverdueRequirements)
-            XCTAssertEqual(account.currentDeadline, Date(timeIntervalSince1970: 1897351200))
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .restricted)
+        XCTAssertTrue(account.hasPendingRequirements)
+        XCTAssertFalse(account.hasOverdueRequirements)
+        XCTAssertEqual(account.currentDeadline, Date(timeIntervalSince1970: 1897351200))
     }
 
     /// Verifies that loadAccount properly handles the restricted - over due response
     ///
-    func test_loadAccount_properly_handles_restricted_over_due_account() {
+    func test_loadAccount_properly_handles_restricted_over_due_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-restricted-overdue")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .restricted)
-            XCTAssertFalse(account.hasPendingRequirements)
-            XCTAssertTrue(account.hasOverdueRequirements)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .restricted)
+        XCTAssertFalse(account.hasPendingRequirements)
+        XCTAssertTrue(account.hasOverdueRequirements)
     }
 
     /// Verifies that loadAccount properly handles an unrecognized status response
     ///
-    func test_loadAccount_properly_handles_unrecognized_status_account() {
+    func test_loadAccount_properly_handles_unrecognized_status_account() throws {
         let remote = WCPayRemote(network: network)
 
         network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-unknown-status")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertEqual(account.status, .unknown)
-        case .failure(let error):
-            XCTAssertNil(error)
-        }
+        XCTAssertTrue(result.isSuccess)
+        let account = try result.get()
+        XCTAssertEqual(account.status, .unknown)
     }
 
-    /// Verifies that loadAccount properly handles an error response
+    /// Verifies that loadAccount properly handles unexpected fields in the response (resulting in a Decoding Error)
     ///
-    func test_loadAccount_properly_handles_error_response() {
+    func test_loadAccount_properly_handles_unexpected_fields_in_response() {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-error")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-wrong-json")
 
-        // When
         let result: Result<WCPayAccount, Error> = waitFor { promise in
             remote.loadAccount(for: self.sampleSiteID) { result in
                 promise(result)
             }
         }
 
-        // Then
-        switch result {
-        case .success(let account):
-            XCTAssertNil(account)
-        case .failure(let error):
-            XCTAssertNotNil(error)
-        }
+        XCTAssertTrue(result.isFailure)
+        let error = result.failure
+        XCTAssertTrue(error is DecodingError)
     }
+
+    /// Verifies that loadAccount properly handles networking errors
+    ///
+    func test_loadAccount_properly_handles_networking_errors() throws {
+        let remote = WCPayRemote(network: network)
+        let expectedError = NSError(domain: #function, code: 0, userInfo: nil)
+
+        network.simulateError(requestUrlSuffix: "payments/accounts", error: expectedError)
+
+        let result: Result<WCPayAccount, Error> = waitFor { promise in
+            remote.loadAccount(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure) as NSError
+        XCTAssertEqual(expectedError, error)
+    }
+
 
     /// Verifies that captureOrderPayment properly handles a payment intent requires payment method response
     ///

--- a/Networking/NetworkingTests/Responses/wcpay-account-error.json
+++ b/Networking/NetworkingTests/Responses/wcpay-account-error.json
@@ -1,7 +1,0 @@
-{
-    "code": "rest_no_route",
-    "message": "No route was found matching the URL and request method.",
-    "data": {
-        "status": 404
-    }
-}

--- a/Networking/NetworkingTests/Responses/wcpay-account-wrong-json.json
+++ b/Networking/NetworkingTests/Responses/wcpay-account-wrong-json.json
@@ -1,0 +1,7 @@
+{
+    "beep": {
+        "bop": "bop",
+        "boop": "boop"
+    }
+}
+


### PR DESCRIPTION
Closes #3900 

## Important Note
- This PR is against the `feature/stripe-terminal-sdk-integration` branch

## Changes
- Replace the many `switch`es in the tests with direct testing of the expected `result`
- Update the existing "error" test to explicitly look for `DecodingError` with an appropriate JSON as well
- Add a test using `network.simulateError` to ensure that is handled as well 
- Remove the "error" JSON that is now no longer needed

## To test:
- Run WCPayRemoteTests and ensure all tests pass