### PR TITLE
Shipping Labels: Add Codegen import for GeneratedFakeable

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelCreationEligibilityResponse.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Codegen
 
 /// Represents a Shipping Label Creation Eligibility response for an order.
 ///

--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -24,9 +24,9 @@ class StorageTypeDeletionsTests: XCTestCase {
     func test_deleteStaleAddOnGroups_does_not_delete_active_addOns() throws {
         // Given
         let initialGroups: [AddOnGroup] = [
-            createAddOnGroup(groupID: 123),
-            createAddOnGroup(groupID: 1234),
-            createAddOnGroup(groupID: 12345)
+            createAddOnGroup(groupID: 123, name: "AAA"),
+            createAddOnGroup(groupID: 1234, name: "BBB"),
+            createAddOnGroup(groupID: 12345, name: "CCC")
         ]
 
         // When
@@ -55,10 +55,11 @@ class StorageTypeDeletionsTests: XCTestCase {
 private extension StorageTypeDeletionsTests {
     /// Inserts and creates an `AddOnGroup` ready to be used on tests.
     ///
-    func createAddOnGroup(groupID: Int64) -> AddOnGroup {
+    func createAddOnGroup(groupID: Int64, name: String) -> AddOnGroup {
         let addOnGroup = storage.insertNewObject(ofType: AddOnGroup.self)
         addOnGroup.siteID = sampleSiteID
         addOnGroup.groupID = groupID
+        addOnGroup.name = name
         return addOnGroup
     }
 


### PR DESCRIPTION
## Description

This fixes the build error in `develop` after https://github.com/woocommerce/woocommerce-ios/pull/4138 was merged. It adds a `Codegen` import to support the changes to `fakeable` types from https://github.com/woocommerce/woocommerce-ios/pull/4117.

## Testing

* Confirm the app builds and tests pass.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
