### PR TITLE
Fix Coupon fake generation

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -94,6 +94,45 @@ extension Address {
         )
     }
 }
+extension Coupon {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Coupon {
+        .init(
+            siteID: .fake(),
+            couponID: .fake(),
+            code: .fake(),
+            amount: .fake(),
+            dateCreated: .fake(),
+            dateModified: .fake(),
+            discountType: .fake(),
+            description: .fake(),
+            dateExpires: .fake(),
+            usageCount: .fake(),
+            individualUse: .fake(),
+            productIds: .fake(),
+            excludedProductIds: .fake(),
+            usageLimit: .fake(),
+            usageLimitPerUser: .fake(),
+            limitUsageToXItems: .fake(),
+            freeShipping: .fake(),
+            productCategories: .fake(),
+            excludedProductCategories: .fake(),
+            excludeSaleItems: .fake(),
+            minimumAmount: .fake(),
+            maximumAmount: .fake(),
+            emailRestrictions: .fake(),
+            usedBy: .fake()
+        )
+    }
+}
+extension Coupon.DiscountType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Coupon.DiscountType {
+        .percent
+    }
+}
 extension CreateProductVariation {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -83,6 +83,56 @@ public struct Coupon {
         case fixedCart = "fixed_cart"
         case fixedProduct = "fixed_product"
     }
+
+    public init(siteID: Int64 = 0,
+                couponID: Int64,
+                code: String,
+                amount: String,
+                dateCreated: Date,
+                dateModified: Date,
+                discountType: DiscountType,
+                description: String,
+                dateExpires: Date?,
+                usageCount: Int64,
+                individualUse: Bool,
+                productIds: [Int64],
+                excludedProductIds: [Int64],
+                usageLimit: Int64?,
+                usageLimitPerUser: Int64?,
+                limitUsageToXItems: Int64?,
+                freeShipping: Bool,
+                productCategories: [Int64],
+                excludedProductCategories: [Int64],
+                excludeSaleItems: Bool,
+                minimumAmount: String,
+                maximumAmount: String,
+                emailRestrictions: [String],
+                usedBy: [String]) {
+        self.siteID = siteID
+        self.couponID = couponID
+        self.code = code
+        self.amount = amount
+        self.dateCreated = dateCreated
+        self.dateModified = dateModified
+        self.discountType = discountType
+        self.description = description
+        self.dateExpires = dateExpires
+        self.usageCount = usageCount
+        self.individualUse = individualUse
+        self.productIds = productIds
+        self.excludedProductIds = excludedProductIds
+        self.usageLimit = usageLimit
+        self.usageLimitPerUser = usageLimitPerUser
+        self.limitUsageToXItems = limitUsageToXItems
+        self.freeShipping = freeShipping
+        self.productCategories = productCategories
+        self.excludedProductCategories = excludedProductCategories
+        self.excludeSaleItems = excludeSaleItems
+        self.minimumAmount = minimumAmount
+        self.maximumAmount = maximumAmount
+        self.emailRestrictions = emailRestrictions
+        self.usedBy = usedBy
+    }
 }
 
 


### PR DESCRIPTION
Part of issue #3912

# Description
This PR fixes the `GeneratedFakeable` conformance of `Coupon`.
Fake generation requires a public initializer, the internal memberwise init is not sufficient for Sourcery to generate the `fake()` method.

# Testing

The Coupon is not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
