### PR TITLE
[Mobile Payments] 2-6 Add No Known No Connected Readers ViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -233,7 +233,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="tableView" destination="cH0-ne-ohw" id="T40-jU-vUP"/>
+                        <outlet property="tableView" destination="cH0-ne-ohw" id="WMq-s3-UmJ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w65-IK-CKC" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -247,30 +247,73 @@
                     <view key="view" contentMode="scaleToFill" id="EOU-z7-aBS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Under Construction" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yAZ-jF-hAZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="l2Q-VL-2yz"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="l2Q-VL-2yz" firstAttribute="trailing" secondItem="yAZ-jF-hAZ" secondAttribute="trailing" id="IoK-Ca-RnF"/>
-                            <constraint firstItem="yAZ-jF-hAZ" firstAttribute="top" secondItem="l2Q-VL-2yz" secondAttribute="top" id="kZc-5O-iDD"/>
-                            <constraint firstItem="yAZ-jF-hAZ" firstAttribute="leading" secondItem="l2Q-VL-2yz" secondAttribute="leading" id="nCI-IL-b21"/>
-                            <constraint firstItem="l2Q-VL-2yz" firstAttribute="bottom" secondItem="yAZ-jF-hAZ" secondAttribute="bottom" id="uBc-a2-Cby"/>
-                        </constraints>
                     </view>
-                    <connections>
-                        <outlet property="temporaryLabel" destination="yAZ-jF-hAZ" id="2Uc-ZW-zKk"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ErC-sp-Qjr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4192.8000000000002" y="2236.7316341829087"/>
+        </scene>
+        <!--Card Reader Settings Unknown View Controller-->
+        <scene sceneID="1hM-QM-F7H">
+            <objects>
+                <viewController storyboardIdentifier="CardReaderSettingsUnknownViewController" id="QbQ-It-W6j" customClass="CardReaderSettingsUnknownViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="OI1-Kx-TMr">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wIN-aE-q96">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="H3D-HM-LVk"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="wIN-aE-q96" firstAttribute="top" secondItem="H3D-HM-LVk" secondAttribute="top" id="Jhc-e4-GIy"/>
+                            <constraint firstItem="wIN-aE-q96" firstAttribute="leading" secondItem="H3D-HM-LVk" secondAttribute="leading" id="oLF-Wz-7a3"/>
+                            <constraint firstItem="H3D-HM-LVk" firstAttribute="trailing" secondItem="wIN-aE-q96" secondAttribute="trailing" id="qD0-0x-GvW"/>
+                            <constraint firstItem="H3D-HM-LVk" firstAttribute="bottom" secondItem="wIN-aE-q96" secondAttribute="bottom" id="yfC-kN-EGt"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="wIN-aE-q96" id="Cyr-Hj-o4e"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lvw-3c-XCx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4929" y="2237"/>
+        </scene>
+        <!--Card Reader Settings Connected View Controller-->
+        <scene sceneID="A3p-G9-5R7">
+            <objects>
+                <viewController storyboardIdentifier="CardReaderSettingsConnectedViewController" id="2oW-u9-QsT" customClass="CardReaderSettingsConnectedViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="UZB-ng-w8d">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="apN-yh-UaI">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="DEX-1K-dv1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="DEX-1K-dv1" firstAttribute="trailing" secondItem="apN-yh-UaI" secondAttribute="trailing" id="2Ai-FO-Fpm"/>
+                            <constraint firstItem="apN-yh-UaI" firstAttribute="leading" secondItem="DEX-1K-dv1" secondAttribute="leading" id="4Bk-xF-dRi"/>
+                            <constraint firstItem="apN-yh-UaI" firstAttribute="top" secondItem="DEX-1K-dv1" secondAttribute="top" id="KUs-Wf-pjk"/>
+                            <constraint firstItem="DEX-1K-dv1" firstAttribute="bottom" secondItem="apN-yh-UaI" secondAttribute="bottom" id="zHj-fm-gmj"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="apN-yh-UaI" id="E7Z-Xw-uZ5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="feV-ex-aGN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5658" y="2237"/>
         </scene>
     </scenes>
     <resources>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -263,7 +263,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wIN-aE-q96">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wIN-aE-q96">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
