### PR TITLE
[Mobile Payments] Add auxiliary button to modal view

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -46,11 +46,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
         viewController?.dismiss(animated: true)
     }
 
-    func didTapSecondaryButton(in viewController: UIViewController?) {
-    }
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
 
-    func didTapAuxiliaryButton(in viewController: UIViewController?) {  
-    }
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
 private extension CardPresentModalError {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -27,6 +27,8 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = nil
 
+    let auxiliaryButtonTitle: String? = nil
+
     var bottomTitle: String? {
         error.localizedDescription
     }
@@ -47,7 +49,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     func didTapSecondaryButton(in viewController: UIViewController?) {
     }
 
-    func didTapAuxiliaryButton(in viewController: UIViewController?) {        
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {  
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -12,7 +12,8 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
     private let primaryAction: () -> Void
 
-    let mode: PaymentsModalMode = .oneActionButton
+    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
 
     let topTitle: String = Localization.paymentFailed
 
@@ -44,6 +45,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {        
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -9,7 +9,8 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     /// Charge amount
     private let amount: String
 
-    let mode: PaymentsModalMode = .fullInfo
+    let textMode: PaymentsModalTextMode = .fullInfo
+    let actionsMode: PaymentsModalActionsMode = .none
 
     var topTitle: String {
         name

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -26,6 +26,8 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = nil
 
+    let auxiliaryButtonTitle: String? = nil
+
     let bottomTitle: String? = Localization.readerIsReady
 
     let bottomSubtitle: String? = Localization.tapInsertOrSwipe

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalRemoveCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalRemoveCard.swift
@@ -10,7 +10,8 @@ final class CardPresentModalRemoveCard: CardPresentPaymentsModalViewModel {
     /// Charge amount
     private let amount: String
 
-    let mode: PaymentsModalMode = .reducedInfo
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .none
 
     var topTitle: String {
         name

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalRemoveCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalRemoveCard.swift
@@ -27,6 +27,8 @@ final class CardPresentModalRemoveCard: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = nil
 
+    let auxiliaryButtonTitle: String? = nil
+
     let bottomTitle: String? = Localization.removeCard
 
     let bottomSubtitle: String? = nil

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -28,6 +28,8 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let secondaryButtonTitle: String? = Localization.emailReceipt
 
+    let auxiliaryButtonTitle: String? = Localization.noThanks
+
     let bottomTitle: String? = nil
 
     let bottomSubtitle: String? = nil

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -13,7 +13,8 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     /// Closure to execute when secondary button is tapped
     private let emailReceiptAction: () -> Void
 
-    let mode: PaymentsModalMode = .twoActionButtons
+    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .twoActionAndAuxiliary
 
     let topTitle: String = Localization.paymentSuccessful
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
@@ -10,7 +10,8 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
     /// Charge amount
     private let amount: String
 
-    let mode: PaymentsModalMode = .fullInfo
+    let textMode: PaymentsModalTextMode = .fullInfo
+    let actionsMode: PaymentsModalActionsMode = .none
 
     var topTitle: String {
         name

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -24,6 +24,9 @@ protocol CardPresentPaymentsModalViewModel {
     /// Provides a title for a secondary action button
     var secondaryButtonTitle: String? { get }
 
+    /// Provides a title for an auxiliary button
+    var auxiliaryButtonTitle: String? { get }
+
     /// The title in the bottom section of the modal. Right below the image
     var bottomTitle: String? { get }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -3,8 +3,11 @@ import UIKit
 /// Abstracts configuration and contents of the modal screens presented
 /// during operations related to Card Present Payments
 protocol CardPresentPaymentsModalViewModel {
-    /// The visual mode of the view. Represents the contents of the view.
-    var mode: PaymentsModalMode { get }
+    /// The number and distribution of text labels
+    var textMode: PaymentsModalTextMode { get }
+
+    /// The number and distribution of action buttons
+    var actionsMode: PaymentsModalActionsMode { get }
 
     /// The title at the top of the modal view.
     var topTitle: String { get }
@@ -34,23 +37,35 @@ protocol CardPresentPaymentsModalViewModel {
     /// Executes action associated to a tap in the view controller secondary button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapSecondaryButton(in viewController: UIViewController?)
+
+    /// Executes action associated to a tap in the view controller auxiliary button
+    /// - Parameter viewController: usually the view controller sending the tap
+    func didTapAuxiliaryButton(in viewController: UIViewController?)
 }
 
 
-/// Represents the different visual modes of the modal view
-enum PaymentsModalMode {
+/// Represents the different visual modes of the modal view's textfields
+enum PaymentsModalTextMode {
     /// From top to bottom: Two lines of text at the top, image, two more lines of text
     case fullInfo
 
     /// From top to bottom: Two lines of text at the top, image, one more line of text
-    case reducedInfo
+    case reducedBottomInfo
 
-    /// From top to bottom: Two lines of text at the top, image, two action buttons
-    case twoActionButtons
+    /// From top to bottom: Two lines of text at the top, and image
+    case noBottomInfo
+}
 
-    /// From top to bottom: Two lines of text at the top, image, one action button
-    case oneActionButton
+enum PaymentsModalActionsMode {
+    /// No action buttons
+    case none
 
-    /// From top to bottom: One line of text at the top, image, one action button
-    case reducedInfoOneActionButton
+    /// One action button
+    case oneAction
+
+    /// Two action buttons
+    case twoAction
+
+    /// Two action buttons and an auxiiary button
+    case twoActionAndAuxiliary
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -49,6 +49,9 @@ enum PaymentsModalTextMode {
     /// From top to bottom: Two lines of text at the top, image, two more lines of text
     case fullInfo
 
+    /// From top to bottom: One line of text at the top, image
+    case reducedTopInfo
+
     /// From top to bottom: Two lines of text at the top, image, one more line of text
     case reducedBottomInfo
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -189,28 +189,28 @@ private extension CardPresentPaymentsModalViewController {
 // MARK: - View layout configuration
 private extension CardPresentPaymentsModalViewController {
     func shouldShowTopSubtitle() -> Bool {
-        viewModel.mode != .reducedInfo
+        viewModel.textMode != .reducedTopInfo
     }
 
     func shouldShowBottomLabels() -> Bool {
-        let mode = viewModel.mode
-        return mode == .fullInfo ||
-            mode == .reducedInfo
+        viewModel.textMode != .noBottomInfo
     }
 
     func shouldShowActionButtons() -> Bool {
-        let mode = viewModel.mode
-        return mode == .oneActionButton ||
-            mode == .twoActionButtons ||
-            mode == .reducedInfoOneActionButton
+        viewModel.actionsMode != .none
     }
 
     func shouldShowBottomSubtitle() -> Bool {
-        viewModel.mode == .fullInfo
+        let textMode = viewModel.textMode
+        return textMode == .fullInfo ||
+            textMode == .reducedTopInfo
     }
 
     func shouldShowBottomActionButton() -> Bool {
-        viewModel.mode == .twoActionButtons
+        let actionMode = viewModel.actionsMode
+
+        return actionMode == .twoAction ||
+            actionMode == .twoActionAndAuxiliary
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -16,6 +16,8 @@ final class CardPresentPaymentsModalViewController: UIViewController {
 
     @IBOutlet private weak var primaryButton: NUXButton!
     @IBOutlet private weak var secondaryButton: NUXButton!
+    @IBOutlet weak var auxiliaryButton: UIButton!
+
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var extraInfoButton: UIButton!
 
@@ -163,6 +165,7 @@ private extension CardPresentPaymentsModalViewController {
 
         configurePrimaryButton()
         configureSecondaryButton()
+        configureAuxiliaryButton()
     }
 
     func configurePrimaryButton() {
@@ -182,6 +185,19 @@ private extension CardPresentPaymentsModalViewController {
         secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
         secondaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapSecondaryButton()
+        }
+    }
+
+    func configureAuxiliaryButton() {
+        guard shouldShowAuxiliaryButton() else {
+            auxiliaryButton.isHidden = true
+            return
+        }
+
+        auxiliaryButton.isHidden = false
+        auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
+        auxiliaryButton.on(.touchUpInside) { [weak self] _ in
+            self?.didTapAuxiliaryButton()
         }
     }
 }
@@ -212,6 +228,10 @@ private extension CardPresentPaymentsModalViewController {
         return actionMode == .twoAction ||
             actionMode == .twoActionAndAuxiliary
     }
+
+    func shouldShowAuxiliaryButton() -> Bool {
+        viewModel.actionsMode == .twoActionAndAuxiliary
+    }
 }
 
 
@@ -223,6 +243,10 @@ private extension CardPresentPaymentsModalViewController {
 
     func didTapSecondaryButton() {
         viewModel.didTapSecondaryButton(in: self)
+    }
+
+    func didTapAuxiliaryButton() {
+        viewModel.didTapAuxiliaryButton(in: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -97,6 +97,7 @@ private extension CardPresentPaymentsModalViewController {
 
         stylePrimaryButton()
         styleSecondaryButton()
+        styleAuxiliaryButton()
     }
 
     func stylePrimaryButton() {
@@ -105,6 +106,10 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleSecondaryButton() {
 
+    }
+
+    func styleAuxiliaryButton() {
+        auxiliaryButton.applyLinkButtonStyle()
     }
 
     func populateContent() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardPresentPaymentsModalViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="actionButtonsView" destination="10Z-y1-ZQ6" id="L1z-Zs-L2J"/>
+                <outlet property="auxiliaryButton" destination="maO-19-PuQ" id="cQA-7p-jmo"/>
                 <outlet property="bottomLabels" destination="k73-qi-GuD" id="LvQ-UE-SBc"/>
                 <outlet property="bottomSubtitleLabel" destination="2Sx-5s-f7J" id="Mco-Vu-Li6"/>
                 <outlet property="bottomTitleLabel" destination="oAj-lv-0k9" id="Clc-oi-Ywf"/>
@@ -29,10 +30,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="67" y="187.5" width="280" height="531"/>
+                    <rect key="frame" x="67" y="162.5" width="280" height="581"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="0.0" y="32" width="280" height="467"/>
+                            <rect key="frame" x="0.0" y="32" width="280" height="517"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="119.5" y="0.0" width="41.5" height="49"/>
@@ -72,10 +73,10 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="319" width="280" height="148"/>
+                                    <rect key="frame" x="0.0" y="319" width="280" height="198"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                                            <rect key="frame" x="16" y="20" width="248" height="120"/>
+                                            <rect key="frame" x="16" y="20" width="248" height="170"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                     <rect key="frame" x="0.0" y="0.0" width="248" height="50"/>
@@ -103,6 +104,10 @@
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
                                                     </userDefinedRuntimeAttributes>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
+                                                    <rect key="frame" x="0.0" y="140" width="248" height="30"/>
+                                                    <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>
                                         </stackView>

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
 
     func test_viewcontroller_presents_top_title_provided_by_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -13,7 +13,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_presents_top_subtitle_provided_by_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -22,7 +22,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_presents_image_provided_by_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -32,7 +32,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_presents_bottom_title_provided_by_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -41,7 +41,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_presents_bottom_subtitle_provided_by_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -50,7 +50,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_primary_button_to_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .twoActionButtons)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .oneAction)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -62,7 +62,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_primary_button_to_viewmodel_in_oneaction_mode() throws {
-        let viewModel = ModalViewModel(mode: .oneActionButton)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .oneAction)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -74,7 +74,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_primary_button_to_viewmodel_in_reducedInfo_mode() throws {
-        let viewModel = ModalViewModel(mode: .reducedInfoOneActionButton)
+        let viewModel = ModalViewModel(textMode: .reducedTopInfo, actionsMode: .oneAction)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -86,7 +86,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_secondary_button_to_viewmodel() throws {
-        let viewModel = ModalViewModel(mode: .twoActionButtons)
+        let viewModel = ModalViewModel(textMode: .reducedTopInfo, actionsMode: .twoAction)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -98,7 +98,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_primary_button_is_not_initialized_in_full_info_mode() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -110,7 +110,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_propagates_tap_in_secondary_button_is_not_initialized_in_full_info_mode() throws {
-        let viewModel = ModalViewModel(mode: .fullInfo)
+        let viewModel = ModalViewModel(textMode: .fullInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -121,8 +121,8 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
         XCTAssertFalse(viewModel.secondaryButtonTapped)
     }
 
-    func test_viewcontroller_hides_bottom_subtitle_label_in_reduced_info_mode() throws {
-        let viewModel = ModalViewModel(mode: .reducedInfo)
+    func test_viewcontroller_hides_bottom_subtitle_label_in_reduced_bottom_info_mode() throws {
+        let viewModel = ModalViewModel(textMode: .reducedBottomInfo, actionsMode: .none)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         _ = try XCTUnwrap(viewController.view)
@@ -135,7 +135,8 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
 
 
 private final class ModalViewModel: CardPresentPaymentsModalViewModel {
-    let mode: PaymentsModalMode
+    let textMode: PaymentsModalTextMode
+    let actionsMode: PaymentsModalActionsMode
 
     /// The title at the top of the modal view.
     let topTitle: String = "top_title"
@@ -152,12 +153,14 @@ private final class ModalViewModel: CardPresentPaymentsModalViewModel {
     /// Provides a title for a secondary action button
     let secondaryButtonTitle: String? = "secondary_button_title"
 
+    /// Provides a title for an auxiliary action button
+    let auxiliaryButtonTitle: String? = "auxiliary_button_title"
+
     /// The title in the bottom section of the modal. Right below the image
     let bottomTitle: String? = "bottom_title"
 
     /// The subtitle in the bottom section of the modal. Right below the image
     let bottomSubtitle: String? = "bottom_subtitle"
-
 
     /// Flag indicating that the primary button has been tapped
     var primaryButtonTapped: Bool = false
@@ -165,8 +168,12 @@ private final class ModalViewModel: CardPresentPaymentsModalViewModel {
     /// Flag indicating that the secondary button has been tapped
     var secondaryButtonTapped: Bool = false
 
-    init(mode: PaymentsModalMode) {
-        self.mode = mode
+    /// Flag indicating that the auxiliary button has been tapped
+    var auxiliaryButtonTapped: Bool = false
+
+    init(textMode: PaymentsModalTextMode, actionsMode: PaymentsModalActionsMode) {
+        self.textMode = textMode
+        self.actionsMode = actionsMode
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -175,5 +182,9 @@ private final class ModalViewModel: CardPresentPaymentsModalViewModel {
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         secondaryButtonTapped = true
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        auxiliaryButtonTapped = true
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -149,20 +149,20 @@ private extension CardPresentPaymentStore {
             // to the WCPay backend managed Payment Intent, which we need
             // to use to capture the payment.
             // This is always failing at this point. Commented out for now.
-            self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
-                switch result {
-                case .success(let intent):
-                    guard intent.status == .succeeded else {
-                        DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
-                        onCompletion(.failure(CardReaderServiceError.paymentCapture()))
-                        return
-                    }
-                    onCompletion(.success(receiptParameters))
-                case .failure(let error):
-                    onCompletion(.failure(error))
-                    return
-                }
-            }
+//            self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
+//                switch result {
+//                case .success(let intent):
+//                    guard intent.status == .succeeded else {
+//                        DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
+//                        onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+//                        return
+//                    }
+//                    onCompletion(.success(receiptParameters))
+//                case .failure(let error):
+//                    onCompletion(.failure(error))
+//                    return
+//                }
+//            }
         }.store(in: &cancellables)
 
         // Observe status events fired by the card reader


### PR DESCRIPTION
Closes #4069

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader ⚠️

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/116466455-7f2b9980-a83c-11eb-93d9-6f3f619b63a8.PNG" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/116998324-08632600-acac-11eb-83b0-723256f80ae1.PNG" width="350"/> |


## Changes
* Add an auxiliary button, partially [missing from the original implementation](https://github.com/woocommerce/woocommerce-ios/pull/4065) of this modal view
* As pointed during the review of #4065 (see [this comment](https://github.com/woocommerce/woocommerce-ios/pull/4065#discussion_r622610207)) we split the enumeration declaring the layout in two, one for labels and one for action buttons.
* Updates to view models backing the alerts.

## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. An external hardware reader.

* Checkout the branch, run bundle exec pod install, just for kicks and giggles.
* Build and run on a device.
* Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
* Log in to an account that matches a store that has been configured for testing.
* Navigate to Settings in the app. (Tap the gear button in the top right)
* In the "Store Settings" section, tap "Manage Card Reader".
* Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
* Tap "Connect card reader"
* Wait until the app suggests one reader to connect to.
* Tap "Connect to reader"
* Make sure the reader light turns solid blue.
* Navigate to an order eligible for Card Present Payments (it has to be a store enrolled to WCPay, and the order needs to have as payment method associated Cash on Delivery or none).
* Tap the "Collect Payment" button.
* Tap the card to the reader when requested.
* If everything goes well, the card should be charged, and the payment should be completed.
* At that point, there should be a "No thanks" button at the bottom of the modal view. Tapping that button should dismiss the modal view.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
