### PR TITLE
[Tooling] Fix code_freeze lane

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 413bdfd2a22e1f1371a4e2845320afb2b0559667
-  tag: 0.17.1
+  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
+  tag: 0.18.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.17.1)
+    fastlane-plugin-wpmreleasetoolkit (0.18.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -230,7 +230,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.2)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -242,10 +242,10 @@ GEM
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.3)
+    oj (3.11.5)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -335,4 +335,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.10
+   2.2.15

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,7 +74,7 @@ GH_ORG_NAME="woocommerce"
     ios_bump_version_release()
     new_version = ios_get_app_version()
     ios_update_release_notes(new_version: new_version)
-    get_prs_list(repository:GHHELPER_REPO, tag:"#{new_version}", report_path:"#{File.expand_path('~')}/wcios_prs_list_#{old_version}_#{new_version}.txt")
+    get_prs_list(repository: GHHELPER_REPO, milestone: new_version, report_path: "#{File.expand_path('~')}/wcios_prs_list_#{old_version}_#{new_version}.txt")
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
     ios_check_beta_deps(podfile:"#{ENV["PROJECT_ROOT_FOLDER"]}Podfile")
@@ -712,9 +712,9 @@ GH_ORG_NAME="woocommerce"
   ########################################################################
   # Helper Lanes
   ########################################################################  
-  desc "Get a list of pull request from `start_tag` to the current state"
+  desc "Get a list of pull requests from the `milestone`"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wcios_prs_list.txt")
+    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wcios_prs_list.txt")
   end
 
   desc "Run release preflight checks"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.17.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
`code_freeze` lane was broken during partial manual fix last release after the breaking change in release toolkit.

Updating to latest release toolkit with fix of the call site for `get_prs_list`.