### PR TITLE
Issue/receips hot fix

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -12,7 +12,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
     private let primaryAction: () -> Void
 
-    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
     let actionsMode: PaymentsModalActionsMode = .oneAction
 
     let topTitle: String = Localization.paymentFailed
@@ -42,8 +42,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        primaryAction()
-        viewController?.dismiss(animated: true)
+        viewController?.dismiss(animated: true, completion: {[weak self] in
+            self?.primaryAction()
+        })
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) { }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -20,7 +20,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.tryAgain
+    let primaryButtonTitle: String? = Localization.dismiss
 
     let secondaryButtonTitle: String? = nil
 
@@ -50,12 +50,12 @@ private extension CardPresentModalNonRetryableError {
     enum Localization {
         static let paymentFailed = NSLocalizedString(
             "Payment failed",
-            comment: "Error message. Presented to users after a collecting a payment fails"
+            comment: "Error message. Presented to users after collecting a payment fails"
         )
 
-        static let tryAgain = NSLocalizedString(
+        static let dismiss = NSLocalizedString(
             "Dismiss",
-            comment: "Button to try to dismiss. Presented to users after a collecting a payment fails"
+            comment: "Button to dismiss. Presented to users after collecting a payment fails"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+/// Modal presented on error
+final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel {
+
+    /// Amount charged
+    private let amount: String
+
+    /// The error returned by the stack
+    private let error: Error
+
+    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
+
+    let topTitle: String = Localization.paymentFailed
+
+    var topSubtitle: String? {
+        amount
+    }
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.tryAgain
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? {
+        error.localizedDescription
+    }
+
+    let bottomSubtitle: String? = nil
+
+    init(amount: String, error: Error) {
+        self.amount = amount
+        self.error = error
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true)
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalNonRetryableError {
+    enum Localization {
+        static let paymentFailed = NSLocalizedString(
+            "Payment failed",
+            comment: "Error message. Presented to users after a collecting a payment fails"
+        )
+
+        static let tryAgain = NSLocalizedString(
+            "Dismiss",
+            comment: "Button to try to dismiss. Presented to users after a collecting a payment fails"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// Modal presented on error
+/// Modal presented on error. Does not provide a retry action.
 final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel {
 
     /// Amount charged

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -9,7 +9,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     /// The error returned by the stack
     private let error: Error
 
-    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
     let actionsMode: PaymentsModalActionsMode = .oneAction
 
     let topTitle: String = Localization.paymentFailed

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -41,8 +41,9 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        printReceiptAction()
-        viewController?.dismiss(animated: true)
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.printReceiptAction()
+        })
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -42,6 +42,12 @@ final class PaymentCaptureOrchestrator {
         ServiceLocator.stores.dispatch(action)
     }
 
+    func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = CardPresentPaymentAction.cancelPayment(onCompletion: onCompletion)
+
+        ServiceLocator.stores.dispatch(action)
+    }
+
     func printReceipt(for order: Order, params: CardPresentReceiptParameters) {
         let action = ReceiptAction.print(order: order, parameters: params)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -55,7 +55,7 @@ final class OrderDetailsPaymentAlerts {
             modalController?.setViewModel(viewModel)
             return
         }
-        
+
         let newAlert = CardPresentPaymentsModalViewController(viewModel: viewModel)
 
         modalController = newAlert

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -48,9 +48,15 @@ final class OrderDetailsPaymentAlerts {
         modalController?.setViewModel(viewModel)
     }
 
-    func nonRetryableError(error: Error) {
+    func nonRetryableError(from: UIViewController?, error: Error) {
         let viewModel = nonRetryableErrorViewModel(amount: amount, error: error)
+        let newAlert = CardPresentPaymentsModalViewController(viewModel: viewModel)
         modalController?.setViewModel(viewModel)
+
+        modalController = newAlert
+        modalController?.modalPresentationStyle = .custom
+        modalController?.transitioningDelegate = AppDelegate.shared.tabBarController
+        from?.present(newAlert, animated: true)
     }
 
     func dismiss() {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -48,6 +48,11 @@ final class OrderDetailsPaymentAlerts {
         modalController?.setViewModel(viewModel)
     }
 
+    func nonRetryableError(error: Error) {
+        let viewModel = nonRetryableErrorViewModel(amount: amount, error: error)
+        modalController?.setViewModel(viewModel)
+    }
+
     func dismiss() {
         modalController?.dismiss(animated: true, completion: nil)
     }
@@ -77,5 +82,9 @@ private extension OrderDetailsPaymentAlerts {
 
     func errorViewModel(amount: String, error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalError(amount: amount, error: error, primaryAction: tryAgain)
+    }
+
+    func nonRetryableErrorViewModel(amount: String, error: Error) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalNonRetryableError(amount: amount, error: error)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -50,8 +50,13 @@ final class OrderDetailsPaymentAlerts {
 
     func nonRetryableError(from: UIViewController?, error: Error) {
         let viewModel = nonRetryableErrorViewModel(amount: amount, error: error)
+
+        guard modalController == nil else {
+            modalController?.setViewModel(viewModel)
+            return
+        }
+        
         let newAlert = CardPresentPaymentsModalViewController(viewModel: viewModel)
-        modalController?.setViewModel(viewModel)
 
         modalController = newAlert
         modalController?.modalPresentationStyle = .custom

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -552,6 +552,10 @@ extension OrderDetailsViewModel {
 
     }
 
+    func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        paymentOrchestrator.cancelPayment(onCompletion: onCompletion)
+    }
+
     func printReceipt(params: CardPresentReceiptParameters) {
         paymentOrchestrator.printReceipt(for: order, params: params)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -624,10 +624,10 @@ private extension OrderDetailsViewController {
     }
 
     private func retryCollectPayment() {
-        self.viewModel.cancelPayment { [weak self] result in
+        viewModel.cancelPayment { [weak self] result in
             switch result {
             case .failure(let error):
-                self?.paymentAlerts.nonRetryableError(error: error)
+                self?.paymentAlerts.nonRetryableError(from: self, error: error)
             case .success:
                 self?.collectPaymentForCurrentOrder()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -604,7 +604,7 @@ private extension OrderDetailsViewController {
             switch result {
             case .failure(let error):
                 self.paymentAlerts.error(error: error, tryAgain: {
-                    // To be implemented.
+                    self.retryCollectPayment()
                 })
             case .success(let receiptParameters):
                 self.syncOrderAfterPaymentCollection {
@@ -619,6 +619,17 @@ private extension OrderDetailsViewController {
                     })
                 }
                 )
+            }
+        }
+    }
+
+    private func retryCollectPayment() {
+        self.viewModel.cancelPayment { [weak self] result in
+            switch result {
+            case .failure(let error):
+                self?.paymentAlerts.nonRetryableError(error: error)
+            case .success:
+                self?.collectPaymentForCurrentOrder()
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1056,6 +1056,7 @@
 		D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */; };
 		D80254822655267A001B2CC1 /* CardPresentModalErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */; };
 		D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */; };
+		D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2318,6 +2319,7 @@
 		D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessTests.swift; sourceTree = "<group>"; };
 		D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorTests.swift; sourceTree = "<group>"; };
 		D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableErrorTests.swift; sourceTree = "<group>"; };
+		D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProcessingTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5542,6 +5544,7 @@
 				D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */,
 				D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */,
 				D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */,
+				D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -6997,6 +7000,7 @@
 				3178C1FD26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift in Sources */,
 				02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */,
 				B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */,
+				D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */,
 				B57C5C9F21B80E8300FF82B2 /* SampleError.swift in Sources */,
 				02404EE42315151400FF1170 /* MockStatsVersionStoresManager.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1058,6 +1058,7 @@
 		D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */; };
 		D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */; };
 		D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */; };
+		D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2322,6 +2323,7 @@
 		D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableErrorTests.swift; sourceTree = "<group>"; };
 		D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProcessingTests.swift; sourceTree = "<group>"; };
 		D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReaderTests.swift; sourceTree = "<group>"; };
+		D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReaderTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5548,6 +5550,7 @@
 				D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */,
 				D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */,
 				D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */,
+				D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7168,6 +7171,7 @@
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,
 				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
+				D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
 				D89C009A25B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1059,6 +1059,7 @@
 		D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */; };
 		D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */; };
 		D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */; };
+		D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802549A265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2324,6 +2325,7 @@
 		D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProcessingTests.swift; sourceTree = "<group>"; };
 		D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReaderTests.swift; sourceTree = "<group>"; };
 		D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReaderTests.swift; sourceTree = "<group>"; };
