### PR TITLE
Add-ons: Adds AddOnGroup Yosemite store

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267439D524E5D45A0090696C /* FeedbackSettings.swift */; };
 		2685C108263C88B000D9EE97 /* AddOnGroup+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C106263C88B000D9EE97 /* AddOnGroup+CoreDataClass.swift */; };
 		2685C109263C88B000D9EE97 /* AddOnGroup+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C107263C88B000D9EE97 /* AddOnGroup+CoreDataProperties.swift */; };
+		2685C11D263DEF0C00D9EE97 /* StorageTypeDeletionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C11C263DEF0B00D9EE97 /* StorageTypeDeletionsTests.swift */; };
 		26B64556259CE7A900EF3FB3 /* ProductAttributeTerm+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64554259CE7A800EF3FB3 /* ProductAttributeTerm+CoreDataProperties.swift */; };
 		26B64557259CE7A900EF3FB3 /* ProductAttributeTerm+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B64555259CE7A800EF3FB3 /* ProductAttributeTerm+CoreDataClass.swift */; };
 		26EA01D124EC3AEA00176A57 /* FeedbackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EA01D024EC3AEA00176A57 /* FeedbackType.swift */; };
@@ -260,6 +261,7 @@
 		2685C105263C84C000D9EE97 /* Model 49.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 49.xcdatamodel"; sourceTree = "<group>"; };
 		2685C106263C88B000D9EE97 /* AddOnGroup+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+CoreDataClass.swift"; sourceTree = "<group>"; };
 		2685C107263C88B000D9EE97 /* AddOnGroup+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		2685C11C263DEF0B00D9EE97 /* StorageTypeDeletionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTypeDeletionsTests.swift; sourceTree = "<group>"; };
 		26B64551259CDF8B00EF3FB3 /* Model 41.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 41.xcdatamodel"; sourceTree = "<group>"; };
 		26B64554259CE7A800EF3FB3 /* ProductAttributeTerm+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductAttributeTerm+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		26B64555259CE7A800EF3FB3 /* ProductAttributeTerm+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductAttributeTerm+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -695,6 +697,7 @@
 				B54CA5C620A4BFDC00F38CD1 /* DummyStack.swift */,
 				57589E8F252275CA000F22CE /* NSManagedObjectContext+TestHelpers.swift */,
 				2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */,
+				2685C11C263DEF0B00D9EE97 /* StorageTypeDeletionsTests.swift */,
 				2619F78525B5D29B0006DAFF /* TypedPredicateTests.swift */,
 			);
 			path = Tools;
@@ -1195,6 +1198,7 @@
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,
 				B59E11DE20A9F1FB004121A4 /* CoreDataManagerTests.swift in Sources */,
 				57A29FB825226BDC004DEE01 /* MigrationTests.swift in Sources */,
+				2685C11D263DEF0C00D9EE97 /* StorageTypeDeletionsTests.swift in Sources */,
 				2619F78625B5D29B0006DAFF /* TypedPredicateTests.swift in Sources */,
 				5772842725BF5BFB0092FB2C /* SpyPersistentStoreCoordinator.swift in Sources */,
 				5772842C25BF62A90092FB2C /* Assertions.swift in Sources */,

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -109,4 +109,13 @@ public extension StorageType {
             deleteObject(review)
         }
     }
+
+    /// Deletes all of the stored `AddOnGroups` for a `siteID` that are not included in the provided `activeGroupIDs` array.
+    ///
+    func deleteStaleAddOnGroups(siteID: Int64, activeGroupIDs: [Int64]) {
+        let staleGroups = loadAddOnGroups(siteID: siteID).filter { !activeGroupIDs.contains($0.groupID) }
+        staleGroups.forEach {
+            deleteObject($0)
+        }
+    }
 }

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -499,4 +499,19 @@ public extension StorageType {
         let predicate = \ShippingLabelAccountSettings.siteID == siteID
         return firstObject(ofType: ShippingLabelAccountSettings.self, matching: predicate)
     }
