### PR TITLE
[Mobile Payments] Reset Stripe Terminal SDK when logging out and/or switching stores

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -134,7 +134,6 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func clear() {
-        // 🧹
         Terminal.shared.clearCachedCredentials()
     }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -20,8 +20,6 @@ public final class StripeCardReaderService: NSObject {
     private let discoveredStripeReadersCache = StripeCardReaderDiscoveryCache()
 
     private var pendingSoftwareUpdate: ReaderSoftwareUpdate?
-
-    private var initialized: Bool = false
 }
 
 
@@ -63,7 +61,6 @@ extension StripeCardReaderService: CardReaderService {
 
     public func start(_ configProvider: CardReaderConfigProvider) {
         setConfigProvider(configProvider)
-        initialized = true
 
         let config = DiscoveryConfiguration(
             discoveryMethod: .bluetoothProximity,
@@ -112,13 +109,13 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func disconnect() -> Future<Void, Error> {
-        return Future() { [weak self] promise in
+        return Future() { promise in
             // Throw an error if the SDK has not been initialized.
             // This prevent a crash when logging out or switching stores before
             // the SDK has been initialized.
             // Why? https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(cpy)shared
             // `Before accessing the singleton for the first time, you must first call setTokenProvider: and setDelegate:.`
-            guard self?.initialized == true else {
+            guard Terminal.hasTokenProvider() else {
                 promise(.failure(CardReaderServiceError.disconnection()))
                 return
             }
@@ -152,7 +149,7 @@ extension StripeCardReaderService: CardReaderService {
         // the SDK has been initialized.
         // Why? https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(cpy)shared
         // `Before accessing the singleton for the first time, you must first call setTokenProvider: and setDelegate:.`
-        guard initialized == true else {
+        guard Terminal.hasTokenProvider() else {
             return
         }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -152,7 +152,7 @@ extension StripeCardReaderService: CardReaderService {
         guard Terminal.hasTokenProvider() else {
             return
         }
-
+        print("=== clearing")
         Terminal.shared.clearCachedCredentials()
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -69,7 +69,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
             group.enter()
-            let resetAction = CardPresentPaymentAction.restart
+            let resetAction = CardPresentPaymentAction.reset
 
             stores.dispatch(resetAction)
 

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -67,6 +67,15 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         }
         stores.dispatch(reviewAction)
 
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
+            group.enter()
+            let resetAction = CardPresentPaymentAction.restart
+
+            stores.dispatch(resetAction)
+
+            group.leave()
+        }
+
         group.notify(queue: .main) {
             onCompletion()
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -159,7 +159,7 @@ class DefaultStoresManager: StoresManager {
     @discardableResult
     func deauthenticate() -> StoresManager {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
-            let resetAction = CardPresentPaymentAction.restart
+            let resetAction = CardPresentPaymentAction.reset
 
             ServiceLocator.stores.dispatch(resetAction)
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -158,6 +158,12 @@ class DefaultStoresManager: StoresManager {
     ///
     @discardableResult
     func deauthenticate() -> StoresManager {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
+            let resetAction = CardPresentPaymentAction.restart
+
+            ServiceLocator.stores.dispatch(resetAction)
+        }
+
         state = DeauthenticatedState()
 
         sessionManager.reset()

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -54,5 +54,5 @@ public enum CardPresentPaymentAction: Action {
     /// 1. Disconnect from a connected reader
     /// 2. Clear all credentials, cached data
     /// 3. Reset all status indicators
-    case restart
+    case reset
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -41,10 +41,18 @@ public enum CardPresentPaymentAction: Action {
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onCompletion: (Result<PaymentIntent, Error>) -> Void )
 
+    /// Check whether there is a software update available.
     case checkForCardReaderUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
                         onCompletion: () -> Void)
 
+    /// Update card reader firmware.
     case startCardReaderUpdate(onProgress: (Float) -> Void,
                         onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Restarts the card present payments system
+    /// This might imply, but not be limited to:
+    /// 1. Disconnect from a connected reader
+    /// 2. Clear all credentials, cached data
+    /// 3. Reset all status indicators
+    case restart
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -58,8 +58,8 @@ public final class CardPresentPaymentStore: Store {
             checkForCardReaderUpdate(onData: data, onCompletion: completion)
         case .startCardReaderUpdate(onProgress: let progress, onCompletion: let completion):
             startCardReaderUpdate(onProgress: progress, onCompletion: completion)
-        case .restart:
-            restart()
+        case .reset:
+            reset()
         }
     }
 }
@@ -188,11 +188,10 @@ private extension CardPresentPaymentStore {
         }.store(in: &cancellables)
     }
 
-    func restart() {
+    func reset() {
         cardReaderService.disconnect().sink(receiveCompletion: { [weak self] _ in
             self?.cardReaderService.clear()
-        }, receiveValue: { [weak self] value in
-            self?.cardReaderService.clear()
+        }, receiveValue: {
         }).store(in: &cancellables)
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -58,6 +58,8 @@ public final class CardPresentPaymentStore: Store {
             checkForCardReaderUpdate(onData: data, onCompletion: completion)
         case .startCardReaderUpdate(onProgress: let progress, onCompletion: let completion):
             startCardReaderUpdate(onProgress: progress, onCompletion: completion)
+        case .restart:
+            restart()
         }
     }
 }
@@ -184,6 +186,14 @@ private extension CardPresentPaymentStore {
         cardReaderService.softwareUpdateEvents.sink { progress in
             onProgress(progress)
         }.store(in: &cancellables)
+    }
+
+    func restart() {
+        cardReaderService.disconnect().sink(receiveCompletion: { [weak self] _ in
+            self?.cardReaderService.clear()
+        }, receiveValue: { [weak self] value in
+            self?.cardReaderService.clear()
+        }).store(in: &cancellables)
     }
 }
 


### PR DESCRIPTION
Closes #4111 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader and uploading a pre-release version of WCPay to a test site⚠️

This PR starts where #4140 ends. As pointed out [in this comment](https://github.com/woocommerce/woocommerce-ios/issues/4111#issuecomment-831909896) the Stripe Terminal SDK [supports multiple accounts and provides a mechanism for switching accounts](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)clearCachedCredentials).

## Changes
* Add a new action to CardPresentPaymentAction to reset the payments integration, and its implementation in CardPresentPaymentStore. This action calls disconnect and clearCacheCredentials in sequence.
* There be dragons though. `disconnect ` would crash [if called before the Terminal has been provided with a way to fetch connection tokens](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(cpy)shared). So we need to add a bit of state tracking to StripeCardReaderService.

## How to test.
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)
3. An external hardware reader.

* Checkout the branch, build and run on device.
* Add a breakpoint to StripeCardReaderService, line 159.
<img width="350" alt="Screen Shot 2021-05-09 at 15 29 47" src="https://user-images.githubusercontent.com/2722505/117584508-6d1ee600-b0db-11eb-93ca-d23d2d09ee48.png">

* Log in, and log out immediately, without doing any operations related to payments. The breakpoint added to StripeCardReaderService should not be hit.
* Log in to a store that does not support payments. Log out or switch to a store that supports payments, the breakpoint should not be hit.
* Log in, switch to a store that supports payments. Connect to a reader. Switch stores, and the breakpoint should be hit. Switch back to the original store, attempt to pair to a reader again. It should work.
* Log in to a store that support payments. Connect to a reader. Log out. The breakpoint should be hit.
* Any variations and combinations of the above that you could think of.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
