### PR TITLE
Shipping Labels: Display the last selected package in Package Details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -67,8 +67,7 @@ private extension ShippingLabelPackageList {
 
 struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
-        // TODO: Add sample packagesResponse
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: nil)
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -67,7 +67,8 @@ private extension ShippingLabelPackageList {
 
 struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder())
+        // TODO: Add sample packagesResponse
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: nil)
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -67,7 +67,8 @@ private extension ShippingLabelPackageList {
 
 struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
+                                                             packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -73,7 +73,8 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
     static var previews: some View {
 
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
+                                                             packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
 
         ShippingLabelPackageDetails(viewModel: viewModel)
             .environment(\.colorScheme, .light)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -73,8 +73,7 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
     static var previews: some View {
 
-        // TODO: Add sample packagesResponse
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: nil)
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
 
         ShippingLabelPackageDetails(viewModel: viewModel)
             .environment(\.colorScheme, .light)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -25,7 +25,7 @@ struct ShippingLabelPackageDetails: View {
                 ListHeaderView(text: Localization.packageDetailsHeader, alignment: .left)
                     .background(Color(.listBackground))
 
-                TitleAndValueRow(title: Localization.packageSelected, value: viewModel.selectedPackageID ?? "", selectable: true) {
+                TitleAndValueRow(title: Localization.packageSelected, value: viewModel.selectedPackageName, selectable: true) {
                     showingAddPackage.toggle()
                 }
 
@@ -73,7 +73,8 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
     static var previews: some View {
 
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder())
+        // TODO: Add sample packagesResponse
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(), packagesResponse: nil)
 
         ShippingLabelPackageDetails(viewModel: viewModel)
             .environment(\.colorScheme, .light)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsResultsControllers.swift
@@ -24,6 +24,13 @@ final class ShippingLabelPackageDetailsResultsControllers {
         return productVariationResultsController.fetchedObjects
     }
 
+    /// Get the account settings in Core Data and that match the predicate.
+    ///
+    var accountSettings: ShippingLabelAccountSettings? {
+        try? accountSettingsResultsController.performFetch()
+        return accountSettingsResultsController.fetchedObjects.first
+    }
+
     /// Product ResultsController.
     ///
     private lazy var productResultsController: ResultsController<StorageProduct> = {
@@ -40,6 +47,13 @@ final class ShippingLabelPackageDetailsResultsControllers {
         let predicate = NSPredicate(format: "siteID == %lld AND productVariationID in %@", siteID, variationIDs)
 
         return ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
+    /// Shipping Label Account Settings ResultsController
+    ///
+    private lazy var accountSettingsResultsController: ResultsController<StorageShippingLabelAccountSettings> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageShippingLabelAccountSettings>(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewController.swift
@@ -4,8 +4,8 @@ import Yosemite
 
 /// Displays the Shipping Label Package Details
 final class ShippingLabelPackageDetailsViewController: UIHostingController<ShippingLabelPackageDetails> {
-    init(order: Order) {
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: order)
+    init(order: Order, packagesResponse: ShippingLabelPackagesResponse?) {
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order, packagesResponse: packagesResponse)
         super.init(rootView: ShippingLabelPackageDetails(viewModel: viewModel))
         configureNavigationBar()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -45,7 +45,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     @Published private(set) var itemsRows: [ItemToFulfillRow] = []
 
-    /// The id of the selected package, if any
+    /// The id of the selected package. Defaults to last selected package, if any.
     ///
     @Published var selectedPackageID: String?
     @Published private(set) var selectedCustomPackage: ShippingLabelCustomPackage?
@@ -56,10 +56,6 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     var showCustomPackagesHeader: Bool {
         return customPackages.count > 0
     }
-
-    /// The id of the last selected package
-    ///
-    @Published var lastSelectedPackageID: String = ""
 
     init(order: Order,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
@@ -77,7 +73,6 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         syncProducts()
         syncProductVariations()
         syncPackageDetails()
-        syncShippingLabelAccountSettings()
     }
 
     private func configureResultsControllers() {
@@ -97,6 +92,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         products = resultsControllers?.products ?? []
         productVariations = resultsControllers?.productVariations ?? []
         itemsRows = generateItemsRows()
+        selectedPackageID = resultsControllers?.accountSettings?.lastSelectedPackageID
     }
 
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,
@@ -220,20 +216,6 @@ private extension ShippingLabelPackageDetailsViewModel {
             case .failure:
                 DDLogError("⛔️ Error synchronizing package details")
                 return
-            }
-        }
-        stores.dispatch(action)
-    }
-
-    func syncShippingLabelAccountSettings() {
-        let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { [weak self] result in
-            switch result {
-            case .success:
-                if let accountSettings = try? result.get() {
-                    self?.lastSelectedPackageID = accountSettings.lastSelectedPackageID
-                }
-            case .failure(let error):
-                DDLogError("⛔️ Error syncing shipping label account settings: \(error)")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -366,4 +366,53 @@ extension ShippingLabelPackageDetailsViewModel {
     static func taxes() -> [OrderItemTax] {
         return [OrderItemTax(taxID: 75, subtotal: "0.45", total: "0.45")]
     }
+
+    static func samplePackageDetails() -> ShippingLabelPackagesResponse {
+        return ShippingLabelPackagesResponse(storeOptions: sampleShippingLabelStoreOptions(),
+                                             customPackages: sampleShippingLabelCustomPackages(),
+                                             predefinedOptions: sampleShippingLabelPredefinedOptions())
+    }
+
+    static func sampleShippingLabelStoreOptions() -> ShippingLabelStoreOptions {
+        return ShippingLabelStoreOptions(currencySymbol: "$", dimensionUnit: "cm", weightUnit: "kg", originCountry: "US")
+    }
+
+    static func sampleShippingLabelCustomPackages() -> [ShippingLabelCustomPackage] {
+        let customPackage1 = ShippingLabelCustomPackage(isUserDefined: true,
+                                                        title: "Krabica",
+                                                        isLetter: false,
+                                                        dimensions: "1 x 2 x 3",
+                                                        boxWeight: 1,
+                                                        maxWeight: 0)
+        let customPackage2 = ShippingLabelCustomPackage(isUserDefined: true,
+                                                        title: "Obalka",
+                                                        isLetter: true,
+                                                        dimensions: "2 x 3 x 4",
+                                                        boxWeight: 5,
+                                                        maxWeight: 0)
+
+        return [customPackage1, customPackage2]
+    }
+
+    static func sampleShippingLabelPredefinedOptions() -> [ShippingLabelPredefinedOption] {
+        let predefinedPackages1 = [ShippingLabelPredefinedPackage(id: "small_flat_box",
+                                                                  title: "Small Flat Rate Box",
+                                                                  isLetter: false,
+                                                                  dimensions: "21.91 x 13.65 x 4.13"),
+                                  ShippingLabelPredefinedPackage(id: "medium_flat_box_top",
+                                                                 title: "Medium Flat Rate Box 1, Top Loading",
+                                                                 isLetter: false,
+                                                                 dimensions: "28.57 x 22.22 x 15.24")]
+        let predefinedOption1 = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                              predefinedPackages: predefinedPackages1)
+
+        let predefinedPackages2 = [ShippingLabelPredefinedPackage(id: "LargePaddedPouch",
+                                                                  title: "Large Padded Pouch",
+                                                                  isLetter: true,
+                                                                  dimensions: "30.22 x 35.56 x 2.54")]
+        let predefinedOption2 = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              predefinedPackages: predefinedPackages2)
+
+        return [predefinedOption1, predefinedOption2]
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -61,6 +61,12 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         return customPackages.count > 0
     }
 
+    /// The id of the last selected package
+    ///
+    private var lastSelectedPackage: String {
+        accountSettings?.lastSelectedPackageID ?? ""
+    }
+
     init(order: Order,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -27,6 +27,10 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     @Published private var packagesResponse: ShippingLabelPackagesResponse?
 
+    /// The account settings fetched from API
+    ///
+    private(set) var accountSettings: ShippingLabelAccountSettings?
+
     var dimensionUnit: String {
         return packagesResponse?.storeOptions.dimensionUnit ?? ""
     }
@@ -73,6 +77,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         syncProducts()
         syncProductVariations()
         syncPackageDetails()
+        syncShippingLabelAccountSettings()
     }
 
     private func configureResultsControllers() {
@@ -215,6 +220,18 @@ private extension ShippingLabelPackageDetailsViewModel {
             case .failure:
                 DDLogError("⛔️ Error synchronizing package details")
                 return
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    func syncShippingLabelAccountSettings() {
+        let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { [weak self] result in
+            switch result {
+            case .success:
+                self?.accountSettings = try? result.get()
+            case .failure(let error):
+                DDLogError("⛔️ Error syncing shipping label account settings: \(error)")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -27,10 +27,6 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     @Published private var packagesResponse: ShippingLabelPackagesResponse?
 
-    /// The account settings fetched from API
-    ///
-    private(set) var accountSettings: ShippingLabelAccountSettings?
-
     var dimensionUnit: String {
         return packagesResponse?.storeOptions.dimensionUnit ?? ""
     }
@@ -63,9 +59,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     /// The id of the last selected package
     ///
-    private var lastSelectedPackage: String {
-        accountSettings?.lastSelectedPackageID ?? ""
-    }
+    @Published var lastSelectedPackageID: String = ""
 
     init(order: Order,
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
@@ -235,7 +229,9 @@ private extension ShippingLabelPackageDetailsViewModel {
         let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { [weak self] result in
             switch result {
             case .success:
-                self?.accountSettings = try? result.get()
+                if let accountSettings = try? result.get() {
+                    self?.lastSelectedPackageID = accountSettings.lastSelectedPackageID
+                }
             case .failure(let error):
                 DDLogError("⛔️ Error syncing shipping label account settings: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -252,7 +252,7 @@ private extension ShippingLabelFormViewController {
     }
 
     func displayPackageDetailsVC() {
-        let vc = ShippingLabelPackageDetailsViewController(order: viewModel.order)
+        let vc = ShippingLabelPackageDetailsViewController(order: viewModel.order, packagesResponse: viewModel.packagesResponse)
         navigationController?.show(vc, sender: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -24,6 +24,7 @@ final class ShippingLabelFormViewModel {
     private(set) var order: Order
     private(set) var originAddress: ShippingLabelAddress?
     private(set) var destinationAddress: ShippingLabelAddress?
+    private(set) var packagesResponse: ShippingLabelPackagesResponse?
 
     private let stores: StoresManager
 
@@ -62,6 +63,7 @@ final class ShippingLabelFormViewModel {
         self.stores = stores
 
         syncShippingLabelAccountSettings()
+        syncPackageDetails()
     }
 
     func handleOriginAddressValueChanges(address: ShippingLabelAddress?, validated: Bool) {
@@ -228,7 +230,20 @@ extension ShippingLabelFormViewModel {
     func syncShippingLabelAccountSettings() {
         let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { result in
             if result.isFailure {
-                DDLogError("⛔️ Error syncing shipping label account settings")
+                DDLogError("⛔️ Error synchronizing shipping label account settings")
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    func syncPackageDetails() {
+        let action = ShippingLabelAction.packagesDetails(siteID: order.siteID) { [weak self] result in
+            switch result {
+            case .success(let value):
+                self?.packagesResponse = value
+            case .failure:
+                DDLogError("⛔️ Error synchronizing package details")
+                return
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -60,6 +60,8 @@ final class ShippingLabelFormViewModel {
 
         state.sections = ShippingLabelFormViewModel.generateInitialSections()
         self.stores = stores
+
+        syncShippingLabelAccountSettings()
     }
 
     func handleOriginAddressValueChanges(address: ShippingLabelAddress?, validated: Bool) {
@@ -216,6 +218,17 @@ extension ShippingLabelFormViewModel {
                 DDLogError("⛔️ Error validating shipping label address: \(error)")
                 self.updateValidatingAddressState(false, type: type)
                 onCompletion?(.genericError, nil)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Syncs account settings specific to shipping labels, such as the last selected package and payment methods.
+    ///
+    func syncShippingLabelAccountSettings() {
+        let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { result in
+            if result.isFailure {
+                DDLogError("⛔️ Error syncing shipping label account settings")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -867,6 +867,7 @@
 		B5FD111621D3F13700560344 /* BordersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FD111521D3F13700560344 /* BordersView.swift */; };
 		B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
+		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
@@ -2072,6 +2073,7 @@
 		B5FD111521D3F13700560344 /* BordersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BordersView.swift; sourceTree = "<group>"; };
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
@@ -4249,6 +4251,7 @@
 				D83A6A7923792B2400419D48 /* UIColor+Muriel-Tests.swift */,
 				CE50345621B1F26C007573C6 /* ZendeskManagerTests.swift */,
 				0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */,
+				CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */,
 				0277AEAA256CAA5300F45C4A /* MockShippingLabelAddress.swift */,
 				0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */,
 				4590B651261C8D1E00A6FCE0 /* WeightFormatterTests.swift */,
@@ -6804,6 +6807,7 @@
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
+				CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */,
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
 				D85DD1E1257F376200861AA8 /* NotWPAccountViewModelTests.swift in Sources */,
 				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockShippingLabelAccountSettings.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockShippingLabelAccountSettings.swift
@@ -1,0 +1,31 @@
+import Yosemite
+
+/// Generates mock `ShippingLabelAccountSettings`
+///
+public struct MockShippingLabelAccountSettings {
+    public static func sampleAccountSettings(siteID: Int64 = 0,
+                                             canManagePayments: Bool = true,
+                                             canEditSettings: Bool = true,
+                                             storeOwnerDisplayName: String = "",
+                                             storeOwnerUsername: String = "",
+                                             storeOwnerWpcomUsername: String = "",
+                                             storeOwnerWpcomEmail: String = "",
+                                             paymentMethods: [ShippingLabelPaymentMethod] = [],
+                                             selectedPaymentMethodID: Int64 = 0,
+                                             isEmailReceiptsEnabled: Bool = true,
+                                             paperSize: ShippingLabelPaperSize = .label,
+                                             lastSelectedPackageID: String = "") -> ShippingLabelAccountSettings {
+        .init(siteID: siteID,
+              canManagePayments: canManagePayments,
+              canEditSettings: canEditSettings,
+              storeOwnerDisplayName: storeOwnerDisplayName,
+              storeOwnerUsername: storeOwnerUsername,
+              storeOwnerWpcomUsername: storeOwnerWpcomUsername,
+              storeOwnerWpcomEmail: storeOwnerWpcomEmail,
+              paymentMethods: paymentMethods,
+              selectedPaymentMethodID: selectedPaymentMethodID,
+              isEmailReceiptsEnabled: isEmailReceiptsEnabled,
+              paperSize: paperSize,
+              lastSelectedPackageID: lastSelectedPackageID)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -162,6 +162,23 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.showCustomPackagesHeader)
     }
+
+    func test_selected_package_defaults_to_last_selected_package() {
+        // Given
+        insert(MockShippingLabelAccountSettings.sampleAccountSettings(siteID: sampleSiteID, lastSelectedPackageID: "package-1"))
+        let order = MockOrders().empty().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             formatter: currencyFormatter,
+                                                             stores: stores,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.selectedPackageID, "package-1")
+        XCTAssertEqual(viewModel.selectedPackageName, "Small")
+    }
 }
 
 // MARK: - Utils
@@ -174,6 +191,11 @@ private extension ShippingLabelPackageDetailsViewModelTests {
     func insert(_ readOnlyOrderProductVariation: Yosemite.ProductVariation) {
         let productVariation = storage.insertNewObject(ofType: StorageProductVariation.self)
         productVariation.update(with: readOnlyOrderProductVariation)
+    }
+
+    func insert(_ readOnlyAccountSettings: Yosemite.ShippingLabelAccountSettings) {
+        let accountSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
+        accountSettings.update(with: readOnlyAccountSettings)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -34,6 +34,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager)
 
@@ -61,6 +62,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -98,8 +100,8 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                        maxWeight: 11)
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        mockRetrieveShippingLabelPackageDetails(result: .success(mockPackageResponse()))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -127,8 +129,8 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                        maxWeight: 11)
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        mockRetrieveShippingLabelPackageDetails(result: .success(mockPackageResponse()))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -149,8 +151,8 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        mockRetrieveShippingLabelPackageDetails(result: .success(mockPackageResponse()))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -172,14 +174,6 @@ private extension ShippingLabelPackageDetailsViewModelTests {
     func insert(_ readOnlyOrderProductVariation: Yosemite.ProductVariation) {
         let productVariation = storage.insertNewObject(ofType: StorageProductVariation.self)
         productVariation.update(with: readOnlyOrderProductVariation)
-    }
-
-    func mockRetrieveShippingLabelPackageDetails(result: Result<ShippingLabelPackagesResponse, Error>) {
-        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
-            if case let ShippingLabelAction.packagesDetails(_, completion: completion) = action {
-                completion(result)
-            }
-        }
     }
 }
 

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -141,6 +141,7 @@ public typealias StorageShipmentTracking = Storage.ShipmentTracking
 public typealias StorageShipmentTrackingProvider = Storage.ShipmentTrackingProvider
 public typealias StorageShipmentTrackingProviderGroup = Storage.ShipmentTrackingProviderGroup
 public typealias StorageShippingLabel = Storage.ShippingLabel
+public typealias StorageShippingLabelAccountSettings = Storage.ShippingLabelAccountSettings
 public typealias StorageShippingLabelAddress = Storage.ShippingLabelAddress
 public typealias StorageShippingLabelRefund = Storage.ShippingLabelRefund
 public typealias StorageShippingLabelSettings = Storage.ShippingLabelSettings


### PR DESCRIPTION
Closes: #3940

## Description

This PR sets the shipping label package as the last selected package (from the API) by default. This displays the package name in the Package Selected field in the Package Details screen and sets it as the selected package (so it is already selected when you open the packages list).

## Changes

* Adds `syncShippingLabelAccountSettings` to the shipping label form screen, to sync the shipping label account settings. These settings include the last selected package ID, as well as other settings we'll use later in the shipping label flow (including payment methods).
* Moves `syncPackageDetails` to the shipping label form screen (from package details) so that package details are already synced when we open the Package Details screen, and passes the response to the Package Details VM.
* Adds `accountSettingsResultsController` to retrieve the shipping label account settings from storage on the Package Details screen.
* Sets the selected package ID to the last selected package ID with `setDefaultPackage`, so the last selected package is selected and displayed.
* Updates the Package Details screen to display `selectedPackageName` — previously it displayed `selectedPackageID`, which isn't the same as the name (title) for predefined packages.

<img src="https://user-images.githubusercontent.com/8658164/116578173-0cd4bb00-a909-11eb-8859-36ee0b305c70.gif" width="300px">


## Testing

Setup:

* If you haven't purchased a shipping label on your store before, the Package Selected field will be blank. You can test first with this scenario and then test after purchasing a shipping label.
* You can follow the internal testing guide at PCYsg-wev-p2 to purchase a shipping label before testing. Alternately, you can use a proxy app like Charles Proxy and edit the API response from the `/wc/v1/connect/account/settings` endpoint to fake a last selected package value; with this approach, enter one of your existing package IDs as the `last_box_id` in `userMeta` in that response.

To test:

1. Launch the app in debug mode (because of the feature flag).
2. Open an order detail.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the `Ship From` cell. Confirm the address.
5. Press the button "Continue" in Create Shipping Label form, under the `Ship To` cell. Confirm the address.
6. Press the button "Continue" in Create Shipping Label form, under the `Package Details` cell.
7. Confirm the `Package Selected` field on the Package Details screen displays your last selected package by default.
8. Tap on Package Selected and confirm the last selected package is selected in the package list.
9. Select a different package and tap Done. Confirm `Package Selected` now shows the new package selection.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.