### PR TITLE
Add-ons: Fix add-on cross-reference for variable products 

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -32,6 +32,11 @@ struct AddOnCrossreferenceUseCase {
         let splitToken = " ("
         let components = attribute.name.components(separatedBy: splitToken)
 
+        // If name the format does not match our format assumptions, return the raw name.
+        guard components.count > 1 else {
+            return attribute.name
+        }
+
         // In case there are more `" ("` occurrences in the string, drop the last one assuming its the add-on price,
         // and join the remaining components to keep the original name integrity
         return components.dropLast().joined(separator: splitToken)

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -32,7 +32,7 @@ struct AddOnCrossreferenceUseCase {
         let splitToken = " ("
         let components = attribute.name.components(separatedBy: splitToken)
 
-        // If name the format does not match our format assumptions, return the raw name.
+        // If name does not match our format assumptions, return the raw name.
         guard components.count > 1 else {
             return attribute.name
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -751,7 +751,7 @@ private extension OrderDetailsDataSource {
     /// Returns an `empty` array if we can't find the product associated with order item or if the `addOns` feature is disabled.
     ///
     private func filterAddOns(of item: AggregateOrderItem) -> [OrderItemAttribute] {
-        guard let product = products.first(where: { $0.productID == item.productOrVariationID }), showAddOns else {
+        guard let product = products.first(where: { $0.productID == item.productID }), showAddOns else {
             return []
         }
         return AddOnCrossreferenceUseCase(orderItem: item, product: product).addOnsAttributes()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
@@ -44,9 +44,15 @@ final class OrderAddOnListI1ViewModel: ObservableObject {
     /// The `attribute.name` comes in the form of "add-on-title (add-on-price)". EG: "Topping (Spicy) ($30.00)"
     ///
     private static func addOnName(from attribute: OrderItemAttribute) -> String {
-        attribute.name.components(separatedBy: " (") // "Topping (Spicy) ($30.00)" -> ["Topping", "Spicy)", "$30.00)"]
-            .dropLast()                              // ["Topping", "Spicy)", "$30.00)"] -> ["Topping", "Spicy)"]
-            .joined(separator: " (")                 // ["Topping", "Spicy)"] -> "Topping (Spicy)"
+        let components = attribute.name.components(separatedBy: " (") // "Topping (Spicy) ($30.00)" -> ["Topping", "Spicy)", "$30.00)"]
+
+        // If name the format does not match our format assumptions, return the raw name.
+        guard components.count > 1 else {
+            return attribute.name
+        }
+
+        return components.dropLast() // ["Topping", "Spicy)", "$30.00)"] -> ["Topping", "Spicy)"]
+            .joined(separator: " (") // ["Topping", "Spicy)"] -> "Topping (Spicy)"
     }
 
     /// Decodes the price of the add-on from the `attribute.name` property using an already decoded add-on name.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListViewModel.swift
@@ -46,7 +46,7 @@ final class OrderAddOnListI1ViewModel: ObservableObject {
     private static func addOnName(from attribute: OrderItemAttribute) -> String {
         let components = attribute.name.components(separatedBy: " (") // "Topping (Spicy) ($30.00)" -> ["Topping", "Spicy)", "$30.00)"]
 
-        // If name the format does not match our format assumptions, return the raw name.
+        // If name does not match our format assumptions, return the raw name.
         guard components.count > 1 else {
             return attribute.name
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
@@ -51,6 +51,25 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
     }
 
+    func tests_addOn_attributes_with_no_price_in_name_are_correctly_filtered_against_product_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 3, name: "Engraving", value: ""),
+        ])
+        let product = Product.fake().copy(addOns: [
+            ProductAddOn.fake().copy(name: "Engraving"),
+        ])
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertEqual(addOnsAttributes, [
+            OrderItemAttribute(metaID: 3, name: "Engraving", value: ""),
+        ])
+    }
+
     func tests_addOnAttributes_is_empty_when_product_does_not_have_addOns() {
         // Given
         let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
@@ -12,6 +12,7 @@ class OrderAddOnListI1Tests: XCTestCase {
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: "Salami"),
             OrderItemAttribute(metaID: 2, name: "Fast Delivery ($7.00)", value: "Yes"),
             OrderItemAttribute(metaID: 3, name: "Soda (No Sugar) ($7.00)", value: "5"),
+            OrderItemAttribute(metaID: 4, name: "Engraving", value: "Earned Not Given"),
         ]
 
         // When
@@ -21,7 +22,8 @@ class OrderAddOnListI1Tests: XCTestCase {
         XCTAssertEqual(viewModel.addOns, [
             OrderAddOnI1ViewModel.init(id: 1, title: "Topping", content: "Salami", price: "$3.00"),
             OrderAddOnI1ViewModel.init(id: 2, title: "Fast Delivery", content: "Yes", price: "$7.00"),
-            OrderAddOnI1ViewModel.init(id: 3, title: "Soda (No Sugar)", content: "5", price: "$7.00")
+            OrderAddOnI1ViewModel.init(id: 3, title: "Soda (No Sugar)", content: "5", price: "$7.00"),
+            OrderAddOnI1ViewModel.init(id: 4, title: "Engraving", content: "Earned Not Given", price: "")
         ])
     }
 }


### PR DESCRIPTION
fix #4008 

# Why

It was reported that variable product orders were not displaying add-ons correctly.
After a bit of investigation, I discovered two problems.

1. I was cross-referencing the order attributes with the product variation add-ons, but the product variation does not have add-on information, the main product has it, so we need to always cross-reference against the main product.

2. I noticed that an add-on without a price does not come with the expected format of `"add-on-title (add-on-price)"` and is just only `"add-on-title"`.

# How 

1. Changed `productOrVariationID` for `productID` for our cross-reference comparison.

2. Exit early and return the raw attribute name, when we detect it does not match our name format assumptions.

# Demo

https://user-images.githubusercontent.com/562080/116251798-9f703100-a734-11eb-8d3f-22820b4ccc54.mov

# Testing Steps

**Prerequisites:** Have your site with the add-ons plugin installed

On Core:
- Set a variable product and create an add-on without a price.
- Create an order with that variable product and that add-on.

On App:
- Launch the app and navigate to the add-on order
- See that there is a "View Add-Ons" button.
- Tap on the button and see that it display the add-ons without a price appropriately.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
