### PR TITLE
Shipping Labels: Networking layer to check shipping label creation eligibility for an order

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -999,6 +999,16 @@ extension ShippingLabelAddressVerification.ShipType {
         .origin
     }
 }
+extension ShippingLabelCreationEligibilityResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCreationEligibilityResponse {
+        .init(
+            isEligible: .fake(),
+            reason: .fake()
+        )
+    }
+}
 extension ShippingLabelCustomPackage {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -367,6 +367,9 @@
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
 		CC9A24F42642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */; };
+		CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC9A253B26442C71005DE56E /* shipping-label-eligibility-success.json */; };
+		CC9A254626442CA7005DE56E /* shipping-label-eligibility-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = CC9A254526442CA7005DE56E /* shipping-label-eligibility-failure.json */; };
+		CC9A254A26442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */; };
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
@@ -838,6 +841,9 @@
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
 		CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityMapper.swift; sourceTree = "<group>"; };
+		CC9A253B26442C71005DE56E /* shipping-label-eligibility-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-eligibility-success.json"; sourceTree = "<group>"; };
+		CC9A254526442CA7005DE56E /* shipping-label-eligibility-failure.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-eligibility-failure.json"; sourceTree = "<group>"; };
+		CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityMapperTests.swift; sourceTree = "<group>"; };
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
@@ -1477,6 +1483,8 @@
 				02E7FFCE25621C7900C53030 /* shipping-label-print.json */,
 				028FA471257E110700F88A48 /* shipping-label-refund-error.json */,
 				028FA472257E110700F88A48 /* shipping-label-refund-success.json */,
+				CC9A253B26442C71005DE56E /* shipping-label-eligibility-success.json */,
+				CC9A254526442CA7005DE56E /* shipping-label-eligibility-failure.json */,
 				45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */,
 				45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */,
 				CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */,
@@ -1667,6 +1675,7 @@
 				020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */,
 				451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */,
 				CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */,
+				CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 			);
 			path = Mapper;
@@ -1836,6 +1845,7 @@
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
 				74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */,
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
+				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
@@ -1944,6 +1954,7 @@
 				028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */,
 				74ABA1C9213F19FE00FFAD30 /* top-performers-month.json in Resources */,
 				743E84F622172D3E00FAC9D7 /* shipment_tracking_single.json in Resources */,
+				CC9A254626442CA7005DE56E /* shipping-label-eligibility-failure.json in Resources */,
 				4524CD9C242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json in Resources */,
 				020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */,
 				45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */,
@@ -2282,6 +2293,7 @@
 				B524194921AC659500D6FC0A /* DevicesRemoteTests.swift in Sources */,
 				2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */,
 				B505F6D320BEE3A500BB1B69 /* AccountMapperTests.swift in Sources */,
+				CC9A254A26442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift in Sources */,
 				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
+		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
@@ -834,6 +835,7 @@
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
@@ -972,6 +974,7 @@
 				45A4B84925D2DECD00776FB4 /* ShippingLabelAddressValidationResponse.swift */,
 				E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */,
 				45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */,
+				CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */,
 				CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
@@ -2063,6 +2066,7 @@
 				D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */,
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
+				CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
+		CC9A24F42642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */; };
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
@@ -836,6 +837,7 @@
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
+		CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityMapper.swift; sourceTree = "<group>"; };
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
@@ -1564,6 +1566,7 @@
 				021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift */,
 				CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */,
+				CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2225,6 +2228,7 @@
 				029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */,
 				B557DA0F20975E07005962F4 /* DotcomRequest.swift in Sources */,
 				740211E321939C84002248DA /* CommentResultMapper.swift in Sources */,
+				CC9A24F42642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift in Sources */,
 				45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelCreationEligibilityMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelCreationEligibilityMapper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Mapper: Shipping Label Creation Eligibility
