### PR TITLE
[Mobile Payments] Disconnect from reader

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -38,9 +38,8 @@ public protocol CardReaderService {
     /// - Parameter reader: The card reader we want to connect to.
     func connect(_ reader: CardReader) -> Future <Void, Error>
 
-    /// Disconnects a card reader
-    /// - Parameter reader: The card reader we want to connect to.
-    func disconnect(_ reader: CardReader) -> Future <Void, Error>
+    /// Disconnects from the currently connected reader
+    func disconnect() -> Future <Void, Error>
 
     /// Clears and resets internal state.
     /// We need to call this method when switching accounts or stores

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -12,6 +12,9 @@ public enum CardReaderServiceError: Error {
     /// Error thrown while connecting to a reader
     case connection(underlyingError: UnderlyingError = .internalServiceError)
 
+    /// Error thrown while disonnecting from a reader
+    case disconnection(underlyingError: UnderlyingError = .internalServiceError)
+
     /// Error thrown while creating a payment intent
     case intentCreation(underlyingError: UnderlyingError = .internalServiceError)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -162,10 +162,19 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
     /// Views can call this method to disconnect from the connected reader.
     func disconnectAndForget() {
-        // TODO dispatch an action to disconnect.
-        connectedReader = nil
-        activeView = .connectYourReader
-        activeAlert = .none
+        let action = CardPresentPaymentAction.disconnect { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
+            if result.isSuccess {
+                self.connectedReader = nil
+                self.activeView = .connectYourReader
+                self.activeAlert = .none
+            }
+        }
+
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Called when a reader has been connected to.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -163,15 +163,13 @@ final class CardReaderSettingsViewModel: ObservableObject {
     /// Views can call this method to disconnect from the connected reader.
     func disconnectAndForget() {
         let action = CardPresentPaymentAction.disconnect { [weak self] result in
-            guard let self = self else {
+            guard let self = self, result.isSuccess else {
                 return
             }
 
-            if result.isSuccess {
-                self.connectedReader = nil
-                self.activeView = .connectYourReader
-                self.activeAlert = .none
-            }
+            self.connectedReader = nil
+            self.activeView = .connectYourReader
+            self.activeAlert = .none
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -14,6 +14,10 @@ public enum CardPresentPaymentAction: Action {
     ///
     case connect(reader: CardReader, onCompletion: (Result<[CardReader], Error>) -> Void)
 
+    /// Disconnect from currently connected Reader
+    ///
+    case disconnect(onCompletion: (Result<Void, Error>) -> Void)
+
     /// Calls the completion block everytime the list of known readers changes
     /// with an array of readers known to us.
     ///

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -104,16 +104,19 @@ private extension CardPresentPaymentStore {
     }
 
     func disconnect(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        cardReaderService.disconnect().sink(receiveCompletion: { error in
-            switch error {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            default:
-                break
+        cardReaderService.disconnect().subscribe(Subscribers.Sink(
+            receiveCompletion: { error in
+                switch error {
+                case .failure(let error):
+                    onCompletion(.failure(error))
+                default:
+                    break
+                }
+            },
+            receiveValue: { result in
+                onCompletion(.success(result))
             }
-        }, receiveValue: { (result) in
-            onCompletion(.success(result))
-        }).store(in: &cancellables)
+        ))
     }
 
     /// Calls the completion block everytime the list of known readers changes

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -42,6 +42,8 @@ public final class CardPresentPaymentStore: Store {
             cancelCardReaderDiscovery(completion: completion)
         case .connect(let reader, let completion):
             connect(reader: reader, onCompletion: completion)
+        case .disconnect(let completion):
+            disconnect(onCompletion: completion)
         case .observeKnownReaders(let completion):
             observeKnownReaders(onCompletion: completion)
         case .observeConnectedReaders(let completion):
@@ -99,6 +101,19 @@ private extension CardPresentPaymentStore {
         cardReaderService.connectedReaders.sink { connectedHardwareReaders in
             onCompletion(.success(connectedHardwareReaders))
         }.store(in: &cancellables)
+    }
+
+    func disconnect(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        cardReaderService.disconnect().sink(receiveCompletion: { error in
+            switch error {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            default:
+                break
+            }
+        }, receiveValue: { (result) in
+            onCompletion(.success(result))
+        }).store(in: &cancellables)
     }
 
     /// Calls the completion block everytime the list of known readers changes

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -38,6 +38,9 @@ final class MockCardReaderService: CardReaderService {
     /// Boolean flag Indicates that clients have called the cancel method
     var didHitCancel = false
 
+    /// Boolean flag Indicates that clients have called the disconnect method
+    var didHitDisconnect = false
+
     /// Boolean flag Indicates that clients have provided a CardReaderConfigProvider
     var didReceiveAConfigurationProvider = false
 
@@ -79,9 +82,8 @@ final class MockCardReaderService: CardReaderService {
     }
 
     func disconnect() -> Future<Void, Error> {
-        Future() { promise in
-            // This will be removed. We just want to pretend we are doing a roundtrip to the SDK for now.
-            /// Delaying the effect of this method so that unit tests are actually async
+        didHitDisconnect = true
+        return Future() { promise in
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 promise(Result.success(()))
             }

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -78,7 +78,7 @@ final class MockCardReaderService: CardReaderService {
         }
     }
 
-    func disconnect(_ reader: Hardware.CardReader) -> Future<Void, Error> {
+    func disconnect() -> Future<Void, Error> {
         Future() { promise in
             // This will be removed. We just want to pretend we are doing a roundtrip to the SDK for now.
             /// Delaying the effect of this method so that unit tests are actually async

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -224,6 +224,21 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_disconnect_action_hits_disconnect_in_service() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let action = CardPresentPaymentAction.disconnect(onCompletion: { result in
+            //
+        })
+
+        cardPresentStore.onAction(action)
+
+        XCTAssertTrue(mockCardReaderService.didHitDisconnect)
+    }
+
     func test_known_readers_array_initially_empty() {
         let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
                                                        storageManager: storageManager,


### PR DESCRIPTION
Closes #4031 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader and uploading a pre-release version of WCPay to a test site⚠️

Add support for disconnecting from the currently connected reader:

https://user-images.githubusercontent.com/2722505/117460522-99d7cf80-af1a-11eb-9052-a9db2eb8dba2.MP4

## Changes
* Implemented `disconnect()` in the integration with the Stripe Terminal SDK (StripeCardReaderService)
* Added an action to CardPresentPaymentAction and its implementation to CardPresentPaymentStore.
* No new tests. Testing the integration is still blocked pending #3864 
* Touched the current UI to integrate with the new action. More about that in a comment in the actual diff.

## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)
3. An external hardware reader.

* Checkout the branch, run bundle exec pod install, just for kicks and giggles.
* Build and run on a device.
* Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
* Log in to an account that matches a store that has been configured for testing.
* Navigate to Settings in the app. (Tap the gear button in the top right)
* In the "Store Settings" section, tap "Manage Card Reader".
* Tap "Connect card reader"
* Wait until the app suggests one reader to connect to.
* Tap "Connect to reader"
* Make sure the reader light turns solid blue.
* Tap the "Disconnect" button. 
* The UI should flip to its initial state. The reader led should start blinking again. 
* Try to connect and disconnect a couple more times, just for kicks and giggles.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
