### PR TITLE
Update the label name for generating screenshots

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'Needs Screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'bot: make screenshots')
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
The label `Needs Screenshots` was changed to `bot: make screenshots` and this PR updates the GitHub Action to reflect the change.

<sup>(internal reference: paaHJt-244-p2)</sup>

Update release notes:
- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
