### PR TITLE
[Mobile Payments] Refresh order after completing mobile payment

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -555,7 +555,7 @@ private extension OrderDetailsViewController {
                     // To be implemented.
                 })
             case .success(let receiptParameters):
-                self.pullToRefresh()
+                self.syncOrder()
                 self.paymentAlerts.success(printReceipt: {
                     self.viewModel.printReceipt(params: receiptParameters)
                 }, emailReceipt: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -407,6 +407,24 @@ private extension OrderDetailsViewController {
             self?.reloadSections()
         }
     }
+
+    func syncOrderAfterPaymentCollection() {
+        let group = DispatchGroup()
+
+        group.enter()
+        syncOrder { _ in
+            group.leave()
+        }
+
+        group.enter()
+        syncNotes { _ in
+            group.leave()
+        }
+
+        group.notify(queue: .main) {
+            NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
+        }
+    }
 }
 
 
@@ -555,7 +573,8 @@ private extension OrderDetailsViewController {
                     // To be implemented.
                 })
             case .success(let receiptParameters):
-                self.syncOrder()
+                self.syncOrderAfterPaymentCollection()
+
                 self.paymentAlerts.success(printReceipt: {
                     self.viewModel.printReceipt(params: receiptParameters)
                 }, emailReceipt: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -408,7 +408,7 @@ private extension OrderDetailsViewController {
         }
     }
 
-    func syncOrderAfterPaymentCollection() {
+    func syncOrderAfterPaymentCollection(onCompletion: @escaping ()-> Void) {
         let group = DispatchGroup()
 
         group.enter()
@@ -423,6 +423,7 @@ private extension OrderDetailsViewController {
 
         group.notify(queue: .main) {
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
+            onCompletion()
         }
     }
 }
@@ -573,7 +574,9 @@ private extension OrderDetailsViewController {
                     // To be implemented.
                 })
             case .success(let receiptParameters):
-                self.syncOrderAfterPaymentCollection()
+                self.syncOrderAfterPaymentCollection {
+                    self.checkCardPresentPaymentEligibility()
+                }
 
                 self.paymentAlerts.success(printReceipt: {
                     self.viewModel.printReceipt(params: receiptParameters)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -322,7 +322,7 @@ extension OrderDetailsViewController {
             group.leave()
         }
 
-	group.enter()
+        group.enter()
         checkOrderAddOnFeatureSwitchState {
             group.leave()
         }
@@ -555,6 +555,7 @@ private extension OrderDetailsViewController {
                     // To be implemented.
                 })
             case .success(let receiptParameters):
+                self.pullToRefresh()
                 self.paymentAlerts.success(printReceipt: {
                     self.viewModel.printReceipt(params: receiptParameters)
                 }, emailReceipt: {


### PR DESCRIPTION
Closes #4097 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️
⚠️ Testing this PR requires a hardware reader and uploading a pre-release version of WCPay to a test site⚠️

Reload an Order and the associated Order Notes after a payment has been collected successfully. 


https://user-images.githubusercontent.com/2722505/117584817-0a2e4e80-b0dd-11eb-90a0-8e88bb3b9412.MP4



## Changes:
* Trigger a reload of Order and Order notes after the payment has been successfully captured.
* Force a reload of the OrderDetailsViewController, so that the "Collect Payment" button should disappear and the Order notes should be updated.

This PR does not add any new UI. It looks like the reload can happen in the background while the receipt is printed / emailed. (for context: p91TBi-56v-p2)

## How to test
* Checkout the branch, run bundle exec pod install, just for kicks and giggles.
* Build and run on a device.
* Switch an external card reader on. The only card reader supported by now is the BBPOS Chipper 2X BT.
* Log in to an account that matches a store that has been configured for testing.
* Navigate to Settings in the app. (Tap the gear button in the top right)
* In the "Store Settings" section, tap "Manage Card Reader".
* Tap "Connect card reader"
* Wait until the app suggests one reader to connect to.
* Tap "Connect to reader"
* Make sure the reader light turns solid blue.
* Navigate to Cash On Delivery order.
* Tap "Collect Payment", and follow the prompts on screen.
* The order whole be refreshed once the "success" modal view is presented, and the order details screen should be refreshed in the backgound. The "Collect Payment" button should disappear and the order notes should be updated with the payment information.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
