### PR TITLE
Apply the WooStyleModifiers to the existing SwiftUI views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
@@ -12,10 +12,9 @@ struct ItemToFulfillRow: View, Identifiable {
             VStack(alignment: .leading,
                    spacing: 8) {
                 Text(title)
-                    .font(.body)
+                    .bodyStyle()
                 Text(subtitle)
-                    .font(.footnote)
-                    .foregroundColor(Color(.textSubtle))
+                    .footnoteStyle()
             }.padding([.leading, .trailing], Constants.vStackPadding)
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ListHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ListHeaderView.swift
@@ -13,8 +13,7 @@ struct ListHeaderView: View {
                     Spacer()
                 }
                 Text(text)
-                    .font(.footnote)
-                    .foregroundColor(Color(.listIcon))
+                    .footnoteStyle()
                 if alignment == .left {
                     Spacer()
                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -16,10 +16,9 @@ struct SelectableItemRow: View {
             VStack(alignment: .leading,
                    spacing: 8) {
                 Text(title)
-                    .font(.body)
+                    .bodyStyle()
                 Text(subtitle)
-                    .font(.footnote)
-                    .foregroundColor(Color(.textSubtle))
+                    .footnoteStyle()
             }.padding([.trailing], Constants.vStackPadding)
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -12,7 +12,7 @@ struct TitleAndTextFieldRow: View {
     var body: some View {
         HStack {
             Text(title)
-                .font(.body)
+                .bodyStyle()
                 .lineLimit(1)
                 .fixedSize()
             Spacer()
@@ -21,7 +21,8 @@ struct TitleAndTextFieldRow: View {
                 .font(.body)
                 .keyboardType(keyboardType)
             if let symbol = symbol {
-                Text(symbol).font(.body)
+                Text(symbol)
+                    .bodyStyle()
             }
         }
         .frame(height: Constants.height)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -11,7 +11,7 @@ struct TitleAndValueRow: View {
     var body: some View {
         HStack {
             Text(title)
-                .font(.body)
+                .bodyStyle()
             Spacer()
             Text(value)
                 .font(.body)


### PR DESCRIPTION
In a [previous PR](https://github.com/woocommerce/woocommerce-ios/pull/3968), @Ecarrion introduced the `WooStyleModifiers` to migrate functions from UILabel+Helpers and UIButton+Helpers as they are needed in SwiftUI views.
In this PR, I aligned the existing SwiftUI views to use those view modifiers.

## Testing
Look at the SwiftUI previews of components modified, to see if the font and the colors of the text are like expected.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
