### PR TITLE
[Mobile Payments] Improve combine subscriptions for card reader software updates

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -58,5 +58,8 @@ public protocol CardReaderService {
 
     /// Triggers a software update. This method requires that checkForUpdates
     /// has been completed successfully
-    func installUpdate() -> Future<Void, Error>
+    ///
+    /// The returned publisher will periodically publish the fraction of progress during the software update
+    /// and it will complete when it's finished, unless there is any error.
+    func installUpdate() -> AnyPublisher<Float, Error>
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReaders/CardReaderSettingsViewModel.swift
@@ -188,13 +188,13 @@ final class CardReaderSettingsViewModel: ObservableObject {
             switch result {
             case .failure(let error):
                 print("===== error checking for updates ", error)
-            case .success(let update):
+            case .success(.some(let update)):
                 print("=== there is an update available")
                 print("=== version ", update.deviceSoftwareVersion)
                 print("=== estimated time ", update.estimatedUpdateTime)
+            case .success(.none):
+                print("=== check for updates completed")
             }
-        } onCompletion: {
-            print("=== check for updates completed")
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -42,8 +42,7 @@ public enum CardPresentPaymentAction: Action {
                         onCompletion: (Result<PaymentIntent, Error>) -> Void )
 
     /// Check whether there is a software update available.
-    case checkForCardReaderUpdate(onData: (Result<CardReaderSoftwareUpdate, Error>) -> Void,
-                        onCompletion: () -> Void)
+    case checkForCardReaderUpdate(onCompletion: (Result<CardReaderSoftwareUpdate?, Error>) -> Void)
 
     /// Update card reader firmware.
     case startCardReaderUpdate(onProgress: (Float) -> Void,

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -163,16 +163,17 @@ private extension CardPresentPaymentStore {
     }
 
     func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
-        cardReaderService.checkForUpdate().sink(receiveCompletion: { value in
-            switch value {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .finished:
-                onCompletion(.success(nil))
-            }
-        }, receiveValue: {softwareUpdate in
-            onCompletion(.success(softwareUpdate))
-        }).store(in: &cancellables)
+        cardReaderService.checkForUpdate()
+            .subscribe(Subscribers.Sink { value in
+                switch value {
+                case .failure(let error):
+                    onCompletion(.failure(error))
+                case .finished:
+                    onCompletion(.success(nil))
+                }
+            } receiveValue: {softwareUpdate in
+                onCompletion(.success(softwareUpdate))
+            })
     }
 
     func startCardReaderUpdate(onProgress: @escaping (Float) -> Void,

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -178,20 +178,18 @@ private extension CardPresentPaymentStore {
 
     func startCardReaderUpdate(onProgress: @escaping (Float) -> Void,
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        cardReaderService.installUpdate().sink(receiveCompletion: { value in
-            switch value {
-            case .failure(let error):
-                onCompletion(.failure(error))
-            case .finished:
-                onCompletion(.success(()))
-            }
-        }, receiveValue: {
-            onCompletion(.success(()))
-        }).store(in: &cancellables)
-        // Observe update progress events fired by the card reader
-        cardReaderService.softwareUpdateEvents.sink { progress in
-            onProgress(progress)
-        }.store(in: &cancellables)
+        cardReaderService.installUpdate()
+            .subscribe(Subscribers.Sink(
+                receiveCompletion: { value in
+                    switch value {
+                    case .failure(let error):
+                        onCompletion(.failure(error))
+                    case .finished:
+                        onCompletion(.success(()))
+                    }
+                },
+                receiveValue: onProgress
+            ))
     }
 
     func reset() {

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -54,8 +54,8 @@ public final class CardPresentPaymentStore: Store {
                            parameters: parameters,
                            onCardReaderMessage: event,
                            onCompletion: completion)
-        case .checkForCardReaderUpdate(onData: let data, onCompletion: let completion):
-            checkForCardReaderUpdate(onData: data, onCompletion: completion)
+        case .checkForCardReaderUpdate(onCompletion: let completion):
+            checkForCardReaderUpdate(onCompletion: completion)
         case .startCardReaderUpdate(onProgress: let progress, onCompletion: let completion):
             startCardReaderUpdate(onProgress: progress, onCompletion: completion)
         case .reset:
@@ -162,17 +162,16 @@ private extension CardPresentPaymentStore {
             })
     }
 
-    func checkForCardReaderUpdate(onData: @escaping (Result<CardReaderSoftwareUpdate, Error>) -> Void,
-                        onCompletion: @escaping () -> Void) {
+    func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
         cardReaderService.checkForUpdate().sink(receiveCompletion: { value in
             switch value {
             case .failure(let error):
-                onData(.failure(error))
+                onCompletion(.failure(error))
             case .finished:
-                onCompletion()
+                onCompletion(.success(nil))
             }
         }, receiveValue: {softwareUpdate in
-            onData(.success(softwareUpdate))
+            onCompletion(.success(softwareUpdate))
         }).store(in: &cancellables)
     }
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -110,9 +110,7 @@ final class MockCardReaderService: CardReaderService {
         }
     }
 
-    func installUpdate() -> Future<Void, Error> {
-        Future() { promise in
-            // To be implemented
-        }
+    func installUpdate() -> AnyPublisher<Float, Error> {
+        Empty<Float, Error>().eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
Part of #3926 

We're almost done 😅. This was the trickiest of all the subscriptions, but also the most interesting.

In this case, we have data coming at `StripeCardReaderService` from two different sources:
- The completion block for `Terminal.installUpdate(_:delegate:completion)` will tell us when the update is finished, or if there is an error
- The `terminal(_:didUpdateDiscoveredReaders:)` delegate method will be called periodically with progress updates.

Previously, the service would offer this two sources separately, but the problem description fits a `Publisher` perfectly: we want to send progress events, and complete when the update is done.

It took some effort to combine these two sources, but I think the end result is not too complicated. The main difficulty is that Combine doesn't offer many operators to take completion events into account, so rather than writing a custom publisher, I managed to find a solution with a boolean publisher. I tried to document this in the code but, as a summary:

- We keep the previous `Future` internally as a way to wrap the `installUpdate` completion in a way that it can be used with Combine.
- However, it now has an `Output` type of `Bool`, so we can prepend an initial `false` value. If we didn't do this, the `Future` would only emit its first event when the update was finished, and the rest wouldn't be useful to forward progress events.
- We map this `Bool` state into another publisher:
  - If the value is `false`, we return the existing `softwareUpdateSubject` so we can forward progress updates
  - If the value is `true`, we are done with the update and return an `Empty` publisher
- We use `map` and `switchToLatest` because `flatMap` would not complete until all the mapped publishers had completed, and `softwareUpdateSubject` never completes.

## To test

I've only been able to use the simulated reader, but my steps were:

1. Go to Settings > Manage Card Readers
2. Tap Connect to reader and connect to the first reader that shows up
3. Tap the 🕵️‍♂️ button to look for updates, make sure the console shows a `=== there is an update available`
4. Tap the 🚀 button to install the update.

The console should show a bunch of `==== progress  0.08` messages, and when it's done, a `=== the update has been completed. Moving on!`

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
