### PR TITLE
Shipping Labels M2: Prevent button flashing when a different address is selected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -38,7 +38,7 @@ final class ShippingLabelSuggestedAddressViewController: UIViewController {
     private var selectedAddress: SelectedAddress = .suggested {
         didSet {
             tableView.reloadData()
-            configureUseAddressButton()
+            updateUseAddressButton()
         }
     }
 
@@ -111,11 +111,17 @@ private extension ShippingLabelSuggestedAddressViewController {
         }
     }
 
+    // Initial configuration for the address button, should only run once
     func configureUseAddressButton() {
-        let title = selectedAddress == .entered ? Localization.useAddressEnteredButton : Localization.useAddressSuggestedButton
-        useAddressButton.setTitle(title, for: .normal)
         useAddressButton.addTarget(self, action: #selector(didTapUseAddressButton), for: .touchUpInside)
         useAddressButton.applyPrimaryButtonStyle()
+        updateUseAddressButton()
+    }
+
+    // Configuration for the address button when the UI needs to change
+    func updateUseAddressButton() {
+        let title = selectedAddress == .entered ? Localization.useAddressEnteredButton : Localization.useAddressSuggestedButton
+        useAddressButton.setTitle(title, for: .normal)
     }
 
     func configureEditAddressButton() {


### PR DESCRIPTION
Closes #3914

## Why

As described in #3914, the primary button would briefly turn black when a different address was selected.

## How

The issue was that `configureUseAddressButton()` was being called every time the address changed to update the label, but this was also configuring all the appearance for the button.

The `applyPrimaryButtonStyle` does a number of things, but the problematic sequence is that it calls `titleLabel?.applyHeadlineStyle()` first, which sets the color to black, then `setTitleColor(.primaryButtonTitle, for: .normal)`, which sets the right color.
Since setting the title does so with animations enabled, we can see the color changing to black then white (if we call `applyPrimaryButtonStyle` but not `setTitle`, there is also no flashing.

To solve this, I have decoupled the initial styling of the button (which shouldn't change), from updating the label with a new `updateUseAddressButton()` method.

The button still animates the label change, but I believe that's the desired behavior.

![wcios-suggested-address-flash](https://user-images.githubusercontent.com/8739/116109634-46ad8380-a6b5-11eb-9995-16930e2a40d2.gif)

## How to test

I followed the steps in  #3916:

> 1. Before testing, make sure you have an order with an address that is slightly different from the suggested mailing address. (For example, enter an incomplete street name "Market" instead of "Market St.")
> 1. Go to the Orders > Processing tab.
> 1. Select an order.
> 1. Select "Create Shipping Label."
> 1. Select "Continue" in the "Ship from" section.
> 1. If the "Ship from" address is accepted, select "Continue" in the "Ship to" section. -> If the order's shipping address is different from the suggested address, you should land on the suggested address screen at this point.
> 1. Select between "Address Entered" and "Address Suggested" and watch the text on the primary button change as you make your selection. -> The text on the button flashes black as it changes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

☝🏽 I understand the feature is not yet released, so I think a bug fix shouldn't make it into the release notes?