### PR TITLE
Plugins: Redirect from Settings to Plugin List screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UIStoryboard+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIStoryboard+Woo.swift
@@ -23,9 +23,10 @@ extension UIStoryboard {
 //
 extension UIStoryboard {
     /// Returns a view controller from a Storyboard assuming the identifier is the same as the class name.
+    /// Accepts an optional creator to inject additional dependencies.
     ///
-    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
+    func instantiateViewController<T: UIViewController>(ofClass classType: T.Type, creator: ((NSCoder) -> T?)? = nil) -> T {
         let identifier = classType.classNameWithoutNamespaces
-        return instantiateViewController(withIdentifier: identifier) as? T
+        return instantiateViewController(identifier: identifier, creator: creator)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -209,6 +210,21 @@
             </objects>
             <point key="canvasLocation" x="2265" y="1525"/>
         </scene>
+        <!--Plugin List View Controller-->
+        <scene sceneID="kYl-xg-36f">
+            <objects>
+                <viewController storyboardIdentifier="PluginListViewController" id="rNI-xD-4Pa" customClass="PluginListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="H3q-kl-QLM">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="LSI-yY-JbA"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BoI-9E-doH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3370" y="1529"/>
+        </scene>
         <!--Card Reader Settings View Controller-->
         <scene sceneID="lIS-bL-sjX">
             <objects>
@@ -240,6 +256,9 @@
     <resources>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+class PluginListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -2,6 +2,17 @@ import UIKit
 
 class PluginListViewController: UIViewController {
 
+    private let viewModel: PluginListViewModel
+
+    init?(coder: NSCoder, viewModel: PluginListViewModel) {
+        self.viewModel = viewModel
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("⛔️ You must create this view controller with a view model!")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -12,7 +12,7 @@ class PluginListViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("⛔️ You must create this view controller with a view model!")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Yosemite
+
+final class PluginListViewModel {
+
+    /// Reference to the StoresManager to dispatch Yosemite Actions.
+    ///
+    private let storesManager: StoresManager
+
+    init(storesManager: StoresManager) {
+        self.storesManager = storesManager
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -3,11 +3,25 @@ import Yosemite
 
 final class PluginListViewModel {
 
+    /// Whether synchronization failed and error state should be displayed
+    ///
+    @Published var shouldShowErrorState: Bool = false
+
     /// Reference to the StoresManager to dispatch Yosemite Actions.
     ///
     private let storesManager: StoresManager
 
     init(storesManager: StoresManager = ServiceLocator.stores) {
         self.storesManager = storesManager
+    }
+
+    func syncPlugins() {
+        guard let id = storesManager.sessionManager.defaultStoreID else {
+            return
+        }
+        let action = SitePluginAction.synchronizeSitePlugins(siteID: id) { [weak self] result in
+            self?.shouldShowErrorState = result.isFailure
+        }
+        storesManager.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -7,7 +7,7 @@ final class PluginListViewModel {
     ///
     private let storesManager: StoresManager
 
-    init(storesManager: StoresManager) {
+    init(storesManager: StoresManager = ServiceLocator.stores) {
         self.storesManager = storesManager
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -7,19 +7,21 @@ final class PluginListViewModel {
     ///
     @Published var shouldShowErrorState: Bool = false
 
+    /// ID of the site to load plugins for
+    ///
+    private let siteID: Int64
+
     /// Reference to the StoresManager to dispatch Yosemite Actions.
     ///
     private let storesManager: StoresManager
 
-    init(storesManager: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64, storesManager: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
         self.storesManager = storesManager
     }
 
     func syncPlugins() {
-        guard let id = storesManager.sessionManager.defaultStoreID else {
-            return
-        }
-        let action = SitePluginAction.synchronizeSitePlugins(siteID: id) { [weak self] result in
+        let action = SitePluginAction.synchronizeSitePlugins(siteID: siteID) { [weak self] result in
             self?.shouldShowErrorState = result.isFailure
         }
         storesManager.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -382,8 +382,13 @@ private extension SettingsViewController {
 
     func sitePluginsWasPressed() {
         // TODO: do we need analytics to track tap here?
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            DDLogError("⛔️ Cannot find ID for current site to load plugins for!")
+            return
+        }
+        let viewModel = PluginListViewModel(siteID: siteID)
         let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PluginListViewController.self, creator: { coder in
-            PluginListViewController(coder: coder, viewModel: PluginListViewModel())
+            PluginListViewController(coder: coder, viewModel: viewModel)
         })
         show(viewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -386,41 +386,31 @@ private extension SettingsViewController {
 
     func supportWasPressed() {
         ServiceLocator.analytics.track(.settingsContactSupportTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: HelpAndSupportViewController.self) else {
-            fatalError("Cannot instantiate `HelpAndSupportViewController` from Dashboard storyboard")
-        }
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: HelpAndSupportViewController.self)
         show(viewController, sender: self)
     }
 
     func cardReadersWasPressed() {
         ServiceLocator.analytics.track(.settingsCardReadersTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self) else {
-            fatalError("Cannot instantiate `CardReaderSettingsViewController` from Dashboard storyboard")
-        }
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsViewController.self)
         show(viewController, sender: self)
     }
 
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
-            fatalError("Cannot instantiate `PrivacySettingsViewController` from Dashboard storyboard")
-        }
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self)
         show(viewController, sender: self)
     }
 
     func aboutWasPressed() {
         ServiceLocator.analytics.track(.settingsAboutLinkTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: AboutViewController.self) else {
-            fatalError("Cannot instantiate `AboutViewController` from Dashboard storyboard")
-        }
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: AboutViewController.self)
         show(viewController, sender: self)
     }
 
     func licensesWasPressed() {
         ServiceLocator.analytics.track(.settingsLicensesLinkTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: LicensesViewController.self) else {
-            fatalError("Cannot instantiate `LicensesViewController` from Dashboard storyboard")
-        }
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: LicensesViewController.self)
         show(viewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -381,7 +381,11 @@ private extension SettingsViewController {
     }
 
     func sitePluginsWasPressed() {
-        // TODO: Pending implementation for issue #4114
+        // TODO: do we need analytics to track tap here?
+        let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PluginListViewController.self, creator: { coder in
+            PluginListViewController(coder: coder, viewModel: PluginListViewModel())
+        })
+        show(viewController, sender: self)
     }
 
     func supportWasPressed() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1119,6 +1119,7 @@
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
+		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2325,6 +2326,7 @@
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
+		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -5468,6 +5470,7 @@
 			isa = PBXGroup;
 			children = (
 				DE8C94652646990000C94823 /* PluginListViewController.swift */,
+				DE8C946D264699B600C94823 /* PluginListViewModel.swift */,
 			);
 			path = Plugins;
 			sourceTree = "<group>";
@@ -6551,6 +6554,7 @@
 				743EDD9F214B05350039071B /* TopEarnerStatsItem+Woo.swift in Sources */,
 				B5BBD6DE21B1703700E3207E /* PushNotificationsManager.swift in Sources */,
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,
+				DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */,
 				45E9A6E924DAE3B800A600E8 /* ProductReviewsDataSource.swift in Sources */,
 				02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */,
 				021125992578D9C20075AD2A /* ShippingLabelPrintingInstructionsView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1118,6 +1118,7 @@
 		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
+		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2323,6 +2324,7 @@
 		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
+		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -5223,6 +5225,7 @@
 		CE85FD5820F7A59E0080B73E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DE8C9464264698E800C94823 /* Plugins */,
 				74C6FEA321C2F189009286B6 /* About */,
 				02D4564A231D059E008CF0A9 /* Beta features */,
 				318A9E8F25D301C60032C245 /* CardReaders */,
@@ -5459,6 +5462,14 @@
 				57532CAB24BFF4DA0032B84E /* MessageComposerPresenter.swift */,
 			);
 			path = ServiceLocator;
+			sourceTree = "<group>";
+		};
+		DE8C9464264698E800C94823 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				DE8C94652646990000C94823 /* PluginListViewController.swift */,
+			);
+			path = Plugins;
 			sourceTree = "<group>";
 		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
@@ -6165,6 +6176,7 @@
 				456396A725C81C9A001F1A26 /* ShippingLabelFormViewController.swift in Sources */,
 				02DD81FA242CAA400060E50B /* Media+WPMediaAsset.swift in Sources */,
 				2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */,
+				DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */,
 				024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */,
 				029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,


### PR DESCRIPTION
Part of #4114 and #3921 
Please make sure that #4146 is merged before testing this.

## Description
To display the list of installed plugins for a selected site, a new view controller needs to be created and showed from the Plugins entry point in the Settings screen. 

## Solution
- I chose MVVM pattern and UIKit to build the Plugin List screen since there's no native support for refresh control in SwiftUI and current solutions aren't really performant and straightforward.
- The view model is injected into PluginListViewController upon initialization. Since I added the view controller to the Dashboard storyboard, I also updated the storyboard extension to [accept `creator` block](https://developer.apple.com/documentation/uikit/uistoryboard/3173166-instantiateviewcontrollerwithide?language=objc), which is a good place for dependency injection.
- PluginListViewModel is initialized with the injection of siteID and stores manager for better testability.

## Testing
When tapping on the Plugins entry point on Settings screen, a new screen should be pushed. This screen is currently empty and will be updated in the next PR.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.