### PR TITLE
Update copy of right bar button of Product Attributes screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -83,7 +83,7 @@ private extension EditAttributesViewController {
         guard viewModel.showDoneButton else {
             return
         }
-        let rightBarButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
+        let rightBarButton = UIBarButtonItem(title: Localization.generate, style: .plain, target: self, action: #selector(doneButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
     }
 }
@@ -171,6 +171,7 @@ private extension EditAttributesViewController {
     enum Localization {
         static let addNewAttribute = NSLocalizedString("Add New Attribute", comment: "Action to add new attribute on the Product Attributes screen")
         static let title = NSLocalizedString("Edit Attributes", comment: "Navigation title for the Product Attributes screen")
+        static let generate = NSLocalizedString("Generate", comment: "Action to generate attributes on the Product Attributes screen")
 
         static let generatingVariation = NSLocalizedString("Generating Variation", comment: "Title for the progress screen while generating a variation")
         static let waitInstructions = NSLocalizedString("Please wait while we create the new variation",


### PR DESCRIPTION
Closes #3905 

## Description

This PR simply updates title of the `Done` button on navigation bar of Product Attribute screens to `Generate`.

## Screenshot
<img src="https://user-images.githubusercontent.com/5533851/116279696-0c75dc00-a7b2-11eb-8987-47826fb0c119.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
