### PR TITLE
[Mobile Payments] Settings 2-7: Tint and link learn more to web view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -263,7 +263,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wIN-aE-q96">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="wIN-aE-q96">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsConnectView.swift
@@ -87,7 +87,7 @@ final class CardReaderSettingsConnectView: NSObject {
     }
 
     private func configureLearnMore(cell: LearnMoreTableViewCell) {
-        cell.learnMoreLabel.text = Localization.learnMore
+        cell.learnMoreTextView.text = Localization.learnMore
         cell.selectionStyle = .none
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -217,8 +217,14 @@ private extension CardReaderSettingsUnknownViewController {
     }
 
     private func configureLearnMore(cell: LearnMoreTableViewCell) {
-        cell.learnMoreLabel.text = Localization.learnMore
+        cell.learnMoreTextView.attributedText = Localization.learnMore
+        cell.learnMoreTextView.tintColor = .textLink
+        cell.learnMoreTextView.delegate = self
         cell.selectionStyle = .none
+    }
+
+    private func urlWasPressed(url: URL) {
+        WebviewHelper.launch(url, with: self)
     }
 }
 
@@ -244,7 +250,7 @@ extension CardReaderSettingsUnknownViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        return CGFloat.leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -276,8 +282,6 @@ extension CardReaderSettingsUnknownViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-
-        // TODO: Connect the connect button to the view model
     }
 }
 
@@ -335,6 +339,17 @@ private enum Row: CaseIterable {
     }
 }
 
