### PR TITLE
Add-ons: Top banner button handling

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -62,6 +62,8 @@ extension WooAnalyticsEvent {
         case productsVariations = "products_variations"
         /// Shown in shipping labels banner for Milestone 1 features.
         case shippingLabelsRelease1 = "shipping_labels_m1"
+        /// Shown in beta feature banner for order add-ons.
+        case addOnsI1 = "add-ons_i1"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -91,6 +91,14 @@ extension WooConstants {
         case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
 #endif
 
+        /// URL for the order add-on i1 feedback survey
+        ///
+#if DEBUG
+        case orderAddOnI1Feedback = "https://automattic.survey.fm/woo-app-addons-testing"
+#else
+        case orderAddOnI1Feedback = "https://automattic.survey.fm/woo-app-addons-production"
+#endif
+
         /// URL for shipping label creation information
         ///
         case shippingLabelCreationInfo = "https://woocommerce.com/products/shipping"

--- a/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension View {
+    /// Renders a view if the provided  `condition` is met.
+    /// If the `condition` is not met, an instance of `EmptyView` will be used in place of the receiver view.
+    ///
+    func renderedIf(_ condition: Bool) -> some View {
+        guard condition else {
+            return AnyView(EmptyView())
+        }
+        return AnyView(self)
+    }
+}
+

--- a/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
@@ -2,15 +2,12 @@ import SwiftUI
 
 extension View {
     /// Renders a view if the provided  `condition` is met.
-    /// If the `condition` is not met, an instance of `EmptyView` will be used in place of the receiver view.
+    /// If the `condition` is not met, an `nil`  will be used in place of the receiver view.
     ///
-    func renderedIf(_ condition: Bool) -> some View {
-        Group {
-            if condition {
-                self
-            } else {
-                EmptyView()
-            }
+    func renderedIf(_ condition: Bool) -> Self? {
+        guard condition else {
+            return nil
         }
+        return self
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
@@ -5,9 +5,12 @@ extension View {
     /// If the `condition` is not met, an instance of `EmptyView` will be used in place of the receiver view.
     ///
     func renderedIf(_ condition: Bool) -> some View {
-        guard condition else {
-            return AnyView(EmptyView())
+        Group {
+            if condition {
+                self
+            } else {
+                EmptyView()
+            }
         }
-        return AnyView(self)
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Conditionals.swift
@@ -11,4 +11,3 @@ extension View {
         return AnyView(self)
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
@@ -16,9 +16,13 @@ final class OrderAddOnListI1ViewModel: ObservableObject {
     ///
     let updateNotice = Localization.updateNotice
 
-    /// Indicates if the top banner should be shown or not
+    /// Indicates if the top banner should be shown or not.
     ///
-    @Published private(set) var shouldShowBetaBanner: Bool = true
+    @Published var shouldShowBetaBanner: Bool = true
+
+    /// Indicates if the survey flow should be shown or not.
+    ///
+    @Published var shouldShowSurvey: Bool = false
 
     /// Member-wise initializer, useful for `SwiftUI` previews
     ///
@@ -51,15 +55,6 @@ final class OrderAddOnListI1ViewModel: ObservableObject {
     private static func addOnPrice(from attribute: OrderItemAttribute, withDecodedName name: String) -> String {
         attribute.name.replacingOccurrences(of: name, with: "")     // "Topping (Spicy) ($30.00)" -> " ($30.00)"
             .trimmingCharacters(in: CharacterSet([" ", "(", ")"]))  // " ($30.00)" -> "$30.00"
-    }
-}
-
-// MARK: Inputs
-extension OrderAddOnListI1ViewModel {
-    /// Tells the view model to hide the beta features banner.
-    ///
-    func hideBetaBanner() {
-        shouldShowBetaBanner = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// ViewModel for `OrderAddOnListI1View`
 ///
-final class OrderAddOnListI1ViewModel {
+final class OrderAddOnListI1ViewModel: ObservableObject {
     /// AddOns to render
     ///
     let addOns: [OrderAddOnI1ViewModel]
@@ -15,6 +15,10 @@ final class OrderAddOnListI1ViewModel {
     /// Update add-ons notice
     ///
     let updateNotice = Localization.updateNotice
+
+    /// Indicates if the top banner should be shown or not
+    ///
+    @Published private(set) var shouldShowBetaBanner: Bool = true
 
     /// Member-wise initializer, useful for `SwiftUI` previews
     ///
@@ -47,6 +51,15 @@ final class OrderAddOnListI1ViewModel {
     private static func addOnPrice(from attribute: OrderItemAttribute, withDecodedName name: String) -> String {
         attribute.name.replacingOccurrences(of: name, with: "")     // "Topping (Spicy) ($30.00)" -> " ($30.00)"
             .trimmingCharacters(in: CharacterSet([" ", "(", ")"]))  // " ($30.00)" -> "$30.00"
+    }
+}
+
+// MARK: Inputs
+extension OrderAddOnListI1ViewModel {
+    /// Tells the view model to hide the beta features banner.
+    ///
+    func hideBetaBanner() {
+        shouldShowBetaBanner = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -56,7 +56,7 @@ struct OrderAddOnListI1View: View {
             }
         }
         .sheet(isPresented: $viewModel.shouldShowSurvey) {
-            Survey()
+            Survey(source: .shippingLabelsRelease1Feedback)
         }
     }
 }
@@ -126,15 +126,3 @@ struct OrderAddOnView_Previews: PreviewProvider {
 }
 
 #endif
-
-
-struct Survey: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> SurveyCoordinatingController {
-        return SurveyCoordinatingController(survey: .shippingLabelsRelease1Feedback)
-
-    }
-
-    func updateUIViewController(_ uiViewController: SurveyCoordinatingController, context: Context) {
-        // No-op
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -20,8 +20,8 @@ final class OrderAddOnsListViewController: UIHostingController<OrderAddOnListI1V
 ///
 struct OrderAddOnListI1View: View {
 
-    /// Static view model to populate the view content
-    let viewModel: OrderAddOnListI1ViewModel
+    /// View model that directs the view content.
+    @ObservedObject private(set) var viewModel: OrderAddOnListI1ViewModel
 
     /// Discussion: Due to the inability of customizing the `List` separators. We have opted to simulate the list behaviour with a `ScrollView` + `VStack`.
     /// We expect performance to be acceptable as normally an order does not have too many add-ons.
@@ -35,15 +35,16 @@ struct OrderAddOnListI1View: View {
 
             ScrollView {
                 VStack {
-                    OrderAddOnTopBanner(width: geometry.size.width)
-                        .onDismiss {
-                            print("Dismiss")
-                        }
-                        .onGiveFeedback {
-                            print("Give feedback")
-                        }
-                        .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
-
+                    if viewModel.shouldShowBetaBanner {
+                        OrderAddOnTopBanner(width: geometry.size.width)
+                            .onDismiss {
+                                viewModel.hideBetaBanner()
+                            }
+                            .onGiveFeedback {
+                                print("Give feedback")
+                            }
+                            .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
+                    }
 
                     ForEach(viewModel.addOns) { addOn in
                         OrderAddOnI1View(viewModel: addOn)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -38,10 +38,10 @@ struct OrderAddOnListI1View: View {
                     if viewModel.shouldShowBetaBanner {
                         OrderAddOnTopBanner(width: geometry.size.width)
                             .onDismiss {
-                                viewModel.hideBetaBanner()
+                                viewModel.shouldShowBetaBanner = false
                             }
                             .onGiveFeedback {
-                                print("Give feedback")
+                                viewModel.shouldShowSurvey = true
                             }
                             .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                     }
@@ -55,6 +55,9 @@ struct OrderAddOnListI1View: View {
                         .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
                 }
             }
+        }
+        .sheet(isPresented: $viewModel.shouldShowSurvey) {
+            Survey()
         }
     }
 }
@@ -124,3 +127,15 @@ struct OrderAddOnView_Previews: PreviewProvider {
 }
 
 #endif
+
+
+struct Survey: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> SurveyCoordinatingController {
+        return SurveyCoordinatingController(survey: .shippingLabelsRelease1Feedback)
+
+    }
+
+    func updateUIViewController(_ uiViewController: SurveyCoordinatingController, context: Context) {
+        // No-op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -35,16 +35,15 @@ struct OrderAddOnListI1View: View {
 
             ScrollView {
                 VStack {
-                    if viewModel.shouldShowBetaBanner {
-                        OrderAddOnTopBanner(width: geometry.size.width)
-                            .onDismiss {
-                                viewModel.shouldShowBetaBanner = false
-                            }
-                            .onGiveFeedback {
-                                viewModel.shouldShowSurvey = true
-                            }
-                            .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
-                    }
+                    OrderAddOnTopBanner(width: geometry.size.width)
+                        .onDismiss {
+                            viewModel.shouldShowBetaBanner = false
+                        }
+                        .onGiveFeedback {
+                            viewModel.shouldShowSurvey = true
+                        }
+                        .renderedIf(viewModel.shouldShowBetaBanner)
+                        .fixedSize(horizontal: false, vertical: true) // Forces view to recalculate it's height
 
                     ForEach(viewModel.addOns) { addOn in
                         OrderAddOnI1View(viewModel: addOn)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -56,7 +56,7 @@ struct OrderAddOnListI1View: View {
             }
         }
         .sheet(isPresented: $viewModel.shouldShowSurvey) {
-            Survey(source: .shippingLabelsRelease1Feedback)
+            Survey(source: .addOnsI1)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/Survey.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/Survey.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// `SwiftUI` wrapper for `SurveyCoordinatingController`
+///
+struct Survey: UIViewControllerRepresentable {
+
+    /// Source for the survey
+    ///
+    let source: SurveyViewController.Source
+
+    func makeUIViewController(context: Context) -> SurveyCoordinatingController {
+        return SurveyCoordinatingController(survey: source)
+
+    }
+
+    func updateUIViewController(_ uiViewController: SurveyCoordinatingController, context: Context) {
+        // No-op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -65,6 +65,7 @@ extension SurveyViewController {
         case inAppFeedback
         case productsVariationsFeedback
         case shippingLabelsRelease1Feedback
+        case addOnsI1
 
         fileprivate var url: URL {
             switch self {
@@ -85,6 +86,11 @@ extension SurveyViewController {
                     .tagPlatform("ios")
                     .tagShippingLabelsMilestone("1")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .addOnsI1:
+                return WooConstants.URLs.orderAddOnI1Feedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -92,7 +98,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsVariationsFeedback, .shippingLabelsRelease1Feedback:
+            case .productsVariationsFeedback, .shippingLabelsRelease1Feedback, .addOnsI1:
                 return Localization.giveFeedback
             }
         }
@@ -106,6 +112,8 @@ extension SurveyViewController {
                 return .productsVariations
             case .shippingLabelsRelease1Feedback:
                 return .shippingLabelsRelease1
+            case .addOnsI1:
+                return .addOnsI1
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
+		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
@@ -1617,6 +1618,7 @@
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
+		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
@@ -3389,6 +3391,7 @@
 		26B119B524D0B36700FED5C7 /* Survey */ = {
 			isa = PBXGroup;
 			children = (
+				26E0AE1826335AA900A5EB3B /* Survey.swift */,
 				2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */,
 				26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */,
 				26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */,
@@ -6589,6 +6592,7 @@
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
+				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0298430C259351F100979CAE /* ShippingLabelsTopBannerFactory.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
+		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
@@ -1615,6 +1616,7 @@
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
+		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
@@ -3300,6 +3302,7 @@
 			isa = PBXGroup;
 			children = (
 				262A09802628A8F40033AD20 /* WooStyleModifiers.swift */,
+				26E0AE12263359F900A5EB3B /* View+Conditionals.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -6441,6 +6444,7 @@
 				CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,
 				57C5FF7F250925C90074EC26 /* OrderListViewModel.swift in Sources */,
+				26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */,
 				CE583A072107849F00D73C1C /* SwitchTableViewCell.swift in Sources */,
 				D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */,
 				0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
@@ -24,4 +24,22 @@ class OrderAddOnListI1Tests: XCTestCase {
             OrderAddOnI1ViewModel.init(id: 3, title: "Soda (No Sugar)", content: "5", price: "$7.00")
         ])
     }
+
+    func test_top_banner_start_visible_and_is_hiden_after_calling_hideBanner_method() {
+        // Given
+        let attributes = [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: "Salami"),
+            OrderItemAttribute(metaID: 2, name: "Fast Delivery ($7.00)", value: "Yes"),
+            OrderItemAttribute(metaID: 3, name: "Soda (No Sugar) ($7.00)", value: "5"),
+        ]
+        let viewModel = OrderAddOnListI1ViewModel(attributes: attributes)
+        XCTAssertTrue(viewModel.shouldShowBetaBanner)
+
+        // When
+        viewModel.hideBetaBanner()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowBetaBanner)
+
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
@@ -24,22 +24,4 @@ class OrderAddOnListI1Tests: XCTestCase {
             OrderAddOnI1ViewModel.init(id: 3, title: "Soda (No Sugar)", content: "5", price: "$7.00")
         ])
     }
-
-    func test_top_banner_start_visible_and_is_hiden_after_calling_hideBanner_method() {
-        // Given
-        let attributes = [
-            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: "Salami"),
-            OrderItemAttribute(metaID: 2, name: "Fast Delivery ($7.00)", value: "Yes"),
-            OrderItemAttribute(metaID: 3, name: "Soda (No Sugar) ($7.00)", value: "5"),
-        ]
-        let viewModel = OrderAddOnListI1ViewModel(attributes: attributes)
-        XCTAssertTrue(viewModel.shouldShowBetaBanner)
-
-        // When
-        viewModel.hideBetaBanner()
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowBetaBanner)
-
-    }
 }


### PR DESCRIPTION
closes #3894

# Why

After #4017, where I introduced a beta top banner view on the order-add on screen this PR is in charge of handling action buttons(Give feedback and dismiss) of that banner.

- The "Give Feedback" button will launch a survey feedback
- The "Dismiss" button will hide the banner for the screen session.

# How

- Updated `WooConstants` with the add-on survey URL under the `orderAddOnI1Feedback` property.

- Added a new `.addOnsI1` case on `SurveyViewController.source`

- Created `Survey.swift` to wrap `SurveyCoordinatingController` for `SwiftUI`.

- Updated `OrderAddOnListI1ViewModel` to conform to `ObservableObject`. This is needed in order for the view to observe changes from this object using the `@ObservedObject` property wrapper.

- Updated `OrderAddOnListI1ViewModel` to add two new `@Published` properties. `shouldShowSurvey` and `shouldShowBetaBanner` which controls when the survey should be presented and when the banner should be rendered.

- Created a new view modifier/extension to render(or not) a view when a condition is met. paNNhX-dg-p2

- Updated `OrderAddOnListI1View` to render content conditionaly according to the view model properties.

# Demo

https://user-images.githubusercontent.com/562080/115928495-ccc69180-a44b-11eb-8948-e4aa841d95dd.mov

# Testing Steps
**Prerequisites:** Have your site with the add-ons plugin installed and with at least one order with add-ons.

- Launch the app and navigate to the add-on order
- Tap on the "View Add-Ons" button.
- See that there is a "beta feature" banner
- Tap on the "Give Feedback" button and make sure you are able to fill the survey
- After dismissing the survey, tap on the "Dismiss" button and make sure the banner is hidden.

Note: The next time you open an order's add-ons, the banner should be visible again.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
