### PR TITLE
[Mobile Payments] Card Reader Settings V2 2: Define ViewModel protocols, add Presenting View Controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -240,6 +240,35 @@
             </objects>
             <point key="canvasLocation" x="3385" y="2237"/>
         </scene>
+        <!--Card Reader Settings Presenting View Controller-->
+        <scene sceneID="NEs-n8-mBS">
+            <objects>
+                <viewController storyboardIdentifier="CardReaderSettingsPresentingViewController" id="PIe-XS-6gZ" customClass="CardReaderSettingsPresentingViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="EOU-z7-aBS">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Under Construction" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yAZ-jF-hAZ">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="l2Q-VL-2yz"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="l2Q-VL-2yz" firstAttribute="trailing" secondItem="yAZ-jF-hAZ" secondAttribute="trailing" id="IoK-Ca-RnF"/>
+                            <constraint firstItem="yAZ-jF-hAZ" firstAttribute="top" secondItem="l2Q-VL-2yz" secondAttribute="top" id="kZc-5O-iDD"/>
+                            <constraint firstItem="yAZ-jF-hAZ" firstAttribute="leading" secondItem="l2Q-VL-2yz" secondAttribute="leading" id="nCI-IL-b21"/>
+                            <constraint firstItem="l2Q-VL-2yz" firstAttribute="bottom" secondItem="yAZ-jF-hAZ" secondAttribute="bottom" id="uBc-a2-Cby"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ErC-sp-Qjr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4192.8000000000002" y="2236.7316341829087"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="groupTableViewBackgroundColor">

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -4,5 +4,7 @@ protocol CardReaderSettingsPresentedViewModel {
     func shouldShow() -> Bool
 }
 
