### PR TITLE
[Mobile Payments] Include battery level on reader connection event

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -140,8 +140,8 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             /// Nothing to do here because, when the observed connectedReaders mutates, the
             /// connected view will be shown automatically.
             switch result {
-            case .success:
-                ServiceLocator.analytics.track(.cardReaderConnectionSuccess)
+            case .success(let reader):
+                ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: ["battery_level": reader.batteryLevel])
             case .failure(let error):
                 ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -141,7 +141,9 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             /// connected view will be shown automatically.
             switch result {
             case .success(let reader):
-                ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: ["battery_level": reader.batteryLevel])
+                let properties = reader.batteryLevel
+                    .map { ["battery_level": $0] }
+                ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)
             case .failure(let error):
                 ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -141,6 +141,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             /// connected view will be shown automatically.
             switch result {
             case .success(let reader):
+                // If the reader does not have a battery, or the battery level is unknown, it will be nil
                 let properties = reader.batteryLevel
                     .map { ["battery_level": $0] }
                 ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)


### PR DESCRIPTION
Part of #4082

In #4244 I forgot to include the battery level as a property in `card_reader_connection_success`.

If the reader does not have a battery, or the battery level is unknown, it will be `nil` so we won't set the property.

## To test

Connect a reader, and ensure the battery level is included in the event looking at the console:

> 🔵 Tracked card_reader_connection_success, properties: [AnyHashable("blog_id"): 191646963, AnyHashable("battery_level"): Optional(1.0), AnyHashable("is_wpcom_store"): false]

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
