### PR TITLE
PR to test localization fix attempt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
-  tag: 0.18.0
+  revision: 155ad828760d8aba998690116cbba6638b55c7fe
+  branch: return-full-path-from-localized-glob
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.18.0)
       activesupport (~> 5)
@@ -21,7 +21,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.4.4)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -95,7 +95,7 @@ GEM
     colorize (0.8.1)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -109,14 +109,18 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     excon (0.79.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
     faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
       http-cookie (~> 1.0.0)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.3)
@@ -219,7 +223,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
@@ -231,7 +235,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -294,7 +298,7 @@ GEM
       tty-cursor (~> 0.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -147,6 +147,9 @@
 /* No comment provided by engineer. */
 "A refund will not be issued to the customer. You will need to manually issue the refund through Stripe." = "A refund will not be issued to the customer. You will need to manually issue the refund through Stripe.";
 
+/* Message explaining that the site may have an invalid SSL certificate. */
+"A secure connection to the site could not be made. Please make sure that your site has a valid SSL certificate." = "A secure connection to the site could not be made. Please make sure that your site has a valid SSL certificate.";
+
 /* Description of the Action sheet option when the user wants to change the Product type to simple product */
 "A unique item to sell" = "A unique item to sell";
 
@@ -193,6 +196,9 @@
 
 /* Add Product Attribute screen navigation title */
 "Add attribute" = "Add attribute";
+
+/* Title on empty state button when the product has no attributes and variations */
+"Add Attributes" = "Add Attributes";
 
 /* Action to add category on the Product Categories screen
    Product Add Category navigation title */
@@ -249,8 +255,7 @@
    Add Tracking row label - Add tracking screen - title. - The title used for a unit test */
 "Add Tracking" = "Add Tracking";
 
-/* Action to add new variation on the variations list
-   Title on add variation button when there are no variations */
+/* Title on empty state button when the product has attributes but no variations */
 "Add Variation" = "Add Variation";
 
 /* Title for adding variations row on Product main screen for a variable product */
@@ -258,9 +263,6 @@
 
 /* Subtitle of the product form bottom sheet action for editing shipping settings. */
 "Add weight and dimensions" = "Add weight and dimensions";
-
-/* Title on the variations list screen when there are no variations */
-"Add your first variation" = "Add your first variation";
 
 /* Text field address in Shipping Label Address Validation */
 "Address" = "Address";
@@ -656,6 +658,9 @@
    Text on the button that starts shipping label creation */
 "Create Shipping Label" = "Create Shipping Label";
 
+/* Title on the variations list screen when there are no variations */
+"Create your first variation" = "Create your first variation";
+
 /* My Store > Settings > Experimental features > Products */
 "Creating products" = "Creating products";
 
@@ -751,7 +756,7 @@
 "Discount" = "Discount";
 
 /* A unit test string for a button title
-   Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog. - Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog. - Add a note screen - button title for closing the view - Button title for dismissing filtering a list. - Dismiss button in store picker - Dismiss button title shown in alert warning users to upgrade to WC 3.5. - Dismiss button title shown in an alert displaying full purchase note text. - Dismiss the action sheet - Dismiss the media picking action sheet - Dismiss the shipment tracking action sheet - The title of the button to dismiss the banner in order details - The title of the button to dismiss the banner on the products tab */
+   Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog. - Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog. - Add a note screen - button title for closing the view - Button title for dismissing filtering a list. - Dismiss button in store picker - Dismiss button title shown in alert warning users to upgrade to WC 3.5. - Dismiss button title shown in an alert displaying full purchase note text. - Dismiss the action sheet - Dismiss the media picking action sheet - Dismiss the shipment tracking action sheet - The title of the button to dismiss the banner in order details - The title of the button to dismiss the banner on the products tab - Title of the button to dismiss the banner notice in the add-ons view */
 "Dismiss" = "Dismiss";
 
 /* Display label for the product's inventory backorders setting option */
@@ -764,7 +769,7 @@
 "Don't have an account? _Sign up_" = "Don't have an account? _Sign up_";
 
 /* Action title to select products to add to a grouped product from search results
-   Edit product categories screen - button title to apply categories selection - Edit product downloadable files screen - button title to apply changes to downloadable files */
+   Done navigation button under the Package Selected screen in Shipping Label flow - Edit product categories screen - button title to apply categories selection - Edit product downloadable files screen - button title to apply changes to downloadable files */
 "Done" = "Done";
 
 /* Link title to see instructions for printing a shipping label on an iOS device */
@@ -878,7 +883,8 @@
 /* Step 3 of shipping label printing instructions screen. The content inside two double asterisks **...** denote bolded text. */
 "Ensure that your **printer firmware is up to date**. See your printer documentation for instructions on updating." = "Ensure that your **printer firmware is up to date**. See your printer documentation for instructions on updating.";
 
-/* Action button linking to instructions for enter another store.Presented when logging in with a site address that is not a WordPress site */
+/* Action button linking to instructions for enter another store.Presented when logging in with a site address that appears to be invalid.
+   Action button linking to instructions for enter another store.Presented when logging in with a site address that is not a WordPress site */
 "Enter Another Store" = "Enter Another Store";
 
 /* Add custom shipping carrier. Placeholder of cell presenting carrier name */
@@ -1030,6 +1036,12 @@
 /* Description for Top Performers section of My Store tab. */
 "Gain insights into how products are performing on your store" = "Gain insights into how products are performing on your store";
 
+/* Action to generate attributes on the Product Attributes screen */
+"Generate" = "Generate";
+
+/* Action to add new variation on the variations list */
+"Generate New Variation" = "Generate New Variation";
+
 /* Title for the progress screen while generating a variation */
 "Generating Variation" = "Generating Variation";
 
@@ -1052,6 +1064,9 @@
 /* The title of the button to give feedback about products beta features on the banner on the products tab
    The title of the button to give feedback about shipping labels features on the banner in order details - Title on the navigation bar for the products feedback survey */
 "Give feedback" = "Give feedback";
+
+/* Title of the button to give feedback about the add-ons feature */
+"Give Feedback" = "Give Feedback";
 
 /* Option to select the Gmail app when logging in with magic links */
 "Gmail" = "Gmail";
@@ -1149,6 +1164,9 @@
 
 /* Detail label for yes/no switch. */
 "If disabled the note will be private" = "If disabled the note will be private";
+
+/* The text below the order add-ons list indicating that the content could be stale. */
+"If renaming an add-on in your web dashboard, please note that previous orders will no longer show that add-on within the app." = "If renaming an add-on in your web dashboard, please note that previous orders will no longer show that add-on within the app.";
 
 /* Header text when reprinting a shipping label */
 "If there was a printing error when you purchased the label, you can print it again." = "If there was a printing error when you purchased the label, you can print it again.";
@@ -1355,8 +1373,8 @@
 /* Instruction text on the login's email address screen. */
 "Log in to your WordPress.com account with your email address." = "Log in to your WordPress.com account with your email address.";
 
-/* Action button that will restart the login flow.Presented when logging in with a site address that does not have a valid Jetpack installation
-   Action button that will restart the login flow.Presented when logging in with an email address that does not match a WordPress.com account */
+/* Action button that will restart the login flow.Presented when logging in with a site address that appears to be invalid.
+   Action button that will restart the login flow.Presented when logging in with a site address that does not have a valid Jetpack installation - Action button that will restart the login flow.Presented when logging in with an email address that does not match a WordPress.com account */
 "Log In With Another Account" = "Log In With Another Account";
 
 /* Sign in instructions on the 'log in using email' screen.
@@ -1599,6 +1617,9 @@
 
 /* Accessibility label for 1 password button */
 "One Password button" = "One Password button";
+
+/* Helper text above photo list in Product images screen */
+"Only one photo can be displayed by variation" = "Only one photo can be displayed by variation";
 
 /* Opens iOS's Device Settings for the app */
 "Open Device Settings" = "Open Device Settings";
@@ -2729,9 +2750,6 @@
 /* Error title when failing to generate a variation. */
 "The variation couldn't be generated." = "The variation couldn't be generated.";
 
-/* Message explaining that a site is not a WordPress site. Reads like 'The website awebsite.com you'll is not a WordPress site... */
-"The website is not a WordPress site. For us to connect to it, the site must have WordPress installed." = "The website is not a WordPress site. For us to connect to it, the site must have WordPress installed.";
-
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "There was a problem blocking posts from the specified site.";
 
@@ -2808,6 +2826,9 @@
 
 /* Title of the cell in Product Price Settings > Schedule sale to a certain date */
 "To" = "To";
+
+/* Subtitle on the variations list screen when there are no variations and attributes */
+"To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first" = "To add a variation, you'll need to set its attributes (ie \"Color\", \"Size\") first";
 
 /* Footer of text field section in Add Attribute screen */
 "To create a variation, you'll need to set its attributes (i.e. \"Color,\" \"Size\") first" = "To create a variation, you'll need to set its attributes (i.e. \"Color,\" \"Size\") first";
@@ -3085,6 +3106,9 @@
 /* Title of the button on the order detail item to navigate to add-ons */
 "View Add-Ons" = "View Add-Ons";
 
+/* Title of the banner notice in the add-ons view */
+"View add-ons from your device!" = "View add-ons from your device!";
+
 /* View application log cell title */
 "View Application Log" = "View Application Log";
 
@@ -3145,6 +3169,9 @@
 /* The info of the shipping labels top banner in order details */
 "We are working on making it easier for you to print shipping labels directly from your device! For now, if you have created labels for an order in your store admin with WooCommerce Shipping, you can print them in your Order details here." = "We are working on making it easier for you to print shipping labels directly from your device! For now, if you have created labels for an order in your store admin with WooCommerce Shipping, you can print them in your Order details here.";
 
+/* Content of the banner notice in the add-ons view */
+"We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashboard." = "We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashboard.";
+
 /* Title when we can't show stats because user is on a deprecated WC Version */
 "We can’t display your store’s analytics" = "We can’t display your store’s analytics";
 
@@ -3156,6 +3183,9 @@
 
 /* Settings > Privacy Settings > cookie info section. Explains what we do with the cookie information we collect. */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We use other tracking tools, including some from third parties. Read about these and how to control them.";
+
+/* Message explaining that WordPress was not detected. */
+"We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version." = "We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.";
 
 /* Banner caption in Shipping Label Address Validation when the origin address can't be verified. */
 "We were unable to automatically verify the origin address." = "We were unable to automatically verify the origin address.";

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'return-full-path-from-localized-glob'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
See https://github.com/wordpress-mobile/release-toolkit/pull/236

It looks like it found all the `strings` files:

![image](https://user-images.githubusercontent.com/1218433/116931163-039a7400-aca4-11eb-9717-7e7e6ebf8456.png)

That list matches what `ls` returns:

```
➜ ls WooCommerce/**/*.strings
WooCommerce/Classes/ViewRelated/it.lproj/Main.strings   WooCommerce/Resources/ja.lproj/Localizable.strings
WooCommerce/Resources/ar.lproj/Localizable.strings      WooCommerce/Resources/ko.lproj/Localizable.strings
WooCommerce/Resources/de.lproj/Localizable.strings      WooCommerce/Resources/nl.lproj/Localizable.strings
WooCommerce/Resources/en.lproj/Localizable.strings      WooCommerce/Resources/pt-BR.lproj/Localizable.strings
WooCommerce/Resources/es.lproj/Localizable.strings      WooCommerce/Resources/ru.lproj/Localizable.strings
WooCommerce/Resources/fr.lproj/Localizable.strings      WooCommerce/Resources/sv.lproj/Localizable.strings
WooCommerce/Resources/he.lproj/Localizable.strings      WooCommerce/Resources/tr.lproj/Localizable.strings
WooCommerce/Resources/id.lproj/Localizable.strings      WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
WooCommerce/Resources/it.lproj/Localizable.strings      WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
```

(_Curious about that `WooCommerce/Classes/ViewRelated/it.lproj/Main.strings`, is it still in use?_ 🤔)