+		D802549A265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingToReaderTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5551,6 +5553,7 @@
 				D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */,
 				D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */,
 				D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */,
+				D802549A265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7143,6 +7146,7 @@
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
+				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1053,6 +1053,7 @@
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
 		D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */; };
+		D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2312,6 +2313,7 @@
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
 		D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRemoveCardTests.swift; sourceTree = "<group>"; };
+		D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5533,6 +5535,7 @@
 				D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */,
 				D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */,
 				D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */,
+				D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7197,6 +7200,7 @@
 				027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */,
 				025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */,
 				45A0E4D32566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift in Sources */,
+				D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */,
 				02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */,
 				45E9A6EB24DAFC3E00A600E8 /* ProductReviewsViewModelTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1054,6 +1054,7 @@
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
 		D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */; };
 		D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */; };
+		D80254822655267A001B2CC1 /* CardPresentModalErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2314,6 +2315,7 @@
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
 		D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRemoveCardTests.swift; sourceTree = "<group>"; };
 		D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessTests.swift; sourceTree = "<group>"; };
+		D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5536,6 +5538,7 @@
 				D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */,
 				D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */,
 				D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */,
+				D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7058,6 +7061,7 @@
 				D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */,
 				02A275C223FE590A005C560F /* MockKingfisherImageDownloader.swift in Sources */,
 				CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */,
