### PR TITLE
[Mobile Payments] Improve publisher subscription management for payment collection

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -46,6 +46,7 @@ public protocol CardReaderService {
     func clear()
 
     /// Captures a payment after collecting a payment method succeeds.
+    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error>
 
     /// Cancels a a PaymentIntent

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -160,6 +160,10 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+        // The documentation for this protocol method promises that this will produce either
+        // a single value or it will fail.
+        // This isn't enforced by the type system, but it is guaranteed as long as all the
+        // steps produce a Future.
         return createPaymentIntent(parameters)
             .flatMap { intent in
                 self.collectPaymentMethod(intent: intent)

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -93,7 +93,9 @@ final class MockCardReaderService: CardReaderService {
     func clear() { }
 
     func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
-        return Empty(completeImmediately: true).eraseToAnyPublisher()
+        Just(MockPaymentIntent.mock())
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
     }
 
     func cancelPaymentIntent(_ intent: PaymentIntent) -> Future<PaymentIntent, Error> {


### PR DESCRIPTION
Part of #3926 

This one improves the cancellable management for the `collectPayment` action.

In this case, managing the subscription gets slightly more complicated, since we have:
1. Two different callback methods.
2. A `readerEvents` publisher that we want to subscribe as long as the payment is in progress.
3. A `capturePayment` method that performs several steps sequentially.

My approach here has been to first declare that `CardReaderService.capturePayment` behaves like a future. I don't think there is a good way to enforce this, or at least not one that wouldn't overcomplicate things, so for now we can state that in the documentation and make sure it behaves like that. This wasn't strictly necessary for the cancellable, but we only want to call the completion callback once, so this makes that more explicit.

For the `readerEvents` subscription, I've stored the cancellable in a local variable, which gets captured by the completion block, which will call `cancel()` on completion.

For the `capturePayment` method, I've switched it to `Subscribers.Sink` like others.

## To test

I'm not sure how to test all the possible payment flows without a physical reader, but I've tried completing the payment flow for a couple of orders with the simulated reader, and everything seemed to work fine.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
