### PR TITLE
Coupon Management: List coupons - add view placeholder

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -121,6 +121,7 @@ public enum WooAnalyticsStat: String {
     case settingsSelectedStoreTapped            = "settings_selected_site_tapped"
     case settingsContactSupportTapped           = "main_menu_contact_support_tapped"
     case settingsCardReadersTapped              = "settings_card_readers_tapped"
+    case settingsCouponManagementTapped         = "settings_coupon_management_tapped"
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -121,7 +121,6 @@ public enum WooAnalyticsStat: String {
     case settingsSelectedStoreTapped            = "settings_selected_site_tapped"
     case settingsContactSupportTapped           = "main_menu_contact_support_tapped"
     case settingsCardReadersTapped              = "settings_card_readers_tapped"
-    case settingsCouponManagementTapped         = "settings_coupon_management_tapped"
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,6 +7,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentPayments:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .couponManagement:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .largeTitles:
             return true
         case .shippingLabelsRelease2:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -14,6 +14,10 @@ enum FeatureFlag: Int {
     ///
     case cardPresentPayments
 
+    /// Coupon Management from the settings screen
+    ///
+    case couponManagement
+
     /// Large titles on the main tabs
     ///
     case largeTitles

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class CouponManagementViewController: UIViewController {
+final class CouponManagementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigation()
@@ -12,6 +12,14 @@ class CouponManagementViewController: UIViewController {
 private extension CouponManagementViewController {
 
     func configureNavigation() {
-        title = NSLocalizedString("Coupons", comment: "Coupon management coupon list screen title")
+        title = Localization.title
+    }
+}
+
+// MARK: - Localization
+//
+private extension CouponManagementViewController {
+    enum Localization {
+        static let title = NSLocalizedString("Coupons", comment: "Coupon management coupon list screen title")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+class CouponManagementViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigation()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension CouponManagementViewController {
+
+    func configureNavigation() {
+        title = NSLocalizedString("Coupons", comment: "Coupon management coupon list screen title")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponManagementViewController.xib
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CouponManagementViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="Jh9-wF-LZg"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Coming soon" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeV-Uk-0a2">
+                    <rect key="frame" x="156.5" y="442.5" width="101" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="DeV-Uk-0a2" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="9an-cc-G6u"/>
+                <constraint firstItem="DeV-Uk-0a2" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="ccv-VX-HxW"/>
+            </constraints>
+            <point key="canvasLocation" x="101" y="49"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -401,7 +401,6 @@ private extension SettingsViewController {
     }
 
     func couponManagementWasPressed() {
-        ServiceLocator.analytics.track(.settingsCouponManagementTapped)
         let viewController = CouponManagementViewController(nibName: nil, bundle: nil)
         show(viewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -162,8 +162,8 @@ private extension SettingsViewController {
         ]
 
         // Store Settings
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
-            sections.append(Section(title: storeSettingsTitle, rows: [.cardReaders], footerHeight: UITableView.automaticDimension))
+        if storeSettingsRows().isNotEmpty {
+            sections.append(Section(title: storeSettingsTitle, rows: storeSettingsRows(), footerHeight: UITableView.automaticDimension))
         }
 
         // Help & Feedback
@@ -207,6 +207,8 @@ private extension SettingsViewController {
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .cardReaders:
             configureCardReaders(cell: cell)
+        case let cell as BasicTableViewCell where row == .couponManagement:
+            configureCouponManagement(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
@@ -251,6 +253,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Manage Card Reader", comment: "Navigates to Card Reader management screen")
+    }
+
+    func configureCouponManagement(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Manage Coupons", comment: "Navigates to Coupon Management screen from Settings.")
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -319,6 +327,19 @@ private extension SettingsViewController {
     func couldShowBetaFeaturesRow() -> Bool {
         false
     }
+
+    func storeSettingsRows() -> [Row] {
+        var storeSettingsRows: [Row] = []
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
+            storeSettingsRows.append(.cardReaders)
+        }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponManagement) {
+            storeSettingsRows.append(.couponManagement)
+        }
+
+        return storeSettingsRows
+    }
 }
 
 
@@ -376,6 +397,12 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsViewController` from Dashboard storyboard")
         }
+        show(viewController, sender: self)
+    }
+
+    func couponManagementWasPressed() {
+        ServiceLocator.analytics.track(.settingsCouponManagementTapped)
+        let viewController = CouponManagementViewController(nibName: nil, bundle: nil)
         show(viewController, sender: self)
     }
 
@@ -513,6 +540,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .cardReaders:
             cardReadersWasPressed()
+        case .couponManagement:
+            couponManagementWasPressed()
         case .privacy:
             privacyWasPressed()
         case .betaFeatures:
@@ -554,6 +583,7 @@ private enum Row: CaseIterable {
     case switchStore
     case support
     case cardReaders
+    case couponManagement
     case logout
     case privacy
     case betaFeatures
@@ -572,6 +602,8 @@ private enum Row: CaseIterable {
         case .support:
             return BasicTableViewCell.self
         case .cardReaders:
+            return BasicTableViewCell.self
+        case .couponManagement:
             return BasicTableViewCell.self
         case .logout:
             return BasicTableViewCell.self

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -373,6 +373,8 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
+		03FBDA9D263AD49200ACE257 /* CouponManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponManagementViewController.swift */; };
+		03FBDAA3263AED2F00ACE257 /* CouponManagementViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponManagementViewController.xib */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
@@ -1542,6 +1544,8 @@
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagService.swift; sourceTree = "<group>"; };
 		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
+		03FBDA9C263AD49100ACE257 /* CouponManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponManagementViewController.swift; sourceTree = "<group>"; };
+		03FBDAA2263AED2F00ACE257 /* CouponManagementViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponManagementViewController.xib; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
@@ -3246,6 +3250,15 @@
 			path = "Shipping Label";
 			sourceTree = "<group>";
 		};
+		03FBDA9B263AD47200ACE257 /* Coupons */ = {
+			isa = PBXGroup;
+			children = (
+				03FBDA9C263AD49100ACE257 /* CouponManagementViewController.swift */,
+				03FBDAA2263AED2F00ACE257 /* CouponManagementViewController.xib */,
+			);
+			path = Coupons;
+			sourceTree = "<group>";
+		};
 		2611EE57243A46C500A74490 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -4369,6 +4382,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				03FBDA9B263AD47200ACE257 /* Coupons */,
 				571B850024CF7E1600CF58A7 /* InAppFeedback */,
 				0235594024496414004BE2B8 /* BottomSheet */,
 				02564A8F246CEBCB00D6DB2A /* Containers */,
@@ -5704,6 +5718,7 @@
 				B5D1AFC820BC7B9600DB0E8C /* StorePickerViewController.xib in Resources */,
 				45CDAFAF2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.xib in Resources */,
 				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
+				03FBDAA3263AED2F00ACE257 /* CouponManagementViewController.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
 				4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */,
 				26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */,
@@ -6618,6 +6633,7 @@
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				456396B625C82691001F1A26 /* ShippingLabelFormStepTableViewCell.swift in Sources */,
+				03FBDA9D263AD49200ACE257 /* CouponManagementViewController.swift in Sources */,
 				02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */,
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
 				456C7EEB25EE71F10016CBC6 /* ShippingLabelSuggestedAddressViewController.swift in Sources */,


### PR DESCRIPTION
Part of #3916

## Description
This PR adds the placeholder view and feature flag for the Manage Coupons list view.

## Testing
Open the alpha or local developer version of the app, and navigate to the settings menu.
A "Manage Coupons" row should be present in the Store Settings section
Tapping this row takes the user to a "Coming soon" screen

Doing the above on a release build should not show the "Manage Coupons" row in settings.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.