### PR TITLE
[Mobile Payments] Simplify card reader connection result handling

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -36,7 +36,7 @@ public protocol CardReaderService {
 
     /// Connects to a card reader
     /// - Parameter reader: The card reader we want to connect to.
-    func connect(_ reader: CardReader) -> Future <Void, Error>
+    func connect(_ reader: CardReader) -> Future <CardReader, Error>
 
     /// Disconnects from the currently connected reader
     func disconnect() -> Future <Void, Error>

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -175,7 +175,7 @@ extension StripeCardReaderService: CardReaderService {
         }
     }
 
-    public func connect(_ reader: CardReader) -> Future <Void, Error> {
+    public func connect(_ reader: CardReader) -> Future <CardReader, Error> {
         return Future() { [weak self] promise in
 
             guard let self = self else {
@@ -207,7 +207,7 @@ extension StripeCardReaderService: CardReaderService {
                 if let reader = reader {
                     self.connectedReadersSubject.send([CardReader(reader: reader)])
                     self.switchStatusToIdle()
-                    promise(.success(()))
+                    promise(.success(CardReader(reader: reader)))
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -142,8 +142,8 @@ final class CardReaderSettingsViewModel: ObservableObject {
 
         let action = CardPresentPaymentAction.connect(reader: foundReaders[0], onCompletion: { [weak self] result in
             switch result {
-            case .success(let cardReaders):
-                self?.didConnectToReader(cardReaders: cardReaders)
+            case .success(let cardReader):
+                self?.didConnectToReader(cardReader: cardReader)
             case .failure(let error):
                 DDLogWarn(error.localizedDescription)
                 // TODO failure message to the user?
@@ -176,15 +176,10 @@ final class CardReaderSettingsViewModel: ObservableObject {
     }
 
     /// Called when a reader has been connected to.
-    private func didConnectToReader(cardReaders: [CardReader]) -> Void {
+    private func didConnectToReader(cardReader: CardReader) -> Void {
         activeAlert = .none
-        guard cardReaders.count > 0 else {
-            // TODO log unexpected failure
-            return
-        }
-
         activeView = .connectedToReader
-        self.connectedReader = cardReaders[0]
+        self.connectedReader = cardReader
     }
 
     /// Views can call this method to initiate a software update on the connected reader.

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -12,7 +12,7 @@ public enum CardPresentPaymentAction: Action {
     /// Connect to a specific CardReader.
     /// Stops Card Reader discovery
     ///
-    case connect(reader: CardReader, onCompletion: (Result<[CardReader], Error>) -> Void)
+    case connect(reader: CardReader, onCompletion: (Result<CardReader, Error>) -> Void)
 
     /// Disconnect from currently connected Reader
     ///

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -70,12 +70,12 @@ final class MockCardReaderService: CardReaderService {
         }
     }
 
-    func connect(_ reader: Hardware.CardReader) -> Future<Void, Error> {
+    func connect(_ reader: Hardware.CardReader) -> Future<Hardware.CardReader, Error> {
         Future() { promise in
             /// Delaying the effect of this method so that unit tests are actually async
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {[weak self] in
                 let connectedReader = MockCardReader.bbposChipper2XBT()
-                promise(Result.success(()))
+                promise(Result.success(connectedReader))
                 self?.connectedReadersSubject.send([connectedReader])
             }
         }

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -206,14 +206,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             switch result {
             case .failure:
                 XCTFail()
-            case .success(let connectedReaders):
-                // This could be called with an empty collection of readers.
-                // So we do not make the test fail if connectedReaders is Empty
-                guard !connectedReaders.isEmpty else {
-                    return
-                }
-
-                XCTAssertTrue(connectedReaders.contains(reader))
+            case .success(let connectedReader):
+                XCTAssertEqual(connectedReader, reader)
 
                 expectation.fulfill()
             }


### PR DESCRIPTION
Part of #3926 

The existing data flow for connecting a reader had a bit of split responsibilities. `CardPaymentStore` was subscribing both to the Future result of `connect()` and the `connectedReaders` property.

Instead, we can pass the reader object as part of the successful completion of the `connect()` future and use that instead. I took the opportunity to replace the existing array arguments with a single instance of `CardReader`, since you can't connect to more than one reader at once. I think we could do the same to `connectedReaders`, but that's used in the newer settings that I haven't been able to test yet, and I think @allendav mentioned changing that anyway.

## To test

See that you can discover, connect and disconnect readers as usual.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