+				D80254822655267A001B2CC1 /* CardPresentModalErrorTests.swift in Sources */,
 				02AC822C2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift in Sources */,
 				D8610BF7256F5F0900A5DF27 /* ULErrorViewControllerTests.swift in Sources */,
 				02279594237A60FD00787C63 /* AztecHeaderFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1049,6 +1049,7 @@
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
+		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2304,6 +2305,7 @@
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
+		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5602,6 +5604,7 @@
 				D8815B062638606B00EDAD62 /* CardPresentModalRemoveCard.swift */,
 				D8815B0C263861A400EDAD62 /* CardPresentModalSuccess.swift */,
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
+				D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */,
 				D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */,
 				D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */,
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
@@ -6358,6 +6361,7 @@
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */,
+				D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */,
 				029F29FC24D94106004751CA /* EditableProductVariationModel.swift in Sources */,
 				0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */,
 				D8815AE726383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1050,6 +1050,7 @@
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
+		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2306,6 +2307,7 @@
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
+		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -4009,6 +4011,7 @@
 		5791FB4024EC833200117FD6 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				D8025469265517F9001B2CC1 /* CardPresentPayments */,
 				5791FB4124EC834300117FD6 /* MainTabViewModelTests.swift */,
 			);
 			path = ViewModels;
@@ -5518,6 +5521,14 @@
 				CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */,
 			);
 			path = AppRatings;
+			sourceTree = "<group>";
+		};
+		D8025469265517F9001B2CC1 /* CardPresentPayments */ = {
+			isa = PBXGroup;
+			children = (
+				D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */,
+			);
+			path = CardPresentPayments;
 			sourceTree = "<group>";
 		};
 		D810F8F62639EDD900437C67 /* CardPresentPayments */ = {
@@ -7191,6 +7202,7 @@
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
+				D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */,
 				45DB706C26161F970064A6CF /* DecimalWooTests.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1051,6 +1051,7 @@
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
+		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2308,6 +2309,7 @@
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
+		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5527,6 +5529,7 @@
 			isa = PBXGroup;
 			children = (
 				D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */,
+				D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7037,6 +7040,7 @@
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,
+				D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */; };
 		D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */; };
 		D80254822655267A001B2CC1 /* CardPresentModalErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */; };
+		D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2316,6 +2317,7 @@
 		D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRemoveCardTests.swift; sourceTree = "<group>"; };
 		D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessTests.swift; sourceTree = "<group>"; };
 		D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorTests.swift; sourceTree = "<group>"; };
+		D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableErrorTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5539,6 +5541,7 @@
 				D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */,
 				D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */,
 				D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */,
+				D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7073,6 +7076,7 @@
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,
+				D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */,
 				02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockTableView.swift in Sources */,
 				0259EF79246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1052,6 +1052,7 @@
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
+		D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2310,6 +2311,7 @@
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
+		D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRemoveCardTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5530,6 +5532,7 @@
 			children = (
 				D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */,
 				D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */,
+				D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7140,6 +7143,7 @@
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
 				453904F323BB88B5007C4956 /* ProductTaxStatusListSelectorCommandTests.swift in Sources */,
 				02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */,
+				D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */,
 				02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */,
 				023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */,
 				AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1057,6 +1057,7 @@
 		D80254822655267A001B2CC1 /* CardPresentModalErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */; };
 		D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */; };
 		D802548C26552F41001B2CC1 /* CardPresentModalProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */; };
