### PR TITLE
[Mobile Payments] Refactor discoveredReaders publisher to clean up when discovery ends

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -6,7 +6,7 @@ public final class StripeCardReaderService: NSObject {
 
     private var discoveryCancellable: StripeTerminal.Cancelable?
 
-    private let discoveredReadersSubject = CurrentValueSubject<[CardReader], Never>([])
+    private var discoveredReadersSubject = CurrentValueSubject<[CardReader], Never>([])
     private let connectedReadersSubject = CurrentValueSubject<[CardReader], Never>([])
     private let serviceStatusSubject = CurrentValueSubject<CardReaderServiceStatus, Never>(.ready)
     private let discoveryStatusSubject = CurrentValueSubject<CardReaderServiceDiscoveryStatus, Never>(.idle)
@@ -169,6 +169,7 @@ extension StripeCardReaderService: CardReaderService {
 
                 if let reader = reader {
                     self.connectedReadersSubject.send([CardReader(reader: reader)])
+                    self.switchStatusToIdle()
                     promise(.success(()))
                 }
             }
@@ -346,7 +347,8 @@ private extension StripeCardReaderService {
     }
 
     func resetDiscoveredReadersSubject() {
-        discoveredReadersSubject.send([])
+        discoveredReadersSubject.send(completion: .finished)
+        discoveredReadersSubject = CurrentValueSubject<[CardReader], Never>([])
     }
 }
 
@@ -355,6 +357,7 @@ private extension StripeCardReaderService {
 private extension StripeCardReaderService {
     func switchStatusToIdle() {
         updateDiscoveryStatus(to: .idle)
+        resetDiscoveredReadersSubject()
     }
 
     func switchStatusToDiscovering() {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -71,9 +71,11 @@ private extension CardPresentPaymentStore {
         // new data via the CardReaderService's stream of discovered readers
         // In here, we should redirect that data to Storage and also up to the UI.
         // For now we are sending the data up to the UI directly
-        cardReaderService.discoveredReaders.sink { readers in
-            completion(readers)
-        }.store(in: &cancellables)
+        cardReaderService.discoveredReaders
+            .subscribe(Subscribers.Sink(
+                receiveCompletion: { _ in },
+                receiveValue: completion
+            ))
     }
 
     func cancelCardReaderDiscovery(completion: @escaping (CardReaderServiceDiscoveryStatus) -> Void) {


### PR DESCRIPTION
Part of #3926

I'm having a hard time testing these with the UI being a work in progress and not having a physical reader yet, but here's a first step towards better subscription management.

# Why

There's a much larger explanation in this comment https://github.com/woocommerce/woocommerce-ios/issues/3926#issuecomment-832628627, but the existing implementation is holding its subscriptions forever, which might lead to unexpected behavior and performance issues.

This PR tackles just one of the instances in `CardPresentPaymentStore` where this happens: starting the discovery process.

# How

Instead of keeping a subscription to `discoveredReaders` indefinitely, this now does a few things differently:
- `StripeCardReaderService` will send a completion event when it stops being in discovery mode.
- `StripeCardReaderService` will replace its internal `discoveredReadersSubject` when this happens with a new one, so new subscriptions can still happen if the discovery process starts again
- `CardPresentPaymentStore` will use a `[Sink](https://developer.apple.com/documentation/combine/subscribers/sink)` subscriber instead of the `sink` operator, which doesn't return a cancellable, automatically manages the subscription, and cleans up when it completes.

# To test

I've tested that the discovery and connection process still works, but I haven't been able to test many edge cases. Sometimes the UI is failing when it gets more than one update from the simulated card reader which makes it impossible to test.

Unless you have a card reader, change the `start` method of `StripeCardReaderService` to use this configuration:
```swift
  let config = DiscoveryConfiguration(
            discoveryMethod: .bluetoothScan,
            simulated: true
        )
```

Then add a quick implementation to stop discovery. In `CardReaderSettingsViewModel.stopSearch()` add:
```swift
ServiceLocator.stores.dispatch(CardPresentPaymentAction.cancelCardReaderDiscovery(onCompletion: { _ in }))
``` 

Finally, in `CardReaderSettingsViewModel.startSearch` add some logging to the completion block of `startCardReaderDiscovery`:

```swift
            print("📶 Discovered \(cardReaders.count) readers")
```


1. Build and run the app
2. Go to Settings > Manage Card Reader
3. Tap Connect Card Reader
4. As soon as the searching alert appears, tap cancel
5. Repeat 3-4 a few times.
6. Ensure the console doesn't start printing duplicated `Discovered %d readers` lines after doing this a few times.

Note: You might see an alert briefly pop up, as the simulated reader comes in very quickly as you are canceling the search.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
