### PR TITLE
AddOns: Add AddOnGroup networking support

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -47,6 +47,19 @@ extension AddOnDisplay {
         .dropdown
     }
 }
+extension AddOnGroup {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> AddOnGroup {
+        .init(
+            siteID: .fake(),
+            groupID: .fake(),
+            name: .fake(),
+            priority: .fake(),
+            addOns: .fake()
+        )
+    }
+}
 extension AddOnPriceType {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -100,9 +100,9 @@
 		2683D70E24456DB8002A1589 /* categories-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70D24456DB7002A1589 /* categories-empty.json */; };
 		2683D71024456EE4002A1589 /* categories-extra.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70F24456EE4002A1589 /* categories-extra.json */; };
 		2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D1263B069500D9EE97 /* AddOnGroup.swift */; };
-		2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */; };
 		2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */; };
 		2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */ = {isa = PBXBuildFile; fileRef = 2685C0DD263B5A4200D9EE97 /* add-on-groups.json */; };
+		2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -552,9 +552,9 @@
 		2683D70D24456DB7002A1589 /* categories-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-empty.json"; sourceTree = "<group>"; };
 		2683D70F24456EE4002A1589 /* categories-extra.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-extra.json"; sourceTree = "<group>"; };
 		2685C0D1263B069500D9EE97 /* AddOnGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroup.swift; sourceTree = "<group>"; };
-		2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddOnGroupMapper.swift; path = ../../../../../../Documents/AddOnGroupMapper.swift; sourceTree = "<group>"; };
 		2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapperTests.swift; sourceTree = "<group>"; };
 		2685C0DD263B5A4200D9EE97 /* add-on-groups.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-on-groups.json"; sourceTree = "<group>"; };
+		2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapper.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1245,7 +1245,6 @@
 			children = (
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
-				2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
@@ -1499,6 +1498,7 @@
 				B567AF2820A0FA1E00AB6C62 /* Mapper.swift */,
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
+				2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
@@ -2048,7 +2048,7 @@
 				B567AF2520A0CCA300AB6C62 /* AuthenticatedRequest.swift in Sources */,
 				453305E92459DF2100264E50 /* PostMapper.swift in Sources */,
 				456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */,
-				2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */,
+				2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */,
 				CE430672234B9EB20073CBFF /* OrderItemTax.swift in Sources */,
 				D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */,
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */ = {isa = PBXBuildFile; fileRef = 2685C0DD263B5A4200D9EE97 /* add-on-groups.json */; };
 		2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */; };
 		2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */; };
+		2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -557,6 +558,7 @@
 		2685C0DD263B5A4200D9EE97 /* add-on-groups.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-on-groups.json"; sourceTree = "<group>"; };
 		2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapper.swift; sourceTree = "<group>"; };
 		2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupRemote.swift; sourceTree = "<group>"; };
+		2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupRemoteTests.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1126,6 +1128,7 @@
 				B5969E1420A47F99005E9DF1 /* RemoteTests.swift */,
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
+				2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
@@ -2307,6 +2310,7 @@
 				D8FBFF1E22D51F39006E3336 /* OrderStatsMapperV4Tests.swift in Sources */,
 				02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */,
 				9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */,
+				2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,
 				D8FBFF0F22D3B25E006E3336 /* WooAPIVersionTests.swift in Sources */,
 				45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		2683D71024456EE4002A1589 /* categories-extra.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70F24456EE4002A1589 /* categories-extra.json */; };
 		2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D1263B069500D9EE97 /* AddOnGroup.swift */; };
 		2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */; };
+		2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -551,6 +552,7 @@
 		2683D70F24456EE4002A1589 /* categories-extra.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-extra.json"; sourceTree = "<group>"; };
 		2685C0D1263B069500D9EE97 /* AddOnGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroup.swift; sourceTree = "<group>"; };
 		2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddOnGroupMapper.swift; path = ../../../../../../Documents/AddOnGroupMapper.swift; sourceTree = "<group>"; };
+		2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapperTests.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1611,6 +1613,7 @@
 			children = (
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
+				2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
@@ -2254,6 +2257,7 @@
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,
 				02698CF824C183A5005337C4 /* ProductVariationListMapperTests.swift in Sources */,
 				B524194921AC659500D6FC0A /* DevicesRemoteTests.swift in Sources */,
