### PR TITLE
[Mobile Payments] Card Reader Settings 2-8 Start/Cancel Reader Discovery

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -5,6 +5,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
 
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
+    var didUpdate: (() -> Void)?
 
     private var didGetConnectedReaders: Bool = false
     private var connectedReaders = [CardReader]()
@@ -13,9 +14,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     var connectedReaderBatteryLevel: String?
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
-
         self.didChangeShouldShow = didChangeShouldShow
-
         beginObservation()
     }
 
@@ -23,7 +22,6 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// connected readers.
     ///
     private func beginObservation() {
-
         // This completion should be called repeatedly as the list of connected readers changes
         let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
             guard let self = self else {
@@ -38,7 +36,6 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     }
 
     private func updateProperties() {
-
         guard connectedReaders.count > 0 else {
             connectedReaderSerialNumber = nil
             connectedReaderBatteryLevel = nil
@@ -73,7 +70,6 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Notifes the viewModel owner if a change occurs via didChangeShouldShow
     ///
     private func reevaluateShouldShow() {
-
         var newShouldShow: CardReaderSettingsTriState = .isUnknown
 
         if !didGetConnectedReaders {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentedViewViewModel.swift
@@ -1,9 +1,22 @@
 import Foundation
 import Combine
 
+/// Defines a protocol that all Card Reader Settings View Models should conform to
+///
 protocol CardReaderSettingsPresentedViewModel {
+    /// Whether this view model and the view it connects to should be shown
+    ///
     var shouldShow: CardReaderSettingsTriState { get }
+
+    /// Called whenever this view model has changed its `shouldShow` value
+    ///
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)? { get set }
+
+    /// Allows the view controller to register a callback to be informed when the viewmodel changes, e.g in
+    /// the view controller's `configure(viewModel: CardReaderSettingsPresentedViewModel)` method
+    /// Care should be taken to avoid reference cycles by un-setting the callback, e.g. in the view controller's `viewWillDisappear`
+    ///
+    var didUpdate: (() -> Void)? { get set }
 }
 
 struct CardReaderSettingsViewModelAndView: Equatable {


### PR DESCRIPTION
Closes #4054 

Changes:
- Hooks up `CardReaderSettingsUnknownViewController` button to ask viewmodel to begin search
- Adds start and cancel discovery action dispatch to viewmodel
- Adds ability for view controllers to listen to viewmodel updates through `didUpdate` on viewmodel protocol
- Adds (temporary use of) alerts to show searching state (will use new richer modals when they are stable)

To test:
- Open Settings > Manage Card Readers V2 while no reader is connected
- Tap on Connect button
- Ensure alert appears
- Tap on Cancel
- Ensure alert disappears

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
