### PR TITLE
Plugins: Sync site plugins automatically

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -53,6 +53,7 @@ class AuthenticatedState: StoresManagerState {
             SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ShipmentStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            SitePluginStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             SitePostStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network),
             TaxClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -358,6 +358,17 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
+    /// Synchronizes all plugins for the store with specified ID.
+    ///
+    func synchronizePlugins(siteID: Int64) {
+        let action = SitePluginAction.synchronizeSitePlugins(siteID: siteID) { result in
+            if let error = result.failure {
+                DDLogError("⛔️ Failed to sync plugins for siteID: \(siteID). Error: \(error)")
+            }
+        }
+        dispatch(action)
+    }
+
     /// Loads the Default Site into the current Session, if possible.
     ///
     func restoreSessionSiteIfPossible() {
@@ -373,6 +384,7 @@ private extension DefaultStoresManager {
         retrieveOrderStatus(with: siteID)
         synchronizePaymentGateways(siteID: siteID)
         synchronizeAddOnsGroups(siteID: siteID)
+        synchronizePlugins(siteID: siteID)
     }
 
     /// Loads the specified siteID into the Session, if possible.

--- a/Yosemite/Yosemite/Base/Dispatcher.swift
+++ b/Yosemite/Yosemite/Base/Dispatcher.swift
@@ -69,7 +69,12 @@ public class Dispatcher {
     public func dispatch(_ action: Action) {
         assertMainThread()
 
-        processors[action.identifier]?.onAction(action)
+        // Avoid silent failure when a store is not retained
+        guard let processor = processors[action.identifier] else {
+            assertionFailure("⛔️ No processor found for \(action.identifier)!")
+            return
+        }
+        processor.onAction(action)
     }
 }
 

--- a/Yosemite/Yosemite/Base/Dispatcher.swift
+++ b/Yosemite/Yosemite/Base/Dispatcher.swift
@@ -71,8 +71,7 @@ public class Dispatcher {
 
         // Avoid silent failure when a store is not retained
         guard let processor = processors[action.identifier] else {
-            assertionFailure("⛔️ No processor found for \(action.identifier)!")
-            return
+            return DDLogWarn("⚠️ No processor found for \(action.identifier)!")
         }
         processor.onAction(action)
     }


### PR DESCRIPTION
Part of #4114 and #3921

## Description
To handle automatic synchronization of site plugins, the data has to be synced in 3 scenarios: 
- After user is logged in and select a site they own.
- When app launches if user is already authenticated.
- After user change selected site.

These 3 cases are all covered when restoring session site, so this is the perfect place to trigger synchronization of plugins.

## Solution
- Create a SitePluginStore instance and retain it in AuthenticatedState
- Add new private method to sync site plugin in `restoreSessionSiteIfPossible` method of `DefaultStoresManager`.
- Since there's a chance of silent failure when trying to dispatch an action whose accompanying store hasn't been retained, I also added an `assertionFailure` to warn about the issue. This does not change the main behavior of the Dispatcher, so I think it's appropriate to include it in this PR.

## Testing
It's not yet possible to write tests to check for appropriate triggering of actions in `DefaultStoresManager`. For now, a quick test would be to add a breakpoint in `onAction` method of `SitePluginStore`, make sure that the application pauses there when running the above 3 scenarios.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
