### PR TITLE
Update Error Message if the Site is not WP

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
@@ -40,9 +40,11 @@ struct NotWPErrorViewModel: ULErrorViewModel {
 // MARK: - Private data structures
 private extension NotWPErrorViewModel {
     enum Localization {
-        static let errorMessage = NSLocalizedString("The website is not a WordPress site. For us to connect to it, the site must have WordPress installed.",
-                                                    comment: "Message explaining that a site is not a WordPress site. "
-                                                        + "Reads like 'The website awebsite.com you'll is not a WordPress site...")
+        static let errorMessage =
+            NSLocalizedString("We were not able to detect a WordPress site at the address you entered."
+                                + " Please make sure WordPress is installed and that you are running"
+                                + " the latest available version.",
+                              comment: "Message explaining that WordPress was not detected.")
 
         static let primaryButtonTitle = NSLocalizedString("Enter Another Store",
                                                           comment: "Action button linking to instructions for enter another store."

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPErrorViewModelTests.swift
@@ -75,9 +75,12 @@ final class NotWPErrorViewModelTests: XCTestCase {
 private extension NotWPErrorViewModelTests {
     private enum Expectations {
         static let image = UIImage.loginNoWordPressError
-        static let errorMessage = NSLocalizedString("The website is not a WordPress site. For us to connect to it, the site must have WordPress installed.",
-                                                    comment: "Message explaining that a site is not a WordPress site. "
-                                                        + "Reads like 'The website awebsite.com you'll is not a WordPress site...")
+
+        static let errorMessage =
+            NSLocalizedString("We were not able to detect a WordPress site at the address you entered."
+                                + " Please make sure WordPress is installed and that you are running"
+                                + " the latest available version.",
+                              comment: "Message explaining that WordPress was not detected.")
 
         static let primaryButtonTitle = NSLocalizedString("Enter Another Store",
                                                           comment: "Action button linking to instructions for enter another store."


### PR DESCRIPTION
Closes #3392. 

## Design

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/116286956-0f8ab100-a74d-11eb-8b2a-ef0eadb67111.png" width="300">       |       <img src="https://user-images.githubusercontent.com/198826/116286960-11ed0b00-a74d-11eb-9722-947c0a3b7074.png" width="300">

## Testing

1. Log out. 
2. Tap “Enter Your Store Address”. 
3. Enter a URL to a site that is not WordPress. 
4. Tap Continue. 
5. Confirm the error message “We were not able to detect...” is shown. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

