### PR TITLE
[Mobile Payments] Add "See Receipt" button to order details screen

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -46,6 +46,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var isEligibleForCardPresentPayment: Bool = false
 
+    /// Whether the order has a receipt associated.
+    ///
+    var shouldShowReceipts: Bool = false
+
     /// Closure to be executed when the cell was tapped.
     ///
     var onCellAction: ((CellActionType, IndexPath?) -> Void)?
@@ -294,6 +298,8 @@ private extension OrderDetailsDataSource {
             configureOrderNote(cell: cell, at: indexPath)
         case let cell as LedgerTableViewCell:
             configurePayment(cell: cell)
+        case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .seeReceipt:
+            configureSeeReceipt(cell: cell)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .customerPaid:
             configureCustomerPaid(cell: cell)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .refund:
@@ -442,6 +448,14 @@ private extension OrderDetailsDataSource {
         cell.accessoryImage = nil
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
+    }
+
+    private func configureSeeReceipt(cell: TwoColumnHeadlineFootnoteTableViewCell) {
+        cell.setLeftTitleToLinkStyle(true)
+        cell.leftText = Titles.seeReceipt
+        cell.rightText = nil
+        cell.hideFootnote()
+        cell.hideSeparator()
     }
 
     private func configureRefund(cell: TwoColumnHeadlineFootnoteTableViewCell, at indexPath: IndexPath) {
@@ -939,6 +953,10 @@ extension OrderDetailsDataSource {
                 rows.append(.collectCardPaymentButton)
             }
 
+            if shouldShowReceipts {
+                rows.append(.seeReceipt)
+            }
+
             if !isRefundedStatus && !isEligibleForCardPresentPayment {
                 rows.append(.issueRefundButton)
             }
@@ -1158,6 +1176,7 @@ extension OrderDetailsDataSource {
         static let collectPayment = NSLocalizedString("Collect Payment", comment: "Text on the button that starts collecting a card present payment.")
         static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
         static let reprintShippingLabel = NSLocalizedString("Reprint Shipping Label", comment: "Text on the button that reprints a shipping label")
+        static let seeReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
     }
 
     enum Icons {
@@ -1295,6 +1314,7 @@ extension OrderDetailsDataSource {
         case billingDetail
         case payment
         case customerPaid
+        case seeReceipt
         case refund
         case netAmount
         case tracking
@@ -1338,6 +1358,8 @@ extension OrderDetailsDataSource {
             case .payment:
                 return LedgerTableViewCell.reuseIdentifier
             case .customerPaid:
+                return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
+            case .seeReceipt:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .refund:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -275,6 +275,9 @@ extension OrderDetailsViewModel {
             }
             productListVC.viewModel = self
             viewController.navigationController?.pushViewController(productListVC, animated: true)
+        case .seeReceipt:
+            print("==== See receipt tapped")
+            print("==== To be continued in #3981")
         case .refund:
             ServiceLocator.analytics.track(.orderDetailRefundDetailTapped)
             guard let refund = dataSource.refund(at: indexPath) else {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -419,14 +419,12 @@ extension OrderDetailsViewModel {
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
         let action = ReceiptAction.loadReceipt(order: order) { [weak self] result in
             switch result {
-            case .success(let parameters):
-                print("====== receipt parameters for order \(String(describing: self?.order.orderID))")
-                print(parameters)
-                print("////// recipt parameters loaded")
-                onCompletion?(nil)
+            case .success:
+                self?.dataSource.shouldShowReceipts = true
             case .failure:
-                print("==== no receipt parameters for order \(String(describing: self?.order.orderID)). moving on")
+                self?.dataSource.shouldShowReceipts = false
             }
+            onCompletion?(nil)
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -377,6 +377,9 @@ private extension OrderDetailsViewController {
     }
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
+            return
+        }
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -324,6 +324,11 @@ extension OrderDetailsViewController {
         }
 
         group.enter()
+        syncSavedReceipts {_ in
+            group.leave()
+        }
+
+        group.enter()
         checkOrderAddOnFeatureSwitchState {
             group.leave()
         }
@@ -380,6 +385,7 @@ private extension OrderDetailsViewController {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
             return
         }
+
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 
@@ -426,6 +432,11 @@ private extension OrderDetailsViewController {
 
         group.enter()
         syncNotes { _ in
+            group.leave()
+        }
+
+        group.enter()
+        syncSavedReceipts { _ in
             group.leave()
         }
 


### PR DESCRIPTION
Closes #3975 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

This PR adds a "See receipt" button to the order details screen, for those orders that have a corresponding receipt saved.

The "See receipt" button does nothing yet. The functionality will be implemented in #3981 

| Order without receipt |  Order with receipt |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/118026274-9f745180-b32e-11eb-890b-37797236d796.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/118026271-9edbbb00-b32e-11eb-990f-4e2dfc8615b9.png" width="350"/> |


## Changes
* Touch OrderDetailsViewController, OrderDetailsViewModel and OrderDetailsDataSource, to add the new section.

## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. The pre-release version of WCPay that implements the endpoint that captures the payment id (see p91TBi-54R#comment-4441-p2 for a downloadable zip)
3. Or, WCPay 2.4.0, released today

* Checkout the branch
* Collect a payment for an order.
* Navigate to a different order (e.g one that is not eligible for card present payments). Notice there should not be a "See Receipt" button
* Navigate to the order that has been charged in the previous step. Notice there should be a "See Receipt" button
* Stop the app, start again, navigate to an eligible order, and the button should still be there.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