+///
+struct ShippingLabelCreationEligibilityMapper: Mapper {
+    /// (Attempts) to convert a dictionary into ShippingLabelAccountSettings.
+    ///
+    func map(response: Data) throws -> ShippingLabelCreationEligibilityResponse {
+        let decoder = JSONDecoder()
+        return try decoder.decode(ShippingLabelCreationEligibilityMapperEnvelope.self, from: response).eligibility
+    }
+}
+
+/// ShippingLabelCreationEligibilityMapperEnvelope Disposable Entity:
+/// `Shipping Label Creation Eligibility` endpoint returns the shipping label account settings in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct ShippingLabelCreationEligibilityMapperEnvelope: Decodable {
+    let eligibility: ShippingLabelCreationEligibilityResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case eligibility = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
@@ -22,7 +22,7 @@ extension ShippingLabelCreationEligibilityResponse: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let isEligible = try container.decode(Bool.self, forKey: .isEligible)
-        let reason = try container.decode(String.self, forKey: .reason)
+        let reason = try container.decodeIfPresent(String.self, forKey: .reason)
 
         self.init(isEligible: isEligible, reason: reason)
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Represents a Shipping Label Creation Eligibility response for an order.
+///
+public struct ShippingLabelCreationEligibilityResponse: Equatable, GeneratedFakeable {
+    /// Whether the order is eligible for shipping label creation.
+    public let isEligible: Bool
+
+    /// The reason if an order is **not** eligible for shipping label creation.
+    /// Returned when `isEligible` is false.
+    public let reason: String?
+
+    public init(isEligible: Bool, reason: String?) {
+        self.isEligible = isEligible
+        self.reason = reason
+    }
+}
+
+// MARK: Decodable
+extension ShippingLabelCreationEligibilityResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let isEligible = try container.decode(Bool.self, forKey: .isEligible)
+        let reason = try container.decode(String.self, forKey: .reason)
+
+        self.init(isEligible: isEligible, reason: reason)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isEligible = "is_eligible"
+        case reason
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ShippingLabelCreationEligibilityMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelCreationEligibilityMapperTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ShippingLabelCreationEligibilityMapper`
+///
+class ShippingLabelCreationEligibilityMapperTests: XCTestCase {
+    /// Sample Site ID
+    private let sampleSiteID: Int64 = 123456
+
+    /// Sample Order ID
+    private let sampleOrderID: Int64 = 123
+
+    func test_shipping_label_creation_eligibility_success_is_properly_parsed() throws {
+        // Given
+        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-success"))
+
+        // Then
+        XCTAssertEqual(response.isEligible, true)
+        XCTAssertEqual(response.reason, nil)
+    }
+
+    func test_shipping_label_creation_eligibility_failure_is_properly_parsed() throws {
+        // Given
+        let response = try XCTUnwrap(mapEligibilityResponse(from: "shipping-label-eligibility-failure"))
+
+        // Then
+        XCTAssertEqual(response.isEligible, false)
+        XCTAssertEqual(response.reason, "no_selected_payment_method_and_user_cannot_manage_payment_methods")
+    }
+}
+
+/// Private Helpers
+///
+private extension ShippingLabelCreationEligibilityMapperTests {
+
+    /// Returns the `ShippingLabelCreationEligibilityMapper` output upon receiving `filename` (Data Encoded)
+    ///
+    func mapEligibilityResponse(from filename: String) -> ShippingLabelCreationEligibilityResponse? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ShippingLabelCreationEligibilityMapper().map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-eligibility-failure.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-eligibility-failure.json
@@ -1,0 +1,6 @@
+{
+    "data": {
+        "is_eligible": false,
+        "reason": "no_selected_payment_method_and_user_cannot_manage_payment_methods"
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-eligibility-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-eligibility-success.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "is_eligible": true
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -254,7 +254,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
             if let result = self.creationEligibilityResults[key] {
                 completion(result)
             } else {
-                XCTFail("\(String(describing:self)) Could not find Result for \(key)")
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
             }
         }
     }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -247,7 +247,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
             guard let self = self else { return }
 
             let key = CreationEligibilityResultKey(siteID: siteID,
-                                                   orderID: siteID,
+                                                   orderID: orderID,
                                                    canCreatePaymentMethod: canCreatePaymentMethod,
                                                    canCreateCustomsForm: canCreateCustomsForm,
                                                    canCreatePackage: canCreatePackage)


### PR DESCRIPTION
Related: #4083 

## Description

This PR adds support to the Networking layer for the [Shipping Label creation eligibility endpoint](https://github.com/Automattic/woocommerce-services/pull/2334). This endpoint takes several parameters (`can_create_payment_method`, `can_create_customs_form`, `can_create_package`) for what features the client supports, and returns the eligibility for creating new shipping labels for an order (along with the reason if it isn't eligible).

We currently have a placeholder action in the Yosemite layer, which will be replaced in a followup PR.

## Changes

* Adds a new Networking Model `ShippingLabelCreationEligibilityResponse` for the eligibility response, with the `isEligible` response and an optional `reason`.
* Adds the response mapper `ShippingLabelCreationEligibilityMapper`.
* Adds the endpoint to `ShippingLabelRemote`, taking arguments for the three client features that affect eligibility.
* Adds unit tests for the remote endpoint and mapper.
* Updates Yosemite mocks in `MockShippingLabelRemote`.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