+
+    /// Returns all stored add-on groups for a provided `siteID`.
+    ///
+    func loadAddOnGroups(siteID: Int64) -> [AddOnGroup] {
+        let predicate = \AddOnGroup.siteID == siteID
+        let descriptor = NSSortDescriptor(keyPath: \AddOnGroup.name, ascending: true)
+        return allObjects(ofType: AddOnGroup.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Returns a single stored add-on group for a provided `siteID` and `groupID`.
+    ///
+    func loadAddOnGroup(siteID: Int64, groupID: Int64) -> AddOnGroup? {
+        let predicate = \AddOnGroup.siteID == siteID && \AddOnGroup.groupID == groupID
+        return firstObject(ofType: AddOnGroup.self, matching: predicate)
+    }
 }

--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Storage
+
+class StorageTypeDeletionsTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 98765
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType! {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = CoreDataManager(name: "WooCommerce", crashLogger: MockCrashLogger())
+    }
+
+    override func tearDown() {
+        storageManager.reset()
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_deleteStaleAddOnGroups_does_not_delete_active_addOns() throws {
+        // Given
+        let initialGroups: [AddOnGroup] = [
+            createAddOnGroup(groupID: 123),
+            createAddOnGroup(groupID: 1234),
+            createAddOnGroup(groupID: 12345)
+        ]
+
+        // When
+        storage.deleteStaleAddOnGroups(siteID: sampleSiteID, activeGroupIDs: [123, 1234])
+
+        // Then
+        let activeGroups = storage.loadAddOnGroups(siteID: sampleSiteID)
+        XCTAssertEqual(activeGroups, initialGroups.dropLast())
+    }
+}
+
+private extension StorageTypeDeletionsTests {
+    /// Inserts and creates an `AddOnGroup` ready to be used on tests.
+    ///
+    func createAddOnGroup(groupID: Int64) -> AddOnGroup {
+        let addOnGroup = storage.insertNewObject(ofType: AddOnGroup.self)
+        addOnGroup.siteID = sampleSiteID
+        addOnGroup.groupID = groupID
+        return addOnGroup
+    }
+}

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -985,4 +985,38 @@ class StorageTypeExtensionsTests: XCTestCase {
         // Then
         XCTAssertEqual(accountSettings, storedAccountSettings)
     }
+
+    func test_loadAddOnGroups_by_site_ID_and_sorted_by_name() throws {
+        // Given
+        let addOnGroup1 = storage.insertNewObject(ofType: AddOnGroup.self)
+        addOnGroup1.name = "BBB"
+        addOnGroup1.siteID = sampleSiteID
+
+        let addOnGroup2 = storage.insertNewObject(ofType: AddOnGroup.self)
+        addOnGroup2.name = "AAA"
+        addOnGroup2.siteID = sampleSiteID
+
+        // When
+        let storedGroups = try XCTUnwrap(storage.loadAddOnGroups(siteID: sampleSiteID))
+
+        // Then
+        XCTAssertEqual(storedGroups, [addOnGroup2, addOnGroup1])
+    }
+
+    func test_loadAddOnGroup_by_siteID_and_groupID() throws {
+        // Given
+        let addOnGroup1 = storage.insertNewObject(ofType: AddOnGroup.self)
+        addOnGroup1.siteID = sampleSiteID
+        addOnGroup1.groupID = 1234
+
+        let addOnGroup2 = storage.insertNewObject(ofType: AddOnGroup.self)
+        addOnGroup2.siteID = sampleSiteID
+        addOnGroup2.groupID = 2345
+
+        // When
+        let storedGroup = try XCTUnwrap(storage.loadAddOnGroup(siteID: sampleSiteID, groupID: 1234))
+
+        // Then
+        XCTAssertEqual(storedGroup, addOnGroup1)
+    }
 }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -31,6 +31,7 @@ class AuthenticatedState: StoresManagerState {
         services = [
             AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             AppSettingsStore(dispatcher: dispatcher, storageManager: storageManager, fileStorage: PListFileStorage()),
+            AddOnGroupStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             AvailabilityStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             MediaStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		266503512620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */; };
 		2685C10D263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */; };
 		2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */; };
+		2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */; };
 		26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */; };
 		26E5A07E25A6640E000DF8F6 /* ProductAttributeTermAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */; };
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
@@ -431,6 +432,7 @@
 		266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOn+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupAction.swift; sourceTree = "<group>"; };
+		2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupStore.swift; sourceTree = "<group>"; };
 		26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAttributeTerm+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermAction.swift; sourceTree = "<group>"; };
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
@@ -1079,6 +1081,7 @@
 				0212AC5F242C680800C51F6C /* Enums */,
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
 				D87F614B22657B150031A13B /* AppSettingsStore.swift */,
+				2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */,
 				02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */,
 				741F34812195EA71005F5BD9 /* CommentStore.swift */,
 				7471401221877A8B009A11CC /* NotificationStore.swift */,
@@ -1589,6 +1592,7 @@
 				02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */,
 				74643EE1221F567E00EDC51A /* ShipmentAction.swift in Sources */,
 				02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */,
+				2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */,
 				CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */,
 				24163BA8257F41C500F94EC3 /* SessionManagerProtocol.swift in Sources */,
 				D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */; };
 		266503512620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */; };
 		2685C10D263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */; };
