### PR TITLE
[Mobile Payments] Saved receipts mark II: Yosemite

### DIFF
--- a/Hardware/Hardware/CardReader/CardBrand.swift
+++ b/Hardware/Hardware/CardReader/CardBrand.swift
@@ -1,5 +1,5 @@
 /// The various card brands for a card.
-public enum CardBrand: CaseIterable {
+public enum CardBrand: String, CaseIterable, Codable {
     /// Visa card
     case visa
 

--- a/Hardware/Hardware/CardReader/CardPresentTransactionDetails.swift
+++ b/Hardware/Hardware/CardReader/CardPresentTransactionDetails.swift
@@ -43,3 +43,17 @@ extension CardPresentTransactionDetails: Equatable {
             lhs.emvAuthData == rhs.emvAuthData
     }
 }
+
+extension CardPresentTransactionDetails {
+    enum CodingKeys: String, CodingKey {
+        case last4 = "last_4"
+        case expMonth = "exp_month"
+        case expYear = "exp_year"
+        case cardholderName = "cardholder_name"
+        case brand = "brand"
+        case fingerprint = "fingerprint"
+        case generatedCard = "generated_card"
+        case receipt = "receipt"
+        case emvAuthData = "emv_auth_data"
+    }
+}

--- a/Hardware/Hardware/CardReader/CardPresentTransactionDetails.swift
+++ b/Hardware/Hardware/CardReader/CardPresentTransactionDetails.swift
@@ -1,5 +1,5 @@
 /// An object representing details from a transaction using a card_present payment method.
-public struct CardPresentTransactionDetails {
+public struct CardPresentTransactionDetails: Codable {
     /// The last 4 digits of the card.
     public let last4: String
 

--- a/Hardware/Hardware/CardReader/ReceiptDetails.swift
+++ b/Hardware/Hardware/CardReader/ReceiptDetails.swift
@@ -1,5 +1,5 @@
 /// Receipt details associated with a card present transaction.
-public struct ReceiptDetails {
+public struct ReceiptDetails: Codable {
     /// Also known as “Application Name”. Required on EMV receipts.
     public let applicationPreferredName: String
 

--- a/Hardware/Hardware/CardReader/ReceiptDetails.swift
+++ b/Hardware/Hardware/CardReader/ReceiptDetails.swift
@@ -33,3 +33,15 @@ extension ReceiptDetails: Equatable {
             lhs.accountType == rhs.accountType
     }
 }
+
+extension ReceiptDetails {
+    enum CodingKeys: String, CodingKey {
+        case applicationPreferredName = "application_preferred_name"
+        case dedicatedFileName = "dedicated_file_name"
+        case authorizationResponseCode = "authorization_response_code"
+        case applicationCryptogram = "application_cryptogram"
+        case terminalVerificationResults = "terminal_verification_results"
+        case transactionStatusInformation = "transaction_status_information"
+        case accountType = "account_type"
+    }
+}

--- a/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
+++ b/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
@@ -33,3 +33,13 @@ public struct CardPresentReceiptParameters: Codable {
 public extension CardPresentReceiptParameters {
     typealias MetadataKeys = PaymentIntent.MetadataKeys
 }
+
+extension CardPresentReceiptParameters {
+    enum CodingKeys: String, CodingKey {
+        case amount = "amount"
+        case currency = "currency"
+        case date = "date"
+        case storeName = "store_name"
+        case cardDetails = "card_details"
+    }
+}

--- a/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
+++ b/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
@@ -1,6 +1,6 @@
 /// Encapsulates the information necessary to print a receipt for a
 /// card present payment
-public struct CardPresentReceiptParameters {
+public struct CardPresentReceiptParameters: Codable {
     /// The total amount
     public let amount: UInt
 

--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -4,8 +4,15 @@ public struct ReceiptContent: Codable {
     public let lineItems: [ReceiptLineItem]
     public let parameters: CardPresentReceiptParameters
 
-    public init(parameters: CardPresentReceiptParameters, lineItems: [ReceiptLineItem] = []) {
+    public init(parameters: CardPresentReceiptParameters, lineItems: [ReceiptLineItem]) {
         self.lineItems = lineItems
         self.parameters = parameters
+    }
+}
+
+extension ReceiptContent {
+    enum CodingKeys: String, CodingKey {
+        case lineItems = "line_items"
+        case parameters = "parameters"
     }
 }

--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -1,6 +1,6 @@
 /// Models the content of the receipt.
 /// To be fully implemented in https://github.com/woocommerce/woocommerce-ios/issues/3978
-public struct ReceiptContent {
+public struct ReceiptContent: Codable {
     public let lineItems: [ReceiptLineItem]
     public let parameters: CardPresentReceiptParameters
 

--- a/Hardware/Hardware/Printer/ReceiptLineItem.swift
+++ b/Hardware/Hardware/Printer/ReceiptLineItem.swift
@@ -11,3 +11,11 @@ public struct ReceiptLineItem: Codable {
         self.amount = amount
     }
 }
+
+extension ReceiptLineItem {
+    enum CodingKeys: String, CodingKey {
+        case title = "title"
+        case quantity = "quantity"
+        case amount = "amount"
+    }
+}

--- a/Hardware/Hardware/Printer/ReceiptLineItem.swift
+++ b/Hardware/Hardware/Printer/ReceiptLineItem.swift
@@ -1,6 +1,6 @@
 /// Models a line in the receipt.
 /// To be implemented in https://github.com/woocommerce/woocommerce-ios/issues/3978
-public struct ReceiptLineItem {
+public struct ReceiptLineItem: Codable {
     public let title: String
     public let quantity: String
     public let amount: String

--- a/Storage/Storage/Tools/PListFileStorage.swift
+++ b/Storage/Storage/Tools/PListFileStorage.swift
@@ -9,9 +9,15 @@ public final class PListFileStorage: FileStorage {
     public func data<T: Decodable>(for fileURL: URL) throws -> T {
         do {
             let data = try Data(contentsOf: fileURL)
+            print("=== data ")
+            print(data)
+            print("/// data ")
             let decoder = PropertyListDecoder()
             return try decoder.decode(T.self, from: data)
         } catch {
+            print("==== codable error")
+            print(error)
+            print("//// codable error")
             throw PListFileStorageErrors.fileReadFailed
         }
     }

--- a/Storage/Storage/Tools/PListFileStorage.swift
+++ b/Storage/Storage/Tools/PListFileStorage.swift
@@ -9,15 +9,9 @@ public final class PListFileStorage: FileStorage {
     public func data<T: Decodable>(for fileURL: URL) throws -> T {
         do {
             let data = try Data(contentsOf: fileURL)
-            print("=== data ")
-            print(data)
-            print("/// data ")
             let decoder = PropertyListDecoder()
             return try decoder.decode(T.self, from: data)
         } catch {
-            print("==== codable error")
-            print(error)
-            print("//// codable error")
             throw PListFileStorageErrors.fileReadFailed
         }
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -41,10 +41,6 @@ final class PaymentCaptureOrchestrator {
     }
 
     func saveReceipt(for order: Order, params: CardPresentReceiptParameters) {
-//        let action = ReceiptAction.print(order: order, parameters: params)
-//
-//        ServiceLocator.stores.dispatch(action)
-
         let action = ReceiptAction.saveReceipt(order: order, parameters: params)
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -417,15 +417,15 @@ extension OrderDetailsViewModel {
     }
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
-        let action = ReceiptAction.loadReceipt(order: order) { result in
+        let action = ReceiptAction.loadReceipt(order: order) { [weak self] result in
             switch result {
             case .success(let parameters):
-                print("====== recipt parameters loaded")
+                print("====== receipt parameters for order \(String(describing: self?.order.orderID))")
                 print(parameters)
                 print("////// recipt parameters loaded")
                 onCompletion?(nil)
             case .failure:
-                print("==== no receipt. moving on")
+                print("==== no receipt parameters for order \(String(describing: self?.order.orderID)). moving on")
             }
         }
 //        let action = ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -416,6 +416,32 @@ extension OrderDetailsViewModel {
         stores.dispatch(action)
     }
 
+    func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
+        let action = ReceiptAction.loadReceipt(order: order) { result in
+            switch result {
+            case .success(let parameters):
+                print("====== recipt parameters loaded")
+                print(parameters)
+                print("////// recipt parameters loaded")
+                onCompletion?(nil)
+            case .failure:
+                print("==== no receipt. moving on")
+            }
+        }
+//        let action = ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in
+//            switch result {
+//            case .success:
+//                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .success))
+//                onCompletion?(nil)
+//            case .failure(let error):
+//                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
+//                DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
+//                onCompletion?(error)
+//            }
+//        }
+        stores.dispatch(action)
+    }
+
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {
         let isFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsRelease2)
         let action = ShippingLabelAction.checkCreationEligibility(siteID: order.siteID,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -428,17 +428,6 @@ extension OrderDetailsViewModel {
                 print("==== no receipt parameters for order \(String(describing: self?.order.orderID)). moving on")
             }
         }
-//        let action = ShippingLabelAction.synchronizeShippingLabels(siteID: order.siteID, orderID: order.orderID) { result in
-//            switch result {
-//            case .success:
-//                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .success))
-//                onCompletion?(nil)
-//            case .failure(let error):
-//                ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
-//                DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
-//                onCompletion?(error)
-//            }
-//        }
         stores.dispatch(action)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -78,6 +78,7 @@ final class OrderDetailsViewController: UIViewController {
         syncProductVariations()
         syncRefunds()
         syncShippingLabels()
+        syncSavedReceipts()
         syncTrackingsHidingAddButtonIfNecessary()
         checkShippingLabelCreationEligibility()
         checkCardPresentPaymentEligibility()
@@ -373,6 +374,10 @@ private extension OrderDetailsViewController {
 
     func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
         viewModel.syncShippingLabels(onCompletion: onCompletion)
+    }
+
+    func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
+        viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -65,7 +65,8 @@ class AuthenticatedState: StoresManagerState {
             ReceiptStore(dispatcher: dispatcher,
                          storageManager: storageManager,
                          network: network,
-                         receiptPrinterService: ServiceLocator.receiptPrinterService)
+                         receiptPrinterService: ServiceLocator.receiptPrinterService,
+                         fileStorage: PListFileStorage())
         ]
 
         startListeningToNotifications()

--- a/Yosemite/Yosemite/Actions/ReceiptAction.swift
+++ b/Yosemite/Yosemite/Actions/ReceiptAction.swift
@@ -1,5 +1,5 @@
 /// RefundAction: Defines all of the Actions supported by the ReceiptStore.
-///  
+///
 public enum ReceiptAction: Action {
     /// Prints a receipt for a given `Order` with the given `CardPresentReceiptParameters`
     case print(order: Order, parameters: CardPresentReceiptParameters)
@@ -7,4 +7,10 @@ public enum ReceiptAction: Action {
     /// Generates content for a receipt for a given `Order` with the given `CardPresentReceiptParameters`
     /// The content is a String containing HTML
     case generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: (String) -> Void)
+
+    /// Saves the metadata necessary to render a receipt
+    case saveReceipt(orderID: Int64, parameters: CardPresentReceiptParameters)
+
+    /// Loads the metadata necessary to render a receipt
+    case loadReceipt(orderID: Int64, onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ReceiptAction.swift
+++ b/Yosemite/Yosemite/Actions/ReceiptAction.swift
@@ -9,8 +9,8 @@ public enum ReceiptAction: Action {
     case generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: (String) -> Void)
 
     /// Saves the metadata necessary to render a receipt
-    case saveReceipt(orderID: Int64, parameters: CardPresentReceiptParameters)
+    case saveReceipt(order: Order, parameters: CardPresentReceiptParameters)
 
     /// Loads the metadata necessary to render a receipt
-    case loadReceipt(orderID: Int64, onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void)
+    case loadReceipt(order: Order, onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -36,6 +36,10 @@ public class ReceiptStore: Store {
             print(order: order, parameters: info)
         case .generateContent(let order, let info, let onContent):
             generateContent(order: order, parameters: info, onContent: onContent)
+        case .loadReceipt(let orderID, let onCompletion):
+            loadReceipt(orderID: orderID, onCompletion: onCompletion)
+        case .saveReceipt(let orderID, let info):
+            saveReceipt(orderID: orderID, parameters: info)
         }
     }
 }
@@ -55,5 +59,13 @@ private extension ReceiptStore {
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
         let renderer = ReceiptRenderer(content: content)
         onContent(renderer.htmlContent())
+    }
+
+    func loadReceipt(orderID: Int64, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+
+    }
+
+    func saveReceipt(orderID: Int64, parameters: CardPresentReceiptParameters) {
+
     }
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -73,7 +73,7 @@ private extension ReceiptStore {
         }
 
         guard let receiptContent: ReceiptContent = try? fileStorage.data(for: outputURL) else {
-            DDLogError("⛔️ Unable to load receipt metadata for order: \(order.orderID)")
+            DDLogWarn("⛔️ Unable to load receipt metadata for order: \(order.orderID)")
             let error = ReceiptStoreError.fileError
             onCompletion(.failure(error))
 

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -80,7 +80,7 @@ private extension ReceiptStore {
         }
 
         Swift.print("==== output receipt URL ", outputURL)
-        guard let receiptParameters: CardPresentReceiptParameters = try? fileStorage.data(for: outputURL) else {
+        guard let receiptContent: ReceiptContent = try? fileStorage.data(for: outputURL) else {
             DDLogError("⛔️ Unable to load receipt metadata for order: \(order.orderID)")
             let error = ReceiptStoreError.fileError
             onCompletion(.failure(error))
@@ -88,7 +88,7 @@ private extension ReceiptStore {
             return
         }
 
-        onCompletion(.success(receiptParameters))
+        onCompletion(.success(receiptContent.parameters))
     }
 
     func saveReceipt(order: Order, parameters: CardPresentReceiptParameters) {

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -36,10 +36,10 @@ public class ReceiptStore: Store {
             print(order: order, parameters: info)
         case .generateContent(let order, let info, let onContent):
             generateContent(order: order, parameters: info, onContent: onContent)
-        case .loadReceipt(let orderID, let onCompletion):
-            loadReceipt(orderID: orderID, onCompletion: onCompletion)
-        case .saveReceipt(let orderID, let info):
-            saveReceipt(orderID: orderID, parameters: info)
+        case .loadReceipt(let order, let onCompletion):
+            loadReceipt(order: order, onCompletion: onCompletion)
+        case .saveReceipt(let order, let info):
+            saveReceipt(order: order, parameters: info)
         }
     }
 }
@@ -61,11 +61,11 @@ private extension ReceiptStore {
         onContent(renderer.htmlContent())
     }
 
-    func loadReceipt(orderID: Int64, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
+    func loadReceipt(order: Order, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
 
     }
 
-    func saveReceipt(orderID: Int64, parameters: CardPresentReceiptParameters) {
+    func saveReceipt(order: Order, parameters: CardPresentReceiptParameters) {
 
     }
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -65,15 +65,7 @@ private extension ReceiptStore {
 
     func loadReceipt(order: Order, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
 
-        guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
-                                                           in: .userDomainMask,
-                                                           appropriateFor: nil,
-                                                           create: false)
-                .appendingPathComponent(fileName(order: order))
-                .appendingPathExtension("plist")
-        else {
-            DDLogError("⛔️ Unable to create file url for receipt for order id: \(order.orderID)")
-
+        guard let outputURL = try? fileURL(order: order) else {
             let error = ReceiptStoreError.fileNotFound
             onCompletion(.failure(error))
             return
@@ -95,13 +87,7 @@ private extension ReceiptStore {
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
 
-        guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
-                                                           in: .userDomainMask,
-                                                           appropriateFor: nil,
-                                                           create: false)
-                .appendingPathComponent(fileName(order: order))
-                .appendingPathExtension("plist")
-        else {
+        guard let outputURL = try? fileURL(order: order) else {
             DDLogError("⛔️ Unable to create file for receipt for order id: \(order.orderID)")
 
             return
@@ -118,12 +104,24 @@ private extension ReceiptStore {
 }
 
 private extension ReceiptStore {
+    func fileURL(order: Order) throws -> URL {
+        return try FileManager.default.url(for: .documentDirectory,
+                                                           in: .userDomainMask,
+                                                           appropriateFor: nil,
+                                                           create: false)
+                .appendingPathComponent(fileName(order: order))
+                .appendingPathExtension("plist")
+    }
+
     func fileName(order: Order) -> String {
         "order-id-\(order.orderID)-receipt"
     }
 }
 
 public enum ReceiptStoreError: Error {
+    /// Signals that the file containing the receipt metadata does not exist
     case fileNotFound
+    /// There was an error reading the content of the file containing the
+    /// receipt metadata
     case fileError
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -79,7 +79,6 @@ private extension ReceiptStore {
             return
         }
 
-        Swift.print("==== output receipt URL ", outputURL)
         guard let receiptContent: ReceiptContent = try? fileStorage.data(for: outputURL) else {
             DDLogError("⛔️ Unable to load receipt metadata for order: \(order.orderID)")
             let error = ReceiptStoreError.fileError
@@ -115,34 +114,6 @@ private extension ReceiptStore {
         } catch {
             DDLogError("⛔️ Unable to save receipt for order id: \(order.orderID)")
         }
-
-//        let renderer = ReceiptRenderer(content: content)
-//
-//        let page = CGRect(x: 0, y: 0, width: 298, height: 500)
-//        renderer.setValue(page, forKey: "paperRect")
-//        renderer.setValue(page, forKey: "printableRect")
-//
-//        let pdfData = NSMutableData()
-//        UIGraphicsBeginPDFContextToData(pdfData, .zero, nil)
-//        UIGraphicsBeginPDFPage()
-//        for i in 0..<renderer.numberOfPages {
-//            UIGraphicsBeginPDFPage()
-//            renderer.drawPage(at: i, in: UIGraphicsGetPDFContextBounds())
-//        }
-//        UIGraphicsEndPDFContext()
-//
-//        guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
-//                                                           in: .userDomainMask,
-//                                                           appropriateFor: nil,
-//                                                           create: false)
-//                .appendingPathComponent("order-id-\(order.orderID)-receipt")
-//                .appendingPathExtension("pdf")
-//            else {
-//            fatalError("Destination URL not created")
-//        }
-//
-//        pdfData.write(to: outputURL, atomically: true)
-//        Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -109,12 +109,12 @@ private extension ReceiptStore {
                                                            in: .userDomainMask,
                                                            appropriateFor: nil,
                                                            create: false)
-                .appendingPathComponent(fileName(order: order))
+            .appendingPathComponent(fileName(order: order))
                 .appendingPathExtension("plist")
     }
 
     func fileName(order: Order) -> String {
-        "order-id-\(order.orderID)-receipt"
+        "site-\(order.siteID)-order-id-\(order.orderID)-receipt"
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -70,32 +70,51 @@ private extension ReceiptStore {
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
 
-        let renderer = ReceiptRenderer(content: content)
-
-        let page = CGRect(x: 0, y: 0, width: 298, height: 500)
-        renderer.setValue(page, forKey: "paperRect")
-        renderer.setValue(page, forKey: "printableRect")
-
-        let pdfData = NSMutableData()
-        UIGraphicsBeginPDFContextToData(pdfData, .zero, nil)
-        UIGraphicsBeginPDFPage()
-        for i in 0..<renderer.numberOfPages {
-            UIGraphicsBeginPDFPage()
-            renderer.drawPage(at: i, in: UIGraphicsGetPDFContextBounds())
-        }
-        UIGraphicsEndPDFContext()
-
         guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
                                                            in: .userDomainMask,
                                                            appropriateFor: nil,
                                                            create: false)
                 .appendingPathComponent("order-id-\(order.orderID)-receipt")
-                .appendingPathExtension("pdf")
-            else {
+                .appendingPathExtension("plist")
+        else {
             fatalError("Destination URL not created")
         }
 
-        pdfData.write(to: outputURL, atomically: true)
-        Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
+        let storage = PListFileStorage()
+
+        do {
+            try storage.write(content, to: outputURL)
+            Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
+        } catch {
+            Swift.print("==== error")
+        }
+
+//        let renderer = ReceiptRenderer(content: content)
+//
+//        let page = CGRect(x: 0, y: 0, width: 298, height: 500)
+//        renderer.setValue(page, forKey: "paperRect")
+//        renderer.setValue(page, forKey: "printableRect")
+//
+//        let pdfData = NSMutableData()
+//        UIGraphicsBeginPDFContextToData(pdfData, .zero, nil)
+//        UIGraphicsBeginPDFPage()
+//        for i in 0..<renderer.numberOfPages {
+//            UIGraphicsBeginPDFPage()
+//            renderer.drawPage(at: i, in: UIGraphicsGetPDFContextBounds())
+//        }
+//        UIGraphicsEndPDFContext()
+//
+//        guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
+//                                                           in: .userDomainMask,
+//                                                           appropriateFor: nil,
+//                                                           create: false)
+//                .appendingPathComponent("order-id-\(order.orderID)-receipt")
+//                .appendingPathExtension("pdf")
+//            else {
+//            fatalError("Destination URL not created")
+//        }
+//
+//        pdfData.write(to: outputURL, atomically: true)
+//        Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
     }
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -72,23 +72,30 @@ private extension ReceiptStore {
 
         let renderer = ReceiptRenderer(content: content)
 
+        let page = CGRect(x: 0, y: 0, width: 298, height: 500)
+        renderer.setValue(page, forKey: "paperRect")
+        renderer.setValue(page, forKey: "printableRect")
+
         let pdfData = NSMutableData()
         UIGraphicsBeginPDFContextToData(pdfData, .zero, nil)
         UIGraphicsBeginPDFPage()
-        renderer.drawPage(at: 0, in: UIGraphicsGetPDFContextBounds())
+        for i in 0..<renderer.numberOfPages {
+            UIGraphicsBeginPDFPage()
+            renderer.drawPage(at: i, in: UIGraphicsGetPDFContextBounds())
+        }
         UIGraphicsEndPDFContext()
 
         guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
                                                            in: .userDomainMask,
                                                            appropriateFor: nil,
                                                            create: false)
-                .appendingPathComponent("output")
+                .appendingPathComponent("order-id-\(order.orderID)-receipt")
                 .appendingPathExtension("pdf")
             else {
             fatalError("Destination URL not created")
         }
 
         pdfData.write(to: outputURL, atomically: true)
-        Swift.print("open \(outputURL.path)") // command to open the generated file
+        Swift.print("new receipt saved: open \(outputURL.path)") // command to open the generated file
     }
 }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -65,7 +65,8 @@ private extension ReceiptStore {
 
     func loadReceipt(order: Order, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
 
-        guard let outputURL = try? fileURL(order: order) else {
+        guard let outputURL = try? fileURL(order: order),
+              FileManager.default.fileExists(atPath: outputURL.path) else {
             let error = ReceiptStoreError.fileNotFound
             onCompletion(.failure(error))
             return

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -79,8 +79,9 @@ private extension ReceiptStore {
             return
         }
 
+        Swift.print("==== output receipt URL ", outputURL)
         guard let receiptParameters: CardPresentReceiptParameters = try? fileStorage.data(for: outputURL) else {
-            DDLogError("⛔️ Unabl to load receipt metadata for order: \(order.orderID)")
+            DDLogError("⛔️ Unable to load receipt metadata for order: \(order.orderID)")
             let error = ReceiptStoreError.fileError
             onCompletion(.failure(error))
 

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -66,6 +66,29 @@ private extension ReceiptStore {
     }
 
     func saveReceipt(order: Order, parameters: CardPresentReceiptParameters) {
+        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
 
+        let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
+
+        let renderer = ReceiptRenderer(content: content)
+
+        let pdfData = NSMutableData()
+        UIGraphicsBeginPDFContextToData(pdfData, .zero, nil)
+        UIGraphicsBeginPDFPage()
+        renderer.drawPage(at: 0, in: UIGraphicsGetPDFContextBounds())
+        UIGraphicsEndPDFContext()
+
+        guard let outputURL = try? FileManager.default.url(for: .documentDirectory,
+                                                           in: .userDomainMask,
+                                                           appropriateFor: nil,
+                                                           create: false)
+                .appendingPathComponent("output")
+                .appendingPathExtension("pdf")
+            else {
+            fatalError("Destination URL not created")
+        }
+
+        pdfData.write(to: outputURL, atomically: true)
+        Swift.print("open \(outputURL.path)") // command to open the generated file
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -53,7 +53,8 @@ final class ReceiptStoreTests: XCTestCase {
         let receiptStore = ReceiptStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
-                                        receiptPrinterService: receiptPrinterService)
+                                        receiptPrinterService: receiptPrinterService,
+                                        fileStorage: MockInMemoryStorage())
 
         let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters)
 
@@ -69,7 +70,8 @@ final class ReceiptStoreTests: XCTestCase {
         let receiptStore = ReceiptStore(dispatcher: dispatcher,
                                         storageManager: storageManager,
                                         network: network,
-                                        receiptPrinterService: receiptPrinterService)
+                                        receiptPrinterService: receiptPrinterService,
+                                        fileStorage: MockInMemoryStorage())
 
         let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters)
 


### PR DESCRIPTION
Closes #3974 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

This is a throwaway solution, that could get us to beta 1 if we do not have an endpoint to fetch the receipt data on time. But at least, it gives us the chance to move forward with the UI side of the solution.

## Changes
* Added actions to save and read receipt metadata.
* Made all the model objects we use to model the receipt metadata conform to Codable
* Added an implementation that saves and reads the receipt metadata to a plist file. Ideal? No. Again, this is something we might (and hopefully will) throw away in the coming days.
* I didn't add any tests. Let's wait a couple of days for that.

## How to test
* Pair with a reader
* Navigate to an order
* Capture a payment. Notice there will be a print out in the console after the order has ben captures with a message like this when running on the simulator:
```
new receipt saved: open /Users/ctarda/Library/Developer/CoreSimulator/Devices/90C3D678-6F22-4DD2-873D-9BB5C7B79217/data/Containers/Data/Application/0388C091-8303-4648-A69C-34206563BE63/Documents/order-id-894-receipt.plist
```

And like this when running on device:
```
new receipt saved: open /var/mobile/Containers/Data/Application/240FD6C4-5871-44C7-8CEB-BB4A6830636E/Documents/order-id-893-receipt.plist
```

* You can copy that and paste it in Terminal to open the new plist file.
* Now navigate out of the order, go to all orders > navigate back into the previous order. There should be a trace like this:
```
====== receipt parameters for order Optional(893)
CardPresentReceiptParameters(amount: 20000, currency: "usd", date: 2021-05-12 14:46:49 +0000, storeName: Optional("wooctarda"), cardDetails: Hardware.CardPresentTransactionDetails(last4: "9999", expMonth: 12, expYear: 2021, cardholderName: Optional("TEST/STRIPE"), brand: Visa, fingerprint: "REDACTED", generatedCard: Optional("pm_REEDACTED"), receipt: Optional(Hardware.ReceiptDetails(applicationPreferredName: "Stripe Credit", dedicatedFileName: "REDACTED", authorizationResponseCode: "3030", applicationCryptogram: "REDACTED", terminalVerificationResults: "REDACTED", transactionStatusInformation: "0000", accountType: Optional("credit"))), emvAuthData: Optional("REDACTED")))
////// recipt parameters loaded
```

That's it. That's all for now. Next steps are #3975 and #3981

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
