### PR TITLE
[Mobile Payments] Receipt details view

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -439,6 +439,12 @@ extension UIImage {
         return UIImage.gridicon(.money, size: CGSize(width: 24, height: 24))
     }
 
+    /// Print Icon
+    ///
+    static var print: UIImage {
+        return UIImage.gridicon(.print)
+    }
+
     /// Product Deleted Icon
     ///
     static var productDeletedImage: UIImage {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -16,4 +16,8 @@ final class ReceiptViewModel {
 
         ServiceLocator.stores.dispatch(action)
     }
+
+    func printReceipt() {
+        print("===== hitting print")
+    }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -18,6 +18,8 @@ final class ReceiptViewModel {
     }
 
     func printReceipt() {
-        print("===== hitting print")
+        let action = ReceiptAction.print(order: order, parameters: receipt)
+
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -1,14 +1,23 @@
 import Yosemite
 
+/// ViewModel supporting the receipt preview.
 final class ReceiptViewModel {
     private let order: Order
     private let receipt: CardPresentReceiptParameters
 
+
+    /// Initializer
+    /// - Parameters:
+    ///   - order: The order associated with the receipt
+    ///   - receipt: the receipt metadata
     init(order: Order, receipt: CardPresentReceiptParameters) {
         self.order = order
         self.receipt = receipt
     }
 
+
+    /// Get the receipt content
+    /// - Parameter onCompletion: a closure containing the receipt content as a HTML string
     func generateContent(onCompletion: @escaping (String) -> Void) {
         let action = ReceiptAction.generateContent(order: order, parameters: receipt) { receiptContent in
             onCompletion(receiptContent)
@@ -17,6 +26,8 @@ final class ReceiptViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
+
+    /// Prints the receipt
     func printReceipt() {
         let action = ReceiptAction.print(order: order, parameters: receipt)
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -1,9 +1,19 @@
 import Yosemite
 
 final class ReceiptViewModel {
+    private let order: Order
     private let receipt: CardPresentReceiptParameters
 
-    init(receipt: CardPresentReceiptParameters) {
+    init(order: Order, receipt: CardPresentReceiptParameters) {
+        self.order = order
         self.receipt = receipt
+    }
+
+    func generateContent(onCompletion: @escaping (String) -> Void) {
+        let action = ReceiptAction.generateContent(order: order, parameters: receipt) { receiptContent in
+            onCompletion(receiptContent)
+        }
+
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -1,0 +1,9 @@
+import Yosemite
+
+final class ReceiptViewModel {
+    private let receipt: CardPresentReceiptParameters
+
+    init(receipt: CardPresentReceiptParameters) {
+        self.receipt = receipt
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -136,6 +136,8 @@ final class OrderDetailsViewModel {
 
     private var paymentsAccount: WCPayAccount? = nil
 
+    private var receipt: CardPresentReceiptParameters? = nil
+
     /// Helpers
     ///
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {
@@ -276,8 +278,12 @@ extension OrderDetailsViewModel {
             productListVC.viewModel = self
             viewController.navigationController?.pushViewController(productListVC, animated: true)
         case .seeReceipt:
-            print("==== See receipt tapped")
-            print("==== To be continued in #3981")
+            guard let receipt = receipt else {
+                return
+            }
+            let viewModel = ReceiptViewModel(receipt: receipt)
+            let receiptViewController = ReceiptViewController(viewModel: viewModel)
+            viewController.navigationController?.pushViewController(receiptViewController, animated: true)
         case .refund:
             ServiceLocator.analytics.track(.orderDetailRefundDetailTapped)
             guard let refund = dataSource.refund(at: indexPath) else {
@@ -422,7 +428,8 @@ extension OrderDetailsViewModel {
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
         let action = ReceiptAction.loadReceipt(order: order) { [weak self] result in
             switch result {
-            case .success:
+            case .success(let parameters):
+                self?.receipt = parameters
                 self?.dataSource.shouldShowReceipts = true
             case .failure:
                 self?.dataSource.shouldShowReceipts = false

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -281,7 +281,7 @@ extension OrderDetailsViewModel {
             guard let receipt = receipt else {
                 return
             }
-            let viewModel = ReceiptViewModel(receipt: receipt)
+            let viewModel = ReceiptViewModel(order: order, receipt: receipt)
             let receiptViewController = ReceiptViewController(viewModel: viewModel)
             viewController.navigationController?.pushViewController(receiptViewController, animated: true)
         case .refund:

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+final class ReceiptViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -19,6 +19,7 @@ final class ReceiptViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureToolbar()
         configureBackground()
     }
 
@@ -30,6 +31,13 @@ final class ReceiptViewController: UIViewController {
 }
 
 private extension ReceiptViewController {
+    func configureToolbar() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: .print,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(printReceipt))
+    }
+
     func configureBackground() {
         view.backgroundColor = .systemBackground
     }
@@ -38,5 +46,9 @@ private extension ReceiptViewController {
         viewModel.generateContent { [weak self] content in
             self?.webView.loadHTMLString(content, baseURL: nil)
         }
+    }
+
+    @objc func printReceipt() {
+        viewModel.printReceipt()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -1,22 +1,24 @@
 import UIKit
+import WebKit
+import Yosemite
 
 final class ReceiptViewController: UIViewController {
+    @IBOutlet private weak var webView: WKWebView!
+
+    private let viewModel: ReceiptViewModel
+
+    init(viewModel: ReceiptViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: Self.nibName, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -21,4 +21,18 @@ final class ReceiptViewController: UIViewController {
 
         // Do any additional setup after loading the view.
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        syncReceiptContent()
+    }
+}
+
+private extension ReceiptViewController {
+    func syncReceiptContent() {
+        viewModel.generateContent { [weak self] content in
+            self?.webView.loadHTMLString(content, baseURL: nil)
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 import WebKit
 import Yosemite
 
+
+/// Previews a receipt
 final class ReceiptViewController: UIViewController {
     @IBOutlet private weak var webView: WKWebView!
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -19,7 +19,7 @@ final class ReceiptViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        configureBackground()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -30,6 +30,10 @@ final class ReceiptViewController: UIViewController {
 }
 
 private extension ReceiptViewController {
+    func configureBackground() {
+        view.backgroundColor = .systemBackground
+    }
+
     func syncReceiptContent() {
         viewModel.generateContent { [weak self] content in
             self?.webView.loadHTMLString(content, baseURL: nil)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
@@ -21,7 +21,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="99B-x5-qzp">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="16" y="60" width="382" height="786"/>
                     <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <wkWebViewConfiguration key="configuration">
                         <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -32,10 +32,10 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="99B-x5-qzp" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="5cC-TA-kQq"/>
-                <constraint firstItem="99B-x5-qzp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="fCV-vm-Ir5"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="99B-x5-qzp" secondAttribute="trailing" id="iTG-Cv-jsm"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="99B-x5-qzp" secondAttribute="bottom" id="lSg-mM-Mr0"/>
+                <constraint firstItem="99B-x5-qzp" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="5cC-TA-kQq"/>
+                <constraint firstItem="99B-x5-qzp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="fCV-vm-Ir5"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="99B-x5-qzp" secondAttribute="trailing" constant="16" id="iTG-Cv-jsm"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="99B-x5-qzp" secondAttribute="bottom" constant="16" id="lSg-mM-Mr0"/>
             </constraints>
             <point key="canvasLocation" x="-32" y="127"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReceiptViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.xib
@@ -1,22 +1,48 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReceiptViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReceiptViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="webView" destination="99B-x5-qzp" id="v0x-fu-bdw"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="99B-x5-qzp">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="99B-x5-qzp" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="5cC-TA-kQq"/>
+                <constraint firstItem="99B-x5-qzp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="fCV-vm-Ir5"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="99B-x5-qzp" secondAttribute="trailing" id="iTG-Cv-jsm"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="99B-x5-qzp" secondAttribute="bottom" id="lSg-mM-Mr0"/>
+            </constraints>
+            <point key="canvasLocation" x="-32" y="127"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1159,6 +1159,8 @@
 		D8CD710F237A49DB007148B9 /* UIColor+SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CD710E237A49DB007148B9 /* UIColor+SemanticColors.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
+		D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */; };
+		D8EE9693264D328A0033B2F9 /* ReceiptViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */; };
 		D8EF1E562605121C00380EA4 /* OrderPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */; };
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
 		D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
@@ -2413,6 +2415,8 @@
 		D8CD710E237A49DB007148B9 /* UIColor+SemanticColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SemanticColors.swift"; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewController.swift; sourceTree = "<group>"; };
+		D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReceiptViewController.xib; sourceTree = "<group>"; };
 		D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentMethod.swift; sourceTree = "<group>"; };
 		D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCardReaderIntegrationTests.swift; sourceTree = "<group>"; };
 		D8F3A972258862BE0085859B /* PrologueScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrologueScreen.swift; sourceTree = "<group>"; };
@@ -5601,6 +5605,8 @@
 			children = (
 				D8815ADD26383EE600EDAD62 /* CardPresentPaymentsModalViewController.swift */,
 				D8815ADE26383EE700EDAD62 /* CardPresentPaymentsModalViewController.xib */,
+				D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */,
+				D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -5998,6 +6004,7 @@
 				CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */,
 				93BCF01F20DC2CE200EBF7A1 /* bash_secrets.tpl in Resources */,
 				02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */,
+				D8EE9693264D328A0033B2F9 /* ReceiptViewController.xib in Resources */,
 				B56DB3D42049BFAA00D4AA8E /* Assets.xcassets in Resources */,
 				CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */,
 				4590CEE5249BA46700949F05 /* AddProductCategoryViewController.xib in Resources */,
@@ -6594,6 +6601,7 @@
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,
 				262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */,
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
+				D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1161,6 +1161,7 @@
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
 		D8EE9692264D328A0033B2F9 /* ReceiptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */; };
 		D8EE9693264D328A0033B2F9 /* ReceiptViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */; };
+		D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */; };
 		D8EF1E562605121C00380EA4 /* OrderPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */; };
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
 		D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
@@ -2417,6 +2418,7 @@
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewController.swift; sourceTree = "<group>"; };
 		D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReceiptViewController.xib; sourceTree = "<group>"; };
+		D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewModel.swift; sourceTree = "<group>"; };
 		D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentMethod.swift; sourceTree = "<group>"; };
 		D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCardReaderIntegrationTests.swift; sourceTree = "<group>"; };
 		D8F3A972258862BE0085859B /* PrologueScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrologueScreen.swift; sourceTree = "<group>"; };
@@ -5625,6 +5627,7 @@
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
+				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -6915,6 +6918,7 @@
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				0229ED00258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift in Sources */,
+				D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -242,6 +242,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.paymentErrorImage)
     }
 
+    func test_print_icon_in_not_nil() {
+        XCTAssertNotNil(UIImage.print)
+    }
+
     func testPlusImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.plusImage)
     }


### PR DESCRIPTION
Closes #3981 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️

This PR starts where #4181 ends, and implements the action triggered when tapping "See Receipt".

https://user-images.githubusercontent.com/2722505/118120902-a2b71e00-b3be-11eb-8be7-ddc30d6c0160.mov

## Changes
* Add a new view controller wrapping a WKWebview
* A view model to access the receipt HTML and to trigger a print action

## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. WCPay 2.4.0

* Checkout the branch
* Navigate to an order with a saved receipt, or collect a payment for an order, and wait until the "See Receipt" button is available
* Tap "See receipt"
* The app should navigate to a preview of the receipt. There should be a button in the top right to print the receipt to AirPrint. (see video above)



Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
