### PR TITLE
Add subtitle and update copies on empty state view of Variations list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -18,7 +18,7 @@ final class ProductVariationsViewController: UIViewController {
         let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
         return .withButton(message: message,
                            image: .emptyBoxImage,
-                           details: "",
+                           details: Localization.emptyStateSubtitle,
                            buttonTitle: Localization.emptyStateButtonTitle) { [weak self] _ in
                             self?.createVariationFromEmptyState()
                            }
@@ -733,8 +733,11 @@ private extension ProductVariationsViewController {
     }
 
     enum Localization {
-        static let emptyStateTitle = NSLocalizedString("Add your first variation", comment: "Title on the variations list screen when there are no variations")
-        static let emptyStateButtonTitle = NSLocalizedString("Add Variation", comment: "Title on add variation button when there are no variations")
+        static let emptyStateTitle = NSLocalizedString("Create your first variation",
+                                                       comment: "Title on the variations list screen when there are no variations")
+        static let emptyStateSubtitle = NSLocalizedString("To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first",
+                                                          comment: "Subtitle on the variations list screen when there are no variations")
+        static let emptyStateButtonTitle = NSLocalizedString("Add Attributes", comment: "Title on add variation button when there are no variations")
         static let addNewVariation = NSLocalizedString("Add Variation", comment: "Action to add new variation on the variations list")
         static let moreButtonLabel = NSLocalizedString("More options", comment: "Accessibility label to show the More Options action sheet")
         static let editAttributesAction = NSLocalizedString("Edit Attributes", comment: "Action to edit the attributes and options used for variations")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -16,9 +16,9 @@ final class ProductVariationsViewController: UIViewController {
     ///
     private var emptyStateConfig: EmptyStateViewController.Config {
         let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
-        let productHasAttributes = product.attributesForVariations.isNotEmpty
-        let subtitle = productHasAttributes ? "" : Localization.emptyStateSubtitle
-        let buttonTitle = productHasAttributes ? Localization.addVariationAction : Localization.addAttributesAction
+        let shouldShowCreatingAttributesGuide = viewModel.shouldShowCreatingAttributesGuide(for: product)
+        let subtitle = shouldShowCreatingAttributesGuide ? Localization.emptyStateSubtitle : ""
+        let buttonTitle = shouldShowCreatingAttributesGuide ? Localization.addAttributesAction : Localization.addVariationAction
         return .withButton(message: message,
                            image: .emptyBoxImage,
                            details: subtitle,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -244,7 +244,7 @@ private extension ProductVariationsViewController {
         emptyStateViewController.view.pinSubviewToAllEdges(view)
         emptyStateViewController.didMove(toParent: self)
 
-        let showAttributeGuide = viewModel.shouldShowCreatingAttributesGuide(for: product)
+        let showAttributeGuide = viewModel.shouldShowAttributeGuide(for: product)
         let emptyStateConfig = createEmptyStateConfig(showAttributeGuide: showAttributeGuide)
         emptyStateViewController.configure(emptyStateConfig)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -18,7 +18,7 @@ final class ProductVariationsViewController: UIViewController {
         let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
         let productHasAttributes = product.attributesForVariations.isNotEmpty
         let subtitle = productHasAttributes ? "" : Localization.emptyStateSubtitle
-        let buttonTitle = productHasAttributes ? Localization.addVariationAction: Localization.addAttributesAction
+        let buttonTitle = productHasAttributes ? Localization.addVariationAction : Localization.addAttributesAction
         return .withButton(message: message,
                            image: .emptyBoxImage,
                            details: subtitle,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -16,10 +16,13 @@ final class ProductVariationsViewController: UIViewController {
     ///
     private lazy var emptyStateConfig: EmptyStateViewController.Config = {
         let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
+        let productHasAttributes = product.attributesForVariations.isNotEmpty
+        let subtitle = productHasAttributes ? "" : Localization.emptyStateSubtitle
+        let buttonTitle = productHasAttributes ? Localization.addVariationAction: Localization.addAttributesAction
         return .withButton(message: message,
                            image: .emptyBoxImage,
-                           details: Localization.emptyStateSubtitle,
-                           buttonTitle: Localization.emptyStateButtonTitle) { [weak self] _ in
+                           details: subtitle,
+                           buttonTitle: buttonTitle) { [weak self] _ in
                             self?.createVariationFromEmptyState()
                            }
     }()
@@ -736,8 +739,11 @@ private extension ProductVariationsViewController {
         static let emptyStateTitle = NSLocalizedString("Create your first variation",
                                                        comment: "Title on the variations list screen when there are no variations")
         static let emptyStateSubtitle = NSLocalizedString("To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first",
-                                                          comment: "Subtitle on the variations list screen when there are no variations")
-        static let emptyStateButtonTitle = NSLocalizedString("Add Attributes", comment: "Title on add variation button when there are no variations")
+                                                          comment: "Subtitle on the variations list screen when there are no variations and attributes")
+        static let addAttributesAction = NSLocalizedString("Add Attributes",
+                                                           comment: "Title on empty state button when the product has no attributes and variations")
+        static let addVariationAction = NSLocalizedString("Add Variation",
+                                                          comment: "Title on empty state button when the product has attributes but no variations")
         static let addNewVariation = NSLocalizedString("Add Variation", comment: "Action to add new variation on the variations list")
         static let moreButtonLabel = NSLocalizedString("More options", comment: "Accessibility label to show the More Options action sheet")
         static let editAttributesAction = NSLocalizedString("Edit Attributes", comment: "Action to edit the attributes and options used for variations")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -12,21 +12,6 @@ final class ProductVariationsViewController: UIViewController {
     ///
     private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
 
-    /// Empty state screen configuration
-    ///
-    private var emptyStateConfig: EmptyStateViewController.Config {
-        let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
-        let shouldShowCreatingAttributesGuide = viewModel.shouldShowCreatingAttributesGuide(for: product)
-        let subtitle = shouldShowCreatingAttributesGuide ? Localization.emptyStateSubtitle : ""
-        let buttonTitle = shouldShowCreatingAttributesGuide ? Localization.addAttributesAction : Localization.addVariationAction
-        return .withButton(message: message,
-                           image: .emptyBoxImage,
-                           details: subtitle,
-                           buttonTitle: buttonTitle) { [weak self] _ in
-                            self?.createVariationFromEmptyState()
-                           }
-    }
-
     @IBOutlet private weak var tableView: UITableView!
 
     /// Pull To Refresh Support.
@@ -258,7 +243,24 @@ private extension ProductVariationsViewController {
 
         emptyStateViewController.view.pinSubviewToAllEdges(view)
         emptyStateViewController.didMove(toParent: self)
+
+        let showAttributeGuide = viewModel.shouldShowCreatingAttributesGuide(for: product)
+        let emptyStateConfig = createEmptyStateConfig(showAttributeGuide: showAttributeGuide)
         emptyStateViewController.configure(emptyStateConfig)
+    }
+
+    /// Creates empty state screen configuration
+    ///
+    private func createEmptyStateConfig(showAttributeGuide: Bool) -> EmptyStateViewController.Config {
+        let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
+        let subtitle = showAttributeGuide ? Localization.emptyStateSubtitle : ""
+        let buttonTitle = showAttributeGuide ? Localization.addAttributesAction : Localization.addVariationAction
+        return .withButton(message: message,
+                           image: .emptyBoxImage,
+                           details: subtitle,
+                           buttonTitle: buttonTitle) { [weak self] _ in
+                            self?.createVariationFromEmptyState()
+                           }
     }
 
     func removeEmptyViewController() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -14,7 +14,7 @@ final class ProductVariationsViewController: UIViewController {
 
     /// Empty state screen configuration
     ///
-    private lazy var emptyStateConfig: EmptyStateViewController.Config = {
+    private var emptyStateConfig: EmptyStateViewController.Config {
         let message = NSAttributedString(string: Localization.emptyStateTitle, attributes: [.font: EmptyStateViewController.Config.messageFont])
         let productHasAttributes = product.attributesForVariations.isNotEmpty
         let subtitle = productHasAttributes ? "" : Localization.emptyStateSubtitle
@@ -25,7 +25,7 @@ final class ProductVariationsViewController: UIViewController {
                            buttonTitle: buttonTitle) { [weak self] _ in
                             self?.createVariationFromEmptyState()
                            }
-    }()
+    }
 
     @IBOutlet private weak var tableView: UITableView!
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -48,7 +48,7 @@ extension ProductVariationsViewModel {
     func shouldShowMoreButton(for product: Product) -> Bool {
         product.attributesForVariations.isNotEmpty
     }
-    
+
     func shouldShowCreatingAttributesGuide(for product: Product) -> Bool {
         product.variations.isEmpty && product.attributesForVariations.isEmpty
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -48,4 +48,8 @@ extension ProductVariationsViewModel {
     func shouldShowMoreButton(for product: Product) -> Bool {
         product.attributesForVariations.isNotEmpty
     }
+    
+    func shouldShowCreatingAttributesGuide(for product: Product) -> Bool {
+        product.variations.isEmpty && product.attributesForVariations.isEmpty
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -51,7 +51,7 @@ extension ProductVariationsViewModel {
 
     /// Defines if empty state screen should show guide for creating attributes
     ///
-    func shouldShowCreatingAttributesGuide(for product: Product) -> Bool {
+    func shouldShowAttributeGuide(for product: Product) -> Bool {
         product.variations.isEmpty && product.attributesForVariations.isEmpty
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -52,6 +52,6 @@ extension ProductVariationsViewModel {
     /// Defines if empty state screen should show guide for creating attributes
     ///
     func shouldShowAttributeGuide(for product: Product) -> Bool {
-        product.variations.isEmpty && product.attributesForVariations.isEmpty
+        product.attributesForVariations.isEmpty
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -49,6 +49,8 @@ extension ProductVariationsViewModel {
         product.attributesForVariations.isNotEmpty
     }
 
+    /// Defines if empty state screen should show guide for creating attributes
+    ///
     func shouldShowCreatingAttributesGuide(for product: Product) -> Bool {
         product.variations.isEmpty && product.attributesForVariations.isEmpty
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -104,7 +104,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         XCTAssertFalse(showAttributesGuide)
     }
 
-    func test_attributes_guide_is_not_shown_when_product_has_variations_but_no_attributes() {
+    func test_attributes_guide_is_shown_when_product_has_variations_but_no_attributes() {
         let product = Product.fake().copy(attributes: [], variations: [1, 2])
         let viewModel = ProductVariationsViewModel(formType: .edit)
 
@@ -112,7 +112,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let showAttributesGuide = viewModel.shouldShowAttributeGuide(for: product)
 
         // Then
-        XCTAssertFalse(showAttributesGuide)
+        XCTAssertTrue(showAttributesGuide)
     }
 
     func test_formType_is_updated_to_edit_when_new_product_exists_remotely_and_formType_was_add() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -80,6 +80,41 @@ final class ProductVariationsViewModelTests: XCTestCase {
         XCTAssertFalse(showEmptyState)
     }
 
+    func test_attributes_guide_is_shown_when_product_does_not_have_attributes_or_variations() {
+        // Given
+        let product = Product.fake()
+        let viewModel = ProductVariationsViewModel(formType: .edit)
+
+        // Then
+        let showAttributesGuide = viewModel.shouldShowAttributeGuide(for: product)
+
+        // Then
+        XCTAssertTrue(showAttributesGuide)
+    }
+
+    func test_attributes_guide_is_not_shown_when_product_has_attributes_but_no_variations() {
+        let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
+        let product = Product.fake().copy(attributes: [attribute], variations: [])
+        let viewModel = ProductVariationsViewModel(formType: .edit)
+
+        // Then
+        let showAttributesGuide = viewModel.shouldShowAttributeGuide(for: product)
+
+        // Then
+        XCTAssertFalse(showAttributesGuide)
+    }
+
+    func test_attributes_guide_is_not_shown_when_product_has_variations_but_no_attributes() {
+        let product = Product.fake().copy(attributes: [], variations: [1, 2])
+        let viewModel = ProductVariationsViewModel(formType: .edit)
+
+        // Then
+        let showAttributesGuide = viewModel.shouldShowAttributeGuide(for: product)
+
+        // Then
+        XCTAssertFalse(showAttributesGuide)
+    }
+
     func test_formType_is_updated_to_edit_when_new_product_exists_remotely_and_formType_was_add() {
         // Given
         let product = Product.fake().copy(productID: 123)


### PR DESCRIPTION
Fix #3903 

## Description

This PR changes empty state view of Variations list screen:
- Updates `emptyStateConfig` with a content string for `detail` to show subtitle.
- Updates copies of title and button.

## Screenshot
<img src="https://user-images.githubusercontent.com/5533851/116255180-358b7200-a79c-11eb-9b84-1851b0d1bdb2.png" width="300">

## Problem
I can see that the current font of subtitle text doesn't really match with the expected design. Also the button size is slightly different too. But I'm keeping both of them as-is for now as they seem to be out of scope of issue #3903. Let me know if the UI needs further adjustments - I'd need detailed specifications for the metrics and constraints too (it's hard to tell from the screenshot).

## Testing
This screen can be reached by either of these two flows:
- Select Product tabs -> Add new variable product
- Select Product tabs -> Add new variable product -> Add a new variation with attributes -> Delete that variation

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