+		D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */; };
 		D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */; };
 		D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
@@ -2320,6 +2321,7 @@
 		D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalErrorTests.swift; sourceTree = "<group>"; };
 		D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableErrorTests.swift; sourceTree = "<group>"; };
 		D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProcessingTests.swift; sourceTree = "<group>"; };
+		D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReaderTests.swift; sourceTree = "<group>"; };
 		D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewAgeTests.swift; sourceTree = "<group>"; };
 		D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewControllerTests.swift; sourceTree = "<group>"; };
 		D8149F552251EE300006A245 /* UITextField+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Helpers.swift"; sourceTree = "<group>"; };
@@ -5545,6 +5547,7 @@
 				D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */,
 				D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */,
 				D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */,
+				D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7233,6 +7236,7 @@
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
+				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
 				A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingToReaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingToReaderTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalConnectingToReaderTests: XCTestCase {
+    private var viewModel: CardPresentModalConnectingToReader!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CardPresentModalConnectingToReader()
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_nil() {
+        XCTAssertNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+}
+
+
+private extension CardPresentModalConnectingToReaderTests {
+    enum Expectations {
+        static var image = UIImage.cardReaderConnecting
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalErrorTests: XCTestCase {
+    private var viewModel: CardPresentModalError!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalError(amount: Expectations.amount, error: Expectations.error, primaryAction: closures.primaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapPrimary)
+    }
+}
+
+
+private extension CardPresentModalErrorTests {
+    enum Expectations {
+        static let amount = "amount"
+        static let image = UIImage.paymentErrorImage
+        static let error = MockError()
+    }
+
+    final class MockError: Error {
+        var localizedDescription: String {
+            "description"
+        }
+    }
+}
+
+
+private final class Closures {
+    var didTapPrimary = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapPrimary = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -44,12 +44,6 @@ final class CardPresentModalErrorTests: XCTestCase {
     func test_bottom_subTitle_is_nil() {
         XCTAssertNil(viewModel.bottomSubtitle)
     }
-
-    func test_primary_button_action_calls_closure() {
-        viewModel.didTapPrimaryButton(in: nil)
-
-        XCTAssertTrue(closures.didTapPrimary)
-    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalFoundReaderTests: XCTestCase {
+    private var viewModel: CardPresentModalFoundReader!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalFoundReader(name: Expectations.name, connect: closures.primaryAction(), continueSearch: closures.secondaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_nil() {
+        XCTAssertNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapConnect)
+    }
+
+    func test_secondary_button_action_calls_closure() {
+        viewModel.didTapSecondaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapContinue)
+    }
+}
+
+
+private extension CardPresentModalFoundReaderTests {
+    enum Expectations {
+        static var name = "name"
+        static var amount = "amount"
+        static var image = UIImage.cardReaderFound
+    }
+}
+
+
+private final class Closures {
+    var didTapConnect = false
+    var didTapContinue = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapConnect = true
+        }
+    }
+
+    func secondaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapContinue = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalNonRetryableErrorTests: XCTestCase {
+    private var viewModel: CardPresentModalNonRetryableError!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount, error: Expectations.error)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+}
+
+
+private extension CardPresentModalNonRetryableErrorTests {
+    enum Expectations {
+        static var amount = "amount"
+        static var image = UIImage.paymentErrorImage
+        static let error = MockError()
+    }
+
+    final class MockError: Error {
+        var localizedDescription: String {
+            "description"
+        }
+    }
+}
+
+
+private final class Closures {
+    var didTapPrint = false
+    var didTapEmail = false
+    var didTapNoThanks = false
+
+    func printReceipt() -> () -> Void {
+        return { [weak self] in
+            self?.didTapPrint = true
+        }
+    }
+
+    func emailReceipt() -> () -> Void {
+        return { [weak self] in
+            self?.didTapEmail = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalProcessingTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalProcessingTests.swift
@@ -1,12 +1,12 @@
 import XCTest
 @testable import WooCommerce
 
-final class CardPresentModalNonRetryableErrorTests: XCTestCase {
-    private var viewModel: CardPresentModalNonRetryableError!
+final class CardPresentModalProcessingTests: XCTestCase {
+    private var viewModel: CardPresentModalProcessing!
 
     override func setUp() {
         super.setUp()
-        viewModel = CardPresentModalNonRetryableError(amount: Expectations.amount, error: Expectations.error)
+        viewModel = CardPresentModalProcessing(name: Expectations.name, amount: Expectations.amount)
     }
 
     override func tearDown() {
@@ -26,8 +26,8 @@ final class CardPresentModalNonRetryableErrorTests: XCTestCase {
         XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
     }
 
-    func test_primary_button_title_is_not_nil() {
-        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    func test_primary_button_title_is_nil() {
+        XCTAssertNil(viewModel.primaryButtonTitle)
     }
 
     func test_secondary_button_title_is_nil() {
@@ -48,16 +48,10 @@ final class CardPresentModalNonRetryableErrorTests: XCTestCase {
 }
 
 
-private extension CardPresentModalNonRetryableErrorTests {
+private extension CardPresentModalProcessingTests {
     enum Expectations {
+        static var name = "name"
         static var amount = "amount"
-        static var image = UIImage.paymentErrorImage
-        static let error = MockError()
-    }
-
-    final class MockError: Error {
-        var localizedDescription: String {
-            "description"
-        }
+        static var image = UIImage.cardPresentImage
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import TestKit
+@testable import WooCommerce
+@testable import Yosemite
+
+final class CardPresentModalReaderIsReadyTests: XCTestCase {
+    private var viewModel: CardPresentModalReaderIsReady!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CardPresentModalReaderIsReady(name: Expectations.name, amount: Expectations.amount)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topTitle, Expectations.name)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_dispatched_canel_action() throws {
+        let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        storesManager.reset()
+
+        ServiceLocator.setStores(storesManager)
+
+        assertEmpty(storesManager.receivedActions)
+
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? CardPresentPaymentAction)
+        switch action {
+        case .cancelPayment(onCompletion: _):
+            XCTAssertTrue(true)
+        default:
+            XCTFail("Primary button does not dispatch .cancelPayment action")
+        }
+    }
+}
+
+
+private extension CardPresentModalReaderIsReadyTests {
+    enum Expectations {
+        static var name = "name"
+        static var amount = "amount"
+        static var image = UIImage.cardPresentImage
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -65,7 +65,7 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
         case .cancelPayment(onCompletion: _):
             XCTAssertTrue(true)
         default:
-            XCTFail("Primary button does not dispatch .cancelPayment action")
+            XCTFail("Primary button failed to dispatch .cancelPayment action")
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalReaderIsReadyTests.swift
@@ -48,7 +48,7 @@ final class CardPresentModalReaderIsReadyTests: XCTestCase {
         XCTAssertNotNil(viewModel.bottomSubtitle)
     }
 
-    func test_primary_button_dispatched_canel_action() throws {
+    func test_primary_button_dispatched_cancel_action() throws {
         let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         storesManager.reset()
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRemoveCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRemoveCardTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import TestKit
+@testable import WooCommerce
+@testable import Yosemite
+
+final class CardPresentModalRemoveCardTests: XCTestCase {
+    private var viewModel: CardPresentModalRemoveCard!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CardPresentModalRemoveCard(name: Expectations.name, amount: Expectations.amount)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topTitle, Expectations.name)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomSubtitle)
+    }
+}
+
+
+private extension CardPresentModalRemoveCardTests {
+    enum Expectations {
+        static var name = "name"
+        static var amount = "amount"
+        static var image = UIImage.cardPresentImage
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRemoveCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRemoveCardTests.swift
@@ -1,7 +1,5 @@
 import XCTest
-import TestKit
 @testable import WooCommerce
-@testable import Yosemite
 
 final class CardPresentModalRemoveCardTests: XCTestCase {
     private var viewModel: CardPresentModalRemoveCard!
@@ -28,8 +26,8 @@ final class CardPresentModalRemoveCardTests: XCTestCase {
         XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
     }
 
-    func test_primary_button_title_is_not_nil() {
-        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    func test_primary_button_title_is_nil() {
+        XCTAssertNil(viewModel.primaryButtonTitle)
     }
 
     func test_secondary_button_title_is_nil() {
@@ -44,8 +42,8 @@ final class CardPresentModalRemoveCardTests: XCTestCase {
         XCTAssertNotNil(viewModel.bottomTitle)
     }
 
-    func test_bottom_subTitle_is_not_nil() {
-        XCTAssertNotNil(viewModel.bottomSubtitle)
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalScanningForReaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalScanningForReaderTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalScanningForReaderTests: XCTestCase {
+    private var viewModel: CardPresentModalScanningForReader!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalScanningForReader(cancel: closures.primaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapCancel)
+    }
+}
+
+
+private extension CardPresentModalScanningForReaderTests {
+    enum Expectations {
+        static var name = "name"
+        static var amount = "amount"
+        static var image = UIImage.cardReaderScanning
+    }
+}
+
+
+private final class Closures {
+    var didTapCancel = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapCancel = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalSuccessTests: XCTestCase {
+    private var viewModel: CardPresentModalSuccess!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalSuccess(amount: Expectations.amount, printReceipt: closures.printReceipt(), emailReceipt: closures.emailReceipt())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_nil() {
+        XCTAssertNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapPrint)
+    }
+
+    func test_secondary_button_action_calls_closure() {
+        viewModel.didTapSecondaryButton(in: nil)
+
+        XCTAssertTrue(closures.didTapEmail)
+    }
+}
+
+
+private extension CardPresentModalSuccessTests {
+    enum Expectations {
+        static var amount = "amount"
+        static var image = UIImage.celebrationImage
+    }
+}
+
+
+private final class Closures {
+    var didTapPrint = false
+    var didTapEmail = false
+    var didTapNoThanks = false
+
+    func printReceipt() -> () -> Void {
+        { [weak self] in
+            self?.didTapPrint = true
+        }
+    }
+
+    func emailReceipt() -> () -> Void {
+        { [weak self] in
+            self?.didTapEmail = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -74,7 +74,6 @@ private extension CardPresentModalSuccessTests {
 private final class Closures {
     var didTapPrint = false
     var didTapEmail = false
-    var didTapNoThanks = false
 
     func printReceipt() -> () -> Void {
         return { [weak self] in

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -77,13 +77,13 @@ private final class Closures {
     var didTapNoThanks = false
 
     func printReceipt() -> () -> Void {
-        { [weak self] in
+        return { [weak self] in
             self?.didTapPrint = true
         }
     }
 
     func emailReceipt() -> () -> Void {
-        { [weak self] in
+        return { [weak self] in
             self?.didTapEmail = true
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
@@ -65,7 +65,7 @@ final class CardPresentModalTapCardTests: XCTestCase {
         case .cancelPayment(onCompletion: _):
             XCTAssertTrue(true)
         default:
-            XCTFail("Primary button does not dispatch .cancelPayment action")
+            XCTFail("Primary button failed to dispatch .cancelPayment action")
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import TestKit
+@testable import WooCommerce
+@testable import Yosemite
+
+final class CardPresentModalTapCardTests: XCTestCase {
+    private var viewModel: CardPresentModalTapCard!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CardPresentModalTapCard(name: Expectations.name, amount: Expectations.amount)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topTitle, Expectations.name)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_dispatched_canel_action() throws {
+        let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        storesManager.reset()
+
+        ServiceLocator.setStores(storesManager)
+
+        assertEmpty(storesManager.receivedActions)
+
+        viewModel.didTapPrimaryButton(in: nil)
+
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? CardPresentPaymentAction)
+        switch action {
+        case .cancelPayment(onCompletion: _):
+            XCTAssertTrue(true)
+        default:
+            XCTFail("Primary button does not dispatch .cancelPayment action")
+        }
+    }
+}
+
+
+private extension CardPresentModalTapCardTests {
+    enum Expectations {
+        static var name = "name"
+        static var amount = "amount"
+        static var image = UIImage.cardPresentImage
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalTapCardTests.swift
@@ -48,7 +48,7 @@ final class CardPresentModalTapCardTests: XCTestCase {
         XCTAssertNotNil(viewModel.bottomSubtitle)
     }
 
-    func test_primary_button_dispatched_canel_action() throws {
+    func test_primary_button_dispatched_cancel_action() throws {
         let storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         storesManager.reset()
 


### PR DESCRIPTION
Closes #4236 

## Changes
* Trigger the "Print receipt" action in the success modal presented when a payment is completed after the modal has been dismissed.

## How to test
* Collect payment for an eligible order
* Tap "print receipt" after the payment has been collected. Notice if the receipt can be printed.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
