### PR TITLE
[Mobile Payments] Tracks events for receipts

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		E1CFC1662643EAA30089F86F /* SampleContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFC1652643EAA30089F86F /* SampleContent.swift */; };
 		E1CFC16D2643EBCB0089F86F /* Hardware.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */; };
 		E1CFC16E2643EBCB0089F86F /* Hardware.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D88FDAFF25DD216B00CB0DBD /* Hardware.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E1E4FA2F2653CFD5007B9D4F /* PrintingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E4FA2E2653CFD5007B9D4F /* PrintingResult.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +215,7 @@
 		E1CFC14F2643E9EE0089F86F /* ReceiptSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptSettingsView.swift; sourceTree = "<group>"; };
 		E1CFC1562643E9EE0089F86F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E1CFC1652643EAA30089F86F /* SampleContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleContent.swift; sourceTree = "<group>"; };
+		E1E4FA2E2653CFD5007B9D4F /* PrintingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingResult.swift; sourceTree = "<group>"; };
 		E9F0AC202B287C1221EA2C99 /* Pods_Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F45592A33DEE569C9775EEE7 /* Pods-PrinterPlayground.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrinterPlayground.release.xcconfig"; path = "Target Support Files/Pods-PrinterPlayground/Pods-PrinterPlayground.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -285,6 +287,7 @@
 			children = (
 				D845BE57262ED81D00A3E40F /* AirPrintReceipt */,
 				D845BE53262ED7CC00A3E40F /* PrinterService.swift */,
+				E1E4FA2E2653CFD5007B9D4F /* PrintingResult.swift */,
 				D8652CB6262F389800350F37 /* ReceiptLineItem.swift */,
 				D8652CBA262F390F00350F37 /* ReceiptContent.swift */,
 				D8652E292630520300350F37 /* CardPresentReceiptParameters.swift */,
@@ -727,6 +730,7 @@
 				D81AE86425E6B77F00D9CFD3 /* CardReaderServiceError.swift in Sources */,
 				D8DF5F4E25DD9F91008AFE25 /* CardReaderType+Stripe.swift in Sources */,
 				D89B8F1225DDCBCD0001C726 /* Charge+Stripe.swift in Sources */,
+				E1E4FA2F2653CFD5007B9D4F /* PrintingResult.swift in Sources */,
 				D80B465A260E1E160092EDC0 /* StatementDescriptor.swift in Sources */,
 				D8DF5F4A25DD9F7A008AFE25 /* CardReader+Stripe.swift in Sources */,
 				D88FDB2A25DD21B000CB0DBD /* PaymentStatus.swift in Sources */,