-/// A tuple containing a reference to the view model for a presented view and the related view controller's class name.
-typealias CardReaderSettingsViewModelAndView = (CardReaderSettingsPresentedViewModel, String)
+struct CardReaderSettingsViewModelAndView {
+    var viewModel: CardReaderSettingsPresentedViewModel
+    var viewIdentifier: String
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol CardReaderSettingsPresentedViewModel {
+    func shouldShow() -> Bool
+}
+
+/// A tuple containing a reference to the view model for a presented view and the related view controller's class name.
+typealias CardReaderSettingsViewModelAndView = (CardReaderSettingsPresentedViewModel, String)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UIKit
+
+final class CardReaderSettingsPresentingViewController: UIViewController {
+
+    /// An array of viewModels and related view classes
+    private var viewModelsAndViews = [CardReaderSettingsViewModelAndView]()
+
+    /// Set our dependencies
+    func configure(viewModelsAndViews: [CardReaderSettingsViewModelAndView]) {
+        self.viewModelsAndViews = viewModelsAndViews
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureBackground()
+        configureNavigation()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension CardReaderSettingsPresentingViewController {
+
+    private func configureBackground() {
+        /// Needed to avoid incorrect background appearing near bottom of view, especially on dark mode
+        view.backgroundColor = .systemBackground
+    }
+
+    private func configureNavigation() {
+        title = Localization.screenTitle
+    }
+}
+
+// MARK: - Localization
+//
+private enum Localization {
+    static let screenTitle = NSLocalizedString(
+        "Manage Card Reader",
+        comment: "Card reader settings screen title"
+    )
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -163,7 +163,11 @@ private extension SettingsViewController {
 
         // Store Settings
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
-            sections.append(Section(title: storeSettingsTitle, rows: [.cardReaders], footerHeight: UITableView.automaticDimension))
+            sections.append(
+                Section(title: storeSettingsTitle,
+                        rows: [.cardReaders, .cardReadersV2],
+                        footerHeight: UITableView.automaticDimension)
+            )
         }
 
         // Help & Feedback
@@ -207,6 +211,8 @@ private extension SettingsViewController {
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .cardReaders:
             configureCardReaders(cell: cell)
+        case let cell as BasicTableViewCell where row == .cardReadersV2:
+            configureCardReadersV2(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
@@ -251,6 +257,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Manage Card Reader", comment: "Navigates to Card Reader management screen")
+    }
+
+    func configureCardReadersV2(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Manage Card Reader (V2)", comment: "Navigates to Card Reader management screen")
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -376,6 +388,15 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsViewController` from Dashboard storyboard")
         }
+        show(viewController, sender: self)
+    }
+
+    func cardReadersV2WasPressed() {
+        ServiceLocator.analytics.track(.settingsCardReadersTapped)
+        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
+            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
+        }
+        viewController.configure(viewModelsAndViews: [])
         show(viewController, sender: self)
     }
 
@@ -513,6 +534,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .cardReaders:
             cardReadersWasPressed()
+        case .cardReadersV2:
+            cardReadersV2WasPressed()
         case .privacy:
             privacyWasPressed()
         case .betaFeatures:
@@ -554,6 +577,7 @@ private enum Row: CaseIterable {
     case switchStore
     case support
     case cardReaders
+    case cardReadersV2
     case logout
     case privacy
     case betaFeatures
@@ -572,6 +596,8 @@ private enum Row: CaseIterable {
         case .support:
             return BasicTableViewCell.self
         case .cardReaders:
+            return BasicTableViewCell.self
+        case .cardReadersV2:
             return BasicTableViewCell.self
         case .logout:
             return BasicTableViewCell.self

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -462,6 +462,8 @@
 		318109E225E5B55C00EE0BE7 /* ImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109E125E5B55C00EE0BE7 /* ImageTableViewCell.xib */; };
 		318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */; };
 		318109EE25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */; };
+		318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */; };
+		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
 		31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */; };
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
@@ -1659,6 +1661,8 @@
 		318109E125E5B55C00EE0BE7 /* ImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageTableViewCell.xib; sourceTree = "<group>"; };
 		318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberedListItemTableViewCell.swift; sourceTree = "<group>"; };
 		318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberedListItemTableViewCell.xib; sourceTree = "<group>"; };
+		318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentingViewController.swift; sourceTree = "<group>"; };
+		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
 		31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedReaderView.swift; sourceTree = "<group>"; };
 		31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedReaderTableViewCell.swift; sourceTree = "<group>"; };
@@ -3486,6 +3490,15 @@
 			path = inAppFeedback;
 			sourceTree = "<group>";
 		};
+		318853452639FE7F00F66A9C /* CardReadersV2 */ = {
+			isa = PBXGroup;
+			children = (
+				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
+				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
+			);
+			path = CardReadersV2;
+			sourceTree = "<group>";
+		};
 		318A9E8F25D301C60032C245 /* CardReaders */ = {
 			isa = PBXGroup;
 			children = (
@@ -5261,6 +5274,7 @@
 				74C6FEA321C2F189009286B6 /* About */,
 				02D4564A231D059E008CF0A9 /* Beta features */,
 				318A9E8F25D301C60032C245 /* CardReaders */,
+				318853452639FE7F00F66A9C /* CardReadersV2 */,
 				CE27257A219249B5002B22EB /* Help */,
 				CE22E3F821714639005A6BEF /* Privacy */,
 				027D4A8B2526FD1700108626 /* SettingsViewController.swift */,
@@ -6596,6 +6610,7 @@
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
 				453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */,
 				45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */,
+				318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */,
 				452FE64B25657EC100EB54A0 /* LinkedProductsViewController.swift in Sources */,
 				45B9C64123A9139A007FC4C5 /* Product+PriceSettingsViewModels.swift in Sources */,
 				773077ED251E943700178696 /* Product+DownloadFileViewModels.swift in Sources */,
@@ -6611,6 +6626,7 @@
 				26578C4126277AFF00A15097 /* OrderAddOnsListViewController.swift in Sources */,
 				02F67FEE25805F9C00C3BAD2 /* ShippingLabelTrackingURLGenerator.swift in Sources */,
 				0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */,
+				3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */,
 				029F29FE24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift in Sources */,
 				57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */,
 				023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */,


### PR DESCRIPTION
Closes #4048

Note: This is against feature/stripe-terminal-sdk-integration, not develop

This is the next step in launching a more SOLID approach to card reader settings. It:

- Adds a protocol for view models to implement and a presenting view controller that accepts an array of a struct of those viewmodels and their related views (class names) to show
- Protocol defines `shouldShow` which will be used in #4051 to actually determine which view to push

To test:
- Navigate to Settings, note the new V2 row. Press it. That's all for now.
- Navigate to Settings, tap on the old row. Press it. It should work as before

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
