### PR TITLE
Products: Provide option to create a virtual product

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.7
 -----
 - [**] Add-Ons: Order add-ons are now available as a beta feature. To try it, enable it from settings! [https://github.com/woocommerce/woocommerce-ios/pull/4119]
+- [**] Products: Added the option to create and edit a virtual product directly from the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/4214]
 
 6.6
 -----

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -121,6 +121,12 @@ extension UIImage {
         return UIImage.gridicon(.cross)
     }
 
+    /// Cloud Outline Icon
+    ///
+    static var cloudOutlineImage: UIImage {
+        return UIImage.gridicon(.cloudOutline)
+    }
+
     /// Gear Icon - used in `UIBarButtonItem`
     ///
     static var gearBarButtonItemImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -43,19 +43,21 @@ private extension AddProductCoordinator {
         let title = NSLocalizedString("Select a product type",
                                       comment: "Message title of bottom sheet for selecting a product type to create a product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
-        let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedProductType in
-            ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedProductType.rawValue])
+        let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedBottomSheetProductType in
+            ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
             self.navigationController.dismiss(animated: true)
-            self.presentProductForm(productType: selectedProductType)
+            self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
         }
-        command.data = [.simple, .variable, .grouped, .affiliate]
+        command.data = [.physical, .virtual, .variable, .grouped, .affiliate]
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
     }
 
