### PR TITLE
Shipping Labels: substituted `VStack` with `LazyVStack` in SwiftUI views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -7,8 +7,7 @@ struct ShippingLabelPackageList: View {
 
     var body: some View {
         ScrollView {
-            /// `List` doesn't allow us to change easily some UI things, like the separators. So, we used `VStack`.
-            VStack(spacing: 0) {
+            LazyVStack(spacing: 0) {
 
                 /// Custom Packages
                 ///
@@ -42,7 +41,7 @@ struct ShippingLabelPackageList: View {
             .background(Color(.systemBackground))
         }
         .background(Color(.listBackground))
-        .navigationBarTitle(Text(Localization.title), displayMode: .inline)
+        .navigationTitle(Localization.title)
         .navigationBarItems(trailing: Button(action: {
             viewModel.confirmPackageSelection()
             presentation.wrappedValue.dismiss()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -18,7 +18,7 @@ struct ShippingLabelPackageDetails: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
+            LazyVStack(spacing: 0) {
                 ShippingLabelPackageNumberRow(packageNumber: 1, numberOfItems: viewModel.itemsRows.count)
 
                 ListHeaderView(text: Localization.itemsToFulfillHeader, alignment: .left)


### PR DESCRIPTION
Since we dropped iOS 13, now we can use `LazyVStack` instead of `VStack` on Shipping Labels views implemented in SwiftUI. The three standard stack views, `HStack`, `VStack`, and `ZStack`, all load their contained view hierarchy when they display, and loading large numbers of views all at once can result in slow runtime performance. Using `LazyVStack` the stack is “lazy,” in that the stack view doesn’t create items until it needs to render them onscreen.

I also updated the method `navigationBarTitle` with `navigationTitle` available on iOS 14.

## Testing
Just check that everything in the Shipping Label flow works like before.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
