### PR TITLE
Fix storage tests inconsistent order

### DIFF
--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -24,9 +24,9 @@ class StorageTypeDeletionsTests: XCTestCase {
     func test_deleteStaleAddOnGroups_does_not_delete_active_addOns() throws {
         // Given
         let initialGroups: [AddOnGroup] = [
-            createAddOnGroup(groupID: 123),
-            createAddOnGroup(groupID: 1234),
-            createAddOnGroup(groupID: 12345)
+            createAddOnGroup(groupID: 123, name: "AAA"),
+            createAddOnGroup(groupID: 1234, name: "BBB"),
+            createAddOnGroup(groupID: 12345, name: "CCC")
         ]
 
         // When
@@ -55,10 +55,11 @@ class StorageTypeDeletionsTests: XCTestCase {
 private extension StorageTypeDeletionsTests {
     /// Inserts and creates an `AddOnGroup` ready to be used on tests.
     ///
-    func createAddOnGroup(groupID: Int64) -> AddOnGroup {
+    func createAddOnGroup(groupID: Int64, name: String) -> AddOnGroup {
         let addOnGroup = storage.insertNewObject(ofType: AddOnGroup.self)
         addOnGroup.siteID = sampleSiteID
         addOnGroup.groupID = groupID
+        addOnGroup.name = name
         return addOnGroup
     }
 


### PR DESCRIPTION
## Description

This fixes inconsistency of Storage unit tests noticed (but not introduced) in https://github.com/woocommerce/woocommerce-ios/pull/4152

I can reproduce this error for around a half of my test runs.

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/3132438/117659181-4e385680-b1a4-11eb-99fb-7f83bb133fa1.png">

## Test

- Just check CI status.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