+				2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */,
 				B505F6D320BEE3A500BB1B69 /* AccountMapperTests.swift in Sources */,
 				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */; };
 		2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */ = {isa = PBXBuildFile; fileRef = 2685C0DD263B5A4200D9EE97 /* add-on-groups.json */; };
 		2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */; };
+		2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -555,6 +556,7 @@
 		2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapperTests.swift; sourceTree = "<group>"; };
 		2685C0DD263B5A4200D9EE97 /* add-on-groups.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-on-groups.json"; sourceTree = "<group>"; };
 		2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapper.swift; sourceTree = "<group>"; };
+		2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupRemote.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1245,6 +1247,7 @@
 			children = (
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
+				2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
@@ -2171,6 +2174,7 @@
 				B524193F21AC5FE400D6FC0A /* DotcomDeviceMapper.swift in Sources */,
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,
+				2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */,
 				450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		26731337255ACA850026F7EF /* PaymentGatewayListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */; };
 		2683D70E24456DB8002A1589 /* categories-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70D24456DB7002A1589 /* categories-empty.json */; };
 		2683D71024456EE4002A1589 /* categories-extra.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70F24456EE4002A1589 /* categories-extra.json */; };
+		2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D1263B069500D9EE97 /* AddOnGroup.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -547,6 +548,7 @@
 		26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayListMapper.swift; sourceTree = "<group>"; };
 		2683D70D24456DB7002A1589 /* categories-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-empty.json"; sourceTree = "<group>"; };
 		2683D70F24456EE4002A1589 /* categories-extra.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-extra.json"; sourceTree = "<group>"; };
+		2685C0D1263B069500D9EE97 /* AddOnGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroup.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1304,6 +1306,7 @@
 				B505F6CE20BEE38B00BB1B69 /* Account.swift */,
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
+				2685C0D1263B069500D9EE97 /* AddOnGroup.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -2114,6 +2117,7 @@
 				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */,
+				2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */,
 				B567AF2920A0FA1E00AB6C62 /* Mapper.swift in Sources */,
 				31884A3B2603F3C7003FE338 /* SitePluginStatusEnum.swift in Sources */,
 				CE50345E21B571A7007573C6 /* SitePlanMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D1263B069500D9EE97 /* AddOnGroup.swift */; };
 		2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */; };
 		2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */; };
+		2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */ = {isa = PBXBuildFile; fileRef = 2685C0DD263B5A4200D9EE97 /* add-on-groups.json */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -553,6 +554,7 @@
 		2685C0D1263B069500D9EE97 /* AddOnGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroup.swift; sourceTree = "<group>"; };
 		2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddOnGroupMapper.swift; path = ../../../../../../Documents/AddOnGroupMapper.swift; sourceTree = "<group>"; };
 		2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupMapperTests.swift; sourceTree = "<group>"; };
+		2685C0DD263B5A4200D9EE97 /* add-on-groups.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-on-groups.json"; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1355,6 +1357,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				2685C0DD263B5A4200D9EE97 /* add-on-groups.json */,
 				CECC759D23D6231900486676 /* order-560-all-refunds.json */,
 				74C8F06F20EEC3A800B6EDC9 /* broken-notes.json */,
 				B5A2417A217F98FC00595DEF /* broken-notifications.json */,
@@ -1824,6 +1827,7 @@
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
+				2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */,
 				CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		2683D70E24456DB8002A1589 /* categories-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70D24456DB7002A1589 /* categories-empty.json */; };
 		2683D71024456EE4002A1589 /* categories-extra.json in Resources */ = {isa = PBXBuildFile; fileRef = 2683D70F24456EE4002A1589 /* categories-extra.json */; };
 		2685C0D2263B069500D9EE97 /* AddOnGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D1263B069500D9EE97 /* AddOnGroup.swift */; };
