### PR TITLE
[Mobile Payments] Add VM for the no-known no-connected readers state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -2,11 +2,17 @@ import Foundation
 import Combine
 
 protocol CardReaderSettingsPresentedViewModel {
-    var shouldShow: Bool { get }
-    var didChangeShouldShow: ((Bool) -> Void)? { get set }
+    var shouldShow: CardReaderSettingsTriState { get }
+    var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)? { get set }
 }
 
 struct CardReaderSettingsViewModelAndView {
     var viewModel: CardReaderSettingsPresentedViewModel
     var viewIdentifier: String
+}
+
+enum CardReaderSettingsTriState {
+    case isUnknown
+    case isFalse
+    case isTrue
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Combine
 
 protocol CardReaderSettingsPresentedViewModel {
-    func shouldShow() -> Bool
+    var shouldShow: Bool { get }
+    var didChangeShouldShow: ((Bool) -> Void)? { get set }
 }
 
 struct CardReaderSettingsViewModelAndView {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Yosemite
+
+final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewModel {
+    var shouldShow: Bool
+    var didChangeShouldShow: ((Bool) -> Void)?
+
+    private var noConnectedReaders: Bool
+    private var noKnownReaders: Bool
+
+    init(didChangeShouldShow: ((Bool) -> Void)?) {
+
+        // Default shouldShow to true, since we don't know if there are any known or connected readers
+        // TODO: Decide if we want a flag to reflect this initial state and use it to drive a loading indicator
+
+        self.shouldShow = true
+        self.didChangeShouldShow = didChangeShouldShow
+        self.noConnectedReaders = true
+        self.noKnownReaders = true
+
+        beginObservation()
+    }
+
+    /// Dispatches actions to the CardPresentPaymentStore so that we can monitor changes to the list of known
+    /// and connected readers.
+    ///
+    private func beginObservation() {
+
+        // This completion should be called repeatedly as the list of known readers changes
+        let knownAction = CardPresentPaymentAction.observeKnownReaders() { [weak self] readers in
+            self?.noKnownReaders = readers.isEmpty
+            self?.reevaluateShouldShow()
+        }
+        ServiceLocator.stores.dispatch(knownAction)
+
+        // This completion should be called repeatedly as the list of connected readers changes
+        let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            self?.noConnectedReaders = readers.isEmpty
+            self?.reevaluateShouldShow()
+        }
+        ServiceLocator.stores.dispatch(connectedAction)
+    }
+
+    /// Updates whether the view this viewModel is associated with should be shown or not
+    /// Notifes the viewModel owner if a change occurs via didChangeShouldShow
+    ///
+    private func reevaluateShouldShow() {
+
+        let newShouldShow = noKnownReaders && noConnectedReaders
+
+        let didChange = newShouldShow != shouldShow
+
+        shouldShow = newShouldShow
+
+        if didChange {
+            didChangeShouldShow?(shouldShow)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -28,15 +28,21 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
 
         // This completion should be called repeatedly as the list of known readers changes
         let knownAction = CardPresentPaymentAction.observeKnownReaders() { [weak self] readers in
-            self?.noKnownReaders = readers.isEmpty
-            self?.reevaluateShouldShow()
+            guard let self = self else {
+                return
+            }
+            self.noKnownReaders = readers.isEmpty
+            self.reevaluateShouldShow()
         }
         ServiceLocator.stores.dispatch(knownAction)
 
         // This completion should be called repeatedly as the list of connected readers changes
         let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            self?.noConnectedReaders = readers.isEmpty
-            self?.reevaluateShouldShow()
+            guard let self = self else {
+                return
+            }
+            self.noConnectedReaders = readers.isEmpty
+            self.reevaluateShouldShow()
         }
         ServiceLocator.stores.dispatch(connectedAction)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 		318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */; };
 		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
+		31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */; };
 		31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */; };
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
@@ -1673,6 +1674,7 @@
 		318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentingViewController.swift; sourceTree = "<group>"; };
 		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
+		31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModel.swift; sourceTree = "<group>"; };
 		31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedReaderView.swift; sourceTree = "<group>"; };
 		31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedReaderTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
@@ -3513,6 +3515,7 @@
 			children = (
 				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
 				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
+				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
 			);
 			path = CardReadersV2;
 			sourceTree = "<group>";
@@ -6247,6 +6250,7 @@
 				57C503DC23E8C70C00EC0790 /* OrdersTabbedViewController.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
+				31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */,
 				265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -467,6 +467,8 @@
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */; };
 		31F21B02263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */; };
+		31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */; };
+		31F21B60263CB78A0035B50A /* MockCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B5F263CB78A0035B50A /* MockCardReader.swift */; };
 		31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */; };
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
@@ -1677,6 +1679,8 @@
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModel.swift; sourceTree = "<group>"; };
 		31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModelTests.swift; sourceTree = "<group>"; };
+		31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsStoresManager.swift; sourceTree = "<group>"; };
+		31F21B5F263CB78A0035B50A /* MockCardReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReader.swift; sourceTree = "<group>"; };
 		31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedReaderView.swift; sourceTree = "<group>"; };
 		31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedReaderTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
@@ -4150,6 +4154,8 @@
 				02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */,
 				023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */,
 				57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */,
