### PR TITLE
[Mobile Payments] Use Sink subscriber for resetting card reader service

### DIFF
--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -193,10 +193,13 @@ private extension CardPresentPaymentStore {
     }
 
     func reset() {
-        cardReaderService.disconnect().sink(receiveCompletion: { [weak self] _ in
-            self?.cardReaderService.clear()
-        }, receiveValue: {
-        }).store(in: &cancellables)
+        cardReaderService.disconnect()
+            .subscribe(Subscribers.Sink(
+                        receiveCompletion: { [weak self] _ in
+                            self?.cardReaderService.clear()
+                        },
+                        receiveValue: { _ in }
+            ))
     }
 }
 


### PR DESCRIPTION
Part of #3926 

This removes the need to store a cancellable for the `reset` action by using `Subscribers.Sink` instead of the `sink` operator.

## To test

Follow the testing steps in #4147

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