+		2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
@@ -549,6 +550,7 @@
 		2683D70D24456DB7002A1589 /* categories-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-empty.json"; sourceTree = "<group>"; };
 		2683D70F24456EE4002A1589 /* categories-extra.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-extra.json"; sourceTree = "<group>"; };
 		2685C0D1263B069500D9EE97 /* AddOnGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroup.swift; sourceTree = "<group>"; };
+		2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddOnGroupMapper.swift; path = ../../../../../../Documents/AddOnGroupMapper.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
@@ -1239,6 +1241,7 @@
 			children = (
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
+				2685C0D5263B186000D9EE97 /* AddOnGroupMapper.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
@@ -2038,6 +2041,7 @@
 				B567AF2520A0CCA300AB6C62 /* AuthenticatedRequest.swift in Sources */,
 				453305E92459DF2100264E50 /* PostMapper.swift in Sources */,
 				456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */,
+				2685C0D6263B186000D9EE97 /* AddOnGroupMapper.swift in Sources */,
 				CE430672234B9EB20073CBFF /* OrderItemTax.swift in Sources */,
 				D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */,
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,

--- a/Networking/Networking/Mapper/AddOnGroupMapper.swift
+++ b/Networking/Networking/Mapper/AddOnGroupMapper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Maps between a raw json response to an array of `AddOnGroups`
+///
+struct AddOnGroupMapper: Mapper {
+    /// Site Identifier associated to the `AddOnGroup` that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because `SiteID` is not returned in any of the `AddOnGroup` endpoints.
+    ///
+    let siteID: Int64
+
+    func map(response: Data) throws -> [AddOnGroup] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [.siteID: siteID]
+        return try decoder.decode(AddOnGroupEnvelope.self, from: response).data
+    }
+}
+
+/// `AddOnGroupEnvelope` Disposable Entity:
+/// `AddOnGroup` endpoints returns it's add-on-groups json in the `data` key.
+///
+private struct AddOnGroupEnvelope: Decodable {
+    let data: [AddOnGroup]
+}
+

--- a/Networking/Networking/Mapper/AddOnGroupMapper.swift
+++ b/Networking/Networking/Mapper/AddOnGroupMapper.swift
@@ -21,4 +21,3 @@ struct AddOnGroupMapper: Mapper {
 private struct AddOnGroupEnvelope: Decodable {
     let data: [AddOnGroup]
 }
-

--- a/Networking/Networking/Model/AddOnGroup.swift
+++ b/Networking/Networking/Model/AddOnGroup.swift
@@ -3,26 +3,33 @@ import Foundation
 /// Represents a `AddOnGroup` entity that groups global add-ons.
 ///
 public struct AddOnGroup: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
-
     /// SiteID
     ///
-    let siteID: Int64
+    public let siteID: Int64
 
     /// Add-on group ID
     ///
-    let groupID: Int64
+    public let groupID: Int64
 
     /// Name of the group
     ///
-    let name: String
+    public let name: String
 
     /// Priority of the group
     ///
-    let priority: Int64
+    public let priority: Int64
 
     /// Associated global add-ons
     ///
-    let addOns: [ProductAddOn]
+    public let addOns: [ProductAddOn]
+
+    public init(siteID: Int64, groupID: Int64, name: String, priority: Int64, addOns: [ProductAddOn]) {
+        self.siteID = siteID
+        self.groupID = groupID
+        self.name = name
+        self.priority = priority
+        self.addOns = addOns
+    }
 }
 
 // MARK: Decoding

--- a/Networking/Networking/Model/AddOnGroup.swift
+++ b/Networking/Networking/Model/AddOnGroup.swift
@@ -3,4 +3,24 @@ import Foundation
 /// Represents a `AddOnGroup` entity that groups global add-ons.
 ///
 public struct AddOnGroup: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
+
+    /// SiteID
+    ///
+    let siteID: Int64
+
+    /// Add-on group ID
+    ///
+    let groupID: Int64
+
+    /// Name of the group
+    ///
+    let name: String
+
+    /// Priority of the group
+    ///
+    let priority: Int64
+
+    /// Associated global add-ons
+    ///
+    let addOns: [ProductAddOn]
 }