@@ -293,7 +293,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="apN-yh-UaI">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="apN-yh-UaI">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -57,6 +57,7 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     func configureTable() {
+        tableView.rowHeight = UITableView.automaticDimension
         tableView.dataSource = self
         tableView.delegate = self
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -1,0 +1,187 @@
+import Foundation
+import UIKit
+
+/// This view controller is used when a reader is currently connected. It assists
+/// the merchant in updating and/or disconnecting from the reader, as needed.
+///
+/// TODO: This is just a placeholder for now. The implementation of this view controller will
+/// begin in earnest with #4056
+///
+final class CardReaderSettingsConnectedViewController: UIViewController {
+
+    /// Main TableView
+    ///
+    @IBOutlet weak private var tableView: UITableView!
+
+    /// ViewModel
+    ///
+    private var viewModel: CardReaderSettingsConnectedViewModel?
+
+    /// Table Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    // MARK: - Overridden Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        registerTableViewCells()
+        configureNavigation()
+        configureSections()
+        configureTable()
+    }
+
+    func configure(viewModel: CardReaderSettingsConnectedViewModel) {
+        self.viewModel = viewModel
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension CardReaderSettingsConnectedViewController {
+
+    /// Set the title and back button.
+    ///
+    func configureNavigation() {
+        title = Localization.title
+    }
+
+    /// Setup the sections in this table view
+    ///
+    func configureSections() {
+        sections = [Section(title: nil,
+                            rows: [
+                                .temporaryHeader
+                            ])]
+    }
+
+    func configureTable() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.reloadData()
+    }
+
+    /// Register table cells.
+    ///
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TitleTableViewCell where row == .temporaryHeader:
+            configureHeader(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    private func configureHeader(cell: TitleTableViewCell) {
+        cell.titleLabel?.text = Localization.temporaryHeader
+        cell.selectionStyle = .none
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension CardReaderSettingsConnectedViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension CardReaderSettingsConnectedViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].title
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension CardReaderSettingsConnectedViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        // TODO: Connect the disconnect button to the view model
+    }
+}
+
+// MARK: - Private Types
+//
+private struct Section {
+    let title: String?
+    let rows: [Row]
+}
+
+private enum Row: CaseIterable {
+    case temporaryHeader
+
+    var type: UITableViewCell.Type {
+        switch self {
+        case .temporaryHeader:
+            return TitleTableViewCell.self
+        }
+    }
+
+    var height: CGFloat {
+        switch self {
+        case .temporaryHeader:
+            return UITableView.automaticDimension
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
+    }
+}
+
+// MARK: - Localization
+//
+private extension CardReaderSettingsConnectedViewController {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Manage Card Reader",
+            comment: "Title for the connected reader screen in settings."
+        )
+
+        static let temporaryHeader = NSLocalizedString(
+            "Connected Reader (Under Construction)",
+            comment: "Temporary Header, TODO remove"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -3,10 +3,11 @@ import UIKit
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
-    @IBOutlet weak var temporaryLabel: UILabel!
-
     /// An array of viewModels and related view classes
     private var viewModelsAndViews: CardReaderSettingsPrioritizedViewModelsProvider?
+
+    /// The view controller we are currently presenting
+    private var childViewController: UIViewController?
 
     /// Set our dependencies
     func configure(viewModelsAndViews: CardReaderSettingsPrioritizedViewModelsProvider) {
@@ -26,9 +27,19 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
     }
 
     private func onViewModelsPriorityChange(viewModelAndView: CardReaderSettingsViewModelAndView?) {
-        // For now, just update the label with the view identifer we should display
-        // A later PR will actually add presented views
-        temporaryLabel.text = viewModelAndView?.viewIdentifier ?? "Loading"
+        childViewController?.willMove(toParent: nil)
+        childViewController?.removeFromParent()
+        childViewController?.view.removeFromSuperview()
+
+        childViewController = self.storyboard!.instantiateViewController(withIdentifier: viewModelAndView!.viewIdentifier)
+
+        guard let childViewController = childViewController else {
+            return
+        }
+
+        self.view.addSubview(childViewController.view)
+        self.addChild(childViewController)
+        childViewController.didMove(toParent: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -1,0 +1,303 @@
+import Foundation
+import UIKit
+
+/// This view controller is used when no readers are known or connected. It assists
+/// the merchant in connecting to a reader, often for the first time.
+///
+final class CardReaderSettingsUnknownViewController: UIViewController {
+
+    /// Main TableView
+    ///
+    @IBOutlet weak var tableView: UITableView!
+
+    /// ViewModel
+    ///
+    private var viewModel: CardReaderSettingsUnknownViewModel?
+
+    /// Table Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    // MARK: - Overridden Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        registerTableViewCells()
+        configureNavigation()
+        configureSections()
+        configureTable()
+    }
+
+    func configure(viewModel: CardReaderSettingsUnknownViewModel) {
+        self.viewModel = viewModel
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension CardReaderSettingsUnknownViewController {
+
+    /// Set the title.
+    ///
+    func configureNavigation() {
+        title = Localization.title
+    }
+
+    /// Setup the sections in this table view
+    ///
+    func configureSections() {
+        sections = [Section(title: nil,
+                            rows: [
+                                .connectHeader,
+                                .connectImage,
+                                .connectHelpHintChargeReader,
+                                .connectHelpHintTurnOnReader,
+                                .connectHelpHintEnableBluetooth,
+                                .connectButton,
+                                .connectLearnMore
+                            ])]
+    }
+
+    func configureTable() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.reloadData()
+    }
+
+    /// Register table cells.
+    ///
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TitleTableViewCell where row == .connectHeader:
+            configureHeader(cell: cell)
+        case let cell as ImageTableViewCell where row == .connectImage:
+            configureImage(cell: cell)
+        case let cell as NumberedListItemTableViewCell where row == .connectHelpHintChargeReader:
+            configureHelpHintChargeReader(cell: cell)
+        case let cell as NumberedListItemTableViewCell where row == .connectHelpHintTurnOnReader:
+            configureHelpHintTurnOnReader(cell: cell)
+        case let cell as NumberedListItemTableViewCell where row == .connectHelpHintEnableBluetooth:
+            configureHelpHintEnableBluetooth(cell: cell)
+        case let cell as ButtonTableViewCell where row == .connectButton:
+            configureButton(cell: cell)
+        case let cell as LearnMoreTableViewCell where row == .connectLearnMore:
+            configureLearnMore(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    private func configureHeader(cell: TitleTableViewCell) {
+        cell.titleLabel?.text = Localization.connectYourCardReaderTitle
+        cell.selectionStyle = .none
+    }
+
+    private func configureImage(cell: ImageTableViewCell) {
+        cell.detailImageView?.image = UIImage(named: "card-reader-connect")
+        cell.selectionStyle = .none
+    }
+
+    private func configureHelpHintChargeReader(cell: NumberedListItemTableViewCell) {
+        cell.numberLabel?.text = Localization.hintOneTitle
+        cell.itemTextLabel?.text = Localization.hintOne
+        cell.selectionStyle = .none
+    }
+
+    private func configureHelpHintTurnOnReader(cell: NumberedListItemTableViewCell) {
+        cell.numberLabel?.text = Localization.hintTwoTitle
+        cell.itemTextLabel?.text = Localization.hintTwo
+        cell.selectionStyle = .none
+    }
+
+    private func configureHelpHintEnableBluetooth(cell: NumberedListItemTableViewCell) {
+        cell.numberLabel?.text = Localization.hintThreeTitle
+        cell.itemTextLabel?.text = Localization.hintThree
+        cell.selectionStyle = .none
+   }
+
+    private func configureButton(cell: ButtonTableViewCell) {
+        let buttonTitle = Localization.connectButton
+        cell.configure(title: buttonTitle) {
+            // TODO connect the connect button
+        }
+        cell.selectionStyle = .none
+    }
+
+    private func configureLearnMore(cell: LearnMoreTableViewCell) {
+        cell.learnMoreLabel.text = Localization.learnMore
+        cell.selectionStyle = .none
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension CardReaderSettingsUnknownViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension CardReaderSettingsUnknownViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].title
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension CardReaderSettingsUnknownViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        // TODO: Connect the connect button to the view model
+    }
+}
+
+// MARK: - Private Types
+//
+private struct Section {
+    let title: String?
+    let rows: [Row]
+}
+
+private enum Row: CaseIterable {
+    case connectHeader
+    case connectImage
+    case connectHelpHintChargeReader
+    case connectHelpHintTurnOnReader
+    case connectHelpHintEnableBluetooth
+    case connectButton
+    case connectLearnMore
+
+    var type: UITableViewCell.Type {
+        switch self {
+        case .connectHeader:
+            return TitleTableViewCell.self
+        case .connectImage:
+            return ImageTableViewCell.self
+        case .connectHelpHintChargeReader:
+            return NumberedListItemTableViewCell.self
+        case .connectHelpHintTurnOnReader:
+            return NumberedListItemTableViewCell.self
+        case .connectHelpHintEnableBluetooth:
+            return NumberedListItemTableViewCell.self
+        case .connectButton:
+            return ButtonTableViewCell.self
+        case .connectLearnMore:
+            return LearnMoreTableViewCell.self
+        }
+    }
+
+    var height: CGFloat {
+        switch self {
+        case .connectHeader,
+             .connectButton,
+             .connectImage:
+            return UITableView.automaticDimension
+        case .connectHelpHintChargeReader,
+             .connectHelpHintTurnOnReader,
+             .connectHelpHintEnableBluetooth,
+             .connectLearnMore:
+            return 70
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
+    }
+}
+
+// MARK: - Localization
+//
+private extension CardReaderSettingsUnknownViewController {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Manage Card Reader",
+            comment: "Title for the no-reader-connected screen in settings."
+        )
+
+        static let connectYourCardReaderTitle = NSLocalizedString(
+            "Connect your card reader",
+            comment: "Settings > Manage Card Reader > Prompt user to connect their first reader"
+        )
+
+        static let hintOneTitle = NSLocalizedString(
+            "1",
+            comment: "Settings > Manage Card Reader > Connect > Help hint number 1"
+        )
+
+        static let hintOne = NSLocalizedString(
+            "Make sure card reader is charged",
+            comment: "Settings > Manage Card Reader > Connect > Hint to charge card reader"
+        )
+
+        static let hintTwoTitle = NSLocalizedString(
+            "2",
+            comment: "Settings > Manage Card Reader > Connect > Help hint number 2"
+        )
+
+        static let hintTwo = NSLocalizedString(
+            "Turn card reader on and place it next to mobile device",
+            comment: "Settings > Manage Card Reader > Connect > Hint to power on reader"
+        )
+
+        static let hintThreeTitle = NSLocalizedString(
+            "3",
+            comment: "Settings > Manage Card Reader > Connect > Help hint number 3"
+        )
+
+        static let hintThree = NSLocalizedString(
+            "Turn mobile device Bluetooth on",
+            comment: "Settings > Manage Card Reader > Connect > Hint to enable Bluetooth"
+        )
+
+        static let connectButton = NSLocalizedString(
+            "Connect Card Reader",
+            comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
+        )
+
+        static let learnMore = NSLocalizedString(
+            "Learn more about accepting payments with your mobile device and ordering card readers",
+            comment: "Settings > Manage Card Reader > Connect > A prompt for new users to start accepting mobile payments"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -60,6 +60,7 @@ private extension CardReaderSettingsUnknownViewController {
     }
 
     func configureTable() {
+        tableView.rowHeight = UITableView.automaticDimension
         tableView.dataSource = self
         tableView.delegate = self
         tableView.reloadData()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -458,6 +458,8 @@
 		31186FF325DF220B001A28D3 /* CardReaderSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31186FF225DF220B001A28D3 /* CardReaderSettingsViewModel.swift */; };
 		3118700725E06758001A28D3 /* CardReaderSettingsConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3118700625E06758001A28D3 /* CardReaderSettingsConnectView.swift */; };
 		31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */; };
+		314265AC26459F7300500598 /* CardReaderSettingsUnknownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */; };
+		314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */; };
 		31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */; };
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
 		3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */; };
@@ -1688,6 +1690,8 @@
 		31186FF225DF220B001A28D3 /* CardReaderSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewModel.swift; sourceTree = "<group>"; };
 		3118700625E06758001A28D3 /* CardReaderSettingsConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectView.swift; sourceTree = "<group>"; };
 		31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModel.swift; sourceTree = "<group>"; };
+		314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewController.swift; sourceTree = "<group>"; };
+		314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewController.swift; sourceTree = "<group>"; };
 		31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectedReaderTableViewCell.xib; sourceTree = "<group>"; };
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
 		3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModel.swift; sourceTree = "<group>"; };
@@ -3556,6 +3560,8 @@
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
 				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
 				31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */,
+				314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */,
+				314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */,
 			);
 			path = CardReadersV2;
 			sourceTree = "<group>";
