### PR TITLE
Update product variation list buttons

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -300,14 +300,14 @@ private extension ProductVariationsViewController {
         let buttonContainer = UIView()
         buttonContainer.backgroundColor = .listForeground
 
-        let editAttributesButton = UIButton()
-        editAttributesButton.translatesAutoresizingMaskIntoConstraints = false
-        editAttributesButton.setTitle(title, for: .normal)
-        editAttributesButton.addTarget(self, action: actionSelector, for: .touchUpInside)
-        stylingHandler(editAttributesButton)
+        let topButton = UIButton()
+        topButton.translatesAutoresizingMaskIntoConstraints = false
+        topButton.setTitle(title, for: .normal)
+        topButton.addTarget(self, action: actionSelector, for: .touchUpInside)
+        stylingHandler(topButton)
 
-        buttonContainer.addSubview(editAttributesButton)
-        buttonContainer.pinSubviewToSafeArea(editAttributesButton, insets: insets)
+        buttonContainer.addSubview(topButton)
+        buttonContainer.pinSubviewToSafeArea(topButton, insets: insets)
 
         if hasBottomBorder {
             let separator = UIView.createBorderView()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -94,6 +94,7 @@ final class ProductVariationsViewController: UIViewController {
         didSet {
             viewModel.updatedFormTypeIfNeeded(newProduct: product)
 
+            configureRightButtonItem()
             resetResultsController(oldProduct: oldValue)
             updateEmptyState()
             onProductUpdate?(product)
@@ -177,6 +178,22 @@ private extension ProductVariationsViewController {
             "Variations",
             comment: "Title that appears on top of the Product Variation List screen."
         )
+        configureRightButtonItem()
+    }
+
+    /// Configure right button item.
+    ///
+    func configureRightButtonItem() {
+        guard viewModel.shouldShowMoreButton(for: product) else {
+            return navigationItem.rightBarButtonItem = nil
+        }
+
+        let moreButton = UIBarButtonItem(image: .moreImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(presentMoreOptionsActionSheet(_:)))
+        moreButton.accessibilityLabel = Localization.moreButtonLabel
+        navigationItem.setRightBarButton(moreButton, animated: false)
     }
 
     /// Apply Woo styles.
@@ -553,6 +570,28 @@ private extension ProductVariationsViewController {
     }
 }
 
+// MARK: - Action sheet
+//
+private extension ProductVariationsViewController {
+    @objc private func presentMoreOptionsActionSheet(_ sender: UIBarButtonItem) {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        let editAttributesAction = UIAlertAction(title: Localization.editAttributesAction, style: .default) { [weak self] _ in
+            self?.editAttributesTapped()
+        }
+        actionSheet.addAction(editAttributesAction)
+
+        let cancelAction = UIAlertAction(title: Localization.cancelAction, style: .cancel)
+        actionSheet.addAction(cancelAction)
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = sender
+
+        present(actionSheet, animated: true)
+    }
+}
+
 // MARK: - Placeholders
 //
 private extension ProductVariationsViewController {
@@ -724,6 +763,9 @@ private extension ProductVariationsViewController {
         static let emptyStateButtonTitle = NSLocalizedString("Add Variation", comment: "Title on add variation button when there are no variations")
         static let addNewVariation = NSLocalizedString("Generate New Variation", comment: "Action to add new variation on the variations list")
         static let editAttributesAction = NSLocalizedString("Edit Attributes", comment: "Action to edit the attributes and options used for variations")
+
+        static let moreButtonLabel = NSLocalizedString("More options", comment: "Accessibility label to show the More Options action sheet")
+        static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel button in the More Options action sheet")
 
         static let generatingVariation = NSLocalizedString("Generating Variation", comment: "Title for the progress screen while generating a variation")
         static let waitInstructions = NSLocalizedString("Please wait while we create the new variation",

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -295,6 +295,14 @@ private extension ProductVariationsViewController {
         buttonContainer.addSubview(editAttributesButton)
         buttonContainer.pinSubviewToSafeArea(editAttributesButton, insets: .init(top: 8, left: 16, bottom: 16, right: 16))
 
+        let separator = UIView.createBorderView()
+        buttonContainer.addSubview(separator)
+        NSLayoutConstraint.activate([
+            buttonContainer.leadingAnchor.constraint(equalTo: separator.leadingAnchor),
+            buttonContainer.bottomAnchor.constraint(equalTo: separator.bottomAnchor),
+            buttonContainer.trailingAnchor.constraint(equalTo: separator.trailingAnchor)
+        ])
+
         topStackView.addArrangedSubview(buttonContainer)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -276,49 +276,48 @@ private extension ProductVariationsViewController {
         headerContainer.addSubview(topStackView)
         headerContainer.pinSubviewToAllEdges(topStackView)
 
-        configureAddButton()
-        configureEditAttributesButton()
+        configureTopButton(title: Localization.addNewVariation,
+                           insets: .init(top: 16, left: 16, bottom: 8, right: 16),
+                           actionSelector: #selector(addButtonTapped),
+                           stylingHandler: { $0.applyPrimaryButtonStyle() })
+
+        configureTopButton(title: Localization.editAttributesAction,
+                           insets: .init(top: 8, left: 16, bottom: 16, right: 16),
+                           hasBottomBorder: true,
+                           actionSelector: #selector(editAttributesTapped),
+                           stylingHandler: { $0.applySecondaryButtonStyle() })
+
         topStackView.addArrangedSubview(topBannerView)
 
         tableView.tableHeaderView = headerContainer
     }
 
-    func configureAddButton() {
-        let buttonContainer = UIView()
-        buttonContainer.backgroundColor = .listForeground
-
-        let addVariationButton = UIButton()
-        addVariationButton.translatesAutoresizingMaskIntoConstraints = false
-        addVariationButton.setTitle(Localization.addNewVariation, for: .normal)
-        addVariationButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
-        addVariationButton.applyPrimaryButtonStyle()
-
-        buttonContainer.addSubview(addVariationButton)
-        buttonContainer.pinSubviewToSafeArea(addVariationButton, insets: .init(top: 16, left: 16, bottom: 8, right: 16))
-
-        topStackView.addArrangedSubview(buttonContainer)
-    }
-
-    func configureEditAttributesButton() {
+    func configureTopButton(title: String,
+                            insets: UIEdgeInsets,
+                            hasBottomBorder: Bool = false,
+                            actionSelector: Selector,
+                            stylingHandler: (UIButton) -> Void) {
         let buttonContainer = UIView()
         buttonContainer.backgroundColor = .listForeground
 
         let editAttributesButton = UIButton()
         editAttributesButton.translatesAutoresizingMaskIntoConstraints = false
-        editAttributesButton.setTitle(Localization.editAttributesAction, for: .normal)
-        editAttributesButton.addTarget(self, action: #selector(editAttributesTapped), for: .touchUpInside)
-        editAttributesButton.applySecondaryButtonStyle()
+        editAttributesButton.setTitle(title, for: .normal)
+        editAttributesButton.addTarget(self, action: actionSelector, for: .touchUpInside)
+        stylingHandler(editAttributesButton)
 
         buttonContainer.addSubview(editAttributesButton)
-        buttonContainer.pinSubviewToSafeArea(editAttributesButton, insets: .init(top: 8, left: 16, bottom: 16, right: 16))
+        buttonContainer.pinSubviewToSafeArea(editAttributesButton, insets: insets)
 
-        let separator = UIView.createBorderView()
-        buttonContainer.addSubview(separator)
-        NSLayoutConstraint.activate([
-            buttonContainer.leadingAnchor.constraint(equalTo: separator.leadingAnchor),
-            buttonContainer.bottomAnchor.constraint(equalTo: separator.bottomAnchor),
-            buttonContainer.trailingAnchor.constraint(equalTo: separator.trailingAnchor)
-        ])
+        if hasBottomBorder {
+            let separator = UIView.createBorderView()
+            buttonContainer.addSubview(separator)
+            NSLayoutConstraint.activate([
+                buttonContainer.leadingAnchor.constraint(equalTo: separator.leadingAnchor),
+                buttonContainer.bottomAnchor.constraint(equalTo: separator.bottomAnchor),
+                buttonContainer.trailingAnchor.constraint(equalTo: separator.trailingAnchor)
+            ])
+        }
 
         topStackView.addArrangedSubview(buttonContainer)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -276,27 +276,27 @@ private extension ProductVariationsViewController {
         headerContainer.addSubview(topStackView)
         headerContainer.pinSubviewToAllEdges(topStackView)
 
-        configureTopButton(title: Localization.addNewVariation,
-                           insets: .init(top: 16, left: 16, bottom: 8, right: 16),
-                           actionSelector: #selector(addButtonTapped),
-                           stylingHandler: { $0.applyPrimaryButtonStyle() })
+        addTopButton(title: Localization.addNewVariation,
+                     insets: .init(top: 16, left: 16, bottom: 8, right: 16),
+                     actionSelector: #selector(addButtonTapped),
+                     stylingHandler: { $0.applyPrimaryButtonStyle() })
 
-        configureTopButton(title: Localization.editAttributesAction,
-                           insets: .init(top: 8, left: 16, bottom: 16, right: 16),
-                           hasBottomBorder: true,
-                           actionSelector: #selector(editAttributesTapped),
-                           stylingHandler: { $0.applySecondaryButtonStyle() })
+        addTopButton(title: Localization.editAttributesAction,
+                     insets: .init(top: 8, left: 16, bottom: 16, right: 16),
+                     hasBottomBorder: true,
+                     actionSelector: #selector(editAttributesTapped),
+                     stylingHandler: { $0.applySecondaryButtonStyle() })
 
         topStackView.addArrangedSubview(topBannerView)
 
         tableView.tableHeaderView = headerContainer
     }
 
-    func configureTopButton(title: String,
-                            insets: UIEdgeInsets,
-                            hasBottomBorder: Bool = false,
-                            actionSelector: Selector,
-                            stylingHandler: (UIButton) -> Void) {
+    func addTopButton(title: String,
+                      insets: UIEdgeInsets,
+                      hasBottomBorder: Bool = false,
+                      actionSelector: Selector,
+                      stylingHandler: (UIButton) -> Void) {
         let buttonContainer = UIView()
         buttonContainer.backgroundColor = .listForeground
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -46,6 +46,6 @@ extension ProductVariationsViewModel {
     /// Defines if the More Options button should be shown
     ///
     func shouldShowMoreButton(for product: Product) -> Bool {
-        product.attributesForVariations.isNotEmpty
+        product.variations.isEmpty && product.attributesForVariations.isNotEmpty
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -3,7 +3,20 @@ import XCTest
 import Yosemite
 
 final class ProductVariationsViewModelTests: XCTestCase {
-    func test_more_button_appears_when_product_is_not_empty() {
+    func test_more_button_appears_when_product_has_attributes_but_no_variations() {
+        // Given
+        let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
+        let product = Product().copy(attributes: [attribute], variations: [])
+        let viewModel = ProductVariationsViewModel(formType: .edit)
+
+        // When
+        let showMoreButton = viewModel.shouldShowMoreButton(for: product)
+
+        // Then
+        XCTAssertTrue(showMoreButton)
+    }
+
+    func test_more_button_does_not_appear_when_product_is_not_empty() {
         // Given
         let variations: [Int64] = [101, 102]
         let attribute = ProductAttribute(siteID: 0, attributeID: 0, name: "attr", position: 0, visible: true, variation: true, options: [])
@@ -14,7 +27,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         let showMoreButton = viewModel.shouldShowMoreButton(for: product)
 
         // Then
-        XCTAssertTrue(showMoreButton)
+        XCTAssertFalse(showMoreButton)
     }
 
     func test_more_button_does_not_appear_when_product_has_variations_does_not_have_attributes() {


### PR DESCRIPTION
Closes #3904 

## Description

This PR updates UI of product variation list screen:
- Updated Add Variation button title to Generate New Variation and change its style to primary.
- Removed right navigation button item along with the corresponding action sheet.
- Moved Edit Attributes button out as a separate view beneath Generate New Variation button.
- Moved the top banner to below the buttons following design.

## Screenshot
<img src="https://user-images.githubusercontent.com/5533851/116268407-7b9a0300-a7a7-11eb-9d55-5f7e68982752.png" width=300 />

## Testing
This screen can be reached with these steps:
- Select product tab
- Choose to add a new variable product
- Choose variations and create a new variation
- Observe the resulting variations list

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