--- a/Networking/Networking/Model/AddOnGroup.swift
+++ b/Networking/Networking/Model/AddOnGroup.swift
@@ -24,3 +24,31 @@ public struct AddOnGroup: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
     ///
     let addOns: [ProductAddOn]
 }
+
+// MARK: Decoding
+extension AddOnGroup {
+    enum CodingKeys: String, CodingKey {
+        case groupID = "id"
+        case name
+        case priority
+        case addOns = "fields"
+    }
+
+    enum DecodingError: Error {
+        case missingSiteID
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ProductCategoryDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.init(siteID: siteID,
+                  groupID: try container.decode(Int64.self, forKey: .groupID),
+                  name: try container.decode(String.self, forKey: .name),
+                  priority: try container.decode(Int64.self, forKey: .priority),
+                  addOns: try container.decode([ProductAddOn].self, forKey: .addOns))
+    }
+}

--- a/Networking/Networking/Model/AddOnGroup.swift
+++ b/Networking/Networking/Model/AddOnGroup.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Represents a `AddOnGroup` entity that groups global add-ons.
+///
+public struct AddOnGroup: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2,6 +2,30 @@
 // DO NOT EDIT
 
 
+extension AddOnGroup {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        groupID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        priority: CopiableProp<Int64> = .copy,
+        addOns: CopiableProp<[ProductAddOn]> = .copy
+    ) -> AddOnGroup {
+        let siteID = siteID ?? self.siteID
+        let groupID = groupID ?? self.groupID
+        let name = name ?? self.name
+        let priority = priority ?? self.priority
+        let addOns = addOns ?? self.addOns
+
+        return AddOnGroup(
+            siteID: siteID,
+            groupID: groupID,
+            name: name,
+            priority: priority,
+            addOns: addOns
+        )
+    }
+}
+
 extension Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Remote/AddOnGroupRemote.swift
+++ b/Networking/Networking/Remote/AddOnGroupRemote.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// `AddOnGroup` remote endpoints.
+///
+public final class AddOnGroupRemote: Remote {
+
+    /// Retrieves all the `AddOnGroups` available for a given `siteID`
+    ///
+    public func loadAddOnGroups(siteID: Int64, onCompletion: @escaping (Result<[AddOnGroup], Error>) -> ()) {
+        let request = JetpackRequest(wooApiVersion: .addOnsV1, method: .get, siteID: siteID, path: Path.addOnGroups)
+        let mapper = AddOnGroupMapper(siteID: siteID)
+        enqueue(request, mapper: mapper, completion: onCompletion)
+    }
+}
+
+// MARK: - Constants
+//
+private extension AddOnGroupRemote {
+    private enum Path {
+        static let addOnGroups = "product-add-ons"
+    }
+}