+				31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */,
+				31F21B5F263CB78A0035B50A /* MockCardReader.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -6977,6 +6983,7 @@
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
 				2667BFDF252F762E008099D4 /* IssueRefundViewModelTests.swift in Sources */,
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
+				31F21B60263CB78A0035B50A /* MockCardReader.swift in Sources */,
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */,
 				D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */,
@@ -6993,6 +7000,7 @@
 				D85DD1E1257F376200861AA8 /* NotWPAccountViewModelTests.swift in Sources */,
 				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
+				31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,
 				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */; };
+		31F21B02263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */; };
 		31F92DDB25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */; };
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
@@ -1675,6 +1676,7 @@
 		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModel.swift; sourceTree = "<group>"; };
+		31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModelTests.swift; sourceTree = "<group>"; };
 		31F92DDA25E85CC800DE04DF /* CardReaderSettingsConnectedReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedReaderView.swift; sourceTree = "<group>"; };
 		31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedReaderTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
@@ -3282,6 +3284,7 @@
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				31F21B07263C8E1F0035B50A /* CardReaderSettings */,
 				576D9F2724DB81BF007B48F4 /* Stats V4 */,
 				02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */,
 				0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */,
@@ -3530,6 +3533,14 @@
 				31F92DFE25E86F4500DE04DF /* CardReaderTableViewCells */,
 			);
 			path = CardReaders;
