### PR TITLE
[Mobile Payments] Update WCPay capture route and restore call to captureOrderPayment

### DIFF
--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -42,7 +42,7 @@ public class WCPayRemote: Remote {
                                orderID: Int64,
                                paymentIntentID: String,
                                completion: @escaping (Result<WCPayPaymentIntent, Error>) -> Void) {
-        let path = "\(Path.orders)/\(orderID)/\(Path.capture)"
+        let path = "\(Path.orders)/\(orderID)/\(Path.captureTerminalPayment)"
 
         let parameters = [
             CaptureOrderPaymentKeys.fields: CaptureOrderPaymentValues.fieldValues,
@@ -64,7 +64,7 @@ private extension WCPayRemote {
         static let connectionTokens = "payments/connection_tokens"
         static let accounts = "payments/accounts"
         static let orders = "payments/orders"
-        static let capture = "capture"
+        static let captureTerminalPayment = "capture_terminal_payment"
     }
 
     enum AccountParameterKeys {

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -297,7 +297,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_requires_payment_method_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-requires-payment-method")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -319,7 +319,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_requires_confirmation_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-requires-confirmation")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -341,7 +341,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_requires_action_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-requires-action")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -363,7 +363,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_processing_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-processing")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -385,7 +385,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_requires_capture_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-requires-capture")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -407,7 +407,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_canceled_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-canceled")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -429,7 +429,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_succeeded_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-succeeded")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -451,7 +451,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_unrecognized_status_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-unknown-status")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in
@@ -473,7 +473,7 @@ final class WCPayRemoteTests: XCTestCase {
     func test_captureOrderPayment_properly_handles_error_response() throws {
         let remote = WCPayRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-error")
 
         let result: Result<WCPayPaymentIntent, Error> = waitFor { promise in

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -129,20 +129,20 @@ private extension CardPresentPaymentStore {
             // to the WCPay backend managed Payment Intent, which we need
             // to use to capture the payment.
             // This is always failing at this point. Commented out for now.
-//            self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
-//                switch result {
-//                case .success(let intent):
-//                    guard intent.status == .succeeded else {
-//                        DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
-//                        onCompletion(.failure(CardReaderServiceError.paymentCapture()))
-//                        return
-//                    }
-//                    onCompletion(.success(receiptParameters))
-//                case .failure(let error):
-//                    onCompletion(.failure(error))
-//                    return
-//                }
-//            }
+            self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
+                switch result {
+                case .success(let intent):
+                    guard intent.status == .succeeded else {
+                        DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
+                        onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+                        return
+                    }
+                    onCompletion(.success(receiptParameters))
+                case .failure(let error):
+                    onCompletion(.failure(error))
+                    return
+                }
+            }
         }.store(in: &cancellables)
 
         // Observe status events fired by the card reader

--- a/Yosemite/YosemiteTests/Stores/WCPayStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WCPayStoreTests.swift
@@ -91,7 +91,7 @@ final class WCPayStoreTests: XCTestCase {
     func test_capturePaymentID_returns_error_on_failure() throws {
         let store = WCPayStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let expectation = self.expectation(description: "Capture Payment Intent error response")
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture", filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment", filename: "generic_error")
         let action = WCPayAction.captureOrderPayment(siteID: sampleSiteID,
                                                      orderID: sampleOrderID,
                                                      paymentIntentID: samplePaymentIntentID,
@@ -109,7 +109,7 @@ final class WCPayStoreTests: XCTestCase {
     func test_capturePaymentID_returns_expected_data() throws {
         let store = WCPayStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let expectation = self.expectation(description: "Load Account fetch response")
-        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture",
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
                                  filename: "wcpay-payment-intent-succeeded")
         let action = WCPayAction.captureOrderPayment(siteID: sampleSiteID,
                                                      orderID: sampleOrderID,


### PR DESCRIPTION
Closes #4074 

**Note: This is against feature/stripe-terminal-sdk-integration, not develop**

Changes made:
- Changed capture route from `payments/orders/ORDERID/capture` to `payments/orders/ORDERID/capture_terminal_payment`
- Updated unit tests accordingly
- Restored call to captureOrderPayment in CardPresentPaymentStore collectPayment

To test:
- Build a plugin ZIP from https://github.com/Automattic/woocommerce-payments/pull/1689
    - clone the repo
    - checkout the branch
    - npm install (I’m using npm 6.14.8 fwiw)
    - npm run build
    - upload the plugin ZIP created (woocommerce-payments.zip) to your test site and activate it
- Go to your test site’s store and add something to your cart
- Go to checkout and use “Pay (Cash) on Delivery” as the payment method to complete checkout
- Launch this branch on your mobile device
- Make sure you see your order in the Processing state
- Connect your card reader in the usual way
- Return to orders and tap on Collect Payment
- Ensure you are able to successfully complete the payment using your Point of Sale Test Card
- Make sure the order is left in the Completed state (NOTE: As of Apr 29 2035 UTC it leaves the order in processing, but a change is forthcoming in the 1689 PR)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
