### PR TITLE
Coupon Management: Yosemite - CouponStore synchronizeCoupons method

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -1,8 +1,20 @@
 import Foundation
 
+/// Protocol for `CouponsRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol CouponsRemoteProtocol {
+    func loadAllCoupons(for siteID: Int64,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        completion: @escaping (Result<[Coupon], Error>) -> ())
+}
+
+
 /// Coupons: Remote endpoints
 ///
-public final class CouponsRemote: Remote {
+public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     // MARK: - Get Coupons
 
     /// Retrieves all of the `Coupon`s from the API.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		02FF056D23DEDCB90058E6E7 /* MockImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */; };
 		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
 		03FBDA222631521100ACE257 /* CouponAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA212631521100ACE257 /* CouponAction.swift */; };
+		03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */; };
 		03FBDA3E2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		24163B9E257F41A600F94EC3 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24163B9D257F41A600F94EC3 /* StoresManager.swift */; };
@@ -388,6 +389,7 @@
 		02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageSourceWriter.swift; sourceTree = "<group>"; };
 		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
 		03FBDA212631521100ACE257 /* CouponAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAction.swift; sourceTree = "<group>"; };
+		03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponsRemote.swift; sourceTree = "<group>"; };
 		03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		24163B9D257F41A600F94EC3 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		24163BA7257F41C500F94EC3 /* SessionManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerProtocol.swift; sourceTree = "<group>"; };
@@ -921,6 +923,7 @@
 				578CE7912475EC9200492EBF /* MockProductsRemote.swift */,
 				020C908024C7D71D001E2BEB /* MockProductVariationsRemote.swift */,
 				02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */,
+				03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1763,6 +1766,7 @@
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,
 				02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */,
 				0248B36B2459127200A271A4 /* MockNetwork+Path.swift in Sources */,
+				03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */,
 				B5C9DE252087FF20006B910A /* MockActionsProcessor.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
 				261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		02FF056D23DEDCB90058E6E7 /* MockImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */; };
 		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
 		03FBDA222631521100ACE257 /* CouponAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA212631521100ACE257 /* CouponAction.swift */; };
+		03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA25263296A100ACE257 /* CouponStore.swift */; };
+		03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA29263296C400ACE257 /* CouponStoreTests.swift */; };
 		03FBDA2E2632A9B400ACE257 /* MockCouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */; };
 		03FBDA3E2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
@@ -389,6 +391,8 @@
 		02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageSourceWriter.swift; sourceTree = "<group>"; };
 		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
 		03FBDA212631521100ACE257 /* CouponAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAction.swift; sourceTree = "<group>"; };
+		03FBDA25263296A100ACE257 /* CouponStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStore.swift; sourceTree = "<group>"; };
+		03FBDA29263296C400ACE257 /* CouponStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStoreTests.swift; sourceTree = "<group>"; };
 		03FBDA2D2632A9B400ACE257 /* MockCouponsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCouponsRemote.swift; sourceTree = "<group>"; };
 		03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		24163B9D257F41A600F94EC3 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
@@ -1078,6 +1082,7 @@
 				D87F614B22657B150031A13B /* AppSettingsStore.swift */,
 				02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */,
 				741F34812195EA71005F5BD9 /* CommentStore.swift */,
+				03FBDA25263296A100ACE257 /* CouponStore.swift */,
 				7471401221877A8B009A11CC /* NotificationStore.swift */,
 				022F00BD24725BAF008CD97F /* NotificationCountStore.swift */,
 				74A7688B20D45EBA00F9D437 /* OrderStore.swift */,
@@ -1116,6 +1121,7 @@
 				458C6DE725ACC554009B300D /* AppSettingsStoreTests+ProductsSettings.swift */,
 				B5BC736720D1AA8F00B5B6FA /* AccountStoreTests.swift */,
 				741F34832195F752005F5BD9 /* CommentStoreTests.swift */,
+				03FBDA29263296C400ACE257 /* CouponStoreTests.swift */,
 				748525AB218A45360036DF75 /* NotificationStoreTests.swift */,
 				74A7688D20D45ED400F9D437 /* OrderStoreTests.swift */,
 				573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */,
