### PR TITLE
[Mobile Payments] Card Reader Settings 2-10: Populate the connected card reader in the connected view controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -293,7 +293,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="apN-yh-UaI">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="apN-yh-UaI">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -22,6 +22,11 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
     ///
     func configure(viewModel: CardReaderSettingsPresentedViewModel) {
         self.viewModel = viewModel as? CardReaderSettingsConnectedViewModel
+
+        guard self.viewModel != nil else {
+            DDLogError("Unexpectedly unable to downcast to CardReaderSettingsConnectedViewModel")
+            return
+        }
     }
 
     // MARK: - Overridden Methods

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -90,12 +90,8 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
-        guard let serialNumber = viewModel?.connectedReaderSerialNumber,
-              let batteryLevel = viewModel?.connectedReaderBatteryLevel else {
-            return
-        }
-        cell.serialNumberLabel?.text = serialNumber
-        cell.batteryLevelLabel?.text = batteryLevel
+        cell.serialNumberLabel?.text = viewModel?.connectedReaderSerialNumber
+        cell.batteryLevelLabel?.text = viewModel?.connectedReaderBatteryLevel
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -101,4 +101,3 @@ private extension CardReaderSettingsConnectedViewModel {
         )
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -9,6 +9,9 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var didGetConnectedReaders: Bool = false
     private var connectedReaders = [CardReader]()
 
+    var connectedReaderSerialNumber: String?
+    var connectedReaderBatteryLevel: String?
+
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
 
         self.didChangeShouldShow = didChangeShouldShow
@@ -28,9 +31,29 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             }
             self.didGetConnectedReaders = true
             self.connectedReaders = readers
+            self.updateProperties()
             self.reevaluateShouldShow()
         }
         ServiceLocator.stores.dispatch(action)
+    }
+
+    private func updateProperties() {
+        guard connectedReaders.count > 0 else {
+            connectedReaderSerialNumber = nil
+            connectedReaderBatteryLevel = nil
+            return
+        }
+
+        connectedReaderSerialNumber = connectedReaders[0].serial
+
+        guard let batteryLevel = connectedReaders[0].batteryLevel else {
+            connectedReaderBatteryLevel = Localization.unknownBatteryStatus
+            return
+        }
+
+        let batteryLevelPercent = Int(100 * batteryLevel)
+        let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
+        connectedReaderBatteryLevel = String.localizedStringWithFormat(Localization.batteryLabelFormat, batteryLevelString)
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not
@@ -57,3 +80,25 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         }
     }
 }
+
+// MARK: - Localization
+//
+private extension CardReaderSettingsConnectedViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Connected Reader",
+            comment: "Settings > Manage Card Reader > Connected Reader Table Section Heading"
+        )
+
+        static let unknownBatteryStatus = NSLocalizedString(
+            "Unknown Battery Level",
+            comment: "Displayed in the unlikely event a card reader has an indeterminate battery status"
+        )
+
+        static let batteryLabelFormat = NSLocalizedString(
+            "%1$@%% Battery",
+            comment: "Card reader battery level as an integer percentage"
+        )
+    }
+}
+

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -37,6 +37,11 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
             return
         }
 
+        guard let presenter = childViewController as? CardReaderSettingsViewModelPresenter else {
+            return
+        }
+        presenter.configure(viewModel: viewModelAndView!.viewModel)
+
         self.view.addSubview(childViewController.view)
         self.addChild(childViewController)
         childViewController.didMove(toParent: self)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -22,6 +22,11 @@ final class CardReaderSettingsUnknownViewController: UIViewController, CardReade
     ///
     func configure(viewModel: CardReaderSettingsPresentedViewModel) {
         self.viewModel = viewModel as? CardReaderSettingsUnknownViewModel
+
+        guard self.viewModel != nil else {
+            DDLogError("Unexpectedly unable to downcast to CardReaderSettingsUnknownViewModel")
+            return
+        }
     }
 
     // MARK: - Overridden Methods

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 /// This view controller is used when no readers are known or connected. It assists
 /// the merchant in connecting to a reader, often for the first time.
 ///
-final class CardReaderSettingsUnknownViewController: UIViewController {
+final class CardReaderSettingsUnknownViewController: UIViewController, CardReaderSettingsViewModelPresenter {
 
     /// Main TableView
     ///
@@ -18,6 +18,12 @@ final class CardReaderSettingsUnknownViewController: UIViewController {
     ///
     private var sections = [Section]()
 
+    /// Accept our viewmodel
+    ///
+    func configure(viewModel: CardReaderSettingsPresentedViewModel) {
+        self.viewModel = viewModel as? CardReaderSettingsUnknownViewModel
+    }
+
     // MARK: - Overridden Methods
 
     override func viewDidLoad() {
@@ -27,10 +33,6 @@ final class CardReaderSettingsUnknownViewController: UIViewController {
         configureNavigation()
         configureSections()
         configureTable()
-    }
-
-    func configure(viewModel: CardReaderSettingsUnknownViewModel) {
-        self.viewModel = viewModel
     }
 }
 
@@ -186,6 +188,11 @@ extension CardReaderSettingsUnknownViewController: UITableViewDataSource {
 //
 extension CardReaderSettingsUnknownViewController: UITableViewDelegate {
 
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let row = rowAtIndexPath(indexPath)
+        return row.height
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
@@ -253,7 +260,7 @@ private extension CardReaderSettingsUnknownViewController {
     enum Localization {
         static let title = NSLocalizedString(
             "Manage Card Reader",
-            comment: "Title for the no-reader-connected screen in settings."
+            comment: "Settings > Manage Card Reader > Title for the no-reader-connected screen in settings."
         )
 
         static let connectYourCardReaderTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelPresenter.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol CardReaderSettingsViewModelPresenter {
+    func configure(viewModel: CardReaderSettingsPresentedViewModel)
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */; };
 		314265AC26459F7300500598 /* CardReaderSettingsUnknownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */; };
 		314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */; };
+		3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */; };
 		31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */; };
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
 		3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */; };
@@ -1692,6 +1693,7 @@
 		31316F9B25CB20FD00D9F129 /* OrderStatusListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModel.swift; sourceTree = "<group>"; };
 		314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewController.swift; sourceTree = "<group>"; };
 		314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewController.swift; sourceTree = "<group>"; };
+		3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewModelPresenter.swift; sourceTree = "<group>"; };
 		31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectedReaderTableViewCell.xib; sourceTree = "<group>"; };
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
 		3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModel.swift; sourceTree = "<group>"; };
@@ -3556,6 +3558,7 @@
 			children = (
 				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
 				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
+				3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */,
 				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
 				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
@@ -6586,6 +6589,7 @@
 				02EAB6D92480AA4900FD873C /* SentryCrashLogger.swift in Sources */,
 				02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
+				3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,


### PR DESCRIPTION
Closes #4056

Note: This is against feature/stripe-terminal-sdk-integration, not develop

Changes:

- I skipped ahead a little to finish populating the connected view with the unknown view fresh in mind.
- This is a next step in Card Reader Settings v2. In this step we add the second child view controller and pass viewmodels into both this view controller and the one added earlier.

To test:

- Launch the app
- Navigate back to Settings (Gear)
- Navigate to Manage Card Readers (not V2)
- Connect your reader
- Navigate to Manage Card Readers V2
- Ensure it shows the connected reader and its battery level. Disconnect comes in a later issue.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
