### PR TITLE
[Mobile Payments] Add user-facing message to indicate payment is being processed

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
@@ -54,7 +54,7 @@ final class CardPresentModalProcessing: CardPresentPaymentsModalViewModel {
 private extension CardPresentModalProcessing {
     enum Localization {
         static let processingPayment = NSLocalizedString(
-            "Processing Payment...",
+            "Processing payment...",
             comment: "Indicates that a payment is being processed"
         )
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProcessing.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+
+/// Modal presented while processing a payment
+final class CardPresentModalProcessing: CardPresentPaymentsModalViewModel {
+
+    /// Customer name
+    private let name: String
+
+    /// Charge amount
+    private let amount: String
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .none
+
+    var topTitle: String {
+        name
+    }
+
+    var topSubtitle: String? {
+        amount
+    }
+
+    let image: UIImage = .cardPresentImage
+
+    let primaryButtonTitle: String? = nil
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String? = Localization.processingPayment
+
+    let bottomSubtitle: String? = nil
+
+    init(name: String, amount: String) {
+        self.name = name
+        self.amount = amount
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        //
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        //
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        //
+    }
+}
+
+private extension CardPresentModalProcessing {
+    enum Localization {
+        static let processingPayment = NSLocalizedString(
+            "Processing Payment...",
+            comment: "Indicates that a payment is being processed"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -11,6 +11,7 @@ final class PaymentCaptureOrchestrator {
     func collectPayment(for order: Order,
                         onPresentMessage: @escaping (String) -> Void,
                         onClearMessage: @escaping () -> Void,
+                        onProcessingMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
 
         // TODO. Check that there is a reader currently connected
@@ -19,6 +20,7 @@ final class PaymentCaptureOrchestrator {
         collectPaymentWithCardReader(for: order,
                                      onPresentMessage: onPresentMessage,
                                      onClearMessage: onClearMessage,
+                                     onProcessingMessage: onProcessingMessage,
                                      onCompletion: onCompletion)
     }
 
@@ -42,6 +44,7 @@ private extension PaymentCaptureOrchestrator {
     func collectPaymentWithCardReader(for order: Order,
                                       onPresentMessage: @escaping (String) -> Void,
                                       onClearMessage: @escaping () -> Void,
+                                      onProcessingMessage: @escaping () -> Void,
                                       onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
             DDLogError("Error: attempted to collect payment for an order without valid total.")
@@ -71,6 +74,7 @@ private extension PaymentCaptureOrchestrator {
                                                                     break
                                                                 }
                                                              }, onCompletion: { [weak self] result in
+                                                                onProcessingMessage()
                                                                 self?.completePaymentIntentCapture(order: order,
                                                                                                  captureResult: result,
                                                                                                  onCompletion: onCompletion)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -33,6 +33,11 @@ final class OrderDetailsPaymentAlerts {
         modalController?.setViewModel(viewModel)
     }
 
+    func processingPayment() {
+        let viewModel = processing()
+        modalController?.setViewModel(viewModel)
+    }
+
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
         let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt)
         modalController?.setViewModel(viewModel)
@@ -60,6 +65,10 @@ private extension OrderDetailsPaymentAlerts {
 
     func remove() -> CardPresentPaymentsModalViewModel {
         CardPresentModalRemoveCard(name: name, amount: amount)
+    }
+
+    func processing() -> CardPresentPaymentsModalViewModel {
+        CardPresentModalProcessing(name: name, amount: amount)
     }
 
     func successViewModel(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -483,10 +483,12 @@ extension OrderDetailsViewModel {
     /// that object outside of Yosemite.
     func collectPayment(onPresentMessage: @escaping (String) -> Void,
                         onClearMessage: @escaping () -> Void,
+                        onProcessingMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         paymentOrchestrator.collectPayment(for: order,
                                            onPresentMessage: onPresentMessage,
                                            onClearMessage: onClearMessage,
+                                           onProcessingMessage: onProcessingMessage,
                                            onCompletion: onCompletion)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -531,6 +531,8 @@ private extension OrderDetailsViewController {
             self?.paymentAlerts.tapOrInsertCard()
         } onClearMessage: { [weak self] in
             self?.paymentAlerts.removeCard()
+        } onProcessingMessage: { [weak self] in
+            self?.paymentAlerts.processingPayment()
         } onCompletion: { [weak self] result in
             guard let self = self else {
                 return

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1058,6 +1058,7 @@
 		D81D9229222E7F0800FFA585 /* OrderStatusListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */; };
 		D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D81F2D34225F0CF70084BF9C /* EmptyListMessageWithActionView.xib */; };
 		D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */; };
+		D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */; };
 		D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */; };
 		D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */; };
 		D831E2DC230E0558000037D0 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2DB230E0558000037D0 /* Authentication.swift */; };
@@ -2303,6 +2304,7 @@
 		D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderStatusListViewController.xib; sourceTree = "<group>"; };
 		D81F2D34225F0CF70084BF9C /* EmptyListMessageWithActionView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyListMessageWithActionView.xib; sourceTree = "<group>"; };
 		D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyListMessageWithActionView.swift; sourceTree = "<group>"; };
+		D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProcessing.swift; sourceTree = "<group>"; };
 		D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Appearance.swift"; sourceTree = "<group>"; };
 		D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmptyListMessageWithActionTests.swift; path = WooCommerceTests/ViewRelated/EmptyListMessageWithActionTests.swift; sourceTree = SOURCE_ROOT; };
 		D831E2DB230E0558000037D0 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
@@ -5588,6 +5590,7 @@
 				D8815B0C263861A400EDAD62 /* CardPresentModalSuccess.swift */,
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
 				D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */,
+				D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -6524,6 +6527,7 @@
 				D8EF1E562605121C00380EA4 /* OrderPaymentMethod.swift in Sources */,
 				02A652FF246A908D00755A01 /* BottomSheetListSelectorPresenter.swift in Sources */,
 				D8CD710F237A49DB007148B9 /* UIColor+SemanticColors.swift in Sources */,
+				D82BB3AA26454F3300A82741 /* CardPresentModalProcessing.swift in Sources */,
 				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,


### PR DESCRIPTION
Closes #4122 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader and uploading a pre-release version of WCPay to a test site⚠️

So far, the sequence of modal messages presented while capturing a payment was: Present card > remove card > success

That worked reasonably well until we introduced the step to submit the payment id to WCPay. That would make the modal view stay in "Remove Card" for too long.

This is how that changes look now:

https://user-images.githubusercontent.com/2722505/117439053-5a03ee80-af00-11eb-8db8-72b51acaeb4e.MP4


## Changes
* Added a new view model for the new modal state.
* Added a new callback to the existing APIs, so that the PaymentCaptureOrchestrator can notify the UI when it submits the payment intent id to WCPay

## Not changed
* I didn't touch the modal layout. 

Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)
3. An external hardware reader.

* Checkout the branch, run bundle exec pod install, just for kicks and giggles.
* Build and run on a device.
* Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
* Log in to an account that matches a store that has been configured for testing.
* Navigate to Settings in the app. (Tap the gear button in the top right)
* In the "Store Settings" section, tap "Manage Card Reader".
* Make sure the card reader is on and the blue light is blinking (we don't do any error handling yet, so it's important that things are setup for the happy path)
* Tap "Connect card reader"
* Wait until the app suggests one reader to connect to.
* Tap "Connect to reader"
* Make sure the reader light turns solid blue.
* Navigate to an order eligible for Card Present Payments (it has to be a store enrolled to WCPay, and the order needs to have as payment method associated Cash on Delivery or none).
* Tap the "Collect Payment" button.
* Tap the card to the reader when requested.
* Notice how the modal view requests you to remove the card, and later notifies that the payment is being processed.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