+		2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */; };
 		26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */; };
 		26E5A07E25A6640E000DF8F6 /* ProductAttributeTermAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */; };
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
@@ -429,6 +430,7 @@
 		2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOnOption+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOn+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupAction.swift; sourceTree = "<group>"; };
 		26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAttributeTerm+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermAction.swift; sourceTree = "<group>"; };
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
@@ -1288,6 +1290,7 @@
 			children = (
 				B5DC3CB020D1B8720063AC41 /* AccountAction.swift */,
 				D87F614922657A690031A13B /* AppSettingsAction.swift */,
+				2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */,
 				02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */,
 				741F347F2195EA62005F5BD9 /* CommentAction.swift */,
 				02FF056223DE9C490058E6E7 /* MediaAction.swift */,
@@ -1572,6 +1575,7 @@
 				247CE7D42582E1FD00F9D9D1 /* ScreenshotStoresManager.swift in Sources */,
 				B5BC736520D1A98500B5B6FA /* AccountStore.swift in Sources */,
 				247CE8562583269900F9D9D1 /* MockProductActionHandler.swift in Sources */,
+				2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */,
 				247CE8382582F21700F9D9D1 /* MockNotificationCountActionHandler.swift in Sources */,
 				02FF056523DE9C8B0058E6E7 /* MediaStore.swift in Sources */,
 				7493751022498AB1007D85D1 /* ProductDefaultAttribute+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		2685C10D263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */; };
 		2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */; };
 		2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */; };
+		2685C121263E064200D9EE97 /* AddOnGroupStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C120263E064200D9EE97 /* AddOnGroupStoreTests.swift */; };
 		26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */; };
 		26E5A07E25A6640E000DF8F6 /* ProductAttributeTermAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */; };
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
@@ -433,6 +434,7 @@
 		2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupAction.swift; sourceTree = "<group>"; };
 		2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupStore.swift; sourceTree = "<group>"; };
+		2685C120263E064200D9EE97 /* AddOnGroupStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupStoreTests.swift; sourceTree = "<group>"; };
 		26E5A07525A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAttributeTerm+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermAction.swift; sourceTree = "<group>"; };
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
@@ -1121,6 +1123,7 @@
 				02DA641A2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift */,
 				458C6DE725ACC554009B300D /* AppSettingsStoreTests+ProductsSettings.swift */,
 				B5BC736720D1AA8F00B5B6FA /* AccountStoreTests.swift */,
+				2685C120263E064200D9EE97 /* AddOnGroupStoreTests.swift */,
 				741F34832195F752005F5BD9 /* CommentStoreTests.swift */,
 				748525AB218A45360036DF75 /* NotificationStoreTests.swift */,
 				74A7688D20D45ED400F9D437 /* OrderStoreTests.swift */,
@@ -1778,6 +1781,7 @@
 				B5C9DE252087FF20006B910A /* MockActionsProcessor.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
 				261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */,
