### PR TITLE
Shipping Labels: Yosemite and UI changes to check shipping label creation eligibility for an order from remote

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,7 +9,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .largeTitles:
             return true
-        case .shippingLabelsRelease2:
+        case .shippingLabelsM2M3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsM4:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,6 +11,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsRelease3:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .addOnsI1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,7 +11,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsRelease2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .shippingLabelsRelease3:
+        case .shippingLabelsM4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .addOnsI1:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -22,9 +22,9 @@ enum FeatureFlag: Int {
     ///
     case reviews
 
-    /// Shipping labels - release 2
+    /// Shipping labels - Milestones 2 & 3
     ///
-    case shippingLabelsRelease2
+    case shippingLabelsM2M3
 
     /// Shipping labels - Milestone 4
     ///

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -26,9 +26,9 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsRelease2
 
-    /// Shipping labels - release 3
+    /// Shipping labels - Milestone 4
     ///
-    case shippingLabelsRelease3
+    case shippingLabelsM4
 
     /// Product AddOns first iteration
     ///

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -26,6 +26,10 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsRelease2
 
+    /// Shipping labels - release 3
+    ///
+    case shippingLabelsRelease3
+
     /// Product AddOns first iteration
     ///
     case addOnsI1

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -389,8 +389,8 @@ extension OrderDetailsViewModel {
     }
 
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
-        // No orders are eligible for shipping label creation unless Release 2 flag (Milestone 2 & 3 features) is enabled
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2) else {
+        // No orders are eligible for shipping label creation unless feature flag for Milestones 2 & 3 is enabled
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsM2M3) else {
             dataSource.isEligibleForShippingLabelCreation = false
             onCompletion?()
             return

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -389,15 +389,15 @@ extension OrderDetailsViewModel {
     }
 
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
-        // No orders are eligible for shipping label creation unless Release 2 flag is enabled
+        // No orders are eligible for shipping label creation unless Release 2 flag (Milestone 2 & 3 features) is enabled
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2) else {
             dataSource.isEligibleForShippingLabelCreation = false
             onCompletion?()
             return
         }
 
