### PR TITLE
[Mobile Payments] Improve layout of printed receipts for roll paper

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -6,21 +6,6 @@ public final class ReceiptRenderer: UIPrintPageRenderer {
     private let lines: [ReceiptLineItem]
     private let parameters: CardPresentReceiptParameters
 
-    private let headerAttributes: [NSAttributedString.Key: Any] = {
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.alignment = .center
-        return [.font: UIFont(name: "HelveticaNeue", size: 24) as Any,
-                .paragraphStyle: paragraph]
-    }()
-
-    private let footerAttributes: [NSAttributedString.Key: Any] = {
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.alignment = .center
-
-        return [.font: UIFont(name: "HelveticaNeue", size: 12) as Any,
-                .paragraphStyle: paragraph]
-    }()
-
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
@@ -180,7 +165,6 @@ private extension ReceiptRenderer {
             "Receipt",
             comment: "Title of receipt."
         )
-
 
         static let amountPaidSectionTitle = NSLocalizedString(
             "Amount paid",

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -32,6 +32,9 @@ public extension ReceiptRenderer {
     /// https://github.com/woocommerce/woocommerce-ios/issues/4033
     /// - Returns: A string containing the HTML that will be rendered to the receipt.
     func htmlContent() -> String {
+        let lineHeight = Constants.fontSize * 1.5
+        let iconHeight = lineHeight
+        let iconWidth = iconHeight * 4/3
         return """
             <html>
             <head>
@@ -52,38 +55,39 @@ public extension ReceiptRenderer {
                     footer {
                         font-size: \(Constants.footerFontSize)pt;
                         border-top: 1px solid #707070;
+                        margin-top: \(Constants.margin)pt;
+                        padding-top: \(Constants.margin)pt;
                     }
                     .card-icon {
-                       width: 24px;
-                       height: 17px;
-                       vertical-align: bottom;
+                       width: \(iconWidth)pt;
+                       height: \(iconHeight)pt;
+                       vertical-align: top;
                        background-repeat: no-repeat;
                        background-position-y: center;
                        display: inline-block;
                     }
+                    p { line-height: \(lineHeight)pt; margin: 0 0 \(Constants.margin / 2) 0; }
                     \(cardIconCSS())
                 </style>
             </head>
                 <body>
                     <header>
                         <h1>\(receiptTitle)</h1>
+                        <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                         <p>
-                            <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                             \(parameters.amount / 100) \(parameters.currency.uppercased())
                         </p>
+                        <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
                         <p>
-                            <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
                             \(dateFormatter.string(from: parameters.date))
                         </p>
+                        <h3>\(Localization.paymentMethodSectionTitle.uppercased())</h3>
                         <p>
-                            <h3>\(Localization.paymentMethodSectionTitle.uppercased())</h3>
                             <span class="card-icon \(parameters.cardDetails.brand.iconName)-icon"></span> - \(parameters.cardDetails.last4)
                         </p>
                     </header>
-                    <p>
-                        <h3>\(Localization.summarySectionTitle.uppercased())</h3>
-                        \(summaryTable())
-                    </p>
+                    <h3>\(Localization.summarySectionTitle.uppercased())</h3>
+                    \(summaryTable())
                     <footer>
                         <p>
                             \(requiredItems())

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -51,12 +51,19 @@ public extension ReceiptRenderer {
             <html>
             <head>
                 <style type="text/css">
-                    html { font-family: "Helvetica Neue", sans-serif; font-size: 12pt; }
-                    h1 { font-size: 24pt; }
+                    html { font-family: "Helvetica Neue", sans-serif; font-size: \(Constants.fontSize)pt; }
+                    header { margin-top: \(Constants.margin); }
+                    h1 { font-size: \(Constants.titleSize)pt; font-weight: 500; text-align: center; }
                     h3 { color: #707070; margin:0; }
-                    table { background-color:#F5F5F5; width:100%; color: #707070 }
+                    table {
+                        background-color:#F5F5F5;
+                        width:100%;
+                        color: #707070;
+                        margin: \(Constants.margin / 2)pt 0;
+                        padding: \(Constants.margin / 2)pt;
+                    }
                     table td:last-child { width: 30%; text-align: right; }
-                    table tr:last-child { color: #000000; }
+                    table tr:last-child { color: #000000; font-weight: bold; }
                     .card-icon {
                        width: 24px;
                        height: 17px;
@@ -69,19 +76,21 @@ public extension ReceiptRenderer {
                 </style>
             </head>
                 <body>
-                    <h1>\(receiptTitle)</h1>
-                    <p>
-                        <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
-                        \(parameters.amount / 100) \(parameters.currency.uppercased())
-                    </p>
-                    <p>
-                        <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
-                        \(dateFormatter.string(from: parameters.date))
-                    </p>
-                    <p>
-                        <h3>\(Localization.paymentMethodSectionTitle.uppercased())</h3>
-                        <span class="card-icon \(parameters.cardDetails.brand.iconName)-icon"></span> - \(parameters.cardDetails.last4)
-                    </p>
+                    <header>
+                        <h1>\(receiptTitle)</h1>
+                        <p>
+                            <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
+                            \(parameters.amount / 100) \(parameters.currency.uppercased())
+                        </p>
+                        <p>
+                            <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
+                            \(dateFormatter.string(from: parameters.date))
+                        </p>
+                        <p>
+                            <h3>\(Localization.paymentMethodSectionTitle.uppercased())</h3>
+                            <span class="card-icon \(parameters.cardDetails.brand.iconName)-icon"></span> - \(parameters.cardDetails.last4)
+                        </p>
+                    </header>
                     <p>
                         <h3>\(Localization.summarySectionTitle.uppercased())</h3>
                         \(summaryTable())
@@ -157,6 +166,8 @@ private extension ReceiptRenderer {
 private extension ReceiptRenderer {
     enum Constants {
         static let margin: CGFloat = 16
+        static let titleSize: CGFloat = 24
+        static let fontSize: CGFloat = 12
     }
 
     enum Localization {

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -42,13 +42,6 @@ public final class ReceiptRenderer: UIPrintPageRenderer {
     }
 
     override public func drawHeaderForPage(at pageIndex: Int, in headerRect: CGRect) {
-        guard let siteName = parameters.storeName else {
-            return
-        }
-
-        let receiptTitle = String.localizedStringWithFormat(Localization.receiptFromFormat,
-                                                            siteName) as NSString
-
         receiptTitle.draw(in: headerRect, withAttributes: headerAttributes)
     }
 
@@ -176,6 +169,14 @@ private extension ReceiptRenderer {
             ".\(cardBrand.iconName)-icon { background-image: url(\"data:image/svg+xml;base64,\(cardBrand.iconData.base64EncodedString())\") }"
         }.joined(separator: "\n\n")
     }
+
+    private var receiptTitle: String {
+        guard let storeName = parameters.storeName else {
+            return Localization.receiptTitle
+        }
+
+        return .localizedStringWithFormat(Localization.receiptFromFormat, storeName)
+    }
 }
 
 
@@ -191,6 +192,12 @@ private extension ReceiptRenderer {
             "Receipt from %1$@",
             comment: "Title of receipt. Reads like Receipt from WooCommerce, Inc."
         )
+
+        static let receiptTitle = NSLocalizedString(
+            "Receipt",
+            comment: "Title of receipt."
+        )
+
 
         static let amountPaidSectionTitle = NSLocalizedString(
             "Amount paid",

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -36,31 +36,7 @@ public final class ReceiptRenderer: UIPrintPageRenderer {
 
         super.init()
 
-        configureHeaderAndFooter()
-
         configureFormatter()
-    }
-
-    override public func drawHeaderForPage(at pageIndex: Int, in headerRect: CGRect) {
-        receiptTitle.draw(in: headerRect, withAttributes: headerAttributes)
-    }
-
-    override public func drawFooterForPage(at pageIndex: Int, in footerRect: CGRect) {
-        guard let emv = parameters.cardDetails.receipt else {
-            return
-        }
-
-        /// According to the documentation, only `Application name` and `AID`
-        /// are required in the US.
-        /// https://stripe.com/docs/terminal/checkout/receipts#custom
-        let mandatoryInfo = """
-            \(Localization.applicationName): \(emv.applicationPreferredName)\n
-            \(Localization.aid): \(emv.dedicatedFileName)
-        """
-
-        let footerString = NSString(string: mandatoryInfo)
-
-        footerString.draw(in: footerRect, withAttributes: footerAttributes)
     }
 }
 
@@ -75,6 +51,8 @@ public extension ReceiptRenderer {
             <html>
             <head>
                 <style type="text/css">
+                    html { font-family: "Helvetica Neue", sans-serif; font-size: 12pt; }
+                    h1 { font-size: 24pt; }
                     h3 { color: #707070; margin:0; }
                     table { background-color:#F5F5F5; width:100%; color: #707070 }
                     table td:last-child { width: 30%; text-align: right; }
@@ -91,6 +69,7 @@ public extension ReceiptRenderer {
                 </style>
             </head>
                 <body>
+                    <h1>\(receiptTitle)</h1>
                     <p>
                         <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                         \(parameters.amount / 100) \(parameters.currency.uppercased())
@@ -118,14 +97,9 @@ public extension ReceiptRenderer {
 
 
 private extension ReceiptRenderer {
-    private func configureHeaderAndFooter() {
-        headerHeight = Constants.headerHeight
-        footerHeight = Constants.footerHeight
-    }
-
     private func configureFormatter() {
         let formatter = UIMarkupTextPrintFormatter(markupText: htmlContent())
-        formatter.perPageContentInsets = .init(top: Constants.headerHeight, left: Constants.marging, bottom: Constants.footerHeight, right: Constants.marging)
+        formatter.perPageContentInsets = .init(top: 0, left: Constants.margin, bottom: 0, right: Constants.margin)
 
         addPrintFormatter(formatter, startingAtPageAt: 0)
     }
@@ -182,9 +156,7 @@ private extension ReceiptRenderer {
 
 private extension ReceiptRenderer {
     enum Constants {
-        static let headerHeight: CGFloat = 80
-        static let footerHeight: CGFloat = 80
-        static let marging: CGFloat = 20
+        static let margin: CGFloat = 16
     }
 
     enum Localization {

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -38,17 +38,21 @@ public extension ReceiptRenderer {
                 <style type="text/css">
                     html { font-family: "Helvetica Neue", sans-serif; font-size: \(Constants.fontSize)pt; }
                     header { margin-top: \(Constants.margin); }
-                    h1 { font-size: \(Constants.titleSize)pt; font-weight: 500; text-align: center; }
+                    h1 { font-size: \(Constants.titleFontSize)pt; font-weight: 500; text-align: center; }
                     h3 { color: #707070; margin:0; }
                     table {
                         background-color:#F5F5F5;
                         width:100%;
                         color: #707070;
-                        margin: \(Constants.margin / 2)pt 0;
+                        margin: \(Constants.margin / 2)pt 0 0 0;
                         padding: \(Constants.margin / 2)pt;
                     }
                     table td:last-child { width: 30%; text-align: right; }
                     table tr:last-child { color: #000000; font-weight: bold; }
+                    footer {
+                        font-size: \(Constants.footerFontSize)pt;
+                        border-top: 1px solid #707070;
+                    }
                     .card-icon {
                        width: 24px;
                        height: 17px;
@@ -80,9 +84,11 @@ public extension ReceiptRenderer {
                         <h3>\(Localization.summarySectionTitle.uppercased())</h3>
                         \(summaryTable())
                     </p>
-                    <p>
-                        \(requiredItems())
-                    </p>
+                    <footer>
+                        <p>
+                            \(requiredItems())
+                        </p>
+                    </footer>
                 </body>
             </html>
         """
@@ -151,8 +157,9 @@ private extension ReceiptRenderer {
 private extension ReceiptRenderer {
     enum Constants {
         static let margin: CGFloat = 16
-        static let titleSize: CGFloat = 24
+        static let titleFontSize: CGFloat = 24
         static let fontSize: CGFloat = 12
+        static let footerFontSize: CGFloat = 10
     }
 
     enum Localization {

--- a/Hardware/SampleReceiptPrinter/SampleContent.swift
+++ b/Hardware/SampleReceiptPrinter/SampleContent.swift
@@ -3,7 +3,7 @@
 extension ReceiptLineItem {
     /// Generates a sample line item with the given number in the title
     static func sampleItem(number: Int) -> ReceiptLineItem {
-        ReceiptLineItem(title: "Sample product #\(number)", amount: "2500")
+        return ReceiptLineItem(title: "Sample product #\(number)", amount: "25")
     }
 }
 
@@ -43,7 +43,7 @@ extension ReceiptContent {
         let items = (1...items)
             .map(ReceiptLineItem.sampleItem)
         let amount = items
-            .map(\.amount)
+            .map { (Float($0.amount) ?? 0) * 100 }
             .compactMap(UInt.init)
             .reduce(0, +)
 


### PR DESCRIPTION
Part of #4033

This PR improves layout and typography to approximate the design in #4033 better.

The biggest change is that I've stopped using headers and footers hoping that it works fine in roll paper, although that might not be great with regular paper. The assumption here is that roll paper will print each page right after the previous one without distinction, which might work until we can actually calculate the receipt height, but this should be tested when we get some hardware.

Other improvements include tweaks in the typography, spacing, and title alignment.

Some sample receipts printed with 1 and 30 items in 4" Roll and US Letter (for some reason the US Letter pages are printed in reverse order, I'm not sure if this is the Printer Simulator, and I don't have any AirPrint capable printers).

![receipts](https://user-images.githubusercontent.com/8739/117798342-58645e80-b251-11eb-8940-ee422c103ef5.png)


## To test

I'd recommend using Apple's Printer simulator, which is available on their [downloads page](https://developer.apple.com/download/more/), in the "Additional tools for Xcode" package. Then from the toolbar, open the "Load Paper" screen and select the 4" Roll for the Simulated Label Printer. When printing, use this printer to simulate a 4" receipt.

![Screen Shot 2021-05-11 at 11 23 32](https://user-images.githubusercontent.com/8739/117792177-55ff0600-b24b-11eb-807c-2453e6d4be04.png)


The easiest way to test is to use the new SampleReceiptPrinter app target, and try to print a sample receipt.

![Screen Shot 2021-05-11 at 11 54 54](https://user-images.githubusercontent.com/8739/117796974-d889c480-b24f-11eb-98e2-b9a31140f988.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