@@ -6482,6 +6488,7 @@
 				02CB9BE424E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
+				314265AC26459F7300500598 /* CardReaderSettingsUnknownViewController.swift in Sources */,
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				02619858256B53DD00E321E9 /* AggregatedShippingLabelOrderItems.swift in Sources */,
@@ -6772,6 +6779,7 @@
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
+				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,
 				45CE2D852625D7ED00E3CA00 /* SelectableItemRow.swift in Sources */,


### PR DESCRIPTION
Closes #4052

Note: This is against feature/stripe-terminal-sdk-integration, not develop

Changes:

- This is the next step in Card Reader Settings v2. In this step we add the first child view controller as a pattern to follow. We also add a bit of the second for grins.
- Note especially the code in `onViewModelsPriorityChanged` which adds and removes the child view controller as shouldShow dictates
- Note that the no-known no-connected view controller section and rows code is largely copied from the v1 implementation

To test:

- Launch the app
- Navigate to Settings (Gear) and then Manage Card Readers V2
- Ensure it shows the familiar "connect your reader" view - note that connecting the button comes in the next PR
- Navigate back to Settings (Gear)
- Navigate to Manage Card Readers (not V2)
- Connect your reader
- Navigate to Manage Card Readers V2
- Ensure it shows that the connected view is under construction (coming in 2-10)

Things to catch up on:
- Row separators should be suppressed
- Row height should be managed

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
