### PR TITLE
Make label name search less specific

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'make screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'Needs Screenshots')
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'Needs Screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'bot\: make screenshots')
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'bot make screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'generate screenshots')
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'bot: make screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'make screenshots')
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'bot\: make screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'bot* make screenshots')
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build Application
-    if: contains(github.event.pull_request.labels.*.name, 'bot* make screenshots')
+    if: contains(github.event.pull_request.labels.*.name, 'bot make screenshots')
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
I think the `:` in the `bot: make screenshots` label name might be causing trouble and I created this PR to try to do a test run of the GitHub action. I'm following the last part of the steps steps in Part 2 from https://github.com/woocommerce/woocommerce-ios/pull/1848#issue-372878538.

<sup>(internal reference: p1620930496044500-slack-CGPNUU63E)</sup>

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
