### PR TITLE
[Mobile Payments] Tracks events for reader discovery and connection

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -5,7 +5,7 @@ public protocol CardReaderService {
 
     // MARK: - Queries
     /// The publisher that emits the list of discovered readers whenever the service discovers a new reader.
-    var discoveredReaders: AnyPublisher<[CardReader], Never> { get }
+    var discoveredReaders: AnyPublisher<[CardReader], Error> { get }
 
     /// The Publisher that emits the connected readers
     var connectedReaders: AnyPublisher<[CardReader], Never> { get }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -139,6 +139,17 @@ public enum WooAnalyticsStat: String {
     case settingsLogoutConfirmation             = "settings_logout_confirmation_dialog_result"
     case settingsWereHiringTapped               = "settings_we_are_hiring_button_tapped"
 
+    // MARK: Card Reader Connection Events
+    //
+    case cardReaderDiscoveryTapped              = "card_reader_discovery_tapped"
+    case cardReaderDiscoveryFailed              = "card_reader_discovery_failed"
+    case cardReaderDiscoveredReader             = "card_reader_discovery_reader_discovered"
+    case cardReaderConnectionTapped             = "card_reader_connection_tapped"
+    case cardReaderConnectionFailed             = "card_reader_connection_failed"
+    case cardReaderConnectionSuccess            = "card_reader_connection_success"
+    case cardReaderDisconnectTapped             = "card_reader_disconnect_tapped"
+    case cardReaderDisconnectUnexpected         = "card_reader_disconnect_unexpected"
+
     // MARK: Order View Events
     //
     case ordersSelected                         = "main_tab_orders_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -148,7 +148,6 @@ public enum WooAnalyticsStat: String {
     case cardReaderConnectionFailed             = "card_reader_connection_failed"
     case cardReaderConnectionSuccess            = "card_reader_connection_success"
     case cardReaderDisconnectTapped             = "card_reader_disconnect_tapped"
-    case cardReaderDisconnectUnexpected         = "card_reader_disconnect_unexpected"
 
     // MARK: Order View Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -57,6 +57,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Dispatch a request to disconnect from a reader
     ///
     func disconnectReader() {
+        ServiceLocator.analytics.track(.cardReaderDisconnectTapped)
         let action = CardPresentPaymentAction.disconnect() { result in
             guard result.isSuccess else {
                 DDLogError("Unexpected error when disconnecting reader")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -140,7 +140,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             /// Nothing to do here because, when the observed connectedReaders mutates, the
             /// connected view will be shown automatically.
             switch result {
-            case .success(_):
+            case .success:
                 ServiceLocator.analytics.track(.cardReaderConnectionSuccess)
             case .failure(let error):
                 ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -135,9 +135,16 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         updateProperties()
         didUpdate?()
 
-        let action = CardPresentPaymentAction.connect(reader: foundReader) { _ in
+        ServiceLocator.analytics.track(.cardReaderConnectionTapped)
+        let action = CardPresentPaymentAction.connect(reader: foundReader) { result in
             /// Nothing to do here because, when the observed connectedReaders mutates, the
             /// connected view will be shown automatically.
+            switch result {
+            case .success(_):
+                ServiceLocator.analytics.track(.cardReaderConnectionSuccess)
+            case .failure(let error):
+                ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
+            }
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -3,7 +3,7 @@
 public enum CardPresentPaymentAction: Action {
     /// Start the Card Reader discovery process.
     ///
-    case startCardReaderDiscovery(siteID: Int64, onCompletion: ([CardReader]) -> Void)
+    case startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: ([CardReader]) -> Void, onError: (Error) -> Void)
 
     /// Cancels the Card Reader discovery process.
     ///

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -8,7 +8,7 @@ final class MockCardReaderService: CardReaderService {
         CurrentValueSubject<[Hardware.CardReader], Never>([]).eraseToAnyPublisher()
     }
 
-    var connectedReaders: AnyPublisher<[Hardware.CardReader], Never> {
+    var connectedReaders: AnyPublisher<[Hardware.CardReader], Error> {
         connectedReadersSubject.eraseToAnyPublisher()
     }
 

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -4,11 +4,11 @@ import Combine
 
 /// Supports tests for CardPresentPaymentStore
 final class MockCardReaderService: CardReaderService {
-    var discoveredReaders: AnyPublisher<[Hardware.CardReader], Never> {
-        CurrentValueSubject<[Hardware.CardReader], Never>([]).eraseToAnyPublisher()
+    var discoveredReaders: AnyPublisher<[Hardware.CardReader], Error> {
+        CurrentValueSubject<[Hardware.CardReader], Error>([]).eraseToAnyPublisher()
     }
 
-    var connectedReaders: AnyPublisher<[Hardware.CardReader], Error> {
+    var connectedReaders: AnyPublisher<[Hardware.CardReader], Never> {
         connectedReadersSubject.eraseToAnyPublisher()
     }
 

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -61,9 +61,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                                        network: network,
                                                        cardReaderService: mockCardReaderService)
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { discoveredReaders in
-            //
-        }
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID, onReaderDiscovered: { _ in }, onError: { _ in })
 
         cardPresentStore.onAction(action)
 
@@ -78,9 +76,13 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let expectation = self.expectation(description: "Readers discovered")
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { discoveredReaders in
-            expectation.fulfill()
-        }
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(
+            siteID: sampleSiteID,
+            onReaderDiscovered: { _ in
+                expectation.fulfill()
+            },
+            onError: { _ in }
+        )
 
         cardPresentStore.onAction(action)
 
@@ -93,9 +95,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                                        network: network,
                                                        cardReaderService: mockCardReaderService)
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { discoveredReaders in
-            //
-        }
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID, onReaderDiscovered: { _ in }, onError: { _ in })
 
         cardPresentStore.onAction(action)
 
@@ -119,12 +119,16 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "payments/connection_tokens", filename: "generic_error")
 
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { discoveredReaders in
-            XCTAssertTrue(self.mockCardReaderService.didReceiveAConfigurationProvider)
-            if discoveredReaders.count == 0 {
-                expectation.fulfill()
-            }
-        }
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(
+            siteID: sampleSiteID,
+            onReaderDiscovered: { discoveredReaders in
+                XCTAssertTrue(self.mockCardReaderService.didReceiveAConfigurationProvider)
+                if discoveredReaders.count == 0 {
+                    expectation.fulfill()
+                }
+            },
+            onError: { _ in }
+        )
 
         cardPresentStore.onAction(action)
 
@@ -175,9 +179,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let expectation = self.expectation(description: "Cancelling discovery changes discoveryStatus to idle")
 
-        let startDiscoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID) { _ in
-
-        }
+        let startDiscoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID, onReaderDiscovered: { _ in }, onError: { _ in })
 
         cardPresentStore.onAction(startDiscoveryAction)
 


### PR DESCRIPTION
Fixes of #4082

## Events included

- card_reader_discovery_tapped: The user taps on Connect Card Reader and the app starts looking for readers to connect to
- card_reader_discovery_failed: The discovery process fails. This is likely because the SDK was busy with another command.
- card_reader_discovery_reader_discovered: The app found an available reader we can connect to.
- card_reader_connection_tapped: The user tapped on the button to connect to a reader that was discovered.
- card_reader_connection_failed: The attempt to connect to a card reader failed.
- card_reader_connection_success: The attempt to connect to a card reader was successful.
- card_reader_disconnect_tapped: The user asked to disconnect a card reader.

## To test

An easy way to test the failure states is to temporarily disable Bluetooth on your device. Keep in mind that doing that might leave the app thinking it's still discovering readers when it's not (#4232).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
