### PR TITLE
[Mobile Payments] Orchestrate payment capture and submit Payment Intent ID to WCPay

### DIFF
--- a/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
+++ b/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
@@ -1,9 +1,6 @@
 /// Encapsulates the information necessary to print a receipt for a
 /// card present payment
 public struct CardPresentReceiptParameters {
-    /// The payment intent identifier
-    public let paymentIntentID: String
-
     /// The total amount
     public let amount: UInt
 
@@ -17,12 +14,10 @@ public struct CardPresentReceiptParameters {
     /// to be added to the receipt required by the card networks.
     public let cardDetails: CardPresentTransactionDetails
 
-    public init(paymentIntentID: String,
-                amount: UInt,
+    public init(amount: UInt,
                 currency: String,
                 storeName: String?,
                 cardDetails: CardPresentTransactionDetails) {
-        self.paymentIntentID = paymentIntentID
         self.amount = amount
         self.currency = currency
         self.storeName = storeName

--- a/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
+++ b/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
@@ -1,6 +1,9 @@
 /// Encapsulates the information necessary to print a receipt for a
 /// card present payment
 public struct CardPresentReceiptParameters {
+    /// The payment intent identifier
+    public let paymentIntentID: String
+
     /// The total amount
     public let amount: UInt
 
@@ -14,10 +17,12 @@ public struct CardPresentReceiptParameters {
     /// to be added to the receipt required by the card networks.
     public let cardDetails: CardPresentTransactionDetails
 
-    public init(amount: UInt,
+    public init(paymentIntentID: String,
+                amount: UInt,
                 currency: String,
                 storeName: String?,
                 cardDetails: CardPresentTransactionDetails) {
+        self.paymentIntentID = paymentIntentID
         self.amount = amount
         self.currency = currency
         self.storeName = storeName

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -30,7 +30,7 @@ private extension PaymentCaptureOrchestrator {
                                       onClearMessage: @escaping () -> Void,
                                       onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
-            DDLogError("Error: attempted to collect payment for an order without valid total. ")
+            DDLogError("Error: attempted to collect payment for an order without valid total.")
             onCompletion(.failure(CardReaderServiceError.paymentCapture()))
             return
         }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,9 +1,9 @@
 import Yosemite
 /// Orchestrates the sequence of actions required to capture a payment:
-/// 1. Check the there is a card reader connected
+/// 1. Check if there is a card reader connected
 /// 2. Launch the reader discovering and pairing UI if there is no reader connected
-/// 3. Obtain a Payment Intent from the card reader
-/// 4. Submit the Payment Intent to WCPay
+/// 3. Obtain a Payment Intent from the card reader (i.e., create a payment intent, collect a payment method, and process the payment)
+/// 4. Submit the Payment Intent to WCPay to capture a payment
 /// Steps 1 and 2 will be implemented as part of https://github.com/woocommerce/woocommerce-ios/issues/4062
 final class PaymentCaptureOrchestrator {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
@@ -13,7 +13,7 @@ final class PaymentCaptureOrchestrator {
                         onClearMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
 
-        // TODO. Check that there i a reader currently connected
+        // TODO. Check that there is a reader currently connected
         // otherwise launch the discovery+pairing UI
         // https://github.com/woocommerce/woocommerce-ios/issues/4062
         collectPaymentWithCardReader(for: order,
@@ -56,7 +56,7 @@ private extension PaymentCaptureOrchestrator {
                                                                     break
                                                                 }
                                                              }, onCompletion: { [weak self] result in
-                                                                self?.completePayentIntentCapture(order: order,
+                                                                self?.completePaymentIntentCapture(order: order,
                                                                                                  captureResult: result,
                                                                                                  onCompletion: onCompletion)
         })
@@ -64,7 +64,7 @@ private extension PaymentCaptureOrchestrator {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func completePayentIntentCapture(order: Order,
+    func completePaymentIntentCapture(order: Order,
                                     captureResult: Result<PaymentIntent, Error>,
                                     onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         switch captureResult {
@@ -90,7 +90,7 @@ private extension PaymentCaptureOrchestrator {
             guard let receiptParameters = paymentIntent.receiptParameters() else {
                 let error = CardReaderServiceError.paymentCapture()
 
-                DDLogError("⛔️ Payment completed without valid regulatory metadata: \(error)")
+                DDLogError("⛔️ Payment completed without required metadata: \(error)")
 
                 onCompletion(.failure(error))
                 return

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -21,15 +21,6 @@ final class PaymentCaptureOrchestrator {
                                      onClearMessage: onClearMessage,
                                      onCompletion: onCompletion)
     }
-
-    func printReceipt(params: CardPresentReceiptParameters) {
-
-    }
-
-    func emailReceipt(params: CardPresentReceiptParameters) {
-        // TO BE IMPLEMENTED
-        // https://github.com/woocommerce/woocommerce-ios/issues/4014
-    }
 }
 
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,0 +1,82 @@
+import Yosemite
+/// Orchestrates the sequence of actions required to capture a payment:
+/// 1. Check the there is a card reader connected
+/// 2. Launch the reader discovering and pairing UI if there is no reader connected
+/// 3. Obtain a Payment Intent from the card reader
+/// 4. Submit the Payment Intent to WCPay
+/// Steps 1 and 2 will be implemented as part of https://github.com/woocommerce/woocommerce-ios/issues/4062
+final class PaymentCaptureOrchestrator {
+    private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+
+    func collectPayment(for order: Order,
+                        onPresentMessage: @escaping (String) -> Void,
+                        onClearMessage: @escaping () -> Void,
+                        onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+
+        // TODO. Check that there i a reader currently connected
+        // otherwise launch the discovery+pairing UI
+        // https://github.com/woocommerce/woocommerce-ios/issues/4062
+        collectPaymentWithCardReader(for: order,
+                                     onPresentMessage: onPresentMessage,
+                                     onClearMessage: onClearMessage,
+                                     onCompletion: onCompletion)
+    }
+
+    func printReceipt(params: CardPresentReceiptParameters) {
+
+    }
+
+    func emailReceipt(params: CardPresentReceiptParameters) {
+        // TO BE IMPLEMENTED
+        // https://github.com/woocommerce/woocommerce-ios/issues/4014
+    }
+}
+
+
+private extension PaymentCaptureOrchestrator {
+    func collectPaymentWithCardReader(for order: Order,
+                                      onPresentMessage: @escaping (String) -> Void,
+                                      onClearMessage: @escaping () -> Void,
+                                      onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+        guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
+            DDLogError("Error: attempted to collect payment for an order without valid total. ")
+            onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+            return
+        }
+
+        let paymentParameters = PaymentParameters(amount: orderTotal as Decimal,
+                                                  currency: order.currency,
+                                                  receiptDescription: "Receipt description.",
+                                                  statementDescription: "Statement description.",
+                                                  metadata: [CardPresentReceiptParameters.MetadataKeys.store:
+                                                                ServiceLocator.stores.sessionManager.defaultSite?.name as Any])
+
+        let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
+                                                             orderID: order.orderID, parameters: paymentParameters,
+                                                             onCardReaderMessage: { (event) in
+                                                                switch event {
+                                                                case .displayMessage (let message):
+                                                                    onPresentMessage(message)
+                                                                case .waitingForInput (let message):
+                                                                    onPresentMessage(message)
+                                                                case .cardRemoved:
+                                                                    onClearMessage()
+                                                                default:
+                                                                    break
+                                                                }
+                                                             }, onCompletion: { [weak self] result in
+                                                                self?.submitPaymentIntentToWCPay(order: order,
+                                                                                                 captureResult: result,
+                                                                                                 onCompletion: onCompletion)
+        })
+
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    func submitPaymentIntentToWCPay(order: Order,
+                                    captureResult: Result<CardPresentReceiptParameters, Error>,
+                                    onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+        onCompletion(captureResult)
+        //let action = WCPayAction.captureOrderPayment(siteID: <#T##Int64#>, orderID: <#T##Int64#>, paymentIntentID: <#T##String#>, completion: <#T##(Result<Void, Error>) -> Void#>)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1080,6 +1080,7 @@
 		D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85136CC231E15B700DD0539 /* MockReviews.swift */; };
 		D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85136D4231E40B500DD0539 /* ProductReviewTableViewCellTests.swift */; };
 		D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85136DC231E613900DD0539 /* ReviewsViewModelTests.swift */; };
+		D85806292642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */; };
 		D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */; };
 		D85B8334222FABD1002168F3 /* StatusListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */; };
 		D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */; };
@@ -2310,6 +2311,7 @@
 		D85136CC231E15B700DD0539 /* MockReviews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReviews.swift; sourceTree = "<group>"; };
 		D85136D4231E40B500DD0539 /* ProductReviewTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProductReviewTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/ProductReviewTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D85136DC231E613900DD0539 /* ReviewsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReviewsViewModelTests.swift; path = WooCommerceTests/Reviews/ReviewsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
+		D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCaptureOrchestrator.swift; sourceTree = "<group>"; };
 		D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusListTableViewCell.swift; sourceTree = "<group>"; };
 		D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusListTableViewCell.xib; sourceTree = "<group>"; };
 		D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StatusListTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/StatusListTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
@@ -5561,6 +5563,7 @@
 				D8815B062638606B00EDAD62 /* CardPresentModalRemoveCard.swift */,
 				D8815B0C263861A400EDAD62 /* CardPresentModalSuccess.swift */,
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
+				D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -6435,6 +6438,7 @@
 				CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
 				02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */,
+				D85806292642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,
 				023D69BC2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift in Sources */,
 				45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -35,7 +35,7 @@ public enum CardPresentPaymentAction: Action {
                         orderID: Int64,
                         parameters: PaymentParameters,
                         onCardReaderMessage: (CardReaderEvent) -> Void,
-                        onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void )
+                        onCompletion: (Result<PaymentIntent, Error>) -> Void )
 
     case checkForCardReaderUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
                         onCompletion: () -> Void)

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -111,6 +111,7 @@ public typealias CardReaderSoftwareUpdate = Hardware.CardReaderSoftwareUpdate
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 public typealias CardReaderServiceError = Hardware.CardReaderServiceError
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
+public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias WCPayAccount = Networking.WCPayAccount
 

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -10,9 +10,10 @@ extension PaymentIntent {
             return nil
         }
 
-        return CardPresentReceiptParameters(amount: amount,
-                                     currency: currency,
-                                     storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store] as? String,
-                                     cardDetails: cardDetails)
+        return CardPresentReceiptParameters(paymentIntentID: id,
+                                            amount: amount,
+                                            currency: currency,
+                                            storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store] as? String,
+                                            cardDetails: cardDetails)
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -1,6 +1,6 @@
 import Hardware
 
-extension PaymentIntent {
+public extension PaymentIntent {
     /// Maps a PaymentIntent into an struct that contains only the data we need to
     /// render a receipt.
     /// - Returns: an optional struct containing all the data that needs to go into a receipt
@@ -10,8 +10,7 @@ extension PaymentIntent {
             return nil
         }
 
-        return CardPresentReceiptParameters(paymentIntentID: id,
-                                            amount: amount,
+        return CardPresentReceiptParameters(amount: amount,
                                             currency: currency,
                                             storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store] as? String,
                                             cardDetails: cardDetails)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -128,36 +128,7 @@ private extension CardPresentPaymentStore {
                 break
             }
         } receiveValue: { intent in
-//            guard let receiptParameters = intent.receiptParameters() else {
-//                let error = CardReaderServiceError.paymentCapture()
-//
-//                DDLogError("⛔️ Payment completed without valid regulatory metadata: \(error)")
-//
-//                onCompletion(.failure(error))
-//                return
-//            }
-
-            // Once ReceiptParameters is persisted, we would not propagate it out
             onCompletion(.success(intent))
-
-            // Note: Here we transition from the Stripe Terminal Payment Intent
-            // to the WCPay backend managed Payment Intent, which we need
-            // to use to capture the payment.
-            // This is always failing at this point. Commented out for now.
-//            self.remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: intent.id) { result in
-//                switch result {
-//                case .success(let intent):
-//                    guard intent.status == .succeeded else {
-//                        DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
-//                        onCompletion(.failure(CardReaderServiceError.paymentCapture()))
-//                        return
-//                    }
-//                    onCompletion(.success(receiptParameters))
-//                case .failure(let error):
-//                    onCompletion(.failure(error))
-//                    return
-//                }
-//            }
         }.store(in: &cancellables)
 
         // Observe status events fired by the card reader

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -119,7 +119,7 @@ private extension CardPresentPaymentStore {
                         orderID: Int64,
                         parameters: PaymentParameters,
                         onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
-                        onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+                        onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
         cardReaderService.capturePayment(parameters).sink { error in
             switch error {
             case .failure(let error):
@@ -128,22 +128,17 @@ private extension CardPresentPaymentStore {
                 break
             }
         } receiveValue: { intent in
-            // A this point, the status of the PaymentIntent should be `requiresCapture`:
-            // https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPPaymentIntentStatus.html#/c:@E@SCPPaymentIntentStatus@SCPPaymentIntentStatusRequiresCapture
-            // TODO. Persist PaymentIntent, so that we can use it later to print a receipt.
-            // Persisting an instance of ReceiptParameters might be a better option.
-            // Deferred to https://github.com/woocommerce/woocommerce-ios/issues/3825
-            guard let receiptParameters = intent.receiptParameters() else {
-                let error = CardReaderServiceError.paymentCapture()
-
-                DDLogError("⛔️ Payment completed without valid regulatory metadata: \(error)")
-
-                onCompletion(.failure(error))
-                return
-            }
+//            guard let receiptParameters = intent.receiptParameters() else {
+//                let error = CardReaderServiceError.paymentCapture()
+//
+//                DDLogError("⛔️ Payment completed without valid regulatory metadata: \(error)")
+//
+//                onCompletion(.failure(error))
+//                return
+//            }
 
             // Once ReceiptParameters is persisted, we would not propagate it out
-            onCompletion(.success(receiptParameters))
+            onCompletion(.success(intent))
 
             // Note: Here we transition from the Stripe Terminal Payment Intent
             // to the WCPay backend managed Payment Intent, which we need


### PR DESCRIPTION
Closes #4030 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader and uploading a pre-release version of WCPay to a test site⚠️

A minor refactor with a significant impact. This PR moves some of the pre-existing pieced around, in a way that the Payment Intent Id is submitted to WCPay after the payment has been captured successfully using a card reader.

This, in turn, makes WCPay register the payment, and change the status of the order to Complete, therefore closing the loop.

Note: there are two issues that we should attack next to polish this: #4097 and #4122, to, respectively, refresh the order on device after the payment is captured, and to add better user-facing messaging.

## Changes
* Add PaymentCaptureOrchestrator, a layer in between OrderDetailsViewModel and Yosemite that is meant to orchestrate the sequence of events that, involving different Stores, end up capturing a payment for an order.
* This new orchestrator adds logic only for: 
1. Capture the payment using the card reader (by leveraging CardPresentPaymentStore)
2. Upload the payment id to WCPay, once it has been created in the card reader. (leveraging WCPayStore)

Eventually, this where we will check if there is a reader connected before initiating the payment capture.

## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)
3. An external hardware reader.

* Checkout the branch, run bundle exec pod install, just for kicks and giggles.
* Build and run on a device.
* Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
* Log in to an account that matches a store that has been configured for testing.
* Navigate to Settings in the app. (Tap the gear button in the top right)
* In the "Store Settings" section, tap "Manage Card Reader".
* Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
* Tap "Connect card reader"
* Wait until the app suggests one reader to connect to.
* Tap "Connect to reader"
* Make sure the reader light turns solid blue.
* Navigate to an order eligible for Card Present Payments (it has to be a store enrolled to WCPay, and the order needs to have as payment method associated Cash on Delivery or none).
* Tap the "Collect Payment" button.
* Tap the card to the reader when requested.
* If everything goes well, the card should be charged, and the payment should be completed.
* Check the order status in your desktop browser. The order notes should reflect that changes in status of the order, and look similar to this:
<img width="288" alt="Screen Shot 2021-05-05 at 13 15 37" src="https://user-images.githubusercontent.com/2722505/117191845-07ff8380-adaf-11eb-8ea6-3b90fb321020.png">
* A pull to refresh in the order details screen should refresh the order on device and reflect the new status. We will improve this in #4097 

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