+// MARK: - UITextViewDelegate Conformance
+//
+extension CardReaderSettingsUnknownViewController: UITextViewDelegate {
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL,
+                  in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        urlWasPressed(url: URL)
+        return false
+    }
+}
+
 // MARK: - Localization
 //
 private extension CardReaderSettingsUnknownViewController {
@@ -384,9 +399,23 @@ private extension CardReaderSettingsUnknownViewController {
             comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
         )
 
-        static let learnMore = NSLocalizedString(
-            "Learn more about accepting payments with your mobile device and ordering card readers",
-            comment: "Settings > Manage Card Reader > Connect > A prompt for new users to start accepting mobile payments"
-        )
+        static var learnMore: NSAttributedString {
+            let learnMoreText = NSLocalizedString(
+                "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
+                comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
+            )
+
+            let learnMoreAttributes: [NSAttributedString.Key: Any] = [
+                .font: StyleManager.footerLabelFont,
+                .foregroundColor: UIColor.textSubtle
+            ]
+
+            let learnMoreAttrText = NSMutableAttributedString()
+            learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
+            let range = NSRange(location: 0, length: learnMoreAttrText.length)
+            learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
+
+            return learnMoreAttrText
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -276,8 +276,7 @@ extension CardReaderSettingsUnknownViewController: UITableViewDataSource {
 extension CardReaderSettingsUnknownViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let row = rowAtIndexPath(indexPath)
-        return row.height
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -317,20 +316,6 @@ private enum Row: CaseIterable {
             return ButtonTableViewCell.self
         case .connectLearnMore:
             return LearnMoreTableViewCell.self
-        }
-    }
-
-    var height: CGFloat {
-        switch self {
-        case .connectHeader,
-             .connectButton,
-             .connectImage:
-            return UITableView.automaticDimension
-        case .connectHelpHintChargeReader,
-             .connectHelpHintTurnOnReader,
-             .connectHelpHintEnableBluetooth,
-             .connectLearnMore:
-            return 70
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
@@ -1,7 +1,6 @@
 import UIKit
 
-/// A table view cell that, when tapped, opens a URL where users can "learn more" about something.
+/// A table view cell with linkable text prompting users to learn more
 class LearnMoreTableViewCell: UITableViewCell {
-
-    @IBOutlet weak var learnMoreLabel: UILabel!
+    @IBOutlet weak var learnMoreTextView: UITextView!
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,25 +25,31 @@
                         </constraints>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </button>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ot5-CO-8GF">
-                        <rect key="frame" x="60" y="30" width="334" height="14.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                        <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pn2-lW-lwh">
+                        <rect key="frame" x="60" y="12.5" width="334" height="49.5"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    </textView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="zTM-KS-b6r" firstAttribute="centerY" secondItem="LCt-GL-faI" secondAttribute="centerY" id="1dG-Vh-eS9"/>
-                    <constraint firstItem="Ot5-CO-8GF" firstAttribute="leading" secondItem="zTM-KS-b6r" secondAttribute="trailing" constant="20" id="7aG-39-Efb"/>
-                    <constraint firstAttribute="trailing" secondItem="Ot5-CO-8GF" secondAttribute="trailing" constant="20" id="8Om-ew-KS1"/>
-                    <constraint firstItem="Ot5-CO-8GF" firstAttribute="centerY" secondItem="LCt-GL-faI" secondAttribute="centerY" id="TyM-r2-SNX"/>
+                    <constraint firstItem="pn2-lW-lwh" firstAttribute="leading" secondItem="zTM-KS-b6r" secondAttribute="trailing" constant="20" id="43S-tV-U7j"/>
+                    <constraint firstAttribute="trailing" secondItem="pn2-lW-lwh" secondAttribute="trailing" constant="20" id="Bdc-wc-k5A"/>
+                    <constraint firstItem="pn2-lW-lwh" firstAttribute="centerY" secondItem="LCt-GL-faI" secondAttribute="centerY" id="k2q-pU-Hcm"/>
                     <constraint firstItem="zTM-KS-b6r" firstAttribute="leading" secondItem="LCt-GL-faI" secondAttribute="leading" constant="20" id="ocx-j6-qGN"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="learnMoreLabel" destination="Ot5-CO-8GF" id="Xip-4J-wAO"/>
+                <outlet property="learnMoreTextView" destination="pn2-lW-lwh" id="A5r-mE-9rz"/>
             </connections>
             <point key="canvasLocation" x="37.681159420289859" y="103.79464285714285"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
@@ -26,7 +26,7 @@
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </button>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pn2-lW-lwh">
-                        <rect key="frame" x="60" y="12.5" width="334" height="49.5"/>
+                        <rect key="frame" x="60" y="10" width="334" height="54"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -37,7 +37,8 @@
                     <constraint firstItem="zTM-KS-b6r" firstAttribute="centerY" secondItem="LCt-GL-faI" secondAttribute="centerY" id="1dG-Vh-eS9"/>
                     <constraint firstItem="pn2-lW-lwh" firstAttribute="leading" secondItem="zTM-KS-b6r" secondAttribute="trailing" constant="20" id="43S-tV-U7j"/>
                     <constraint firstAttribute="trailing" secondItem="pn2-lW-lwh" secondAttribute="trailing" constant="20" id="Bdc-wc-k5A"/>
-                    <constraint firstItem="pn2-lW-lwh" firstAttribute="centerY" secondItem="LCt-GL-faI" secondAttribute="centerY" id="k2q-pU-Hcm"/>
+                    <constraint firstItem="pn2-lW-lwh" firstAttribute="top" secondItem="LCt-GL-faI" secondAttribute="top" constant="10" id="HXe-lL-aq2"/>
+                    <constraint firstAttribute="bottom" secondItem="pn2-lW-lwh" secondAttribute="bottom" constant="10" id="T0d-9M-VAi"/>
                     <constraint firstItem="zTM-KS-b6r" firstAttribute="leading" secondItem="LCt-GL-faI" secondAttribute="leading" constant="20" id="ocx-j6-qGN"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/NumberedListItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/NumberedListItemTableViewCell.xib
@@ -18,9 +18,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b8B-E4-1cG">
-                        <rect key="frame" x="30" y="19" width="32" height="33"/>
+                        <rect key="frame" x="30" y="19.5" width="32" height="32"/>
                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                         <constraints>
+                            <constraint firstAttribute="width" secondItem="b8B-E4-1cG" secondAttribute="height" multiplier="32:32" id="71A-ms-0Es"/>
                             <constraint firstAttribute="width" constant="32" id="KU0-Pg-Zp2"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -43,11 +44,10 @@
                 <constraints>
                     <constraint firstItem="uTV-ZV-8LG" firstAttribute="top" secondItem="N2W-yf-dgL" secondAttribute="top" constant="10" id="2ec-4H-7e3"/>
                     <constraint firstAttribute="trailing" secondItem="uTV-ZV-8LG" secondAttribute="trailing" constant="30" id="D3n-oR-tyS"/>
+                    <constraint firstItem="b8B-E4-1cG" firstAttribute="centerY" secondItem="N2W-yf-dgL" secondAttribute="centerY" id="E5a-7R-RJ0"/>
                     <constraint firstItem="uTV-ZV-8LG" firstAttribute="leading" secondItem="b8B-E4-1cG" secondAttribute="trailing" constant="19" id="FVE-Xj-vsD"/>
-                    <constraint firstAttribute="bottom" secondItem="b8B-E4-1cG" secondAttribute="bottom" constant="19" id="HyR-K3-dEJ"/>
                     <constraint firstItem="b8B-E4-1cG" firstAttribute="leading" secondItem="N2W-yf-dgL" secondAttribute="leading" constant="30" id="RNX-PQ-BLs"/>
                     <constraint firstAttribute="bottom" secondItem="uTV-ZV-8LG" secondAttribute="bottom" constant="10" id="jMj-VA-tCn"/>
-                    <constraint firstItem="b8B-E4-1cG" firstAttribute="top" secondItem="N2W-yf-dgL" secondAttribute="top" constant="19" id="kTc-6F-H5c"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>


### PR DESCRIPTION
Fixes #4053 

Note:
- This PR is against feature/stripe-temrinal-sdk-integration and not develop

Changes:
- I had to give up on UILabel :) I swapped it out with a UITextView and everything else fell into place
- Inspired by the We're Hiring approach
- I had to update the v1 settings usage too, but I didn't bother linking it since it will be deleted soon.
- I also fixed some of the background colors and section heading sizes in the no known no connected reader (unknown) view controller

To test:
- Enter Settings > Manage Card Readers V2 when you are not connected to a reader
- Note the "Learn more" part of the link near the bottom of the screen is tinted. Tap on it. Note the webview that loads
- Try it in Dark and Light modes

Screenshots:

<img src="https://user-images.githubusercontent.com/1595739/118051690-47414d80-b336-11eb-892c-1bec52eaf0a5.png" width=50% />

<img src="https://user-images.githubusercontent.com/1595739/118051696-4a3c3e00-b336-11eb-9c2a-77b303e18770.png" width=50% />

<img src="https://user-images.githubusercontent.com/1595739/118051699-4ad4d480-b336-11eb-87b3-00d1954a33fd.png" width=50% />

<img src="https://user-images.githubusercontent.com/1595739/118051702-4c060180-b336-11eb-8093-287e287f5ebc.png" width=50% />

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
