### PR TITLE
Add-ons: Show global add-ons on order's items.

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -84,6 +84,10 @@ final class OrderDetailsDataSource: NSObject {
         return resultsControllers.refunds
     }
 
+    var addOnGroups: [AddOnGroup] {
+        resultsControllers.addOnGroups
+    }
+
     /// Shipping Labels for an Order
     ///
     private(set) var shippingLabels: [ShippingLabel] = []

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -754,7 +754,7 @@ private extension OrderDetailsDataSource {
         guard let product = products.first(where: { $0.productID == item.productID }), showAddOns else {
             return []
         }
-        return AddOnCrossreferenceUseCase(orderItem: item, product: product).addOnsAttributes()
+        return AddOnCrossreferenceUseCase(orderItem: item, product: product, addOnGroups: []).addOnsAttributes()
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -758,7 +758,7 @@ private extension OrderDetailsDataSource {
         guard let product = products.first(where: { $0.productID == item.productID }), showAddOns else {
             return []
         }
-        return AddOnCrossreferenceUseCase(orderItem: item, product: product, addOnGroups: []).addOnsAttributes()
+        return AddOnCrossreferenceUseCase(orderItem: item, product: product, addOnGroups: addOnGroups).addOnsAttributes()
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -70,6 +70,13 @@ final class OrderDetailsResultsControllers {
                                                        sortedBy: [dateCreatedDescriptor, shippingLabelIDDescriptor])
     }()
 
+    /// AddOnGroup ResultsController.
+    ///
+    private lazy var addOnGroupResultsController: ResultsController<StorageAddOnGroup> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageAddOnGroup>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
     /// Order shipment tracking list
     ///
     var orderTracking: [ShipmentTracking] {
@@ -106,6 +113,12 @@ final class OrderDetailsResultsControllers {
         return shippingLabelResultsController.fetchedObjects
     }
 
+    /// Site's add-on groups.
+    ///
+    var addOnGroups: [AddOnGroup] {
+        return addOnGroupResultsController.fetchedObjects
+    }
+
     init(order: Order,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.order = order
@@ -120,6 +133,7 @@ final class OrderDetailsResultsControllers {
         configureProductVariationResultsController(onReload: onReload)
         configureRefundResultsController(onReload: onReload)
         configureShippingLabelResultsController(onReload: onReload)
+        configureAddOnGroupResultsController(onReload: onReload)
     }
 }
 
@@ -213,6 +227,20 @@ private extension OrderDetailsResultsControllers {
         try? shippingLabelResultsController.performFetch()
     }
 
+    private func configureAddOnGroupResultsController(onReload: @escaping () -> Void) {
+        addOnGroupResultsController.onDidChangeContent = {
+            onReload()
+        }
+
+        addOnGroupResultsController.onDidResetContent = { [weak self] in
+            guard let self = self else { return }
+            self.refetchAllResultsControllers()
+            onReload()
+        }
+
+        try? addOnGroupResultsController.performFetch()
+    }
+
     /// Refetching all the results controllers is necessary after a storage reset in `onDidResetContent` callback and before reloading UI that
     /// involves more than one results controller.
     func refetchAllResultsControllers() {
@@ -222,5 +250,6 @@ private extension OrderDetailsResultsControllers {
         try? trackingResultsController.performFetch()
         try? statusResultsController.performFetch()
         try? shippingLabelResultsController.performFetch()
+        try? addOnGroupResultsController.performFetch()
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -347,6 +347,17 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
+    /// Synchronizes all add-ons groups(global add-ons).
+    ///
+    func synchronizeAddOnsGroups(siteID: Int64) {
+        let action = AddOnGroupAction.synchronizeAddOnGroups(siteID: siteID) { result in
+            if let error = result.failure {
+                DDLogError("⛔️ Failed to sync add-on groups for siteID: \(siteID). Error: \(error)")
+            }
+        }
+        dispatch(action)
+    }
+
     /// Loads the Default Site into the current Session, if possible.
     ///
     func restoreSessionSiteIfPossible() {
@@ -361,6 +372,7 @@ private extension DefaultStoresManager {
         }
         retrieveOrderStatus(with: siteID)
         synchronizePaymentGateways(siteID: siteID)
+        synchronizeAddOnsGroups(siteID: siteID)
     }
 
     /// Loads the specified siteID into the Session, if possible.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
@@ -22,7 +22,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -42,7 +42,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -61,7 +61,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -81,7 +81,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         let product = Product.fake()
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -98,10 +98,64 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product)
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
         XCTAssertTrue(addOnsAttributes.isEmpty)
+    }
+
+    func tests_addOn_attributes_are_correctly_filtered_against_global_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: "")
+        ])
+        let product = Product.fake()
+        let addOnGroups = [
+            AddOnGroup.fake().copy(addOns: [ProductAddOn.fake().copy(name: "Fast Delivery")]),
+            AddOnGroup.fake().copy(addOns: [ProductAddOn.fake().copy(name: "Topping")]),
+        ]
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: addOnGroups)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertEqual(addOnsAttributes, [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
+        ])
+    }
+
+    func tests_addOn_attributes_are_correctly_filtered_against_product_addOns_and_global_addOns() {
+        // Given
+        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
+            OrderItemAttribute(metaID: 4, name: "Gift Wrapping ($7.00)", value: ""),
+        ])
+        let product = Product.fake().copy(addOns: [
+            ProductAddOn.fake().copy(name: "Fast Delivery"),
+            ProductAddOn.fake().copy(name: "Topping"),
+            ProductAddOn.fake().copy(name: "Schedule"),
+        ])
+        let addOnGroups = [
+            AddOnGroup.fake().copy(addOns: [ProductAddOn.fake().copy(name: "Format")]),
+            AddOnGroup.fake().copy(addOns: [ProductAddOn.fake().copy(name: "Gift Wrapping")]),
+        ]
+
+        // When
+        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: addOnGroups)
+        let addOnsAttributes = useCase.addOnsAttributes()
+
+        // Then
+        XCTAssertEqual(addOnsAttributes, [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
+            OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
+            OrderItemAttribute(metaID: 4, name: "Gift Wrapping ($7.00)", value: "")
+        ])
     }
 }


### PR DESCRIPTION
closes #4044 
closes #4045 

# Why

#4102 Added the ability to sync a site's add-on groups(global add-ons). This PR makes sure that:
 - Add-on groups are synchronized when the app starts or then a store is switched.
 
 - We use the new add-on groups information to cross-reference it with and order's item's attributes.

# How

- Call `synchronizeAddOnGroups` on `DefaultStoreManager.restoreSessionSiteIfPossible` method

- Update `OrderDetailDataSource` to provide a add-on groups using a `ResultsFetchedController`

- Update `AddOnCrossreferenceUseCase` to receive an array of add-on groups and use it in it's cross-reference calculation.

# Screenshots

Before | After
--- | ---
<img width="403" alt="previous" src="https://user-images.githubusercontent.com/562080/116827090-ff177380-ab5c-11eb-8133-395fa21e6b7f.png"> | <img width="408" alt="now" src="https://user-images.githubusercontent.com/562080/116827092-0048a080-ab5d-11eb-99e1-da6da12e9d59.png">


# Testing Steps

**Prerequisites:** Have your site with the add-ons plugin installed and at least one add-on group(global add-ons) created.

- Create an order that uses a global add-on.
- Launch the app and navigate to the add-on order
- Tap on the "View Add-Ons" button.
- See that the correct add-on is displayed


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
