### PR TITLE
[Mobile Payments] Card Reader Settings: Allow for priority viewmodelandview to be nil

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -34,7 +34,11 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
         childViewController?.removeFromParent()
         childViewController?.view.removeFromSuperview()
 
-        childViewController = self.storyboard!.instantiateViewController(withIdentifier: viewModelAndView!.viewIdentifier)
+        guard let viewModelAndView = viewModelAndView else {
+            return
+        }
+
+        childViewController = self.storyboard!.instantiateViewController(withIdentifier: viewModelAndView.viewIdentifier)
 
         guard let childViewController = childViewController else {
             return
@@ -43,7 +47,7 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
         guard let presenter = childViewController as? CardReaderSettingsViewModelPresenter else {
             return
         }
-        presenter.configure(viewModel: viewModelAndView!.viewModel)
+        presenter.configure(viewModel: viewModelAndView.viewModel)
 
         self.view.addSubview(childViewController.view)
         self.addChild(childViewController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -48,9 +48,11 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
     }
 
     private func reevaluatePriorityViewModelAndView() {
-        guard let newPriorityViewModelAndView = viewModelsAndViews.first(
+        let newPriorityViewModelAndView = viewModelsAndViews.first(
             where: { $0.viewModel.shouldShow == .isTrue }
-        ), newPriorityViewModelAndView != priorityViewModelAndView else {
+        )
+
+        guard newPriorityViewModelAndView != priorityViewModelAndView else {
             return
         }
 


### PR DESCRIPTION
Fixes #4195 

Changes:
- Restores the possibility of `reevaluatePriorityViewModelAndView` returning nil (i.e. when no viewmodel thinks it should show)
- On further inspection, this can happen imperceptibly briefly as we advance through connecting a reader

To test:
- Settings > Manage Card Readers V2
- Connect a reader
- Disconnect it

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