-    func presentProductForm(productType: ProductType) {
-        guard let product = ProductFactory().createNewProduct(type: productType, siteID: siteID) else {
-            assertionFailure("Unable to create product of type: \(productType)")
+    func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
+        guard let product = ProductFactory().createNewProduct(type: bottomSheetProductType.productType,
+                                                              isVirtual: bottomSheetProductType.isVirtual,
+                                                              siteID: siteID) else {
+            assertionFailure("Unable to create product of type: \(bottomSheetProductType)")
             return
         }
         let model = EditableProductModel(product: product)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -48,7 +48,6 @@ private extension AddProductCoordinator {
             self.navigationController.dismiss(animated: true)
             self.presentProductForm(productType: selectedProductType)
         }
-        // Until we support adding a variation, adding a variable product is disabled.
         command.data = [.simple, .variable, .grouped, .affiliate]
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -48,7 +48,7 @@ private extension AddProductCoordinator {
             self.navigationController.dismiss(animated: true)
             self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
         }
-        command.data = [.physical, .virtual, .variable, .grouped, .affiliate]
+        command.data = [.simple(isVirtual: false), .simple(isVirtual: true), .variable, .grouped, .affiliate]
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -8,10 +8,10 @@ struct ProductFactory {
     /// - Parameters:
     ///   - type: The type of the product.
     ///   - siteID: The site ID where the product is added to.
-    func createNewProduct(type: ProductType, siteID: Int64) -> Product? {
+    func createNewProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product? {
         switch type {
         case .simple, .grouped, .variable, .affiliate:
-            return createEmptyProduct(type: type, siteID: siteID)
+            return createEmptyProduct(type: type, isVirtual: isVirtual, siteID: siteID)
         default:
             return nil
         }
@@ -19,7 +19,7 @@ struct ProductFactory {
 }
 
 private extension ProductFactory {
-    func createEmptyProduct(type: ProductType, siteID: Int64) -> Product {
+    func createEmptyProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product {
         Product(siteID: siteID,
                 productID: 0,
                 name: "",
@@ -43,7 +43,7 @@ private extension ProductFactory {
                 onSale: false,
                 purchasable: false,
                 totalSales: 0,
-                virtual: false,
+                virtual: isVirtual,
                 downloadable: false,
                 downloads: [],
                 downloadLimit: -1,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -1,13 +1,53 @@
 import Yosemite
 
-private extension ProductType {
+/// Represents the product types available when creating or editing products.
+///
+public enum BottomSheetProductType: Hashable {
+    case physical
+    case virtual
+    case grouped
+    case affiliate
+    case variable
+    case custom(String) // in case there are extensions modifying product types
+
+    /// ProductType
+    ///
+    var productType: ProductType {
+        switch self {
+        case .physical, .virtual:
+            return .simple
+        case .variable:
+            return .variable
+        case .grouped:
+            return .grouped
+        case .affiliate:
+            return .affiliate
+        case .custom(let title):
+            return .custom(title)
+        }
+    }
+
+    /// Whether product is virtual
+    ///
+    var isVirtual: Bool {
+        switch self {
+        case .virtual:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Title shown on the action sheet.
     ///
     var actionSheetTitle: String {
         switch self {
-        case .simple:
-            return NSLocalizedString("Simple product",
-                                     comment: "Action sheet option when the user wants to change the Product type to simple product")
+        case .physical:
+            return NSLocalizedString("Simple physical product",
+                                     comment: "Action sheet option when the user wants to change the Product type to simple physical product")
+        case .virtual:
+            return NSLocalizedString("Simple virtual product",
+                                     comment: "Action sheet option when the user wants to change the Product type to simple virtual product")
         case .variable:
             return NSLocalizedString("Variable product",
                                      comment: "Action sheet option when the user wants to change the Product type to varible product")
@@ -26,9 +66,12 @@ private extension ProductType {
     ///
     var actionSheetDescription: String {
         switch self {
-        case .simple:
+        case .physical:
             return NSLocalizedString("A unique item to sell",
-                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple product")
+                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple physical product")
+        case .virtual:
+            return NSLocalizedString("A unique item to sell",
+                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")
         case .variable:
             return NSLocalizedString("A product with variations like color or size",
                                      comment: "Description of the Action sheet option when the user wants to change the Product type to variable product")
@@ -47,7 +90,7 @@ private extension ProductType {
     ///
     var actionSheetImage: UIImage {
         switch self {
-        case .simple:
+        case .physical, .virtual:
             return UIImage.productImage
         case .variable:
             return UIImage.variationsImage
@@ -64,21 +107,22 @@ private extension ProductType {
 /// `BottomSheetListSelectorCommand` for selecting a product type for the selected Product.
 ///
 final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCommand {
-    typealias Model = ProductType
+    typealias Model = BottomSheetProductType
     typealias Cell = ImageAndTitleAndTextTableViewCell
 
-    var data: [ProductType] = [
-        .simple,
+    var data: [BottomSheetProductType] = [
+        .physical,
+        .virtual,
         .variable,
         .grouped,
         .affiliate
     ]
 
-    var selected: ProductType? = nil
+    var selected: BottomSheetProductType? = nil
 
-    private let onSelection: (ProductType) -> Void
+    private let onSelection: (BottomSheetProductType) -> Void
 
-    init(selected: ProductType?, onSelection: @escaping (ProductType) -> Void) {
+    init(selected: BottomSheetProductType?, onSelection: @escaping (BottomSheetProductType) -> Void) {
         self.onSelection = onSelection
 
         /// Remove from `data` the selected product type, so that it is not shown in the list.
@@ -87,7 +131,7 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
         }
     }
 
-    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: ProductType) {
+    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: BottomSheetProductType) {
         let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.actionSheetTitle,
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetImage,
@@ -97,11 +141,11 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
         cell.updateUI(viewModel: viewModel)
     }
 
-    func handleSelectedChange(selected: ProductType) {
+    func handleSelectedChange(selected: BottomSheetProductType) {
         onSelection(selected)
     }
 
-    func isSelected(model: ProductType) -> Bool {
+    func isSelected(model: BottomSheetProductType) -> Bool {
         return model == selected
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -4,8 +4,7 @@ import Yosemite
 /// This includes the remote `ProductType`, whether the product type is virtual, and strings/images shown in the bottom sheet.
 ///
 public enum BottomSheetProductType: Hashable {
-    case physical
-    case virtual
+    case simple(isVirtual: Bool)
     case grouped
     case affiliate
     case variable
@@ -15,7 +14,7 @@ public enum BottomSheetProductType: Hashable {
     ///
     var productType: ProductType {
         switch self {
-        case .physical, .virtual:
+        case .simple:
             return .simple
         case .variable:
             return .variable
@@ -32,8 +31,8 @@ public enum BottomSheetProductType: Hashable {
     ///
     var isVirtual: Bool {
         switch self {
-        case .virtual:
-            return true
+        case .simple(let isVirtual):
+            return isVirtual
         default:
             return false
         }
@@ -43,12 +42,14 @@ public enum BottomSheetProductType: Hashable {
     ///
     var actionSheetTitle: String {
         switch self {
-        case .physical:
+        case .simple(let isVirtual):
+            if isVirtual {
+                return NSLocalizedString("Simple virtual product",
+                                         comment: "Action sheet option when the user wants to change the Product type to simple virtual product")
+            } else {
             return NSLocalizedString("Simple physical product",
                                      comment: "Action sheet option when the user wants to change the Product type to simple physical product")
-        case .virtual:
-            return NSLocalizedString("Simple virtual product",
-                                     comment: "Action sheet option when the user wants to change the Product type to simple virtual product")
+            }
         case .variable:
             return NSLocalizedString("Variable product",
                                      comment: "Action sheet option when the user wants to change the Product type to varible product")
@@ -67,12 +68,14 @@ public enum BottomSheetProductType: Hashable {
     ///
     var actionSheetDescription: String {
         switch self {
-        case .physical:
+        case .simple(let isVirtual):
+            if isVirtual {
+                return NSLocalizedString("A unique item to sell",
+                                    comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")
+            } else {
             return NSLocalizedString("A unique item to sell",
                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple physical product")
-        case .virtual:
-            return NSLocalizedString("A unique item to sell",
-                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")
+            }
         case .variable:
             return NSLocalizedString("A product with variations like color or size",
                                      comment: "Description of the Action sheet option when the user wants to change the Product type to variable product")
@@ -91,7 +94,7 @@ public enum BottomSheetProductType: Hashable {
     ///
     var actionSheetImage: UIImage {
         switch self {
-        case .physical, .virtual:
+        case .simple:
             return UIImage.productImage
         case .variable:
             return UIImage.variationsImage
@@ -103,6 +106,21 @@ public enum BottomSheetProductType: Hashable {
             return UIImage.productImage
         }
     }
+
+    init(productType: ProductType, isVirtual: Bool) {
+        switch productType {
+        case .simple:
+            self = .simple(isVirtual: isVirtual)
+        case .variable:
+            self = .variable
+        case .affiliate:
+            self = .affiliate
+        case .grouped:
+            self = .grouped
+        case .custom(let string):
+            self = .custom(string)
+        }
+    }
 }
 
 /// `BottomSheetListSelectorCommand` for selecting a product type for the selected Product.
@@ -112,8 +130,8 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
     typealias Cell = ImageAndTitleAndTextTableViewCell
 
     var data: [BottomSheetProductType] = [
-        .physical,
-        .virtual,
+        .simple(isVirtual: false),
+        .simple(isVirtual: true),
         .variable,
         .grouped,
         .affiliate

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -70,10 +70,10 @@ public enum BottomSheetProductType: Hashable {
         switch self {
         case .simple(let isVirtual):
             if isVirtual {
-                return NSLocalizedString("A unique item to sell",
+                return NSLocalizedString("A unique digital product like services, downloadable books, music or videos",
                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")
             } else {
-            return NSLocalizedString("A unique item to sell",
+                return NSLocalizedString("A unique physical product that you may have to ship to the customer",
                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple physical product")
             }
         case .variable:
@@ -94,8 +94,12 @@ public enum BottomSheetProductType: Hashable {
     ///
     var actionSheetImage: UIImage {
         switch self {
-        case .simple:
-            return UIImage.productImage
+        case .simple(let isVirtual):
+            if isVirtual {
+                return UIImage.cloudOutlineImage
+            } else {
+                return UIImage.productImage
+            }
         case .variable:
             return UIImage.variationsImage
         case .grouped:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -1,6 +1,7 @@
 import Yosemite
 
 /// Represents the product types available when creating or editing products.
+/// This includes the remote `ProductType`, whether the product type is virtual, and strings/images shown in the bottom sheet.
 ///
 public enum BottomSheetProductType: Hashable {
     case physical
@@ -10,7 +11,7 @@ public enum BottomSheetProductType: Hashable {
     case variable
     case custom(String) // in case there are extensions modifying product types
 
-    /// ProductType
+    /// Remote ProductType
     ///
     var productType: ProductType {
         switch self {
@@ -68,7 +69,7 @@ public enum BottomSheetProductType: Hashable {
         switch self {
         case .physical:
             return NSLocalizedString("A unique item to sell",
-                                     comment: "Description of the Action sheet option when the user wants to change the Product type to simple physical product")
+                                    comment: "Description of the Action sheet option when the user wants to change the Product type to simple physical product")
         case .virtual:
             return NSLocalizedString("A unique item to sell",
                                      comment: "Description of the Action sheet option when the user wants to change the Product type to simple virtual product")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -974,7 +974,8 @@ private extension ProductFormViewController {
         let title = NSLocalizedString("Change product type",
                                       comment: "Message title of bottom sheet for selecting a product type")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
-        let command = ProductTypeBottomSheetListSelectorCommand(selected: viewModel.productModel.productType) { [weak self] (selectedProductType) in
+        let productType = BottomSheetProductType(productType: viewModel.productModel.productType, isVirtual: viewModel.productModel.virtual)
+        let command = ProductTypeBottomSheetListSelectorCommand(selected: productType) { [weak self] (selectedProductType) in
             self?.dismiss(animated: true, completion: nil)
 
             guard let originalProductType = self?.product.productType else {
@@ -983,7 +984,7 @@ private extension ProductFormViewController {
 
             ServiceLocator.analytics.track(.productTypeChanged, withProperties: [
                 "from": originalProductType.rawValue,
-                "to": selectedProductType.rawValue
+                "to": selectedProductType.productType.rawValue
             ])
 
             self?.presentProductTypeChangeAlert(for: originalProductType, completion: { (change) in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -225,7 +225,7 @@ extension ProductFormViewModel {
                                                                      taxClass: taxClass?.slug))
     }
 
-    func updateProductType(productType: ProductType) {
+    func updateProductType(productType: BottomSheetProductType) {
         /// The property `manageStock` is set to `false` if the new `productType` is `affiliate`
         /// because it seems there is a small bug in APIs that doesn't allow us to change type from a product with
         /// manage stock enabled to external product type. More info: PR-2665
@@ -234,7 +234,9 @@ extension ProductFormViewModel {
         if productType == .affiliate {
             manageStock = false
         }
-        product = EditableProductModel(product: product.product.copy(productTypeKey: productType.rawValue, manageStock: manageStock))
+        product = EditableProductModel(product: product.product.copy(productTypeKey: productType.productType.rawValue,
+                                                                     virtual: productType.isVirtual,
+                                                                     manageStock: manageStock))
     }
 
     func updateInventorySettings(sku: String?,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -87,7 +87,7 @@ protocol ProductFormViewModelProtocol {
                                  backordersSetting: ProductBackordersSetting?,
                                  stockStatus: ProductStockStatus?)
 
-    func updateProductType(productType: ProductType)
+    func updateProductType(productType: BottomSheetProductType)
 
     func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: String?, shippingClassID: Int64?)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -216,7 +216,7 @@ extension ProductVariationFormViewModel {
                                                          parentProductSKU: parentProductSKU)
     }
 
-    func updateProductType(productType: ProductType) {
+    func updateProductType(productType: BottomSheetProductType) {
         // no-op
     }
 

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -440,4 +440,8 @@ final class IconsTests: XCTestCase {
     func test_prologueReviewsImage_is_not_nil() {
         XCTAssertNotNil(UIImage.prologueReviewsImage)
     }
+
+    func test_cloudOutlineImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.cloudOutlineImage)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -4,32 +4,40 @@ import XCTest
 final class ProductFactoryTests: XCTestCase {
     private let siteID: Int64 = 134
 
-    func test_created_simple_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, siteID: siteID))
+    func test_created_simple_physical_product_has_expected_fields() throws {
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID))
         XCTAssertEqual(product.productType, .simple)
+        XCTAssertEqual(product.virtual, false)
+        XCTAssertEqual(product.siteID, siteID)
+    }
+
+    func test_created_simple_virtual_product_has_expected_fields() throws {
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: true, siteID: siteID))
+        XCTAssertEqual(product.productType, .simple)
+        XCTAssertEqual(product.virtual, true)
         XCTAssertEqual(product.siteID, siteID)
     }
 
     func test_created_grouped_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .grouped, siteID: siteID))
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .grouped, isVirtual: false, siteID: siteID))
         XCTAssertEqual(product.productType, .grouped)
         XCTAssertEqual(product.siteID, siteID)
     }
 
     func test_created_external_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .affiliate, siteID: siteID))
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .affiliate, isVirtual: false, siteID: siteID))
         XCTAssertEqual(product.productType, .affiliate)
         XCTAssertEqual(product.siteID, siteID)
     }
 
     func test_created_variable_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .variable, siteID: siteID))
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .variable, isVirtual: false, siteID: siteID))
         XCTAssertEqual(product.productType, .variable)
         XCTAssertEqual(product.siteID, siteID)
     }
 
     func test_creating_a_non_core_product_returns_nil() {
-        let product = ProductFactory().createNewProduct(type: .custom("any"), siteID: siteID)
+        let product = ProductFactory().createNewProduct(type: .custom("any"), isVirtual: false, siteID: siteID)
         XCTAssertNil(product)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
@@ -7,18 +7,20 @@ final class ProductTypeBottomSheetListSelectorCommandTests: XCTestCase {
 
     func test_callback_is_called_on_selection() {
         // Arrange
-        var selectedActions = [ProductType]()
-        let command = ProductTypeBottomSheetListSelectorCommand(selected: .simple) { (selected) in
+        var selectedActions = [BottomSheetProductType]()
+        let command = ProductTypeBottomSheetListSelectorCommand(selected: .simple(isVirtual: false)) { (selected) in
             selectedActions.append(selected)
         }
 
         // Action
+        command.handleSelectedChange(selected: .simple(isVirtual: true))
         command.handleSelectedChange(selected: .grouped)
         command.handleSelectedChange(selected: .variable)
         command.handleSelectedChange(selected: .affiliate)
 
         // Assert
-        let expectedActions: [ProductType] = [
+        let expectedActions: [BottomSheetProductType] = [
+            .simple(isVirtual: true),
             .grouped,
             .variable,
             .affiliate


### PR DESCRIPTION
Fixes: #4006 

## Description

There has been some feedback from users not able to find the option to create a virtual product from the app. This PR updates the bottom sheet "Product type" selector to include `Simple physical product` and `Simple virtual product` options when creating a new product or editing an existing product.

**Design:**

<img src="https://user-images.githubusercontent.com/8658164/118649269-3af83d00-b7db-11eb-8e9a-95ffa9deb14e.png" width="300px">


## Changes

* In `ProductTypeBottomSheetListSelectorCommand.swift`, there is a new `BottomSheetProductType` enum to decouple the options in the bottom sheet from the remote `ProductType` options and support physical and virtual simple products.
* Updates `ProductFactory` so a product's `virtual` property can be set when creating a new product.
* Updates `ProductFormViewModel` so a product's `virtual` property can be set when editing the product type for an existing product.

Add a product (Before) | Add a product (After)
-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-05-18 at 13 25 36](https://user-images.githubusercontent.com/8658164/118650659-9d057200-b7dc-11eb-9735-0c5f2ee47c1b.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-05-18 at 13 10 57](https://user-images.githubusercontent.com/8658164/118650667-9e369f00-b7dc-11eb-8b92-98f883e92c88.png)


Edit product type (Before) | Edit product type (After)
-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-05-18 at 13 25 44](https://user-images.githubusercontent.com/8658164/118650688-a1318f80-b7dc-11eb-9343-25259efd6a5c.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-05-18 at 13 11 48](https://user-images.githubusercontent.com/8658164/118650689-a262bc80-b7dc-11eb-90d3-60027bd416ed.png)


## Testing

**Add a product**

1. Click on the + icon from the Products tab.
2. Notice the virtual product type added to the list.
3. Click on the virtual product type and notice the product type set to virtual product.
4. Verify that you are able to publish the product and view the product page when clicking on the View product on Store.

**Edit a product**

1. Click on an existing product from the products tab.
2. Click on the Product type section and change the product type to Virtual.
3. Verify that the confirmation dialog is displayed and once clicked, the product type displayed is Virtual.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
