### PR TITLE
Fix separator padding in Shipping Label Package Details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -18,7 +18,7 @@ struct ShippingLabelPackageDetails: View {
                     .background(Color(.listBackground))
 
                 ForEach(viewModel.itemsRows) { productItemRow in
-                    Divider()
+                    Divider().padding(.leading, Constants.dividerPadding)
                     productItemRow
                 }
 
@@ -62,6 +62,10 @@ private extension ShippingLabelPackageDetails {
                                                           comment: "Title of the row for adding the package weight in Shipping Label Package Detail screen")
         static let footer = NSLocalizedString("Sum of products and package weight",
                                               comment: "Title of the footer in Shipping Label Package Detail screen")
+    }
+
+    enum Constants {
+        static let dividerPadding: CGFloat = 16
     }
 }
 


### PR DESCRIPTION
Fixes: #4036 

In this PR I fixed the separator padding in the items rows under the Shipping Label Package Details.

## Testing
1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the **Ship From** cell. Confirm the address.
5. Press the button "Continue" in Create Shipping Label form, under the **Ship To** cell. Confirm the address.
6. Press the button "Continue" in Create Shipping Label form, under the **Package Details** cell.
7. You should see the new screen that shows the Package Details screen and all the items that will be shipped.
8. The items rows should show the correct padding in the separator (looks at the screenshots below).


## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/495617/116226769-b1150100-a753-11eb-903e-cfa5755082bd.png) | ![after](https://user-images.githubusercontent.com/495617/116226786-b5d9b500-a753-11eb-874d-40ed39538028.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
