### PR TITLE
[Mobile Payments] Tracks events for collecting payment

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -213,6 +213,13 @@ public enum WooAnalyticsStat: String {
     case receiptPrintCanceled                   = "receipt_print_canceled"
     case receiptPrintSuccess                    = "receipt_print_success"
 
+    // MARK: Payment Events
+    //
+    case collectPaymentTapped                   = "card_present_collect_payment_tapped"
+    case collectPaymentCanceled                 = "card_present_collect_payment_canceled"
+    case collectPaymentFailed                   = "card_present_collect_payment_failed"
+    case collectPaymentSuccess                  = "card_present_collect_payment_success"
+
     // MARK: Push Notifications Events
     //
     case pushNotificationReceived               = "push_notification_received"

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalReaderIsReady.swift
@@ -39,6 +39,8 @@ final class CardPresentModalReaderIsReady: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        ServiceLocator.analytics.track(.collectPaymentCanceled)
+
         let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
@@ -39,6 +39,7 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        ServiceLocator.analytics.track(.collectPaymentCanceled)
         let action = CardPresentPaymentAction.cancelPayment(onCompletion: nil)
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -78,8 +78,7 @@ private extension PaymentCaptureOrchestrator {
                                     captureResult: Result<PaymentIntent, Error>,
                                     onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
         switch captureResult {
-        case .failure:
-            let error = CardReaderServiceError.paymentCapture()
+        case .failure(let error):
             onCompletion(.failure(error))
         case .success(let paymentIntent):
             submitPaymentIntent(siteID: order.siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -590,6 +590,7 @@ private extension OrderDetailsViewController {
                                     title: viewModel.collectPaymentFrom,
                                     amount: viewModel.order.total)
 
+        ServiceLocator.analytics.track(.collectPaymentTapped)
         viewModel.collectPayment { [weak self] readerEventMessage in
             self?.paymentAlerts.tapOrInsertCard()
         } onClearMessage: { [weak self] in
@@ -603,10 +604,12 @@ private extension OrderDetailsViewController {
 
             switch result {
             case .failure(let error):
+                ServiceLocator.analytics.track(.collectPaymentFailed, withError: error)
                 self.paymentAlerts.error(error: error, tryAgain: {
                     // To be implemented.
                 })
             case .success(let receiptParameters):
+                ServiceLocator.analytics.track(.collectPaymentSuccess)
                 self.syncOrderAfterPaymentCollection {
                     self.checkCardPresentPaymentEligibility()
                 }


### PR DESCRIPTION
Part of #4082 

## Events included

- card_present_collect_payment_tapped: The user tapped on the Collect Payment button to collect a card payment.
- card_present_collect_payment_canceled: The user canceled the payment process.
- card_present_collect_payment_failed: The payment process failed.
- card_present_collect_payment_success: The payment was completed successfully.

I tested that all the events are triggered and received on the backend.

One question I have is whether we should add more detail on some of the errors. For instance, for `paymentDeclinedByPaymentProcessorAPI`, the documentation says to inspect `SCPProcessPaymentError.requestError` 
for more details, which could include useful information:

> ...requestError = Error Domain=com.stripe-terminal Code=9020 "Allowable number of PIN tries exceeded." UserInfo={com.stripe-terminal:StripeAPIDocUrl=https://stripe.com/docs/error-codes/card-declined...


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
