### PR TITLE
[Mobile Payments] Card Reader Settings V2-5: Register viewmodels

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -264,6 +264,9 @@
                             <constraint firstItem="l2Q-VL-2yz" firstAttribute="bottom" secondItem="yAZ-jF-hAZ" secondAttribute="bottom" id="uBc-a2-Cby"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="temporaryLabel" destination="yAZ-jF-hAZ" id="2Uc-ZW-zKk"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ErC-sp-Qjr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -6,7 +6,12 @@ protocol CardReaderSettingsPresentedViewModel {
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)? { get set }
 }
 
-struct CardReaderSettingsViewModelAndView {
+struct CardReaderSettingsViewModelAndView: Equatable {
+    static func == (lhs: CardReaderSettingsViewModelAndView, rhs: CardReaderSettingsViewModelAndView) -> Bool {
+        // It is sufficient to test on just the view identifier. No need to compare the viewmodels.
+        lhs.viewIdentifier == rhs.viewIdentifier
+    }
+
     var viewModel: CardReaderSettingsPresentedViewModel
     var viewIdentifier: String
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -3,18 +3,32 @@ import UIKit
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
+    @IBOutlet weak var temporaryLabel: UILabel!
+
     /// An array of viewModels and related view classes
-    private var viewModelsAndViews = [CardReaderSettingsViewModelAndView]()
+    private var viewModelsAndViews: CardReaderSettingsPrioritizedViewModelsProvider?
 
     /// Set our dependencies
-    func configure(viewModelsAndViews: [CardReaderSettingsViewModelAndView]) {
+    func configure(viewModelsAndViews: CardReaderSettingsPrioritizedViewModelsProvider) {
         self.viewModelsAndViews = viewModelsAndViews
+        self.viewModelsAndViews?.onPriorityChanged = onViewModelsPriorityChange
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureBackground()
         configureNavigation()
+        configureInitialState()
+    }
+
+    private func configureInitialState() {
+        onViewModelsPriorityChange(viewModelAndView: viewModelsAndViews?.priorityViewModelAndView)
+    }
+
+    private func onViewModelsPriorityChange(viewModelAndView: CardReaderSettingsViewModelAndView?) {
+        // For now, just update the label with the view identifer we should display
+        // A later PR will actually add presented views
+        temporaryLabel.text = viewModelAndView?.viewIdentifier ?? "Loading"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPrioritizedViewModelsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPrioritizedViewModelsProvider.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Defines a protocol for conforming classes to reveal which of several peer viewmodels and views
+/// should have the priority at a given moment.
+///
+protocol CardReaderSettingsPrioritizedViewModelsProvider {
+
+    /// Allows the caller (i.e. a Presenting View Controller) to register a callback to be informed when the
+    /// priorty viewmodel changes so that it can change what view controller it presents. It is possible
+    /// that NO viewmodel has the priority, hence the optionality.
+    ///
+    var onPriorityChanged: ((CardReaderSettingsViewModelAndView?) -> ())? { get set }
+
+    /// Returns which viewmodel (and view), if any, should have the priority
+    ///
+    var priorityViewModelAndView: CardReaderSettingsViewModelAndView? { get }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -48,12 +48,12 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
     }
 
     private func reevaluatePriorityViewModelAndView() {
-        let newPriorityViewModelAndView = viewModelsAndViews.first(
+        guard let newPriorityViewModelAndView = viewModelsAndViews.first(
             where: { $0.viewModel.shouldShow == .isTrue }
-        )
-
-        if newPriorityViewModelAndView != priorityViewModelAndView {
-            priorityViewModelAndView = newPriorityViewModelAndView
+        ), newPriorityViewModelAndView != priorityViewModelAndView else {
+            return
         }
+
+        priorityViewModelAndView = newPriorityViewModelAndView
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Aggregates an ordered list of viewmodels, conforming to the viewmodel provider protocol. Priority is given to
+/// the first viewmodel in the list to return true for shouldShow
+///
+final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritizedViewModelsProvider {
+
+    private var viewModelsAndViews = [CardReaderSettingsViewModelAndView]()
+
+    var priorityViewModelAndView: CardReaderSettingsViewModelAndView? {
+        didSet {
+            onPriorityChanged?(priorityViewModelAndView)
+        }
+    }
+
+    var onPriorityChanged: ((CardReaderSettingsViewModelAndView?) -> ())?
+
+    init() {
+        /// Instantiate and add each viewmodel related to card reader settings to the
+        /// array. Viewmodels will be evaluated for shouldShow starting at the top
+        /// of the array. The first viewmodel to return true for shouldShow is given
+        /// priority, so viewmodels related to no-known-readers should come before viewmodels
+        /// that expect a connected reader, etc.
+        ///
+        viewModelsAndViews.append(
+            CardReaderSettingsViewModelAndView(
+                viewModel: CardReaderSettingsUnknownViewModel(
+                    didChangeShouldShow: onDidChangeShouldShow
+                ),
+                viewIdentifier: "CardReaderSettingsUnknownViewController"
+            )
+        )
+        viewModelsAndViews.append(
+            CardReaderSettingsViewModelAndView(
+                viewModel: CardReaderSettingsConnectedViewModel(
+                    didChangeShouldShow: onDidChangeShouldShow
+                ),
+                viewIdentifier: "CardReaderSettingsConnectedViewController"
+            )
+        )
+
+        /// And then immediately get a priority view if possible
+        reevaluatePriorityViewModelAndView()
+    }
+
+    private func onDidChangeShouldShow(_ : CardReaderSettingsTriState) {
+        reevaluatePriorityViewModelAndView()
+    }
+
+    private func reevaluatePriorityViewModelAndView() {
+        let newPriorityViewModelAndView = viewModelsAndViews.first(
+            where: { $0.viewModel.shouldShow == .isTrue }
+        )
+
+        if newPriorityViewModelAndView != priorityViewModelAndView {
+            priorityViewModelAndView = newPriorityViewModelAndView
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -396,7 +396,9 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
         }
-        viewController.configure(viewModelsAndViews: [])
+
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
+        viewController.configure(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
 		3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */; };
 		3178C1FD26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */; };
+		317F679826420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */; };
 		318109C625E59E4000EE0BE7 /* TitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */; };
 		318109D625E5A7E300EE0BE7 /* TitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */; };
 		318109DC25E5B51900EE0BE7 /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318109DB25E5B51900EE0BE7 /* ImageTableViewCell.swift */; };
@@ -468,6 +469,7 @@
 		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
 		318A9E9125D302370032C245 /* CardReaderSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */; };
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */; };
+		31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */; };
 		31F21B02263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */; };
 		31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */; };
 		31F21B60263CB78A0035B50A /* MockCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B5F263CB78A0035B50A /* MockCardReader.swift */; };