--- a/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
@@ -15,7 +15,7 @@ public final class AirPrintReceiptPrinterService: PrinterService {
 
     public init() { }
 
-    public func printReceipt(content: ReceiptContent) {
+    public func printReceipt(content: ReceiptContent, completion: @escaping (PrintingResult) -> Void) {
         let printController = UIPrintInteractionController.shared
 
         printController.printInfo = printInfo
@@ -23,6 +23,18 @@ public final class AirPrintReceiptPrinterService: PrinterService {
         let renderer = ReceiptRenderer(content: content)
         printController.printPageRenderer = renderer
 
-        printController.present(animated: true, completionHandler: nil)
+        printController.present(animated: true) { (controller, completed, error) in
+            switch (completed, error) {
+            case (_, .some(let error)):
+                // Printing failed
+                completion(.failure(error))
+            case (true, .none):
+                // Successful print job
+                completion(.success)
+            case (false, .none):
+                // User canceled the print job
+                completion(.cancel)
+            }
+        }
     }
 }

--- a/Hardware/Hardware/Printer/PrinterService.swift
+++ b/Hardware/Hardware/Printer/PrinterService.swift
@@ -2,5 +2,5 @@
 public protocol PrinterService {
     /// Prints a receipt
     /// - Parameter ReceiptContent: the data that needs to be printed in the receipt
-    func printReceipt(content: ReceiptContent)
+    func printReceipt(content: ReceiptContent, completion: @escaping (PrintingResult) -> Void)
 }

--- a/Hardware/Hardware/Printer/PrintingResult.swift
+++ b/Hardware/Hardware/Printer/PrintingResult.swift
@@ -1,0 +1,10 @@
+/// Encapsulates possible results of a printing request
+///
+public enum PrintingResult {
+    /// Successful print job
+    case success
+    /// User canceled the print job
+    case cancel
+    /// Printing failed
+    case failure(Error)
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -201,6 +201,18 @@ public enum WooAnalyticsStat: String {
     case shipmentTrackingMenuAction = "shipment_tracking_menu_action"
     case shippingLabelsAPIRequest = "shipping_label_api_request"
 
+    // MARK: Receipt Events
+    //
+    case receiptViewTapped                      = "receipt_view_tapped"
+    case receiptEmailTapped                     = "receipt_email_tapped"
+    case receiptEmailFailed                     = "receipt_email_failed"
+    case receiptEmailCanceled                   = "receipt_email_canceled"
+    case receiptEmailSuccess                    = "receipt_email_success"
+    case receiptPrintTapped                     = "receipt_print_tapped"
+    case receiptPrintFailed                     = "receipt_print_failed"
+    case receiptPrintCanceled                   = "receipt_print_canceled"
+    case receiptPrintSuccess                    = "receipt_print_success"
+
     // MARK: Push Notifications Events
     //
     case pushNotificationReceived               = "push_notification_received"

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -43,7 +43,16 @@ final class PaymentCaptureOrchestrator {
     }
 
     func printReceipt(for order: Order, params: CardPresentReceiptParameters) {
-        let action = ReceiptAction.print(order: order, parameters: params)
+        let action = ReceiptAction.print(order: order, parameters: params) { (result) in
+            switch result {
+            case .success:
+                ServiceLocator.analytics.track(.receiptPrintSuccess)
+            case .cancel:
+                ServiceLocator.analytics.track(.receiptPrintCanceled)
+            case .failure(let error):
+                ServiceLocator.analytics.track(.receiptPrintFailed, withError: error)
+            }
+        }
 
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -29,6 +29,7 @@ final class ReceiptViewModel {
 
     /// Prints the receipt
     func printReceipt() {
+        ServiceLocator.analytics.track(.receiptPrintTapped)
         let action = ReceiptAction.print(order: order, parameters: receipt)
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptViewModel.swift
@@ -30,8 +30,16 @@ final class ReceiptViewModel {
     /// Prints the receipt
     func printReceipt() {
         ServiceLocator.analytics.track(.receiptPrintTapped)
-        let action = ReceiptAction.print(order: order, parameters: receipt)
-
+        let action = ReceiptAction.print(order: order, parameters: receipt) { (result) in
+            switch result {
+            case .success:
+                ServiceLocator.analytics.track(.receiptPrintSuccess)
+            case .cancel:
+                ServiceLocator.analytics.track(.receiptPrintCanceled)
+            case .failure(let error):
+                ServiceLocator.analytics.track(.receiptPrintFailed, withError: error)
+            }
+        }
         ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -278,6 +278,7 @@ extension OrderDetailsViewModel {
             productListVC.viewModel = self
             viewController.navigationController?.pushViewController(productListVC, animated: true)
         case .seeReceipt:
+            ServiceLocator.analytics.track(.receiptViewTapped)
             guard let receipt = receipt else {
                 return
             }
@@ -543,10 +544,12 @@ extension OrderDetailsViewModel {
     }
 
     func printReceipt(params: CardPresentReceiptParameters) {
+        ServiceLocator.analytics.track(.receiptPrintTapped)
         paymentOrchestrator.printReceipt(for: order, params: params)
     }
 
     func emailReceipt(params: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
+        ServiceLocator.analytics.track(.receiptEmailTapped)
         paymentOrchestrator.emailReceipt(for: order, params: params, onContent: onContent)
     }
 }

--- a/Yosemite/Yosemite/Actions/ReceiptAction.swift
+++ b/Yosemite/Yosemite/Actions/ReceiptAction.swift
@@ -2,7 +2,7 @@
 ///
 public enum ReceiptAction: Action {
     /// Prints a receipt for a given `Order` with the given `CardPresentReceiptParameters`
-    case print(order: Order, parameters: CardPresentReceiptParameters)
+    case print(order: Order, parameters: CardPresentReceiptParameters, completion: (PrintingResult) -> Void)
 
     /// Generates content for a receipt for a given `Order` with the given `CardPresentReceiptParameters`
     /// The content is a String containing HTML

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -114,6 +114,7 @@ public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDi
 public typealias CardReaderServiceError = Hardware.CardReaderServiceError
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 public typealias PaymentIntent = Hardware.PaymentIntent
+public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias WCPayAccount = Networking.WCPayAccount
 

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -34,8 +34,8 @@ public class ReceiptStore: Store {
         }
 
         switch action {
-        case .print(let order, let info):
-            print(order: order, parameters: info)
+        case .print(let order, let info, let completion):
+            print(order: order, parameters: info, completion: completion)
         case .generateContent(let order, let info, let onContent):
             generateContent(order: order, parameters: info, onContent: onContent)
         case .loadReceipt(let order, let onCompletion):
@@ -48,11 +48,11 @@ public class ReceiptStore: Store {
 
 
 private extension ReceiptStore {
-    func print(order: Order, parameters: CardPresentReceiptParameters) {
+    func print(order: Order, parameters: CardPresentReceiptParameters, completion: @escaping (PrintingResult) -> Void) {
         let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
-        receiptPrinterService.printReceipt(content: content)
+        receiptPrinterService.printReceipt(content: content, completion: completion)
     }
 
     func generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockReceiptPrinterService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockReceiptPrinterService.swift
@@ -2,14 +2,15 @@
 
 /// Supports tests for ReceiptStore
 final class MockReceiptPrinterService: PrinterService {
-    /// Boolean flag indicating metod printReceipt has been hit
+    /// Boolean flag indicating method printReceipt has been hit
     var printWasCalled: Bool = false
 
     /// The parameter passed to the printReceipt method
     var contentProvided: ReceiptContent?
 
-    func printReceipt(content: ReceiptContent) {
+    func printReceipt(content: ReceiptContent, completion: @escaping (PrintingResult) -> Void) {
         printWasCalled = true
         contentProvided = content
+        completion(.success)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -56,7 +56,7 @@ final class ReceiptStoreTests: XCTestCase {
                                         receiptPrinterService: receiptPrinterService,
                                         fileStorage: MockInMemoryStorage())
 
-        let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters)
+        let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters, completion: { _ in })
 
         receiptStore.onAction(action)
 
@@ -73,7 +73,7 @@ final class ReceiptStoreTests: XCTestCase {
                                         receiptPrinterService: receiptPrinterService,
                                         fileStorage: MockInMemoryStorage())
 
-        let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters)
+        let action = ReceiptAction.print(order: mockOrder, parameters: mockParameters, completion: { _ in })
 
         receiptStore.onAction(action)
 


### PR DESCRIPTION
Part of #4082

This PR includes all the events related to receipts.

## Events included

- receipt_view_tapped: The user viewed a saved receipt
- receipt_email_tapped: The user tapped on the button to email a receipt.
- receipt_email_failed: Sending or saving the receipt email failed.
- receipt_email_canceled: The user canceled sending the receipt by email.
- receipt_email_success: The receipt was sent by email.
- receipt_print_tapped: The user tapped on the button to print a receipt.
- receipt_print_failed: Printing the receipt failed.
- receipt_print_canceled: The user canceled printing the receipt.
- receipt_print_success: The receipt was successfully sent to the printer. iOS won't guarantee that the receipt has actually printed

## To test

I can't figure out how to make either email or printing fail, so I haven't been able to verify those, but they would be triggered on the same code paths as the other results, so I think we can leave these and maybe not validate until we receive some events from users?

- After completing payment:
  -  [x] Tap on Email receipt: `receipt_email_tapped `
      - [x] Send email: `receipt_email_success`
      - [x] Cancel and save as draft: `receipt_email_success`
      - [x] Cancel and discard draft: `receipt_email_canceled`
      - [ ] ❓Make the email fail: `receipt_email_failed`
  -  [x] Tap on Print receipt: `receipt_print_tapped `
      - [x] Print receipt: `receipt_print_success`
      - [x] Cancel printing: `receipt_print_canceled`
      - [ ] ❓Make printing fail: `receipt_print_failed`
- From an order with a saved receipt:
  - [x] Tap See Receipt: `receipt_view_tapped`
    -  [x] Tap on Print receipt: `receipt_print_tapped `
        - [x] Print receipt: `receipt_print_success`
        - [x] Cancel printing: `receipt_print_canceled`
        - [ ] ❓Make printing fail: `receipt_print_failed`

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