+				2685C121263E064200D9EE97 /* AddOnGroupStoreTests.swift in Sources */,
 				02124DB02431C18700980D74 /* Media+ProductImageTests.swift in Sources */,
 				0248B3672459020500A271A4 /* ResultsController+FilterProductTests.swift in Sources */,
 				B54EAF2121188C470029C35E /* EntityListenerTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AddOnGroupAction.swift
+++ b/Yosemite/Yosemite/Actions/AddOnGroupAction.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Defines all actions supported by the `AddOnGroupStore`
+///
+public enum AddOnGroupAction: Action {
+
+    /// Synchronizes all add-on groups for a given `siteID`
+    ///
+    case synchronizeAddOnGroups(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
+++ b/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
@@ -81,6 +81,7 @@ private extension AddOnGroupStore {
 
             // Update values and relationships
             storedAddOnGroup.update(with: readOnlyAddOnGroup)
+            handleGroupAddOns(readOnlyGroup: readOnlyAddOnGroup, storageGroup: storedAddOnGroup, storage: storage)
         }
 
         // Delete stale groups

--- a/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
+++ b/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Networking
+import Storage
+
+public final class AddOnGroupStore: Store {
+}

--- a/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
+++ b/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
@@ -2,5 +2,34 @@ import Foundation
 import Networking
 import Storage
 
+/// Implements actions from `AddOnGroupAction`
+///
 public final class AddOnGroupStore: Store {
+
+    /// Remote source
+    ///
+    private let remote: AddOnGroupRemote
+
+    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.remote = AddOnGroupRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: AddOnGroupAction.self)
+    }
+
+    /// Receives and executes actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? AddOnGroupAction else {
+            assertionFailure("ProductCategoryStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case let .synchronizeAddOnGroups(siteID, onCompletion):
+            break
+        }
+    }
 }

--- a/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
+++ b/Yosemite/Yosemite/Stores/AddOnGroupStore.swift
@@ -29,7 +29,47 @@ public final class AddOnGroupStore: Store {
 
         switch action {
         case let .synchronizeAddOnGroups(siteID, onCompletion):
-            break
+            synchronizeAddOnGroups(siteID: siteID, onCompletion: onCompletion)
         }
+    }
+}
+
+// MARK: Services
+private extension AddOnGroupStore {
+    /// Downloads and stores all add-on groups for a given `siteID`.
+    ///
+    func synchronizeAddOnGroups(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        remote.loadAddOnGroups(siteID: siteID) { [weak self] result in
+            switch result {
+            case .success(let groups):
+                self?.upsertAddOnGroupsInBackground(readOnlyAddOnGroups: groups, onCompletion: onCompletion)
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+}
+
+// MARK: Storage
+private extension AddOnGroupStore {
+    /// Updates (OR Inserts) the provided ReadOnly `AddOnGroups` entities *in a background thread*.
+    /// onCompletion will be called on the main thread!
+    ///
+    func upsertAddOnGroupsInBackground(readOnlyAddOnGroups: [AddOnGroup], onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let derivedStorage = storageManager.writerDerivedStorage
+        derivedStorage.perform {
+            self.upsertAddOnGroups(readOnlyAddOnGroups: readOnlyAddOnGroups, in: derivedStorage)
+        }
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async {
+                onCompletion(.success(()))
+            }
+        }
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly `AddOnGroups` entities into the Storage Layer.
+    ///
+    func upsertAddOnGroups(readOnlyAddOnGroups: [AddOnGroup], in storage: StorageType) {
+        // TODO: Add implementation
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AddOnGroupStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AddOnGroupStoreTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import Fakes
+
+@testable import Yosemite
+@testable import Networking
+@testable import Storage
+
+final class AddOnGroupStoreTests: XCTestCase {
+    /// Mock Dispatcher
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockNetwork!
+
+    /// Convenience Property: Returns the StorageType associated with the main thread.
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID: Int64 = 123
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+        network = MockNetwork()
+    }
+
+    func test_syncAddOnGroups_stores_groups_correctly() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "product-add-ons", filename: "add-on-groups")
+        let store = AddOnGroupStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AddOnGroupAction.synchronizeAddOnGroups(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageAddOnGroup.self), 2) // 2 groups in the "add-on-groups" json
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductAddOn.self), 3) // 2 add-ons in the 1st group and 1 add-on in the 2nd group
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductAddOnOption.self), 6) // 2 options in the 1st add-on, 1 in the 2nd, and 3 in the 3rd
+    }
+
+    func test_syncAddOnGroups_deletes_stale_groups() throws {
+        // Given
+        let oldGroup = AddOnGroup.fake().copy(siteID: sampleSiteID, groupID: 123)
+        let oldStoredGroup = viewStorage.insertNewObject(ofType: AddOnGroup.self)
+        oldStoredGroup.update(with: oldGroup)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageAddOnGroup.self), 1)
+
+        network.simulateResponse(requestUrlSuffix: "product-add-ons", filename: "add-on-groups")
+        let store = AddOnGroupStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = AddOnGroupAction.synchronizeAddOnGroups(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageAddOnGroup.self), 2) // 2 groups in the "add-on-groups" json
+        XCTAssertNil(viewStorage.loadAddOnGroup(siteID: oldGroup.siteID, groupID: oldGroup.groupID)) // Stored old group
+    }
+}


### PR DESCRIPTION
part of #4044 

# Why 

After being able to fetch #4080 and store #4100 global add-ons, this PR takes care of integrating those services into a single Yosemite store.

# How

- Adds storage functions to fetch add-on groups.
- Adds storage functions to delete stale add-on groups.
- Adds `AddOnGroupAction` enum to provide a `syncAddOnGroups` signature.
- Adds `AddOnGroupStore` to implement the `syncAddOnGroups` action. This will be in charge of fetching, storing, and deleting stale add-on groups.

# Testing Steps

- Have your site with the add-ons plugin installed and configured with at least one add-on group(global add-on).

- Paste the following code at the end of `DashboardViewController.viewDidLoad`
```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
    let action = AddOnGroupAction.synchronizeAddOnGroups(siteID: self.siteID) { _ in
        let groups = ServiceLocator.storageManager.viewStorage.loadAddOnGroups(siteID: self.siteID)
        print("-------- Add-on Groups Begin -----")
        print(groups)
        print("-------- Add-on Groups End -----")
    }
    ServiceLocator.stores.dispatch(action)
}
```

- Make sure the console outputs the add-ons you have created before.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
