### PR TITLE
Cleanup OrderStatusStore and ReportRemote

### DIFF
--- a/Networking/Networking/Remote/ReportRemote.swift
+++ b/Networking/Networking/Remote/ReportRemote.swift
@@ -1,41 +1,13 @@
 import Foundation
-import Alamofire
 
 
 /// Reports: Remote Endpoints
 ///
 public class ReportRemote: Remote {
 
-    /// Retrieves all of the order totals for a given site.
-    /// Wraps the API request.
+    /// Retrieves an orders totals report (for all known order statuses)
     ///
-    /// *Note:* This is a Woo REST API v3 endpoint! It will not work on any Woo site under v3.5.
-    ///
-    /// - Parameters:
-    ///   - siteID: Site for which we'll fetch the order totals.
-    ///   - completion: Closure to be executed upon completion.
-    ///
-    public func loadOrderTotals(for siteID: Int64, completion: @escaping ([OrderStatusEnum: Int]?, Error?) -> Void) {
-        loadReportOrderTotals(for: siteID) { (orderStatuses, error) in
-            var returnDict = [OrderStatusEnum: Int]()
-            orderStatuses?.forEach({ (orderStatus) in
-                let status = OrderStatusEnum(rawValue: orderStatus.slug)
-                returnDict[status] = orderStatus.total
-            })
-            completion(returnDict, error)
-        }
-    }
-
-    /// Retrieves all known order statuses.
-    /// Wraps the API request.
-    ///
-    public func loadOrderStatuses(for siteID: Int64, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
-        loadReportOrderTotals(for: siteID, completion: completion)
-    }
-
-    /// Retrieves an order totals report
-    ///
-    private func loadReportOrderTotals(for siteID: Int64, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
+    public func loadOrdersTotals(for siteID: Int64, completion: @escaping (Result<[OrderStatus], Error>) -> Void) {
         let path = Constants.orderTotalsPath
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ReportOrderTotalsMapper(siteID: siteID)

--- a/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
@@ -25,7 +25,7 @@ class ReportRemoteTests: XCTestCase {
 
     /// Verifies that `loadOrdersTotals` properly parses the successful response
     ///
-    func testLoadOrdersTotalsReturnsSuccess() throws {
+    func test_loadOrdersTotals_returns_success() throws {
         // Given
         let remote = ReportRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
@@ -45,7 +45,7 @@ class ReportRemoteTests: XCTestCase {
 
     /// Verifies that `loadOrdersTotals` correctly returns a Dotcom Error, whenever the request failed.
     ///
-    func testLoadOrdersTotalsProperlyParsesErrorResponses() {
+    func test_loadOrdersTotals_properly_parses_error_responses() {
         // Given
         let remote = ReportRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "generic_error")

--- a/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
@@ -21,89 +21,44 @@ class ReportRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
-    // MARK: - loadOrderTotals
+    // MARK: - loadOrdersTotals
 
-    /// Verifies that 'loadOrderTotals' properly parses the successful response
+    /// Verifies that `loadOrdersTotals` properly parses the successful response
     ///
-    func testOrderTotalsReturnsSuccess() {
-        let expectation = self.expectation(description: "Load order totals")
+    func testLoadOrdersTotalsReturnsSuccess() throws {
+        // Given
         let remote = ReportRemote(network: network)
-
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
-        remote.loadOrderTotals(for: sampleSiteID) { (reportTotals, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(reportTotals)
-            XCTAssertEqual(reportTotals?.count, 9)
-            XCTAssertEqual(reportTotals?[.pending], 123)
-            XCTAssertEqual(reportTotals?[.processing], 4)
-            XCTAssertEqual(reportTotals?[.onHold], 5)
-            XCTAssertEqual(reportTotals?[.completed], 6)
-            XCTAssertEqual(reportTotals?[.cancelled], 7)
-            XCTAssertEqual(reportTotals?[.refunded], 8)
-            XCTAssertEqual(reportTotals?[.failed], 9)
-            XCTAssertEqual(reportTotals?[OrderStatusEnum(rawValue: "cia-investigation")], 10)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-    }
 
-    /// Verifies that `loadOrderTotals` correctly returns a Dotcom Error, whenever the request failed.
-    ///
-    func testOrderTotalsProperlyParsesErrorResponses() {
-        let expectation = self.expectation(description: "Error Handling")
-        let remote = ReportRemote(network: network)
-
-        network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "generic_error")
-        remote.loadOrderTotals(for: sampleSiteID) { (reportTotals, error) in
-            guard let error = error as? DotcomError else {
-                XCTFail()
-                return
+        // When
+        let result: Result<[OrderStatus], Error> = waitFor { promise in
+            remote.loadOrdersTotals(for: self.sampleSiteID) { result in
+                promise(result)
             }
-
-            XCTAssert(error == .unauthorized)
-            XCTAssertEqual(reportTotals?.isEmpty, true)
-
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        //Then
+        XCTAssertTrue(result.isSuccess)
+        let reportTotals = try XCTUnwrap(result.get())
+        XCTAssertEqual(reportTotals.count, 9)
     }
 
-    // MARK: - loadOrderStatuses
-
-    /// Verifies that 'loadOrderStatuses' properly parses the successful response
+    /// Verifies that `loadOrdersTotals` correctly returns a Dotcom Error, whenever the request failed.
     ///
-    func testLoadOrderStatusesReturnsSuccess() {
-        let expectation = self.expectation(description: "Load order statuses")
+    func testLoadOrdersTotalsProperlyParsesErrorResponses() {
+        // Given
         let remote = ReportRemote(network: network)
-
-        network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
-        remote.loadOrderStatuses(for: sampleSiteID) { (orderStatuses, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(orderStatuses)
-            XCTAssertEqual(orderStatuses?.count, 9)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-    }
-
-    /// Verifies that `loadOrderStatuses` correctly returns a Dotcom Error, whenever the request failed.
-    ///
-    func testLoadOrderStatusesProperlyParsesErrorResponses() {
-        let expectation = self.expectation(description: "Error Handling")
-        let remote = ReportRemote(network: network)
-
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "generic_error")
-        remote.loadOrderTotals(for: sampleSiteID) { (reportTotals, error) in
-            guard let error = error as? DotcomError else {
-                XCTFail()
-                return
+
+        // When
+        let result: Result<[OrderStatus], Error> = waitFor { promise in
+            remote.loadOrdersTotals(for: self.sampleSiteID) { result in
+                promise(result)
             }
-
-            XCTAssert(error == .unauthorized)
-            XCTAssertEqual(reportTotals?.isEmpty, true)
-
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        //Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? DotcomError, .unauthorized)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewModel.swift
@@ -39,8 +39,8 @@ final class OrdersTabbedViewModel {
     /// Fetch all `OrderStatus` from the API
     ///
     func syncOrderStatuses() {
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { (_, error) in
-            if let error = error {
+        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
+            if case let .failure(error) = result {
                 DDLogError("⛔️ Order List — Error synchronizing order statuses: \(error)")
             }
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -338,8 +338,8 @@ private extension DefaultStoresManager {
             return
         }
 
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { (_, error) in
-            if let error = error {
+        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
+            if case let .failure(error) = result {
                 DDLogError("⛔️ Could not successfully fetch order statuses for siteID \(siteID): \(error)")
             }
         }

--- a/Yosemite/Yosemite/Actions/OrderStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderStatusAction.swift
@@ -5,6 +5,6 @@ import Networking
 // MARK: - OrderStatusAction: Defines all of the Actions supported by the OrderStatusStore.
 //
 public enum OrderStatusAction: Action {
-    case retrieveOrderStatuses(siteID: Int64, onCompletion: ([OrderStatus]?, Error?) -> Void)
+    case retrieveOrderStatuses(siteID: Int64, onCompletion: (Result<[OrderStatus], Error>) -> Void)
     case resetStoredOrderStatuses(onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderStatusActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderStatusActionHandler.swift
@@ -11,7 +11,7 @@ struct MockOrderStatusActionHandler: MockActionHandler {
     func handle(action: ActionType) {
         switch action {
             // Order status is not currently supported by `MockObjectGraph`, so pretend none exist
-            case .retrieveOrderStatuses(_, let onCompletion): success(onCompletion)
+            case .retrieveOrderStatuses(_, let onCompletion): onCompletion(.success([]))
             default: unimplementedAction(action: action)
         }
     }

--- a/Yosemite/Yosemite/Stores/OrderStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStatusStore.swift
@@ -49,15 +49,15 @@ private extension OrderStatusStore {
 
     /// Retrieves the order statuses associated with the provided Site ID (if any!).
     ///
-    func retrieveOrderStatuses(siteID: Int64, onCompletion: @escaping ([OrderStatus]?, Error?) -> Void) {
-        remote.loadOrderStatuses(for: siteID) { [weak self] (orderStatuses, error) in
-            guard let orderStatuses = orderStatuses else {
-                onCompletion(nil, error)
-                return
-            }
-
-            self?.upsertStatusesInBackground(siteID: siteID, readOnlyOrderStatuses: orderStatuses) {
-                onCompletion(orderStatuses, nil)
+    func retrieveOrderStatuses(siteID: Int64, onCompletion: @escaping (Result<[OrderStatus], Error>) -> Void) {
+        remote.loadOrdersTotals(for: siteID) { result in
+            switch result {
+            case .success(let orderStatuses):
+                self.upsertStatusesInBackground(siteID: siteID, readOnlyOrderStatuses: orderStatuses) {
+                    onCompletion(.success(orderStatuses))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
@@ -73,7 +73,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses returns success on valid response.
     ///
-    func testRetrieveOrderStatusesReturnsExpectedStatuses() throws {
+    func test_retrieveOrderStatuses_returns_expected_statuses() throws {
         // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
@@ -95,7 +95,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses returns an error, whenever there is an error response.
     ///
-    func testRetrieveOrderStatusesReturnsErrorUponResponseError() {
+    func test_retrieveOrderStatuses_returns_error_upon_response_error() {
         // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "generic_error")
@@ -114,7 +114,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses returns an error, whenever there is not backend response.
     ///
-    func testRetrieveOrderStatusesReturnsErrorUponEmptyResponse() {
+    func test_retrieveOrderStatuses_returns_error_upon_empty_response() {
         // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -132,7 +132,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses effectively persists any retrieved statuses.
     ///
-    func testRetrieveOrderStatusesEffectivelyPersistsRetrievedOrderStatuses() {
+    func test_retrieveOrderStatuses_effectively_persists_retrieved_OrderStatuses() {
         // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
@@ -154,7 +154,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredStatusesInBackground` does not produce duplicate entries.
     ///
-    func testUpdateRetrieveOrderStatusesEffectivelyUpdatesPreexistantOrderStatuses() {
+    func test_upsertStatuses_effectively_updates_preexistant_OrderStatuses() {
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
 
@@ -191,7 +191,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredStatusesInBackground` removes deleted entities.
     ///
-    func testUpdateRetrieveShipmentTrackingListEffectivelyRemovesDeletedShipmentTrackingData() {
+    func test_upsertStatuses_effectively_removes_deleted_OrderStatuses() {
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
 

--- a/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
@@ -71,79 +71,85 @@ class OrderStatusStoreTests: XCTestCase {
 
     // MARK: - OrderStatusAction.retrieveOrderStatuses
 
-    /// Verifies that OrderStatusAction.retrieveOrderStatuses returns the expected statuses.
+    /// Verifies that OrderStatusAction.retrieveOrderStatuses returns success on valid response.
     ///
-    func testRetrieveOrderStatusesReturnsExpectedStatuses() {
-        let expectation = self.expectation(description: "Retrieve order statuses")
+    func testRetrieveOrderStatusesReturnsExpectedStatuses() throws {
+        // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: sampleSiteID) { (statuses, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(statuses)
-            XCTAssertEqual(statuses?.count, 9)
-            XCTAssertEqual(statuses, self.sampleOrderStatuses())
-            expectation.fulfill()
+
+        // When
+        let result: Result<[Yosemite.OrderStatus], Error> = waitFor { promise in
+            let action = OrderStatusAction.retrieveOrderStatuses(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            orderStatusStore.onAction(action)
         }
 
-        orderStatusStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let receivedStatuses = try XCTUnwrap(result.get())
+        XCTAssertEqual(receivedStatuses.count, 9)
+        XCTAssertEqual(receivedStatuses, sampleOrderStatuses())
     }
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses returns an error, whenever there is an error response.
     ///
-    func testRetrieveOrderStatusesReturnsErrorUponReponseError() {
-        let expectation = self.expectation(description: "Retrieve order statuses error response")
+    func testRetrieveOrderStatusesReturnsErrorUponResponseError() {
+        // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "generic_error")
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: sampleSiteID) { (statuses, error) in
-            XCTAssertNotNil(error)
-            XCTAssertNil(statuses)
-            expectation.fulfill()
+
+        // When
+        let result: Result<[Yosemite.OrderStatus], Error> = waitFor { promise in
+            let action = OrderStatusAction.retrieveOrderStatuses(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            orderStatusStore.onAction(action)
         }
 
-        orderStatusStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses returns an error, whenever there is not backend response.
     ///
     func testRetrieveOrderStatusesReturnsErrorUponEmptyResponse() {
-        let expectation = self.expectation(description: "Retrieve order statuses empty response error")
+        // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: sampleSiteID) { (statuses, error) in
-            XCTAssertNotNil(error)
-            XCTAssertNil(statuses)
-            expectation.fulfill()
+        // When
+        let result: Result<[Yosemite.OrderStatus], Error> = waitFor { promise in
+            let action = OrderStatusAction.retrieveOrderStatuses(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            orderStatusStore.onAction(action)
         }
 
-        orderStatusStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 
     /// Verifies that OrderStatusAction.retrieveOrderStatuses effectively persists any retrieved statuses.
     ///
     func testRetrieveOrderStatusesEffectivelyPersistsRetrievedOrderStatuses() {
-        let expectation = self.expectation(description: "Retrieving order statii shall persist order statii")
+        // Given
         let orderStatusStore = OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "report-orders")
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: sampleSiteID) { (statuses, error) in
-            XCTAssertNil(error)
 
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderStatus.self), 9)
-            let storageOrderStatuses = self.viewStorage.loadOrderStatuses(siteID: self.sampleSiteID)
-            XCTAssertNotNil(storageOrderStatuses)
-            let readOnlyList = storageOrderStatuses?.map({ $0.toReadOnly() })
-            XCTAssertEqual(readOnlyList?.sorted(), self.sampleOrderStatuses().sorted())
-
-            expectation.fulfill()
+        // When
+        let result: Result<[Yosemite.OrderStatus], Error> = waitFor { promise in
+            let action = OrderStatusAction.retrieveOrderStatuses(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            orderStatusStore.onAction(action)
         }
 
-        orderStatusStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 9)
+        let storedStatuses = viewStorage.loadOrderStatuses(siteID: sampleSiteID)?.map({ $0.toReadOnly() })
+        XCTAssertEqual(storedStatuses?.sorted(), sampleOrderStatuses().sorted())
     }
 
     /// Verifies that `upsertStoredStatusesInBackground` does not produce duplicate entries.


### PR DESCRIPTION
## Description

It's a sliced part of bigger networking/store improvements related to orders.

This PR:
1. Updates completion blocks from `([OrderStatus]?, Error?)` to `Result<[OrderStatus], Error>)`.
2. Removes `loadOrderTotals` which was unused and just returned some manipulated set of data.
3. Renames `loadOrderStatuses` to `loadOrdersTotals` to better describe that it's a call to `reports/orders/totals` API.

`OrderStatusStore` action is still left with old name `retrieveOrderStatuses` for now.

## Test

1. Verify that unit tests pass
2. Reset Core Data cache (logout or delete app), launch it again and open orders -> search. Verify that all orders statuses are loaded.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
