### PR TITLE
[Mobile Payments] Card Reader Settings 2-4: Add VM for when a reader is connected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -3,18 +3,15 @@ import Yosemite
 
 final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedViewModel {
 
-    var shouldShow: CardReaderSettingsTriState
+    var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
 
-    private var didGetConnectedReaders: Bool
-    private var connectedReaders: [CardReader]
+    private var didGetConnectedReaders: Bool = false
+    private var connectedReaders = [CardReader]()
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
 
         self.didChangeShouldShow = didChangeShouldShow
-        self.shouldShow = .isUnknown
-        self.didGetConnectedReaders = false
-        self.connectedReaders = []
 
         beginObservation()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Yosemite
+
+final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedViewModel {
+
+    var shouldShow: CardReaderSettingsTriState
+    var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
+
+    private var didGetConnectedReaders: Bool
+    private var connectedReaders: [CardReader]
+
+    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
+
+        self.didChangeShouldShow = didChangeShouldShow
+        self.shouldShow = .isUnknown
+        self.didGetConnectedReaders = false
+        self.connectedReaders = []
+
+        beginObservation()
+    }
+
+    /// Dispatches actions to the CardPresentPaymentStore so that we can monitor changes to the list of
+    /// connected readers.
+    ///
+    private func beginObservation() {
+
+        // This completion should be called repeatedly as the list of connected readers changes
+        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            guard let self = self else {
+                return
+            }
+            self.didGetConnectedReaders = true
+            self.connectedReaders = readers
+            self.reevaluateShouldShow()
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    /// Updates whether the view this viewModel is associated with should be shown or not
+    /// Notifes the viewModel owner if a change occurs via didChangeShouldShow
+    ///
+    private func reevaluateShouldShow() {
+
+        var newShouldShow: CardReaderSettingsTriState = .isUnknown
+
+        if !didGetConnectedReaders {
+            newShouldShow = .isUnknown
+        } else if connectedReaders.isEmpty {
+            newShouldShow = .isFalse
+        } else {
+            newShouldShow = .isTrue
+        }
+
+        let didChange = newShouldShow != shouldShow
+
+        shouldShow = newShouldShow
+
+        if didChange {
+            didChangeShouldShow?(shouldShow)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedViewModel {
 
-    var shouldShow: CardReaderSettingsTriState = .isUnknown
+    private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
 
     private var didGetConnectedReaders: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewModel {
 
-    var shouldShow: CardReaderSettingsTriState = .isUnknown
+    private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
 
     private var noConnectedReaders: CardReaderSettingsTriState = .isUnknown

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -3,18 +3,15 @@ import Yosemite
 
 final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewModel {
 
-    var shouldShow: CardReaderSettingsTriState
+    var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
 
-    private var noConnectedReaders: CardReaderSettingsTriState
-    private var noKnownReaders: CardReaderSettingsTriState
+    private var noConnectedReaders: CardReaderSettingsTriState = .isUnknown
+    private var noKnownReaders: CardReaderSettingsTriState = .isUnknown
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
 
         self.didChangeShouldShow = didChangeShouldShow
-        self.shouldShow = .isUnknown
-        self.noConnectedReaders = .isUnknown
-        self.noKnownReaders = .isUnknown
 
         beginObservation()
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -456,6 +456,8 @@
 		31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */; };
 		31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */; };
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
+		3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */; };
+		3178C1FD26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */; };
 		318109C625E59E4000EE0BE7 /* TitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */; };
 		318109D625E5A7E300EE0BE7 /* TitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */; };
 		318109DC25E5B51900EE0BE7 /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109DB25E5B51900EE0BE7 /* ImageTableViewCell.swift */; };
@@ -1669,6 +1671,8 @@
 		31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModel.swift; sourceTree = "<group>"; };
 		31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectedReaderTableViewCell.xib; sourceTree = "<group>"; };
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
+		3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModel.swift; sourceTree = "<group>"; };
+		3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModelTests.swift; sourceTree = "<group>"; };
 		318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
 		318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleTableViewCell.xib; sourceTree = "<group>"; };
 		318109DB25E5B51900EE0BE7 /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -3524,6 +3528,7 @@
 			children = (
 				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
 				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
+				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
 			);
 			path = CardReadersV2;
@@ -3544,6 +3549,7 @@
 		31F21B07263C8E1F0035B50A /* CardReaderSettings */ = {
 			isa = PBXGroup;
 			children = (
+				3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */,
 				31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */,
 			);
 			path = CardReaderSettings;
@@ -6790,6 +6796,7 @@
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
 				451B1747258BD7B600836277 /* AddAttributeOptionsViewModel.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
+				3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */,
 				CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */,
 				265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */,
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
@@ -6877,6 +6884,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45C8B2692316B2440002FA77 /* BillingAddressTableViewCellTests.swift in Sources */,
+				3178C1FD26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift in Sources */,
 				02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */,
 				B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */,
 				B57C5C9F21B80E8300FF82B2 /* SampleError.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
+
+    func test_did_change_should_show_returns_false_if_no_connected_readers() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [],
+            connectedReaders: [],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectation = self.expectation(description: "Check shouldShow returns isFalse")
+        let _ = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isFalse)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_did_change_should_show_returns_true_if_a_reader_is_connected() {
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            knownReaders: [],
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectation = self.expectation(description: "Check shouldShow returns isTrue")
+
+        let _ = CardReaderSettingsConnectedViewModel(didChangeShouldShow: { shouldShow in
+            XCTAssertTrue(shouldShow == .isTrue)
+            expectation.fulfill()
+        } )
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}


### PR DESCRIPTION
Closes #4050

**Note: This is against feature/stripe-terminal-sdk-integration, not develop**

Changes:
- This is the next viewmodel in a series of viewmodels for card reader settings
- Updates shouldShow based on whether there are connected readers
- Adds unit tests

Work not yet done:
- Add this VM to the array of ViewModels passed to CardReaderSettingsPresentingViewController - I'm going to defer that to #4051

To test:
- Ensure all unit tests pass, especially CardReaderSettingsConnectedViewModelTests

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.