### PR TITLE
[Mobile Payments] Fix receipt printing

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -41,8 +41,9 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        printReceiptAction()
-        viewController?.dismiss(animated: true)
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.printReceiptAction()
+        })
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {


### PR DESCRIPTION
Closes #4236 

## Changes
* Trigger the "Print receipt" action in the success modal presented when a payment is completed after the modal has been dismissed.

## How to test
* Collect payment for an eligible order
* Tap "print receipt" after the payment has been collected. Notice if the receipt can be printed.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
