### PR TITLE
[Mobile Payments] Include quantity in receipt lines

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -111,7 +111,7 @@ private extension ReceiptRenderer {
     private func summaryTable() -> String {
         var summaryContent = "<table>"
         for line in lines {
-            summaryContent += "<tr><td>\(line.title)</td><td>\(line.amount) \(parameters.currency.uppercased())</td></tr>"
+            summaryContent += "<tr><td>\(line.title) × \(line.quantity)</td><td>\(line.amount) \(parameters.currency.uppercased())</td></tr>"
         }
         summaryContent += """
                             <tr>

--- a/Hardware/Hardware/Printer/ReceiptLineItem.swift
+++ b/Hardware/Hardware/Printer/ReceiptLineItem.swift
@@ -2,10 +2,12 @@
 /// To be implemented in https://github.com/woocommerce/woocommerce-ios/issues/3978
 public struct ReceiptLineItem {
     public let title: String
+    public let quantity: String
     public let amount: String
 
-    public init(title: String, amount: String) {
+    public init(title: String, quantity: String, amount: String) {
         self.title = title
+        self.quantity = quantity
         self.amount = amount
     }
 }

--- a/Hardware/SampleReceiptPrinter/SampleContent.swift
+++ b/Hardware/SampleReceiptPrinter/SampleContent.swift
@@ -3,7 +3,15 @@
 extension ReceiptLineItem {
     /// Generates a sample line item with the given number in the title
     static func sampleItem(number: Int) -> ReceiptLineItem {
-        return ReceiptLineItem(title: "Sample product #\(number)", amount: "25")
+        return ReceiptLineItem(title: "Sample product #\(number)", quantity: "2", amount: "25")
+    }
+
+    fileprivate var sampleSubtotal: UInt {
+        guard let quantity = Float(quantity),
+              let amount = Float(amount) else {
+            return 0
+        }
+        return UInt(quantity * amount * 100)
     }
 }
 
@@ -43,8 +51,7 @@ extension ReceiptContent {
         let items = (1...items)
             .map(ReceiptLineItem.sampleItem)
         let amount = items
-            .map { (Float($0.amount) ?? 0) * 100 }
-            .compactMap(UInt.init)
+            .map(\.sampleSubtotal)
             .reduce(0, +)
 
         let parameters: CardPresentReceiptParameters = .sampleParameters(amount: amount)

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -43,14 +43,14 @@ public class ReceiptStore: Store {
 
 private extension ReceiptStore {
     func print(order: Order, parameters: CardPresentReceiptParameters) {
-        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, amount: $0.price.stringValue)}
+        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
         receiptPrinterService.printReceipt(content: content)
     }
 
     func generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
-        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, amount: $0.price.stringValue)}
+        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
         let renderer = ReceiptRenderer(content: content)


### PR DESCRIPTION
Part of #4033

This PR ensures each line in the receipt includes the quantity. The amount shown in the receipt is per item, and so the numbers won't add up to the total amount if the quantity isn't displayed.

![Screen Shot 2021-05-11 at 13 10 25](https://user-images.githubusercontent.com/8739/117806430-a336a400-b25a-11eb-8405-53246eba4bbf.png)

I've tweaked the sample content generation a bit to simplify, but otherwise this is just passing extra information already present for the order item.


## To test

I'd recommend using Apple's Printer simulator, which is available on their [downloads page](https://developer.apple.com/download/more/), in the "Additional tools for Xcode" package. Then from the toolbar, open the "Load Paper" screen and select the 4" Roll for the Simulated Label Printer. When printing, use this printer to simulate a 4" receipt.

![Screen Shot 2021-05-11 at 11 23 32](https://user-images.githubusercontent.com/8739/117792177-55ff0600-b24b-11eb-807c-2453e6d4be04.png)


The easiest way to test is to use the new SampleReceiptPrinter app target, and try to print a sample receipt.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