@@ -1673,6 +1675,7 @@
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
 		3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModel.swift; sourceTree = "<group>"; };
 		3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModelTests.swift; sourceTree = "<group>"; };
+		317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewModelsOrderedList.swift; sourceTree = "<group>"; };
 		318109C525E59E4000EE0BE7 /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
 		318109D525E5A7E300EE0BE7 /* TitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleTableViewCell.xib; sourceTree = "<group>"; };
 		318109DB25E5B51900EE0BE7 /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1683,6 +1686,7 @@
 		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
 		318A9E9025D302370032C245 /* CardReaderSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewController.swift; sourceTree = "<group>"; };
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModel.swift; sourceTree = "<group>"; };
+		31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPrioritizedViewModelsProvider.swift; sourceTree = "<group>"; };
 		31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModelTests.swift; sourceTree = "<group>"; };
 		31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsStoresManager.swift; sourceTree = "<group>"; };
 		31F21B5F263CB78A0035B50A /* MockCardReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReader.swift; sourceTree = "<group>"; };
@@ -3526,10 +3530,12 @@
 		318853452639FE7F00F66A9C /* CardReadersV2 */ = {
 			isa = PBXGroup;
 			children = (
+				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
 				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
 				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
-				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
+				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
+				31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */,
 			);
 			path = CardReadersV2;
 			sourceTree = "<group>";
@@ -6431,6 +6437,7 @@
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
 				021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
+				317F679826420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
@@ -6460,6 +6467,7 @@
 				45DB704A26121F3C0064A6CF /* TitleAndValueRow.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
+				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
 				CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,


### PR DESCRIPTION
Closes #4051

Note: This is against feature/stripe-terminal-sdk-integration, not develop

Changes:
- This is the next step in Card Reader Settings v2.
- We add a new protocol `CardReaderSettingsPrioritizedViewModelsProvider` - objects that conform to this protocol will be able to tell consumers (like a presenting view controller) which of many viewmodels should have priority at a given moment.
- We add `CardReaderSettingsViewModelsOrderedList` which 1) conforms to that protocol, 2) instantiates the viewmodels we created in previous PRs and 3) figures out which viewmodel is prioritized by calling `shouldShow` on each
- We build out `CardReaderSettingsPresentingViewController` a little further to accept a `CardReaderSettingsPrioritizedViewModelsProvider` and then update a temporary label with the identifier of the view controller it would present (based on which viewmodel should be prioritized according to the provider passed in

To test:
- Launch the app
- Navigate to Settings (Gear) and then Manage Card Readers V2
- Ensure it shows “CardReaderSettingsUnknownViewController”
- Navigate back to Settings (Gear)
- Navigate to Manage Card Readers (not V2)
- Connect your reader
- Navigate to Manage Card Readers V2
- Ensure it shows “CardReaderSettingsConnectedViewController”

Work not yet done
- Add unit tests for `CardReaderSettingsViewModelsOrderedList` to ensure it prioritizes viewmodels as expected

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
