### PR TITLE
[Mobile Payments] Add first set of metadata to the payment intent

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */; };
 		5A747BE9FA06EC8752A35752 /* Pods_HardwareTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1DC5B6141B8184FAC29B0A4 /* Pods_HardwareTests.framework */; };
 		8FFAA245E257B9EB98E2FCBD /* Pods_SampleReceiptPrinter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */; };
 		C5D2CB7D21CEE28FEBF18BF6 /* Pods_Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9F0AC202B287C1221EA2C99 /* Pods_Hardware.framework */; };
@@ -125,6 +126,7 @@
 		0C16E0AAFF5A7B364BD4E171 /* Pods-Hardware.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release-alpha.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1CC96A71F2937BCB7432766F /* Pods-HardwareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HardwareTests.debug.xcconfig"; path = "Target Support Files/Pods-HardwareTests/Pods-HardwareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AFA997D6786C67B0A061854 /* Pods_SampleReceiptPrinter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleReceiptPrinter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentMetadataTests.swift; sourceTree = "<group>"; };
 		3CF9348BADD5E0518080A61A /* Pods-Hardware.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.debug.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.debug.xcconfig"; sourceTree = "<group>"; };
 		47BDD50287B7B0CF8D769BFC /* Pods-PrinterPlayground.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrinterPlayground.release-alpha.xcconfig"; path = "Target Support Files/Pods-PrinterPlayground/Pods-PrinterPlayground.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		9726331F55A9621F2F887E13 /* Pods-Hardware.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hardware.release.xcconfig"; path = "Target Support Files/Pods-Hardware/Pods-Hardware.release.xcconfig"; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				D88303DA25E450E700C877F9 /* PaymentIntentTests.swift */,
 				D81AE85D25E6A89F00D9CFD3 /* StripeCardReaderCacheTests.swift */,
 				D854FC25260A6B5800A219CD /* ErrorCodesTests.swift */,
+				311889EA2653286B0080AEA2 /* PaymentIntentMetadataTests.swift */,
 				D80B4651260E19590092EDC0 /* PaymentIntentParametersTests.swift */,
 				D845BDFE262DDA6A00A3E40F /* ReceiptDetailsTests.swift */,
 				D845BE02262DDBF500A3E40F /* CardBrandTests.swift */,
@@ -773,6 +776,7 @@
 				D892F21025E3F4C0001D7134 /* MockStripeCardReader.swift in Sources */,
 				D88303DB25E450E700C877F9 /* PaymentIntentTests.swift in Sources */,
 				D845BE03262DDBF500A3E40F /* CardBrandTests.swift in Sources */,
+				311889EB2653286B0080AEA2 /* PaymentIntentMetadataTests.swift in Sources */,
 				D845BDFB262DD97E00A3E40F /* MockStripeReceiptDetails.swift in Sources */,
 				D845BDF5262DD67E00A3E40F /* MockStripeCardPresentDetails.swift in Sources */,
 				D88303D125E44B2500C877F9 /* ChargeTests.swift in Sources */,