@@ -1696,6 +1702,7 @@
 				02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */,
 				749737672141CC8C0008C490 /* TopEarnerStats+ReadOnlyType.swift in Sources */,
 				7493751222498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift in Sources */,
+				03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */,
 				7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */,
 				7455D4692141B59E00FA8C1F /* TopEarnerStatsItem+ReadOnlyConvertible.swift in Sources */,
 				D8C11A5222DF2DA200D4A88D /* StatsActionV4.swift in Sources */,
@@ -1754,6 +1761,7 @@
 				02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */,
 				45AB8B1E24AB363D00B5B36E /* ProductTagStoreTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,
+				03FBDA2A263296C400ACE257 /* CouponStoreTests.swift in Sources */,
 				02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */,
 				B53A56A0211245E0000776C9 /* MockStorageManager+Sample.swift in Sources */,
 				453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Networking
+import Storage
+
+// MARK: - CouponStore
+//
+public final class CouponStore: Store {
+    private let remote: CouponsRemoteProtocol
+
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.writerDerivedStorage
+    }()
+
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: CouponsRemoteProtocol) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Initialize a new CouponStore
+    /// - Parameters:
+    ///   - dispatcher: The dispatcher used to subscribe to `CouponActions`.
+    ///   - storageManager: The storage layer used to store and retrieve persisted coupons.
+    ///   - network: The network layer used to fetch Coupons
+    ///
+    public override convenience init(dispatcher: Dispatcher,
+                                     storageManager: StorageManagerType,
+                                     network: Network) {
+        self.init(dispatcher: dispatcher,
+                  storageManager: storageManager,
+                  network: network,
+                  remote: CouponsRemote(network: network))
+    }
+
+    // MARK: - Actions
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: CouponAction.self)
+    }
+
+    /// Receives and executes Actions.
+    /// - Parameters:
+    ///   - action: An action to handle. Must be a `CouponAction`
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? CouponAction else {
+            assertionFailure("CouponStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .synchronizeCoupons(let siteID, let pageNumber, let pageSize, let onCompletion):
+            synchronizeCoupons(siteID: siteID,
+                               pageNumber: pageNumber,
+                               pageSize: pageSize,
+                               onCompletion: onCompletion)
+        }
+    }
+}
+
+
+// MARK: - Services
+//
+private extension CouponStore {
+
+    /// Synchronizes coupons from a Site with what is persisted in the storage layer.
+    /// A successful sync of the first page will delete all coupons for the specified site from
+    /// storage, in order to reflect deletions made on other devices.
+    ///
+    /// - Parameters:
+    ///   - siteId: The site to synchronizes coupons for.
+    ///   - pageNumber: Page number of coupons to fetch from the API
+    ///   - pageSize: Number of coupons per page to fetch from the API
+    ///   - onCompletion: Closure to call after sychronizing is complete. Called on the main thread.
+    ///   - result: `.success(hasNextPage: Bool)` or `.failure(error: Error)`
+    ///
+    func synchronizeCoupons(siteID: Int64,
+                            pageNumber: Int,
+                            pageSize: Int,
+                            onCompletion: @escaping (_ result: Result<Bool, Error>) -> Void) {
+        remote.loadAllCoupons(for: siteID,
+                              pageNumber: pageNumber,
+                              pageSize: pageSize) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+
+            case .success(let coupons):
+                if pageNumber == Default.firstPageNumber {
+                    self.deleteStoredCoupons(siteID: siteID)
+                }
+
+                let hasNextPage = coupons.count == pageSize
+                self.upsertStoredCouponsInBackground(readOnlyCoupons: coupons,
+                                                     siteID: siteID) {
+                    onCompletion(.success(hasNextPage))
+                }
+            }
+        }
+    }
+}
+
+
+// MARK: - Storage: Coupon
+//
+private extension CouponStore {
+
+    /// Updates or Inserts specified Coupon Entities in a background thread
+    /// `onCompletion` will be called on the main thred
+    ///
+    func upsertStoredCouponsInBackground(readOnlyCoupons: [Networking.Coupon],
+                                         siteID: Int64,
+                                         onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform { [weak self] in
+            self?.upsertStoredCoupons(readOnlyCoupons: readOnlyCoupons,
+                                      in: derivedStorage,
+                                      siteID: siteID)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+
+    /// Updates or Inserts the specified Coupon entities
+    ///
+    func upsertStoredCoupons(readOnlyCoupons: [Networking.Coupon],
+                             in storage: StorageType,
+                             siteID: Int64) {
+        for coupon in readOnlyCoupons {
+            let storageCoupon: Storage.Coupon = {
+                if let storedCoupon = storage.loadCoupon(siteID: siteID,
+                                                         couponID: coupon.couponID) {
+                    return storedCoupon
+                }
+                return storage.insertNewObject(ofType: Storage.Coupon.self)
+            }()
+
+            storageCoupon.update(with: coupon)
+        }
+    }
+
+    /// Deletes all Storage.Coupon with the specified `siteID`
+    ///
+    func deleteStoredCoupons(siteID: Int64) {
+        let storage = storageManager.viewStorage
+        storage.deleteCoupons(siteID: siteID)
+        storage.saveIfNeeded()
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Networking
+
+final class MockCouponsRemote: CouponsRemoteProtocol {
+    // MARK: - Spy properties
+    var didCallLoadAllCoupons = false
+    var spyLoadAllCouponsSiteID: Int64?
+    var spyLoadAllCouponsPageNumber: Int?
+    var spyLoadAllCouponsPageSize: Int?
+
+    // MARK: - Stub responses
+    var resultForLoadAllCoupons: Result<[Coupon], Error>?
+
+    // MARK: - CouponsRemoteProtocol conformance
+    func loadAllCoupons(for siteID: Int64,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        completion: @escaping (Result<[Coupon], Error>) -> ()) {
+        didCallLoadAllCoupons = true
+        spyLoadAllCouponsSiteID = siteID
+        spyLoadAllCouponsPageNumber = pageNumber
+        spyLoadAllCouponsPageSize = pageSize
+        guard let result = resultForLoadAllCoupons else { return }
+        completion(result)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import Networking
+@testable import Storage
+@testable import Yosemite
+import Fakes
+
+final class CouponStoreTests: XCTestCase {
+    /// Mock network to inject responses
+    ///
+    private var network: MockNetwork!
+
+    /// Spy remote to check request parameter use
+    ///
+    private var remote: MockCouponsRemote!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Storage
+    ///
+    private var storage: StorageType! {
+        storageManager.viewStorage
+    }
+
+    /// Convenience: returns the StorageType associated with the main thread
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Convenience: returns the number of stored coupons
+    ///
+    private var storedCouponsCount: Int {
+        return viewStorage.countObjects(ofType: StorageCoupon.self)
+    }
+
+    /// Store
+    ///
+    private var store: CouponStore!
+
+    /// SiteID
+    ///
+    private let sampleSiteID: Int64 = 120934
+
+    /// Default page number
+    ///
+    private let defaultPageNumber = 1
+
+    /// Default page size
+    ///
+    private let defaultPageSize = 12
+
+    // MARK: - Set up and Tear down
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork(useResponseQueue: true)
+        storageManager = MockStorageManager()
+        store = CouponStore(dispatcher: Dispatcher(),
+                            storageManager: storageManager,
+                            network: network)
+    }
+
+    func setUpUsingSpyRemote() {
+        network = MockNetwork(useResponseQueue: true)
+        remote = MockCouponsRemote()
+        storageManager = MockStorageManager()
+        store = CouponStore(dispatcher: Dispatcher(),
+                            storageManager: storageManager,
+                            network: network,
+                            remote: remote)
+    }
+
+    // MARK: - Tests
+
+    func test_synchronizeCoupons_calls_remote_using_correct_request_parameters() {
+        setUpUsingSpyRemote()
+        // Given
+        let action = CouponAction.synchronizeCoupons(siteID: 1092,
+                                                     pageNumber: 12,
+                                                     pageSize: 3) { _ in }
+
+        // When
+        store.onAction(action)
+
+        // Then
+        XCTAssertTrue(remote.didCallLoadAllCoupons)
+        XCTAssertEqual(remote.spyLoadAllCouponsSiteID, 1092)
+        XCTAssertEqual(remote.spyLoadAllCouponsPageNumber, 12)
+        XCTAssertEqual(remote.spyLoadAllCouponsPageSize, 3)
+    }
+
+    func test_synchronizeCoupons_returns_network_error_on_failure() {
+        setUpUsingSpyRemote()
+        // Given
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 418)
+        remote.resultForLoadAllCoupons = .failure(expectedError)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = CouponAction.synchronizeCoupons(siteID: 1092,
+                                                         pageNumber: 12,
+                                                         pageSize: 3) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? NetworkError, expectedError)
+    }
+
+    func test_synchronizeCoupons_returns_has_next_page_true_when_number_of_retrieved_results_matches_pagesize() throws {
+        setUpUsingSpyRemote()
+        // Given
+        let coupons = [Networking.Coupon.fake(), Networking.Coupon.fake()]
+        remote.resultForLoadAllCoupons = .success(coupons)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         pageNumber: self.defaultPageNumber,
+                                         pageSize: 2) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        //Then
+        let hasNextPage = try! result.get()
+        XCTAssertTrue(hasNextPage)
+    }
+
+    func test_synchronizeCoupons_returns_has_next_page_false_when_number_of_retrieved_results_differs_from_pagesize() throws {
+        setUpUsingSpyRemote()
+        // Given
+        let coupons = [Networking.Coupon.fake(), Networking.Coupon.fake()]
+        remote.resultForLoadAllCoupons = .success(coupons)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         pageNumber: self.defaultPageNumber,
+                                         pageSize: 10) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        //Then
+        let hasNextPage = try! result.get()
+        XCTAssertFalse(hasNextPage)
+    }
+
+    func test_synchronizeCoupons_stores_coupons_upon_success() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "coupons",
+                                 filename: "coupons-all")
+        XCTAssertEqual(storedCouponsCount, 0)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         pageNumber: self.defaultPageNumber,
+                                         pageSize: self.defaultPageSize) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedCouponsCount, 3)
+    }
+
+    func test_synchronizeCoupons_deletes_coupons_when_first_page_recieved_from_API() {
+        // Given
+        storeCoupon(Coupon.fake(), for: sampleSiteID)
+        network.simulateResponse(requestUrlSuffix: "coupons",
+                                 filename: "coupons-all")
+        XCTAssertEqual(storedCouponsCount, 1)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         pageNumber: 1,
+                                         pageSize: self.defaultPageSize) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedCouponsCount, 3)
+    }
+
+    func test_synchronizeCoupons_does_not_delete_coupons_when_subsequent_pages_recieved_from_API() {
+        // Given
+        storeCoupon(Coupon.fake(), for: sampleSiteID)
+        network.simulateResponse(requestUrlSuffix: "coupons",
+                                 filename: "coupons-all")
+        XCTAssertEqual(storedCouponsCount, 1)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action: CouponAction
+            action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         pageNumber: 2,
+                                         pageSize: self.defaultPageSize) { result in
+                promise(result)
+            }
+            self.store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedCouponsCount, 4)
+    }
+}
+
+private extension CouponStoreTests {
+    @discardableResult
+    func storeCoupon(_ coupon: Networking.Coupon, for siteID: Int64) -> Storage.Coupon {
+        let storedCoupon = storage.insertNewObject(ofType: Coupon.self)
+        storedCoupon.update(with: coupon)
+        storedCoupon.siteID = siteID
+        return storedCoupon
+    }
+}


### PR DESCRIPTION
Part of #3915 
Please ensure #4025 is merged before this PR

## Description
This PR adds the initial implementation of the `CouponStore`, containing what it needs to enable us to list coupons either in a table view, or a `PaginatedListSelectorViewController`. This requires only the `synchronizeCoupons` method, which inserts or updates coupons retrieved from the `Remote`, deleting any previously stored coupons as it does so, to avoid showing coupons which were previously deleted on another device.

## Testing
The endpoint and storage are not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
