### PR TITLE
Documentation: Add info about rake generate to Networking doc

### DIFF
--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -54,6 +54,8 @@ Model objects declared in `Networking` are immutable, and modelled as value type
 
 Model objects should implement `Comparable`.
 
+Model objects should conform to `GeneratedFakeable` and `Copiable`. [Fakeable](fakeable.md) and [Copiable](copiable.md) methods should be generated automatically with `rake generate`.
+
 ## Unit tests
 As mentioned previously, there is an implementation of the `Network` protocol called [`MockNetwork`](../Networking/Networking/Network/MockNetwork.swift) used to mock network requests in the unit tests. This way we prevent the tests from hitting the actual network.
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -54,7 +54,7 @@ Model objects declared in `Networking` are immutable, and modelled as value type
 
 Model objects should implement `Comparable`.
 
-Model objects should conform to `GeneratedFakeable` and `Copiable`. [Fakeable](fakeable.md) and [Copiable](copiable.md) methods should be generated automatically with `rake generate`.
+Model objects should conform to `GeneratedFakeable` and `GeneratedCopiable`. [Fakeable](fakeable.md) and [Copiable](copiable.md) methods should be generated automatically with `rake generate`.
 
 ## Unit tests
 As mentioned previously, there is an implementation of the `Network` protocol called [`MockNetwork`](../Networking/Networking/Network/MockNetwork.swift) used to mock network requests in the unit tests. This way we prevent the tests from hitting the actual network.


### PR DESCRIPTION
## Description

Although we already have documentation about how to use `rake generate` to generate `fake()` and `copy()` methods, there isn't any reference to those docs from higher-level docs. I overlooked that step when making Networking changes, since I wasn't aware it was needed, so I'd suggest adding links from the Networking doc just for awareness.

Any suggested changes to the placement/wording are welcome!

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
