### PR TITLE
Plugins: Add new feature flag and add new entry point for plugin list on Settings screen

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -13,6 +13,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .addOnsI1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .sitePlugins:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -29,4 +29,8 @@ enum FeatureFlag: Int {
     /// Product AddOns first iteration
     ///
     case addOnsI1
+
+    /// Site Plugin list entry point on Settings screen
+    ///
+    case sitePlugins
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -381,7 +381,9 @@ private extension SettingsViewController {
         }
     }
 
-    func sitePluginsWasPressed() {}
+    func sitePluginsWasPressed() {
+        // TODO: Pending implementation for issue #4114
+    }
 
     func supportWasPressed() {
         ServiceLocator.analytics.track(.settingsContactSupportTapped)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -167,7 +167,7 @@ private extension SettingsViewController {
 
         // Plugins
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sitePlugins) {
-            sections.append(Section(title: pluginsTitle, rows: [], footerHeight: UITableView.automaticDimension))
+            sections.append(Section(title: pluginsTitle, rows: [.plugins], footerHeight: UITableView.automaticDimension))
         }
 
         // Store Settings
@@ -212,6 +212,8 @@ private extension SettingsViewController {
             configureSelectedStore(cell: cell)
         case let cell as BasicTableViewCell where row == .switchStore:
             configureSwitchStore(cell: cell)
+        case let cell as BasicTableViewCell where row == .plugins:
+            configurePlugins(cell: cell)
         case let cell as BasicTableViewCell where row == .support:
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .cardReaders:
@@ -247,6 +249,13 @@ private extension SettingsViewController {
         cell.textLabel?.text = NSLocalizedString(
             "Switch Store",
             comment: "This action allows the user to change stores without logging out and logging back in again."
+        )
+    }
+
+    func configurePlugins(cell: BasicTableViewCell) {
+        cell.selectionStyle = .default
+        cell.accessoryType = .disclosureIndicator
+        cell.textLabel?.text = NSLocalizedString("Plugins", comment: "Navigates to Plugins screen."
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -132,6 +132,10 @@ private extension SettingsViewController {
             comment: "My Store > Settings > Selected Store information section. " +
             "This is the heading listed above the information row that displays the store website and their username."
         ).uppercased()
+        let pluginsTitle = NSLocalizedString(
+            "Plugins",
+            comment: "My Store > Settings > Plugins section title"
+        ).uppercased()
         let storeSettingsTitle = NSLocalizedString(
             "Store Settings",
             comment: "My Store > Settings > Store Settings section title"
@@ -160,6 +164,11 @@ private extension SettingsViewController {
         sections = [
             Section(title: selectedStoreTitle, rows: storeRows, footerHeight: UITableView.automaticDimension),
         ]
+
+        // Plugins
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sitePlugins) {
+            sections.append(Section(title: pluginsTitle, rows: [], footerHeight: UITableView.automaticDimension))
+        }
 
         // Store Settings
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -255,8 +255,7 @@ private extension SettingsViewController {
     func configurePlugins(cell: BasicTableViewCell) {
         cell.selectionStyle = .default
         cell.accessoryType = .disclosureIndicator
-        cell.textLabel?.text = NSLocalizedString("Plugins", comment: "Navigates to Plugins screen."
-        )
+        cell.textLabel?.text = NSLocalizedString("Plugins", comment: "Navigates to Plugins screen.")
     }
 
     func configureSupport(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -372,6 +372,8 @@ private extension SettingsViewController {
         }
     }
 
+    func sitePluginsWasPressed() {}
+
     func supportWasPressed() {
         ServiceLocator.analytics.track(.settingsContactSupportTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: HelpAndSupportViewController.self) else {
@@ -518,6 +520,8 @@ extension SettingsViewController: UITableViewDelegate {
         switch rowAtIndexPath(indexPath) {
         case .switchStore:
             switchStoreWasPressed()
+        case .plugins:
+            sitePluginsWasPressed()
         case .support:
             supportWasPressed()
         case .cardReaders:
@@ -561,6 +565,7 @@ private struct Section {
 private enum Row: CaseIterable {
     case selectedStore
     case switchStore
+    case plugins
     case support
     case cardReaders
     case logout
@@ -577,6 +582,8 @@ private enum Row: CaseIterable {
         case .selectedStore:
             return HeadlineLabelTableViewCell.self
         case .switchStore:
+            return BasicTableViewCell.self
+        case .plugins:
             return BasicTableViewCell.self
         case .support:
             return BasicTableViewCell.self


### PR DESCRIPTION
closes #4112 
part of #4114
Implements #3921 

## Description
In order to let users find the list of plugins added to their selected sites, a new entry point to the Plugins screen should be added to Settings screen.

This feature is not intended to be released to the wild yet so I also added a feature flag to make it visible in only local and alpha builds.

## Solution
- Added new case `sitePlugins` to  `FeatureFlag` enum
- Updated `DefaultFeatureFlagService` to enable site plugins feature only for local and alpha builds.
- Updated Settings screen with new section Plugins. This section contains only one row Plugins to redirect to new Plugins screen (the action is pending for implementation coming soon).
- The Plugins section is only available when `sitePlugins` feature flag is enabled.

## Testing
When built in local and alpha environments, the app should show Settings screen with Plugins section like screenshot below:

<img src="https://user-images.githubusercontent.com/5533851/117397730-fc36cd00-af26-11eb-85de-36fa8edc3553.png" width=300 />

P.s: `SettingsViewController` has not yet been migrated to MVVM pattern so it cannot be unit tested for now. It is desirable to handled this migration soon with dependency injection of `FeatureFlagService` to double check for visibility of beta features like this one, as we sure cannot test the app in production environment.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