--- a/Networking/Networking/Settings/WooAPIVersion.swift
+++ b/Networking/Networking/Settings/WooAPIVersion.swift
@@ -34,6 +34,10 @@ public enum WooAPIVersion: String {
     ///
     case wcConnectV1 = "wc/v1/connect"
 
+    /// WooCommerce Product Add-ons plugin.
+    ///
+    case addOnsV1 = "wc-product-add-ons/v1"
+
     /// Returns the path for the current API Version
     ///
     var path: String {

--- a/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
@@ -1,0 +1,5 @@
+import XCTest
+@testable import Networking
+
+class AddOnGroupMapperTests: XCTestCase {
+}

--- a/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AddOnGroupMapperTests.swift
@@ -2,4 +2,36 @@ import XCTest
 @testable import Networking
 
 class AddOnGroupMapperTests: XCTestCase {
+
+    private let dummySiteID: Int64 = 123
+
+    func test_addOnGroups_field_are_properly_parsed() throws {
+        // Given & When
+        let addOnGroups = try XCTUnwrap(mapLoadGroupAddOnsResponse())
+
+        // Then
+        XCTAssertEqual(addOnGroups.count, 2)
+
+        let firstGroup = addOnGroups[0]
+        XCTAssertEqual(firstGroup.siteID, dummySiteID)
+        XCTAssertEqual(firstGroup.groupID, 422)
+        XCTAssertEqual(firstGroup.name, "Gifts")
+        XCTAssertEqual(firstGroup.addOns.count, 2)
+
+        let secondGroup = addOnGroups[1]
+        XCTAssertEqual(secondGroup.siteID, dummySiteID)
+        XCTAssertEqual(secondGroup.groupID, 427)
+        XCTAssertEqual(secondGroup.name, "Music")
+        XCTAssertEqual(secondGroup.addOns.count, 1)
+    }
+}
+
+// MARK: JSON Loading
+private extension AddOnGroupMapperTests {
+    func mapLoadGroupAddOnsResponse() -> [AddOnGroup]? {
+        guard let response = Loader.contentsOf("add-on-groups") else {
+            return nil
+        }
+        return try? AddOnGroupMapper(siteID: dummySiteID).map(response: response)
+    }
 }

--- a/Networking/NetworkingTests/Remote/AddOnGroupRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AddOnGroupRemoteTests.swift
@@ -20,4 +20,39 @@ final class AddOnGroupRemoteTests: XCTestCase {
         network = nil
         super.tearDown()
     }
+
+    func test_loadAddOnGroups_returns_the_correctly_number_of_addOns() throws {
+        // Given
+        let remote = AddOnGroupRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "product-add-ons", filename: "add-on-groups")
+
+        // When
+        let result: Result<[AddOnGroup], Error> = waitFor { promise in
+            remote.loadAddOnGroups(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let addOnGroups = try XCTUnwrap(result.get())
+        XCTAssertEqual(addOnGroups.count, 2)
+    }
+
+    func test_loadAddOnGroups_returns_the_correctly_relays_errors() throws {
+        // Given
+        let sampleError = NSError(domain: "AddOnGroup", code: 1, userInfo: nil)
+        let remote = AddOnGroupRemote(network: network)
+        network.simulateError(requestUrlSuffix: "product-add-ons", error: sampleError)
+
+        // When
+        let result: Result<[AddOnGroup], Error> = waitFor { promise in
+            remote.loadAddOnGroups(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let errorFound = try XCTUnwrap(result.failure as NSError?)
+        XCTAssertEqual(errorFound, sampleError)
+    }
 }

--- a/Networking/NetworkingTests/Remote/AddOnGroupRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AddOnGroupRemoteTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Networking
+
+final class AddOnGroupRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+}

--- a/Networking/NetworkingTests/Responses/add-on-groups.json
+++ b/Networking/NetworkingTests/Responses/add-on-groups.json
@@ -1,0 +1,115 @@
+{
+  "data": [
+    {
+      "id": 422,
+      "name": "Gifts",
+      "priority": 10,
+      "restrict_to_categories": [],
+      "fields": [
+        {
+          "name": "Gift Wrapping",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "multiple_choice",
+          "display": "select",
+          "position": 0,
+          "required": 0,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Basic",
+              "price": "5",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Complex",
+              "price": "7",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Dedicatory Card",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "custom_textarea",
+          "display": "select",
+          "position": 1,
+          "required": 0,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 1,
+          "price_type": "flat_fee",
+          "price": "1",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 427,
+      "name": "Music",
+      "priority": 10,
+      "restrict_to_categories": {
+        "21": "Music"
+      },
+      "fields": [
+        {
+          "name": "Format",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "multiple_choice",
+          "display": "select",
+          "position": 0,
+          "required": 1,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "MP3",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "ACC",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "WAV",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
closes #4042 

# Why 

In order to fully display add-ons for an order, we need to download global add-ons first to then store them on the device. 

This PR adds the networking classes needed to fetch add-on-groups in a future `Yosemite` PR.

# How

- Added `AddOnGroup` networking entity.
- Added `AddOnGroupMapper` struct to decode the json response
- Added `AddOnGroupRemote` class to link `AddOnGroup` and `AddOnGroupMapper`

# Testing steps
- Run networking unit tests!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