--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -66,16 +66,16 @@ public extension PaymentIntent {
 }
 
 public extension PaymentIntent {
-    enum PaymentTypes {
+    enum PaymentTypes: String {
         /// A payment that IS NOT associated with an order containing a subscription
         /// This key is also used by the plugin when it creates payment intents.
         ///
-        public static let single = "single"
+        case single = "single"
 
         /// A payment that IS associated with an order containing a subscription
         /// This key is also used by the plugin when it creates payment intents.
         ///
-        public static let recurring = "recurring"
+        case recurring = "recurring"
     }
 }
 
@@ -88,7 +88,7 @@ public extension PaymentIntent {
                           siteURL: String? = nil,
                           orderID: Int64? = nil,
                           orderKey: String? = nil,
-                          paymentType: String? = nil
+                          paymentType: PaymentTypes? = nil
     ) -> [AnyHashable: Any] {
         var metadata = [AnyHashable: Any]()
 
@@ -117,7 +117,7 @@ public extension PaymentIntent {
         }
 
         if paymentType != nil {
-            metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType
+            metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType?.rawValue
         }
 
         return metadata

--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -92,33 +92,13 @@ public extension PaymentIntent {
     ) -> [AnyHashable: Any] {
         var metadata = [AnyHashable: Any]()
 
-        if store != nil {
-            metadata[PaymentIntent.MetadataKeys.store] = store
-        }
-
-        if customerName != nil {
-            metadata[PaymentIntent.MetadataKeys.customerName] = customerName
-        }
-
-        if customerEmail != nil {
-            metadata[PaymentIntent.MetadataKeys.customerEmail] = customerEmail
-        }
-
-        if siteURL != nil {
-            metadata[PaymentIntent.MetadataKeys.siteURL] = siteURL
-        }
-
-        if orderID != nil {
-            metadata[PaymentIntent.MetadataKeys.orderID] = orderID
-        }
-
-        if orderKey != nil {
-            metadata[PaymentIntent.MetadataKeys.orderKey] = orderKey
-        }
-
-        if paymentType != nil {
-            metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType?.rawValue
-        }
+        metadata[PaymentIntent.MetadataKeys.store] = store
+        metadata[PaymentIntent.MetadataKeys.customerName] = customerName
+        metadata[PaymentIntent.MetadataKeys.customerEmail] = customerEmail
+        metadata[PaymentIntent.MetadataKeys.siteURL] = siteURL
+        metadata[PaymentIntent.MetadataKeys.orderID] = orderID
+        metadata[PaymentIntent.MetadataKeys.orderKey] = orderKey
+        metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType?.rawValue
 
         return metadata
     }

--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -30,5 +30,96 @@ public extension PaymentIntent {
     /// Metadata Keys
     enum MetadataKeys {
         public static let store = "paymentintent.storename"
+
+        /// The customer's name - first name then last name separated by a space, or
+        /// empty if neither first name nor last name is given.
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let customerName = "customer_name"
+
+        /// The customer's email address, or empty if not given.
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let customerEmail = "customer_email"
+
+        /// The store URL, e.g. `https://mydomain.com`
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let siteURL = "site_url"
+
+        /// The order ID, e.g. 6140
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let orderID = "order_id"
+
+        /// The order key, e.g. `wc_order_0000000000000`
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let orderKey = "order_key"
+
+        /// The payment type, i.e. `single` or `recurring`
+        /// See also PaymentIntent.PaymentTypes
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let paymentType = "payment_type"
+    }
+}
+
+public extension PaymentIntent {
+    enum PaymentTypes {
+        /// A payment that IS NOT associated with an order containing a subscription
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let single = "single"
+
+        /// A payment that IS associated with an order containing a subscription
+        /// This key is also used by the plugin when it creates payment intents.
+        ///
+        public static let recurring = "recurring"
+    }
+}
+
+// MARK: - Convenience Initializers
+//
+public extension PaymentIntent {
+    static func initMetadata(store: String? = nil,
+                          customerName: String? = nil,
+                          customerEmail: String? = nil,
+                          siteURL: String? = nil,
+                          orderID: Int64? = nil,
+                          orderKey: String? = nil,
+                          paymentType: String? = nil
+    ) -> [AnyHashable: Any] {
+        var metadata = [AnyHashable: Any]()
+
+        if store != nil {
+            metadata[PaymentIntent.MetadataKeys.store] = store
+        }
+
+        if customerName != nil {
+            metadata[PaymentIntent.MetadataKeys.customerName] = customerName
+        }
+
+        if customerEmail != nil {
+            metadata[PaymentIntent.MetadataKeys.customerEmail] = customerEmail
+        }
+
+        if siteURL != nil {
+            metadata[PaymentIntent.MetadataKeys.siteURL] = siteURL
+        }
+
+        if orderID != nil {
+            metadata[PaymentIntent.MetadataKeys.orderID] = orderID
+        }
+
+        if orderKey != nil {
+            metadata[PaymentIntent.MetadataKeys.orderKey] = orderKey
+        }
+
+        if paymentType != nil {
+            metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType
+        }
+
+        return metadata
     }
 }

--- a/Hardware/HardwareTests/PaymentIntentMetadataTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentMetadataTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import Hardware
+
+/// Ensures that metadata is populated correctly
+///
+final class PaymentIntentMetadataTests: XCTestCase {
+
+    func test_no_meta_data() {
+        let metadata = PaymentIntent.initMetadata()
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    func test_nil_store() {
+        let metadata = PaymentIntent.initMetadata(store: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    func test_non_nil_store() throws {
+        let metadata = PaymentIntent.initMetadata(store: "foo")
+        let store = try XCTUnwrap(metadata["paymentintent.storename"])
+        XCTAssertEqual(store as? String, "foo")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_customer_name() {
+        let metadata = PaymentIntent.initMetadata(customerName: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key is NOT changed unexpectedly
+    /// since it is used by the backend as well.
+    ///
+    func test_non_nil_customer_name() throws {
+        let metadata = PaymentIntent.initMetadata(customerName: "foo")
+        let customerName = try XCTUnwrap(metadata["customer_name"])
+        XCTAssertEqual(customerName as? String, "foo")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_customer_email() {
+        let metadata = PaymentIntent.initMetadata(customerEmail: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key is NOT changed unexpectedly
+    /// since it is used by the backend as well.
+    ///
+    func test_non_nil_customer_email() throws {
+        let metadata = PaymentIntent.initMetadata(customerEmail: "foo")
+        let customerEmail = try XCTUnwrap(metadata["customer_email"])
+        XCTAssertEqual(customerEmail as? String, "foo")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_site_url() {
+        let metadata = PaymentIntent.initMetadata(siteURL: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key is NOT changed unexpectedly
+    /// since it is used by the backend as well.
+    ///
+    func test_non_nil_site_url() throws {
+        let metadata = PaymentIntent.initMetadata(siteURL: "foo")
+        let siteURL = try XCTUnwrap(metadata["site_url"])
+        XCTAssertEqual(siteURL as? String, "foo")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_order_id() {
+        let metadata = PaymentIntent.initMetadata(orderID: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key is NOT changed unexpectedly
+    /// since it is used by the backend as well.
+    ///
+    func test_non_nil_orderID() throws {
+        let metadata = PaymentIntent.initMetadata(orderID: 1234)
+        let orderID = try XCTUnwrap(metadata["order_id"])
+        XCTAssertEqual(orderID as? Int64, 1234)
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_order_key() {
+        let metadata = PaymentIntent.initMetadata(orderKey: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key is NOT changed unexpectedly
+    /// since it is used by the backend as well.
+    ///
+    func test_non_nil_order_key() throws {
+        let metadata = PaymentIntent.initMetadata(orderKey: "wc_order_0000000000000")
+        let orderKey = try XCTUnwrap(metadata["order_key"])
+        XCTAssertEqual(orderKey as? String, "wc_order_0000000000000")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    func test_nil_payment_type() {
+        let metadata = PaymentIntent.initMetadata(paymentType: nil)
+        XCTAssertEqual(metadata.count, 0)
+    }
+
+    /// Note: This test also ensures that encoding key and value are NOT changed unexpectedly
+    /// since both are used by the backend as well.
+    ///
+    func test_single_payment_type() throws {
+        let metadata = PaymentIntent.initMetadata(paymentType: PaymentIntent.PaymentTypes.single)
+        let paymentType = try XCTUnwrap(metadata["payment_type"])
+        XCTAssertEqual(paymentType as? String, "single")
+        XCTAssertEqual(metadata.count, 1)
+    }
+
+    /// Note: This test also ensures that encoding key and value are NOT changed unexpectedly
+    /// since both are used by the backend as well.
+    ///
+    func test_recurring_payment_type() throws {
+        let metadata = PaymentIntent.initMetadata(paymentType: PaymentIntent.PaymentTypes.recurring)
+        let paymentType = try XCTUnwrap(metadata["payment_type"])
+        XCTAssertEqual(paymentType as? String, "recurring")
+        XCTAssertEqual(metadata.count, 1)
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -116,13 +116,35 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
+        var customerName: String?
+
+        if let firstName = order.billingAddress?.firstName {
+            customerName = firstName
+        }
+
+        if let lastName = order.billingAddress?.lastName {
+            if customerName == nil {
+                customerName = lastName
+            } else {
+                customerName? += " " + lastName
+            }
+        }
+
+        let metadata = PaymentIntent.initMetadata(
+            store: ServiceLocator.stores.sessionManager.defaultSite?.name,
+            customerName: customerName,
+            customerEmail: order.billingAddress?.email,
+            siteURL: ServiceLocator.stores.sessionManager.defaultSite?.url,
+            orderID: order.orderID,
+            paymentType: PaymentIntent.PaymentTypes.single
+        )
+
         return PaymentParameters(amount: orderTotal as Decimal,
                                                   currency: order.currency,
                                                   receiptDescription: receiptDescription(),
                                                   statementDescription: account?.statementDescriptor,
                                                   receiptEmail: order.billingAddress?.email,
-                                                  metadata: [CardPresentReceiptParameters.MetadataKeys.store:
-                                                                ServiceLocator.stores.sessionManager.defaultSite?.name as Any])
+                                                  metadata: metadata)
     }
 
     func receiptDescription() -> String? {


### PR DESCRIPTION
Partially addresses #4077 

This PR adds all the metadata except for order key. That will come in a later PR.

There are two ways to see this working:
- Set a breakpoint in `PaymentCaptureOrchestrator.swift` to halt after metadata is set. Ensure you see the expected values for your order after you begin the capture payment flow, i.e.:

<img width="1502" alt="breakpoint" src="https://user-images.githubusercontent.com/1595739/118571747-a38bdf00-b733-11eb-94a3-05c8940f0df3.png">

- Or, load the transaction in the Stripe dashboard after switching to that account's view:

<img width="1773" alt="dashboard2" src="https://user-images.githubusercontent.com/1595739/118572136-915e7080-b734-11eb-82c7-e9fc75a1270e.png">

- Also, optionally ensure that the transaction can be rendered, including the order ID, in wp-admin using this branch (note: the other metadata values are NOT displayed in this view): https://github.com/Automattic/woocommerce-payments/pull/1840

- Lastly, please run the newly added unit tests

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