-        // Check shipping label creation eligibility remotely, according to client features under Release 3 feature flag
-        let isFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease3)
+        // Check shipping label creation eligibility remotely, according to client features available in Shipping Labels Milestone 4
+        let isFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsM4)
         let action = ShippingLabelAction.checkCreationEligibility(siteID: order.siteID,
                                                                   orderID: order.orderID,
                                                                   canCreatePaymentMethod: isFeatureFlagEnabled,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -406,7 +406,7 @@ extension OrderDetailsViewModel {
             self?.dataSource.isEligibleForShippingLabelCreation = isEligible
             onCompletion?()
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     func deleteTracking(_ tracking: ShipmentTracking, onCompletion: @escaping (Error?) -> Void) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -1,19 +1,19 @@
 @testable import WooCommerce
 
 struct MockFeatureFlagService: FeatureFlagService {
-    private let isShippingLabelsRelease2On: Bool
+    private let isShippingLabelsM2M3On: Bool
     private let isShippingLabelsM4On: Bool
 
-    init(isShippingLabelsRelease2On: Bool = false,
+    init(isShippingLabelsM2M3On: Bool = false,
          isShippingLabelsM4On: Bool = false) {
-        self.isShippingLabelsRelease2On = isShippingLabelsRelease2On
+        self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isShippingLabelsM4On = isShippingLabelsM4On
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
-        case .shippingLabelsRelease2:
-            return isShippingLabelsRelease2On
+        case .shippingLabelsM2M3:
+            return isShippingLabelsM2M3On
         case .shippingLabelsM4:
             return isShippingLabelsM4On
         default:

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -2,20 +2,20 @@
 
 struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsRelease2On: Bool
-    private let isShippingLabelsRelease3On: Bool
+    private let isShippingLabelsM4On: Bool
 
     init(isShippingLabelsRelease2On: Bool = false,
-         isShippingLabelsRelease3On: Bool = false) {
+         isShippingLabelsM4On: Bool = false) {
         self.isShippingLabelsRelease2On = isShippingLabelsRelease2On
-        self.isShippingLabelsRelease3On = isShippingLabelsRelease3On
+        self.isShippingLabelsM4On = isShippingLabelsM4On
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
         case .shippingLabelsRelease2:
             return isShippingLabelsRelease2On
-        case .shippingLabelsRelease3:
-            return isShippingLabelsRelease3On
+        case .shippingLabelsM4:
+            return isShippingLabelsM4On
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -1,8 +1,21 @@
 @testable import WooCommerce
 
 struct MockFeatureFlagService: FeatureFlagService {
+    private let isShippingLabelsRelease2On: Bool
+    private let isShippingLabelsRelease3On: Bool
+
+    init(isShippingLabelsRelease2On: Bool = false,
+         isShippingLabelsRelease3On: Bool = false) {
+        self.isShippingLabelsRelease2On = isShippingLabelsRelease2On
+        self.isShippingLabelsRelease3On = isShippingLabelsRelease3On
+    }
+
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
+        case .shippingLabelsRelease2:
+            return isShippingLabelsRelease2On
+        case .shippingLabelsRelease3:
+            return isShippingLabelsRelease3On
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -71,9 +71,9 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     // MARK: Shipping Labels feature flags
 
-    func test_checkShippingLabelCreationEligibility_returns_ineligible_when_shippingLabelsRelease2_is_disabled() throws {
+    func test_checkShippingLabelCreationEligibility_returns_ineligible_when_shippingLabelsM2M3_is_disabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsRelease2On: false)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: false)
         ServiceLocator.setFeatureFlagService(featureFlagService)
 
         // When
@@ -84,9 +84,9 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.dataSource.isEligibleForShippingLabelCreation)
     }
 
-    func test_checkShippingLabelCreationEligibility_dispatches_eligibility_check_without_client_features_when_only_shippingLabelsRelease2_is_enabled() throws {
+    func test_checkShippingLabelCreationEligibility_dispatches_eligibility_check_without_client_features_when_only_shippingLabelsM2M3_is_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsRelease2On: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
@@ -116,7 +116,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_checkShippingLabelCreationEligibility_dispatches_eligibility_check_with_client_features_when_both_flags_are_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsRelease2On: true, isShippingLabelsM4On: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isShippingLabelsM4On: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -116,7 +116,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_checkShippingLabelCreationEligibility_dispatches_eligibility_check_with_client_features_when_both_flags_are_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsRelease2On: true, isShippingLabelsRelease3On: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsRelease2On: true, isShippingLabelsM4On: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -34,7 +34,12 @@ public enum ShippingLabelAction: Action {
 
     /// Checks whether an order is eligible for shipping label creation.
     ///
-    case checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: (_ isEligible: Bool) -> Void)
+    case checkCreationEligibility(siteID: Int64,
+                                  orderID: Int64,
+                                  canCreatePaymentMethod: Bool,
+                                  canCreateCustomsForm: Bool,
+                                  canCreatePackage: Bool,
+                                  onCompletion: (_ isEligible: Bool) -> Void)
 
     /// Creates a custom package with provided package details.
     ///

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -49,8 +49,13 @@ public final class ShippingLabelStore: Store {
             validateAddress(siteID: siteID, address: address, completion: completion)
         case .packagesDetails(let siteID, let completion):
             packagesDetails(siteID: siteID, completion: completion)
-        case .checkCreationEligibility(let siteID, let orderID, let isFeatureFlagEnabled, let onCompletion):
-            checkCreationEligibility(siteID: siteID, orderID: orderID, isFeatureFlagEnabled: isFeatureFlagEnabled, onCompletion: onCompletion)
+        case .checkCreationEligibility(let siteID, let orderID, let canCreatePaymentMethod, let canCreateCustomsForm, let canCreatePackage, let onCompletion):
+            checkCreationEligibility(siteID: siteID,
+                                     orderID: orderID,
+                                     canCreatePaymentMethod: canCreatePaymentMethod,
+                                     canCreateCustomsForm: canCreateCustomsForm,
+                                     canCreatePackage: canCreatePackage,
+                                     onCompletion: onCompletion)
         case .createPackage(let siteID, let customPackage, let completion):
             createPackage(siteID: siteID, customPackage: customPackage, completion: completion)
         case .synchronizeShippingLabelAccountSettings(let siteID, let completion):
@@ -118,9 +123,32 @@ private extension ShippingLabelStore {
         remote.packagesDetails(siteID: siteID, completion: completion)
     }
 
-    func checkCreationEligibility(siteID: Int64, orderID: Int64, isFeatureFlagEnabled: Bool, onCompletion: @escaping (_ isEligible: Bool) -> Void) {
-        // TODO-2971: implement shipping label creation eligibility check, hopefully with the new `/creation_eligibility` endpoint.
-        onCompletion(isFeatureFlagEnabled)
+    func checkCreationEligibility(siteID: Int64,
+                                  orderID: Int64,
+                                  canCreatePaymentMethod: Bool,
+                                  canCreateCustomsForm: Bool,
+                                  canCreatePackage: Bool,
+                                  onCompletion: @escaping (_ isEligible: Bool) -> Void) {
+        remote.checkCreationEligibility(siteID: siteID,
+                                        orderID: orderID,
+                                        canCreatePaymentMethod: canCreatePaymentMethod,
+                                        canCreateCustomsForm: canCreateCustomsForm,
+                                        canCreatePackage: canCreatePackage) { result in
+            switch result {
+            case .success(let eligibility):
+                if !eligibility.isEligible {
+                    if let reason = eligibility.reason {
+                        DDLogError("Order \(orderID) not eligible for shipping label creation: \(reason)")
+                    } else {
+                        DDLogError("Order \(orderID) not eligible for shipping label creation")
+                    }
+                }
+                onCompletion(eligibility.isEligible)
+            case .failure(let error):
+                DDLogError("⛔️ Error checking shipping label creation eligibility for order \(orderID): \(error)")
+                onCompletion(false)
+            }
+        }
     }
 
     func createPackage(siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -446,7 +446,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         // Given
         let remote = MockShippingLabelRemote()
         let orderID: Int64 = 22
-        let isFeatureFlagEnabled = true
+        let isFeatureFlagEnabled = false
         let expectedEligibility = true
         remote.whenCheckingCreationEligiblity(siteID: sampleSiteID,
                                               orderID: orderID,
@@ -477,6 +477,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let remote = MockShippingLabelRemote()
         let orderID: Int64 = 22
         let isFeatureFlagEnabled = false
+        let expectedEligibility = false
         remote.whenCheckingCreationEligiblity(siteID: sampleSiteID,
                                               orderID: orderID,
                                               canCreatePaymentMethod: isFeatureFlagEnabled,
@@ -498,7 +499,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(isEligibleForCreation, false)
+        XCTAssertEqual(isEligibleForCreation, expectedEligibility)
     }
 
     // MARK: `createPackage`

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -442,23 +442,63 @@ final class ShippingLabelStoreTests: XCTestCase {
 
     // MARK: `checkCreationEligibility`
 
-    func test_checkCreationEligibility_returns_feature_flag_value() throws {
+    func test_checkCreationEligibility_returns_eligibility_on_success() throws {
         // Given
-        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let remote = MockShippingLabelRemote()
+        let orderID: Int64 = 22
+        let isFeatureFlagEnabled = true
+        let expectedEligibility = true
+        remote.whenCheckingCreationEligiblity(siteID: sampleSiteID,
+                                              orderID: orderID,
+                                              canCreatePaymentMethod: isFeatureFlagEnabled,
+                                              canCreateCustomsForm: isFeatureFlagEnabled,
+                                              canCreatePackage: isFeatureFlagEnabled,
+                                              thenReturn: .success(ShippingLabelCreationEligibilityResponse(isEligible: expectedEligibility, reason: nil)))
+        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let isFeatureFlagEnabled = false
         let isEligibleForCreation: Bool = waitFor { promise in
             let action = ShippingLabelAction.checkCreationEligibility(siteID: self.sampleSiteID,
-                                                                      orderID: 134,
-                                                                      isFeatureFlagEnabled: isFeatureFlagEnabled) { isEligible in
+                                                                      orderID: orderID,
+                                                                      canCreatePaymentMethod: isFeatureFlagEnabled,
+                                                                      canCreateCustomsForm: isFeatureFlagEnabled,
+                                                                      canCreatePackage: isFeatureFlagEnabled) { isEligible in
                 promise(isEligible)
             }
             store.onAction(action)
         }
 
         // Then
-        XCTAssertEqual(isEligibleForCreation, isFeatureFlagEnabled)
+        XCTAssertEqual(isEligibleForCreation, expectedEligibility)
+    }
+
+    func test_checkCreationEligibility_returns_false_on_failure() throws {
+        // Given
+        let remote = MockShippingLabelRemote()
+        let orderID: Int64 = 22
+        let isFeatureFlagEnabled = false
+        remote.whenCheckingCreationEligiblity(siteID: sampleSiteID,
+                                              orderID: orderID,
+                                              canCreatePaymentMethod: isFeatureFlagEnabled,
+                                              canCreateCustomsForm: isFeatureFlagEnabled,
+                                              canCreatePackage: isFeatureFlagEnabled,
+                                              thenReturn: .failure(NetworkError.notFound))
+        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let isEligibleForCreation: Bool = waitFor { promise in
+            let action = ShippingLabelAction.checkCreationEligibility(siteID: self.sampleSiteID,
+                                                                      orderID: orderID,
+                                                                      canCreatePaymentMethod: isFeatureFlagEnabled,
+                                                                      canCreateCustomsForm: isFeatureFlagEnabled,
+                                                                      canCreatePackage: isFeatureFlagEnabled) { isEligible in
+                promise(isEligible)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(isEligibleForCreation, false)
     }
 
     // MARK: `createPackage`


### PR DESCRIPTION
Fixes: #4083, #2971 
Relies on: #4138 ✅ 

## Description

Up to now, we have been using a placeholder `checkCreationEligibility` action to determine shipping label creation eligibility — that is, whether to show the "Create Shipping Label" button for an order. This has been entirely based on the `.shippingLabelsRelease2` feature flag.

This PR updates that action in the Yosemite layer to use the remote `/creation-eligibility` endpoint to determine shipping label creation eligibility, and updates the UI layer to check both the `.shippingLabelsRelease2` feature flag and the `.shippingLabelsRelease3` feature flag:

* `.shippingLabelsRelease2` controls whether the Create Shipping Label button is shown at all. (This matches Shipping Labels Milestone 3, currently in development.)
* `.shippingLabelsRelease3` includes additional shipping label creation features (payment method, customs form, and package creation). These client feature capabilities are passed to the remote endpoint to determine eligibility. (These features are planned for development in Milestone 4.)

## Changes

### Yosemite layer
* Updates `ShippingLabelAction` to include parameters for payment method, customs form, and package creation.
* Updates `ShippingLabelStore` to use the remote endpoint for `checkCreationEligibility`. This method now checks the remote endpoint, logs any errors (either network errors or the reason if an order is ineligible), and passes the eligibility (`Bool`) for use in the UI layer.
* Updates `ShippingLabelStoreTests` unit tests to test for `checkCreationEligibility` success and failure responses.

### UI layer
* Added a new feature flag `.shippingLabelsRelease3` that will be used for Milestone 4 shipping label features.
* Updates `OrderDetailsViewModel` to check both the `.shippingLabelsRelease2` and the `.shippingLabelsRelease3` feature flags to determine shipping label creation eligibility.

Ineligible order | Eligible order
-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-05-07 at 13 46 26](https://user-images.githubusercontent.com/8658164/117451625-a3712f80-af3a-11eb-93ba-a9b652e2dac0.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-05-07 at 13 39 52](https://user-images.githubusercontent.com/8658164/117451171-129a5400-af3a-11eb-835a-a8e18d8b906d.png)


## Testing

### Release 2 & 3 Feature Flags On

1. Ensure you have the WooCommerce Shipping & Tax extension enabled on your test store.
2. Launch the app in debug mode (for feature flags to be enabled).
3. Select an order -> there **should** be a "Create Shipping Label" button.

### Release 2 Feature Flag On / Release 3 Feature Flag Off

Release 2 eligibility requirements:

1. Have at least version 1.25.11 of the plugin [WooCommerce Shipping](https://woocommerce.com/products/shipping/) installed and activated.
2. Store’s country set to US.
3. Store’s currency set to USD.
4. Plugin is set up ([documentation](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#set-up-shipping-labels)).
5. Have at least one payment method configured in the previous step.
6. Added at least one package in the plugin [settings](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-3).
7. Order’s destination address is in the US.

Testing:

1. Make sure your test store or test order does **not** meet all of the eligibility requirements listed above.
2. In `DefaultFeatureFlagService`, hard code to return `false` for the `shippingLabelsRelease3` feature flag.
3. Go to the Orders tab.
4. Select an order -> there **should not** be a "Create Shipping Label" button.
5. Now, make sure your test store and order **does** meet all of the eligibility requirements listed above.
6. Select an order -> there **should** be a "Create Shipping Label" button.

### Release 2 & 3 Feature Flags Off

1. In `DefaultFeatureFlagService`, hard code to return `false` for both the `shippingLabelsRelease2` and `shippingLabelsRelease3` feature flags.
2. Go to the Orders tab.
3. Select an order -> there **should not** be a "Create Shipping Label" button.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
