### PR TITLE
Coupon Management - Yosemite: CouponStore registration

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -33,6 +33,7 @@ class AuthenticatedState: StoresManagerState {
             AppSettingsStore(dispatcher: dispatcher, storageManager: storageManager, fileStorage: PListFileStorage()),
             AvailabilityStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            CouponStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             MediaStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             NotificationCountStore(dispatcher: dispatcher, storageManager: storageManager, fileStorage: PListFileStorage()),


### PR DESCRIPTION
Part of #3915 

## Description
The implementation of Coupons in Yosemite was incomplete, as the CouponStore was not registered with the AuthenticatedState stores manager.

This meant that any CouponActions which were dispatched would never be handled.

## Testing
None applicable yet, as the Coupons entity is not yet in use.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
