### PR TITLE
[Mobile Payments] Show "Collect Payment" and "Manage Card Readers" only for eligible accounts

### DIFF
--- a/Networking/Networking/Model/WCPayAccount.swift
+++ b/Networking/Networking/Model/WCPayAccount.swift
@@ -15,6 +15,8 @@ public struct WCPayAccount: Decodable {
     /// A two character country code, e.g. `US`
     /// See https://stripe.com/docs/api/accounts/object#account_object-country
     public let country: String
+    /// A boolean flag indicating if this Account can collect card present payments
+    public let canCollectPayments: Bool
 
     public init(
         status: WCPayAccountStatusEnum,
@@ -34,6 +36,8 @@ public struct WCPayAccount: Decodable {
         self.defaultCurrency = defaultCurrency
         self.supportedCurrencies = supportedCurrencies
         self.country = country
+        /// Hardcoded until support for this property in WCPay is available
+        self.canCollectPayments = true
     }
 
     /// The public initializer for WCPay Account.

--- a/Networking/Networking/Model/WCPayAccount.swift
+++ b/Networking/Networking/Model/WCPayAccount.swift
@@ -36,7 +36,7 @@ public struct WCPayAccount: Decodable {
         self.defaultCurrency = defaultCurrency
         self.supportedCurrencies = supportedCurrencies
         self.country = country
-        /// Hardcoded until support for this property in WCPay is available
+        /// Hardcoded until support for this property is available in WCPay
         self.canCollectPayments = true
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -426,20 +426,12 @@ extension OrderDetailsViewModel {
     }
 
     func checkCardPaymentEligibility(onCompletion: (() -> Void)? = nil) {
-        // For now, this defaults to the feature flag,
-        // combined with the order payment method being cash on delivery
-        // We also need to take into account wheter the store is enrolled into WCPay.
-        // TODO. This is synchronous for now, but it will be async in the nearly future:
-        // https://github.com/woocommerce/woocommerce-ios/issues/3828
-        // We need to add a unit test for this, after the logic is settled
-
         // Orders are eligible for card present payment if:
         // the status is pending or on hold
         // and
         // the payment method is none or cash on delivery
-        dataSource.isEligibleForCardPresentPayment = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) &&
-            isOrderEligibleForCardPayment()
-
+        // and
+        // if the account is eligible for card present payments
         let action = WCPayAction.loadAccount(siteID: order.siteID) { [weak self] result in
             guard let self = self else {
                 return


### PR DESCRIPTION
Closes #3828 . 

Well, not really, but reduces the scope of presenting functionality related to CPP to parsing a boolean flag in the Networking layer (#4160)

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️


## Changes
* Added a flag to WCPayAccount to signal if the account is enrolled into Card Present Payments. This flag is hardcoded to true at the moment because
a) We are waiting for this to happen: https://github.com/Automattic/woocommerce-payments-server/issues/725
b) we like to live dangerously.
* Added logic to OrderDetailsViewModel and SettingsViewController to fetch the WCPayAccount and then show or hide the "Collect Payment" button (in OrderDetailsViewModel) or the "Manage Card Settings" section (in SettingsViewController)

But wait! That requires a network request every time we present Settings or we navigate into the Order Details screen! 
True, it does, partially because WCPayAccount is not persisted to the coredata store yet, but also partially because we are going to have to refresh that account information anyway, every time we present the order details screen or the settings view, to make sure we don't show buttons e should not show. So 🤷🏼 

## How to test.
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)

Testing this PR does not require a hardware reader.

* Checkout the branch, build and run
* Navigate to Settings. If the store has WCPay installed, the "Store Settings" section should be visible. It takes a second.
* Navigate to a COD order. The "Collect Payment " button should be visible.
* In WCPayAccount, line 40, change the value of the flag `canCollectPayments` to false.

<img width="350" alt="Screen Shot 2021-05-10 at 16 21 01" src="https://user-images.githubusercontent.com/2722505/117719767-c8200e00-b1ab-11eb-97fe-b789cbcb9cfe.png">

* Build and run again. Navigate to Settings. There should not be a "Store Settings" section 
* Navigate to a COD order. There should not be a "Collect Payment" button

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
