### PR TITLE
Add-ons: Add track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -279,3 +279,25 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Variations
+//
+extension WooAnalyticsEvent {
+    // Namespace
+    enum OrderDetailAddOns {
+        /// Common event keys
+        ///
+        private enum Keys {
+            static let state = "state"
+            static let addOns = "add-ons"
+        }
+    }
+
+    static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: ["state": isOn])
+    }
+
+    static func orderAddOnsViewed(addOnNames: [String]) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .orderDetailAddOnsViewed, properties: ["add-ons": addOnNames.joined(separator: ",")])
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -280,7 +280,7 @@ extension WooAnalyticsEvent {
     }
 }
 
-// MARK: - Variations
+// MARK: - Order Detail Add-ons
 //
 extension WooAnalyticsEvent {
     // Namespace

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -293,11 +293,11 @@ extension WooAnalyticsEvent {
         }
 
         static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: ["state": isOn])
+            WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: [Keys.state: isOn])
         }
 
         static func orderAddOnsViewed(addOnNames: [String]) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderDetailAddOnsViewed, properties: ["add-ons": addOnNames.joined(separator: ",")])
+            WooAnalyticsEvent(statName: .orderDetailAddOnsViewed, properties: [Keys.addOns: addOnNames.joined(separator: ",")])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -291,13 +291,13 @@ extension WooAnalyticsEvent {
             static let state = "state"
             static let addOns = "add-ons"
         }
-    }
 
-    static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: ["state": isOn])
-    }
+        static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: ["state": isOn])
+        }
 
-    static func orderAddOnsViewed(addOnNames: [String]) -> WooAnalyticsEvent {
-        WooAnalyticsEvent(statName: .orderDetailAddOnsViewed, properties: ["add-ons": addOnNames.joined(separator: ",")])
+        static func orderAddOnsViewed(addOnNames: [String]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailAddOnsViewed, properties: ["add-ons": addOnNames.joined(separator: ",")])
+        }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -289,7 +289,7 @@ extension WooAnalyticsEvent {
         ///
         private enum Keys {
             static let state = "state"
-            static let addOns = "add-ons"
+            static let addOns = "add_ons"
         }
 
         static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -293,7 +293,7 @@ extension WooAnalyticsEvent {
         }
 
         static func betaFeaturesSwitchToggled(isOn: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: [Keys.state: isOn])
+            WooAnalyticsEvent(statName: .settingsBetaFeaturesOrderAddOnsToggled, properties: [Keys.state: isOn ? "on" : "off"])
         }
 
         static func orderAddOnsViewed(addOnNames: [String]) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -124,6 +124,7 @@ public enum WooAnalyticsStat: String {
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"
+    case settingsBetaFeaturesOrderAddOnsToggled = "settings_beta_features_order_add-ons_toggled"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled             = "privacy_settings_collect_info_toggled"
@@ -160,6 +161,7 @@ public enum WooAnalyticsStat: String {
     case orderDetailOrderStatusEditButtonTapped = "order_detail_order_status_edit_button_tapped"
     case orderDetailProductDetailTapped         = "order_detail_product_detail_button_tapped"
     case orderDetailRefundDetailTapped          = "order_detail_refund_detail_tapped"
+    case orderDetailAddOnsViewed                = "order_detail_add-ons_viewed"
     case refundedProductsDetailTapped           = "order_detail_refunded_products_detail_tapped"
     case orderDetailTrackPackageButtonTapped    = "order_detail_track_package_button_tapped"
     case orderDetailTrackingDeleteButtonTapped  = "order_detail_tracking_delete_button_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -124,7 +124,7 @@ public enum WooAnalyticsStat: String {
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"
-    case settingsBetaFeaturesOrderAddOnsToggled = "settings_beta_features_order_add-ons_toggled"
+    case settingsBetaFeaturesOrderAddOnsToggled = "settings_beta_features_order_addons_toggled"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled             = "privacy_settings_collect_info_toggled"
@@ -161,7 +161,7 @@ public enum WooAnalyticsStat: String {
     case orderDetailOrderStatusEditButtonTapped = "order_detail_order_status_edit_button_tapped"
     case orderDetailProductDetailTapped         = "order_detail_product_detail_button_tapped"
     case orderDetailRefundDetailTapped          = "order_detail_refund_detail_tapped"
-    case orderDetailAddOnsViewed                = "order_detail_add-ons_viewed"
+    case orderDetailAddOnsViewed                = "order_detail_addons_viewed"
     case refundedProductsDetailTapped           = "order_detail_refunded_products_detail_tapped"
     case orderDetailTrackPackageButtonTapped    = "order_detail_track_package_button_tapped"
     case orderDetailTrackingDeleteButtonTapped  = "order_detail_tracking_delete_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -126,7 +126,7 @@ private extension BetaFeaturesViewController {
 
         // Change switch's state stored value
         cell.onChange = { isSwitchOn in
-            // TODO: Add analytics
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailAddOns.betaFeaturesSwitchToggled(isOn: isSwitchOn))
 
             let action = AppSettingsAction.setOrderAddOnsFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
                 // Roll back toggle if an error occurred

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnsListViewController.swift
@@ -58,6 +58,9 @@ struct OrderAddOnListI1View: View {
         .sheet(isPresented: $viewModel.shouldShowSurvey) {
             Survey(source: .addOnsI1)
         }
+        .onAppear(perform: {
+            viewModel.trackAddOns()
+        })
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
@@ -44,7 +44,7 @@ class OrderAddOnListI1Tests: XCTestCase {
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderDetailAddOnsViewed.rawValue])
 
-        let properties = try XCTUnwrap(analytics.receivedProperties.first?["add-ons"] as? String)
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["add_ons"] as? String)
         XCTAssertEqual(properties, "Topping,Fast Delivery,Soda (No Sugar),Engraving")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/OrderAddOnListI1Tests.swift
@@ -26,4 +26,25 @@ class OrderAddOnListI1Tests: XCTestCase {
             OrderAddOnI1ViewModel.init(id: 4, title: "Engraving", content: "Earned Not Given", price: "")
         ])
     }
+
+    func test_addOns_are_properly_tracked() throws {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let attributes = [
+            OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: "Salami"),
+            OrderItemAttribute(metaID: 2, name: "Fast Delivery ($7.00)", value: "Yes"),
+            OrderItemAttribute(metaID: 3, name: "Soda (No Sugar) ($7.00)", value: "5"),
+            OrderItemAttribute(metaID: 4, name: "Engraving", value: "Earned Not Given"),
+        ]
+        let viewModel = OrderAddOnListI1ViewModel(attributes: attributes, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.trackAddOns()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderDetailAddOnsViewed.rawValue])
+
+        let properties = try XCTUnwrap(analytics.receivedProperties.first?["add-ons"] as? String)
+        XCTAssertEqual(properties, "Topping,Fast Delivery,Soda (No Sugar),Engraving")
+    }
 }


### PR DESCRIPTION
# Why

As the order add-on workaround gets ready to be released, this PR adds some event tracking to the feature.

- orderAddOnsViewed
- betaFeaturesSwitchToggled


# How

- In the beta settings screen, fire `betaFeaturesSwitchToggled` when the switch is toggled.
- In the order add-on list screen, fire `orderAddOnsViewed` when the screen appears.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
