### PR TITLE
[Mobile Payments] Reader Settings 2-11 Hook up disconnect button

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -69,6 +69,8 @@ extension StripeCardReaderService: CardReaderService {
 
         switchStatusToDiscovering()
 
+        Terminal.shared.delegate = self
+
         /**
          * https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)discoverReaders:delegate:completion:
          *
@@ -334,6 +336,15 @@ extension StripeCardReaderService: ReaderDisplayDelegate {
 extension StripeCardReaderService: ReaderSoftwareUpdateDelegate {
     public func terminal(_ terminal: Terminal, didReportReaderSoftwareUpdateProgress progress: Float) {
         softwareUpdateSubject.send(progress)
+    }
+}
+
+
+// MARK: - Terminal delegate
+extension StripeCardReaderService: TerminalDelegate {
+    public func terminal(_ terminal: Terminal, didReportUnexpectedReaderDisconnect reader: Reader) {
+        print("==== didReportUnexpectedReaderDisconnect ===")
+        connectedReadersSubject.send([])
     }
 }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -127,6 +127,7 @@ extension StripeCardReaderService: CardReaderService {
                 }
 
                 if error == nil {
+                    self.connectedReadersSubject.send([])
                     promise(.success(()))
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -96,8 +96,8 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     private func configureButton(cell: ButtonTableViewCell) {
-        cell.configure(title: Localization.buttonTitle) {
-            // TODO: Connect in 4057
+        cell.configure(title: Localization.buttonTitle) { [weak self] in
+            self?.viewModel?.disconnectReader()
         }
         cell.selectionStyle = .none
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -38,6 +38,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     }
 
     private func updateProperties() {
+
         guard connectedReaders.count > 0 else {
             connectedReaderSerialNumber = nil
             connectedReaderBatteryLevel = nil
@@ -54,6 +55,18 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         let batteryLevelPercent = Int(100 * batteryLevel)
         let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
         connectedReaderBatteryLevel = String.localizedStringWithFormat(Localization.batteryLabelFormat, batteryLevelString)
+    }
+
+    /// Dispatch a request to disconnect from a reader
+    ///
+    func disconnectReader() {
+        let action = CardPresentPaymentAction.disconnect() { result in
+            guard result.isSuccess else {
+                DDLogError("Unexpected error when disconnecting reader")
+                return
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -23,6 +23,9 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
     }
 
     private func configureInitialState() {
+        /// To avoid child view controllers extending underneath the navigation bar
+        self.edgesForExtendedLayout = []
+
         onViewModelsPriorityChange(viewModelAndView: viewModelsAndViews?.priorityViewModelAndView)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3559,14 +3559,14 @@
 			isa = PBXGroup;
 			children = (
 				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
-				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
-				3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */,
-				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
-				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
-				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
-				31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */,
-				314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */,
 				314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */,
+				3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */,
+				318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */,
+				31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */,
+				31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */,
+				314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */,
+				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
+				3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */,
 			);
 			path = CardReadersV2;
 			sourceTree = "<group>";


### PR DESCRIPTION
Closes #4057 

Changes:
- Hooks up the disconnect button

To test:

- Settings > Manage Card Readers (not V1)
- Tap connect button
- Power on reader if needed
- Connect to reader once it is found
- Settings > Manage Card Readers V2
- Tap on disconnect button
- Ensure you are navigated back to the "connect a reader" view

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
