### PR TITLE
Add quick check for nested frameworks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,16 +71,6 @@ jobs:
       - run:
           name: Build for Testing
           command: bundle exec fastlane build_for_testing device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
-      - run:
-          name: Test for nested Frameworks
-          command: |
-            NESTED_FMKS=$(find DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app/Frameworks/*.framework -name Frameworks) 
-            if [ -n "$NESTED_FMKS" ]; then
-              echo "Found some nested frameworks inside Frameworks/*/Frameworks subdirectories. Such a configuration is invalid and will be rejected by TestFlight"
-              echo "Please fix by choosing 'Do Not Embed' for the nested framework in the Xcode project of the parent framework containing it"
-              echo $NESTED_FMKS
-              exit 1
-            fi 
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,16 @@ jobs:
       - run:
           name: Build for Testing
           command: bundle exec fastlane build_for_testing device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
+      - run:
+          name: Test for nested Frameworks
+          command: |
+            NESTED_FMKS=$(find DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app/Frameworks/*.framework -name Frameworks) 
+            if [ -n "$NESTED_FMKS" ]; then
+              echo "Found some nested frameworks inside Frameworks/*/Frameworks subdirectories. Such a configuration is invalid and will be rejected by TestFlight"
+              echo "Please fix by choosing 'Do Not Embed' for the nested framework in the Xcode project of the parent framework containing it"
+              echo $NESTED_FMKS
+              exit 1
+            fi 
       - persist_to_workspace:
           root: ./
           paths:

--- a/Scripts/check-nested-frameworks.sh
+++ b/Scripts/check-nested-frameworks.sh
@@ -12,7 +12,12 @@ if [ -z "$NESTED_FMKS_DIRS" ]; then
 else
     echo "❌ Found nested \`Frameworks\` folder inside frameworks of final bundle."
     for fmk_dir in $NESTED_FMKS_DIRS; do
+        # Extract the name of the parent framework containing the nested ones
         parent_fmk=$(basename $(dirname $fmk_dir) .framework)
+        # Extract the list of frameworks nested inside that parent framework. In the next command:
+        #  * `-depth 1` is to avoid logging cases of "C nested in B itself nested in A" (2+ levels of nesting), since C nested in B will already be logged when looping on fmk_dir=B, so no need to log it during fmk_dir=A too.
+        #  * The `sed` command removes the leading `./` in the paths returned by `find`, then quote the results in backticks for nicer formatting in final message.
+        #  * The `tr` command joins all the lines (= found frameworks) with a `,`. Note that this will result in an extra comma at the end of the list too, but we'll get rid of that in the final message using ${nested_fmks%,} bash substitution.
         nested_fmks=$(cd "${fmk_dir}" && find . -name '*.framework' -depth 1 | sed "s:^./\(.*\)$:\`\1\`:" | tr '\n' ',')
         echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2"
     done

--- a/Scripts/check-nested-frameworks.sh
+++ b/Scripts/check-nested-frameworks.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -euo pipefail
+
+# Nested frameworks (i.e. having a Frameworks/ folder inside *.app/Frameworks/.framework) is invalid and will make the build be rejected during TestFlight validation.
+# This can happen especially due to an Xcode 12.4 UI bug when linking binary frameworks to the project which always embed the binary (and if you try to change to Do Not Embed it also removes it from linked libraries)
+# This is a bug in Xcode 12.4 UI that is fixed in Xcode 12.5, so fixing nested frameworks to "Do Not Embed" can be fixed using Xcode 12.5, while still continue using Xcode 12.4 for development after the fix.
+
+# This script is intended to be used as a Build Phase on the main app target, as the very last build phase (and especially after the "Embed Frameworks" phase)
+
+NESTED_FMKS_DIRS=$(find "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}" -name Frameworks -depth 2) 
+if [ -z "$NESTED_FMKS_DIRS" ]; then
+    echo "✅ No nested framework found, you're good to go!"
+else
+    echo "❌ Found nested \`Frameworks\` folder inside frameworks of final bundle."
+    for fmk_dir in $NESTED_FMKS_DIRS; do
+        parent_fmk=$(basename $(dirname $fmk_dir) .framework)
+        nested_fmks=$(cd "${fmk_dir}" && find . -name '*.framework' -depth 1 | sed "s:^./\(.*\)$:\`\1\`:" | tr '\n' ',')
+        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2"
+    done
+    exit 1
+fi 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -6010,8 +6010,8 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Nested frameworks (i.e. having a Frameworks/ folder inside *.app/Frameworks/.framework) is invalid and will make the build be rejected during TestFlight validation. But this can happen especially due to an Xcode 12.4 UI bug when linking binary frameworks to the project which always embed the binary (bug that is fixed in Xcode 12.5)\n\nNESTED_FMKS=$(find \"${TARGET_BUILD_DIR}\"/WooCommerce.app/Frameworks/*.framework/Frameworks -name '*.framework') \nif [ -z \"$NESTED_FMKS\" ]; then\n    echo \"✅ No nested framework found, you're good to go!\"\nelse\n    for f in $NESTED_FMKS; do\n        nested=$(basename $f)\n        parent=$(basename $(dirname $(dirname $f)) .framework)\n        echo \"error: Found nested framework in $f -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework \\`$nested\\` within the \\`$parent\\` Xcode project containing it. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2\"\n    done\n    exit 1\nfi \n";
+			shellPath = "/bin/sh -euo pipefail";
+			shellScript = "${PROJECT_DIR}/../Scripts/check-nested-frameworks.sh\n";
 			showEnvVarsInLog = 0;
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -5605,6 +5605,7 @@
 				B7A94351C1ADC31EA528B895 /* [CP] Embed Pods Frameworks */,
 				CE1445302188ED0300A991D8 /* Zendesk Strip Frameworks */,
 				59DF5B32D7C07692EC8B4C59 /* [CP] Copy Pods Resources */,
+				095040D72655531C001D08FA /* Check for nested frameworks */,
 			);
 			buildRules = (
 			);
@@ -5994,6 +5995,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		095040D72655531C001D08FA /* Check for nested frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check for nested frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Nested frameworks (i.e. having a Frameworks/ folder inside *.app/Frameworks/.framework) is invalid and will make the build be rejected during TestFlight validation. But this can happen especially due to an Xcode 12.4 UI bug when linking binary frameworks to the project which always embed the binary (bug that is fixed in Xcode 12.5)\n\nNESTED_FMKS=$(find \"${TARGET_BUILD_DIR}\"/WooCommerce.app/Frameworks/*.framework/Frameworks -name '*.framework') \nif [ -z \"$NESTED_FMKS\" ]; then\n    echo \"✅ No nested framework found, you're good to go!\"\nelse\n    for f in $NESTED_FMKS; do\n        nested=$(basename $f)\n        parent=$(basename $(dirname $(dirname $f)) .framework)\n        echo \"error: Found nested framework in $f -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework \\`$nested\\` within the \\`$parent\\` Xcode project containing it. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2\"\n    done\n    exit 1\nfi \n";
+			showEnvVarsInLog = 0;
+		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
Following the issue we had with TestFlight validation and nested frameworks introduced by the Xcode 12.4 bug (see paNNhX-ee-p2 for details), this check will hopefully catch if we encounter such a configuration issue again later.


## To test

I already tested this myself (see comments below) but it could be nice to validate the check works on other's machines too.
To test this:

- Checkout this branch, open the WooCommerce workspace in Xcode 12.4 and build the project
- Check that you don't get any error during the build. In particular, you might want to go to the Build Log tab and expand the `Run custom shell script 'Check for nested frameworks'` step at the end and check that it says `✅ No nested framework found, you're good to go!`
- Select the `Yosemite` project in the workspace, go to the "General" tab, and in the "Frameworks and Libraries" section, change the line for `Codegen` from "Do Not Embed" to "Embed & Sign"
- Build the project again, and check that you get a build error telling you all about the nested framework issue.