+			sourceTree = "<group>";
+		};
+		31F21B07263C8E1F0035B50A /* CardReaderSettings */ = {
+			isa = PBXGroup;
+			children = (
+				31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */,
+			);
+			path = CardReaderSettings;
 			sourceTree = "<group>";
 		};
 		31F92DFE25E86F4500DE04DF /* CardReaderTableViewCells */ = {
@@ -6951,6 +6962,7 @@
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
+				31F21B02263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift in Sources */,
 				45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */,
 				D8610BDD256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -1,0 +1,34 @@
+import Yosemite
+@testable import WooCommerce
+
+/// Allows mocking for `CardPresentPaymentAction`.
+///
+final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
+    private var knownReaders: [CardReader]
+    private var connectedReaders: [CardReader]
+
+    init(knownReaders: [CardReader], connectedReaders: [CardReader], sessionManager: SessionManager) {
+        self.knownReaders = knownReaders
+        self.connectedReaders = connectedReaders
+        super.init(sessionManager: sessionManager)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let action = action as? CardPresentPaymentAction {
+            onCardPresentPaymentAction(action: action)
+        } else {
+            super.dispatch(action)
+        }
+    }
+
+    private func onCardPresentPaymentAction(action: CardPresentPaymentAction) {
+        switch action {
+        case .observeKnownReaders(let onCompletion):
+            onCompletion(knownReaders)
+        case .observeConnectedReaders(let onCompletion):
+            onCompletion(connectedReaders)
+        default:
+            fatalError("Not available")
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReader.swift
@@ -1,0 +1,13 @@
+@testable import Hardware
+
+struct MockCardReader {
+    static func bbposChipper2XBT() -> CardReader {
+        CardReader(serial: "WPE-SIMULATOR-1",
+                   vendorIdentifier: "SIMULATOR",
+                   name: "Simulated POS E",
+                   status: .init(connected: false, remembered: false),
+                   softwareVersion: "1.00.03.34-SZZZ_Generic_v45-300001",
+                   batteryLevel: 0.5,
+                   readerType: .mobile)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsUnknownViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsUnknownViewModelTests.swift
@@ -2,32 +2,73 @@ import XCTest
 @testable import Yosemite
 @testable import WooCommerce
 
-import Storage
-
 final class CardReaderSettingsUnknownViewModelTests: XCTestCase {
-    /// Mock Dispatcher!
-    ///
-    private var dispatcher: Dispatcher!
 
-    /// Mock Storage: InMemory
-    ///
-    private var storageManager: MockStorageManager!
+    func test_did_change_should_show_returns_true_if_no_known_no_connected_readers() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [],
+            connectedReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
 
-    override func setUp() {
-        super.setUp()
-        dispatcher = Dispatcher()
-        storageManager = MockStorageManager()
-    }
-
-    override func tearDown() {
-        storageManager = nil
-        super.tearDown()
-    }
-
-    func test_did_change_should_show_returns_true_if_no_known_no_connected_readers() throws {
         let expectation = self.expectation(description: "Check shouldShow returns isTrue")
         let _ = CardReaderSettingsUnknownViewModel(didChangeShouldShow: { shouldShow in
             XCTAssertTrue(shouldShow == .isTrue)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_did_change_should_show_returns_false_if_reader_known() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [MockCardReader.bbposChipper2XBT()],
+            connectedReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectation = self.expectation(description: "Check shouldShow returns isFalse")
+
+        let _ = CardReaderSettingsUnknownViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isFalse)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_did_change_should_show_returns_false_if_reader_connected() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [],
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectation = self.expectation(description: "Check shouldShow returns isFalse")
+
+        let _ = CardReaderSettingsUnknownViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isFalse)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_did_change_should_show_returns_false_if_reader_known_and_connected() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [MockCardReader.bbposChipper2XBT()],
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectation = self.expectation(description: "Check shouldShow returns isFalse")
+
+        let _ = CardReaderSettingsUnknownViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isFalse)
             expectation.fulfill()
         } )
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsUnknownViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsUnknownViewModelTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+import Storage
+
+final class CardReaderSettingsUnknownViewModelTests: XCTestCase {
+    /// Mock Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_did_change_should_show_returns_true_if_no_known_no_connected_readers() throws {
+        let expectation = self.expectation(description: "Check shouldShow returns isTrue")
+        let _ = CardReaderSettingsUnknownViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isTrue)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -14,14 +14,20 @@ public enum CardPresentPaymentAction: Action {
     ///
     case connect(reader: CardReader, onCompletion: (Result<[CardReader], Error>) -> Void)
 
-    /// Returns an array of readers (if any) known to us.
+    /// Calls the completion block everytime the list of known readers changes
+    /// with an array of readers known to us.
     ///
     /// What does "known" mean?
     /// If the user connects to a reader, we declare it known. If the user explicitly disconnects from a reader,
     /// we treat that as a "forget" request and un-declare known-ness. During discovery, if a known reader is
     /// detected, it should be connected to automatically. The list of known readers (most merchants will only
     /// have 1 or 2) will be persisted across application sessions.
-    case loadKnownReaders(onCompletion: ([CardReader]) -> Void)
+    case observeKnownReaders(onCompletion: ([CardReader]) -> Void)
+
+    /// Calls the completion block everytime the list of connected readers changes
+    /// with an array of connected readers.
+    ///
+    case observeConnectedReaders(onCompletion: ([CardReader]) -> Void)
 
     /// Collected payment for an order.
     ///

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -42,8 +42,10 @@ public final class CardPresentPaymentStore: Store {
             cancelCardReaderDiscovery(completion: completion)
         case .connect(let reader, let completion):
             connect(reader: reader, onCompletion: completion)
-        case .loadKnownReaders(let completion):
-            loadKnownReaders(onCompletion: completion)
+        case .observeKnownReaders(let completion):
+            observeKnownReaders(onCompletion: completion)
+        case .observeConnectedReaders(let completion):
+            observeConnectedReaders(onCompletion: completion)
         case .collectPayment(let siteID, let orderID, let parameters, let event, let completion):
             collectPayment(siteID: siteID,
                            orderID: orderID,
@@ -97,9 +99,20 @@ private extension CardPresentPaymentStore {
         }.store(in: &cancellables)
     }
 
-    func loadKnownReaders(onCompletion: @escaping ([Yosemite.CardReader]) -> Void) {
+    /// Calls the completion block everytime the list of known readers changes
+    ///
+    func observeKnownReaders(onCompletion: @escaping ([Yosemite.CardReader]) -> Void) {
         // TODO: Hook up to storage (see #3559) - for now, we return an empty array
         onCompletion([])
+    }
+
+    /// Calls the completion block everytime the list of connected readers changes
+    ///
+    func observeConnectedReaders(onCompletion: @escaping ([Yosemite.CardReader]) -> Void) {
+        cardReaderService.connectedReaders.sink { _ in
+        } receiveValue: { readers in
+            onCompletion(readers)
+        }.store(in: &cancellables)
     }
 
     func collectPayment(siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -232,7 +232,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let expectation = self.expectation(description: "Known readers array initially empty")
 
-        let action = CardPresentPaymentAction.loadKnownReaders() { knownReaders in
+        let action = CardPresentPaymentAction.observeKnownReaders() { knownReaders in
             XCTAssertTrue(knownReaders.isEmpty)
             expectation.fulfill()
         }


### PR DESCRIPTION
Closes #4049 

**Note: This is against feature/stripe-terminal-sdk-integration, not develop**

Changes:
- This is the first viewmodel in a series of viewmodels for card reader settings
- Modifies the protocol to make the "shouldShow" a readonly property
- Adds a didChangeShouldShow optional callback that can be used by the VM to tell its creator shouldShow changed
- Adds a new action to subscribe to changes in the list of connected readers
- Fires actions to subscribe to the list of known readers and the list of connected readers
- Updates shouldShow based on those subscriptions
- Unit tests, including a new MockCardPresentPaymentsStoresManager

Rationale:
- It might have been interesting to use Combine and have our VMs Publish shouldShow, but Swift doesn't allow for @Published vars in protocols (yet) https://danielbernal.co/combine-and-protocols-in-swift/
- Conceivably, if we started having stores Publish things, it would be easy to modify a VM like what I have here to Observe things
- I am assuming this idea of having a completion called repeatedly will actually result in the completion being called repeatedly (or at least as long as the VM exists). Or is there something special I need to do that I missed to ensure that happens?

Work not yet done:
- Add this VM to the array of ViewModels passed to CardReaderSettingsPresentingViewController - I'm going to defer that to #4051 since this PR is already > 200 lines

To test:
- Ensure all unit tests pass, especially CardReaderSettingsUnknownViewModelTests

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
