### PR TITLE
Run all unit tests in English (US) by default

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -2,7 +2,7 @@
   "configurations" : [
     {
       "id" : "7E8B43A4-950E-425F-A333-D1D696025D02",
-      "name" : "Configuration 1",
+      "name" : "Default",
       "options" : {
 
       }
@@ -16,6 +16,8 @@
         "enabled" : false
       }
     ],
+    "language" : "en",
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:WooCommerce.xcodeproj",
       "identifier" : "B56DB3C52049BFAA00D4AA8E",


### PR DESCRIPTION
Fixes #2132
Fixes #2382

Some unit tests will fail if the simulator is in a language different than English. Arabic shows the most errors, but also other languages like Spanish where the decimal separator is different.

I thought we could also add a new test plan with only the tests that use formatters, and add a number of languages as possible configurations, but that means there would be a bunch of tests that need to be updated with the expected results in all those languages. It sounds like a fun project, but I'm leaving that for a future occasion.

To test:

1. Set your simulator to a different language like Arabic. Change the region as well, since some settings are region-specific.
2. Run the unit tests and verify they all pass

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
