### PR TITLE
[Mobile Payments] Tracks events for email receipts (take 2)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -663,6 +663,16 @@ private extension OrderDetailsViewController {
 
 extension OrderDetailsViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        switch result {
+        case .cancelled:
+            ServiceLocator.analytics.track(.receiptEmailCanceled)
+        case .sent, .saved:
+            ServiceLocator.analytics.track(.receiptEmailSuccess)
+        case .failed:
+            ServiceLocator.analytics.track(.receiptEmailFailed, withError: error ?? UnknownEmailError())
+        @unknown default:
+            assertionFailure("MFMailComposeViewController finished with an unknown result type")
+        }
         controller.dismiss(animated: true)
     }
 }
@@ -905,4 +915,8 @@ private extension OrderDetailsViewController {
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
     }
+
+    /// Mailing a receipt failed but the SDK didn't return a more specific error
+    ///
+    struct UnknownEmailError: Error {}
 }


### PR DESCRIPTION
Part of #4082

This was meant to be included in #4213 but I didn't realize this last change was uncommitted 🤦🏽 . I actually tested #4213 with this changes applied.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
