### PR TITLE
[6.5 Backport] Prevent crash when the media library has exactly the same amount of items as the request page size

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 6.5
 -----
 - [*] Fix: Product images with non-latin characters in filenames now will load correctly and won't break Media Library. [https://github.com/woocommerce/woocommerce-ios/pull/3935]
+- [*] Fix: The screen to select images from the Media Library would sometimes crash when the library had a specific number of images. [https://github.com/woocommerce/woocommerce-ios/pull/4070]
 
 6.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
@@ -177,6 +177,12 @@ private extension WordPressMediaLibraryPickerDataSource {
     /// Appends the new media items to the existing media items.
     ///
     func updateMediaItems(_ newMediaItems: [Media], pageNumber: Int, pageSize: Int) {
+        // If the response contains no new items, there is nothing to update.
+        // We return early since the code would generate an invalid range of indices to update otherwise.
+        guard newMediaItems.isNotEmpty else {
+            return
+        }
+
         let pageFirstIndex = syncingCoordinator.pageFirstIndex
         let mediaStartIndex = (pageNumber - pageFirstIndex) * pageSize
         let mediaStartIndexOfTheNextPage = (pageNumber + 1 - pageFirstIndex) * pageSize


### PR DESCRIPTION
Backporting #4003 to 6.5, copying the description from there:

Fixes #3369

## Description

When the media library contains exactly the amount of items defined as the page size (currently 25) the app would crash. In theory, this would also happen with any exact multiple of that page size.

The problem is that when we have a full page and request the next one, the response will have no items. The previous code tried to generate a range of indices to update that was invalid because the end was lower than the start. Instead, if there is no new data to update, we can bail early and skip the callback.

## Testing

1. Ensure your media library has exactly 25 images
2. Create or tap into a product, then tap Add a product image
3. Tap Add Photos > WP Media Library
4. The app shouldn't crash

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
