### PR TITLE
[Mobile Payments] Prevent retain cycles when presenting Card Reader Settings V2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -12,7 +12,9 @@ final class CardReaderSettingsPresentingViewController: UIViewController {
     /// Set our dependencies
     func configure(viewModelsAndViews: CardReaderSettingsPrioritizedViewModelsProvider) {
         self.viewModelsAndViews = viewModelsAndViews
-        self.viewModelsAndViews?.onPriorityChanged = onViewModelsPriorityChange
+        self.viewModelsAndViews?.onPriorityChanged = { [weak self] viewModelAndView in
+            self?.onViewModelsPriorityChange(viewModelAndView: viewModelAndView)
+        }
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -210,8 +210,8 @@ private extension CardReaderSettingsUnknownViewController {
 
     private func configureButton(cell: ButtonTableViewCell) {
         let buttonTitle = Localization.connectButton
-        cell.configure(title: buttonTitle) {
-            self.viewModel?.startReaderDiscovery()
+        cell.configure(title: buttonTitle) { [weak self] in
+            self?.viewModel?.startReaderDiscovery()
         }
         cell.selectionStyle = .none
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -25,7 +25,9 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
         viewModelsAndViews.append(
             CardReaderSettingsViewModelAndView(
                 viewModel: CardReaderSettingsUnknownViewModel(
-                    didChangeShouldShow: onDidChangeShouldShow
+                    didChangeShouldShow: { [weak self] state in
+                        self?.onDidChangeShouldShow(state)
+                    }
                 ),
                 viewIdentifier: "CardReaderSettingsUnknownViewController"
             )
@@ -33,7 +35,9 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
         viewModelsAndViews.append(
             CardReaderSettingsViewModelAndView(
                 viewModel: CardReaderSettingsConnectedViewModel(
-                    didChangeShouldShow: onDidChangeShouldShow
+                    didChangeShouldShow: { [weak self] state in
+                        self?.onDidChangeShouldShow(state)
+                    }
                 ),
                 viewIdentifier: "CardReaderSettingsConnectedViewController"
             )


### PR DESCRIPTION
Fixes #4201

This PR tweaks a few callbacks in the Card Reader Settings V2 files to prevent retain cycles.

## To test

Follow the instructions in #4201, and make sure no extra instances of the `CardReader*` classes are kept in memory after navigating away.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
