### PR TITLE
Shipping Labels M2: Fix address validation banner showing by default even if there are no errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -156,14 +156,16 @@ private extension ShippingLabelSuggestedAddressViewController {
     }
 
     func displayEditAddressFormVC(address: ShippingLabelAddress?, type: ShipType) {
-        let shippingAddressVC = ShippingLabelAddressFormViewController(siteID: siteID,
-                                                                       type: type,
-                                                                       address: address,
-                                                                       completion: { [weak self] (newShippingLabelAddress) in
-                                                                        guard let self = self else { return }
-                                                                        self.onCompletion(newShippingLabelAddress)
-                                                                        self.navigationController?.popViewController(animated: true)
-                                                                       })
+        let shippingAddressVC = ShippingLabelAddressFormViewController(
+            siteID: siteID,
+            type: type,
+            address: address,
+            validationError: nil,
+            completion: { [weak self] (newShippingLabelAddress) in
+                guard let self = self else { return }
+                self.onCompletion(newShippingLabelAddress)
+                self.navigationController?.popViewController(animated: true)
+            })
         navigationController?.pushViewController(shippingAddressVC, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -52,8 +52,14 @@ final class ShippingLabelAddressFormViewController: UIViewController {
 
     /// Init
     ///
-    init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, completion: @escaping Completion) {
-        viewModel = ShippingLabelAddressFormViewModel(siteID: siteID, type: type, address: address)
+    init(
+        siteID: Int64,
+        type: ShipType,
+        address: ShippingLabelAddress?,
+        validationError: ShippingLabelAddressValidationError?,
+        completion: @escaping Completion
+    ) {
+        viewModel = ShippingLabelAddressFormViewModel(siteID: siteID, type: type, address: address, validationError: validationError)
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
     }
@@ -69,6 +75,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
         configureTableView()
         observeViewModel()
         configureConfirmButton()
+        updateTopBannerView()
         keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -46,11 +46,21 @@ final class ShippingLabelAddressFormViewModel {
 
     var sections: [Section] = []
 
-    init(siteID: Int64, type: ShipType, address: ShippingLabelAddress?, stores: StoresManager = ServiceLocator.stores) {
+    init(
+        siteID: Int64,
+        type: ShipType,
+        address: ShippingLabelAddress?,
+        stores: StoresManager = ServiceLocator.stores,
+        validationError: ShippingLabelAddressValidationError?
+    ) {
         self.siteID = siteID
         self.type = type
         self.address = address
         self.stores = stores
+        if let validationError = validationError {
+            addressValidationError = validationError
+            addressValidated = .remote
+        }
         updateSections()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -204,10 +204,10 @@ extension ShippingLabelFormViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Error validating shipping label address: \(error)")
                 self.updateValidatingAddressState(false, type: type)
-                if error is ShippingLabelAddressValidationError {
-                    onCompletion?(.validationError, nil)
+                if let error = error as? ShippingLabelAddressValidationError {
+                    onCompletion?(.validationError(error), nil)
                 } else {
-                    onCompletion?(.genericError, nil)
+                    onCompletion?(.genericError(error), nil)
                 }
             }
         }
@@ -217,7 +217,7 @@ extension ShippingLabelFormViewModel {
     enum ValidationState {
         case validated
         case suggestedAddress
-        case validationError
-        case genericError
+        case validationError(ShippingLabelAddressValidationError)
+        case genericError(Error)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -8,7 +8,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
 
         // Given
         let shippingAddress = MockShippingLabelAddress.sampleAddress()
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, validationError: nil)
 
         // When
         viewModel.handleAddressValueChanges(row: .name, newValue: "Skylar Ferry")
@@ -46,7 +46,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                    postcode: "94121-2303")
 
         // When
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, validationError: nil)
 
         // Then
         let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name, .company, .phone, .address, .address2, .city, .postcode, .state, .country]
@@ -69,7 +69,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores, validationError: nil)
         viewModel.validateAddress(onlyLocally: false) { (result) in
         }
 
@@ -117,7 +117,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores, validationError: nil)
         viewModel.validateAddress(onlyLocally: false) { (result) in
         }
 
@@ -150,7 +150,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores, validationError: nil)
         viewModel.validateAddress(onlyLocally: false) { (result) in
         }
 
@@ -183,7 +183,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores, validationError: nil)
         viewModel.validateAddress(onlyLocally: false) { (result) in
         }
 
@@ -220,7 +220,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores)
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10, type: .origin, address: shippingAddress, stores: stores, validationError: nil)
         viewModel.validateAddress(onlyLocally: false) { (result) in
         }
 


### PR DESCRIPTION
Fixes #3919 
Requires #4063 to be merged first

## Why

As reported on #3919, the address form will show a validation error when presented even if the address is correct. The cause is that it seems to assume that it was presented because there was an error.

In reality there are two scenarios where this might get presented:
1. If there is an error validating after the user taps Continue on the "Create Shipping Label" screen
2. If the validation has been successful previously but the user taps on the address row again (for instance, to edit a valid address)

There were two problems specifically:

1. The view model was configuring the alert as visible by default, and only updating its visibility after performing address validation when the user tapped on Done.
2. There was no way for the previous screen to communicate the result of a previous validation.

## How

This PR adds the ability for the address view to be initialized with an error, so the view can differentiate the two scenarios.
Also, it will update the state of the alert when it's loaded, and hide it if there is no known validation error.

One potential improvement I didn't add here was that, since the previous view already knows if the address was validated successfully, the address screen could skip validation if the address hasn't changed. This seems useful but also a different issue from fixing the original bug.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
