### PR TITLE
Update processing orders badge logic

### DIFF
--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -33,8 +33,8 @@ final class MainTabViewModel {
     /// Setup: ResultsController for `processing` OrderStatus updates
     ///
     func configureOrdersStatusesListener(for siteID: Int64) {
-        statusResultsController = updateStatusResultsController(siteID: siteID)
-        configureResultsController()
+        statusResultsController = createStatusResultsController(siteID: siteID)
+        configureStatusResultsController()
     }
 
     /// Callback to be executed when this view model receives new data
@@ -65,14 +65,14 @@ private extension MainTabViewModel {
 
     /// Construct `ResultsController` with `siteID`
     ///
-    func updateStatusResultsController(siteID: Int64) -> ResultsController<StorageOrderStatus> {
+    func createStatusResultsController(siteID: Int64) -> ResultsController<StorageOrderStatus> {
         let predicate = NSPredicate(format: "siteID == %lld AND slug == %@", siteID, OrderStatusEnum.processing.rawValue)
         return ResultsController<StorageOrderStatus>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
 
     /// Connect hooks on `ResultsController` and query cached data
     ///
-    func configureResultsController() {
+    func configureStatusResultsController() {
         statusResultsController?.onDidChangeObject = { [weak self] (updatedOrdersStatus, _, _, _) in
             self?.processBadgeCount(updatedOrdersStatus)
         }

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -20,8 +20,21 @@ final class MainTabViewModel {
 
     private let storesManager: StoresManager
 
+    private var statusResultsController: ResultsController<StorageOrderStatus>?
+
     init(storesManager: StoresManager = ServiceLocator.stores) {
         self.storesManager = storesManager
+
+        if let siteID = storesManager.sessionManager.defaultStoreID {
+            configureOrdersStatusesListener(for: siteID)
+        }
+    }
+
+    /// Setup: ResultsController for `processing` OrderStatus updates
+    ///
+    func configureOrdersStatusesListener(for siteID: Int64) {
+        statusResultsController = updateStatusResultsController(siteID: siteID)
+        configureResultsController()
     }
 
     /// Callback to be executed when this view model receives new data
@@ -42,39 +55,68 @@ final class MainTabViewModel {
     ///
     func startObservingOrdersCount() {
         observeBadgeRefreshNotifications()
+        updateBadgeFromCache()
         requestBadgeCount()
     }
 }
 
 
 private extension MainTabViewModel {
+
+    /// Construct `ResultsController` with `siteID`
+    ///
+    func updateStatusResultsController(siteID: Int64) -> ResultsController<StorageOrderStatus> {
+        let predicate = NSPredicate(format: "siteID == %lld AND slug == %@", siteID, OrderStatusEnum.processing.rawValue)
+        return ResultsController<StorageOrderStatus>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
+    }
+
+    /// Connect hooks on `ResultsController` and query cached data
+    ///
+    func configureResultsController() {
+        statusResultsController?.onDidChangeObject = { [weak self] (updatedOrdersStatus, _, _, _) in
+            self?.processBadgeCount(updatedOrdersStatus)
+        }
+
+        try? statusResultsController?.performFetch()
+        updateBadgeFromCache()
+    }
+
+    /// Get last known data from cache (if exists) and draw it on a badge
+    ///
+    func updateBadgeFromCache() {
+        let initialCachedOrderStatus = statusResultsController?.fetchedObjects.first
+        processBadgeCount(initialCachedOrderStatus)
+    }
+
+    /// Trigger network action to update underlying cache. Badge redraw will be triggered by `statusResultsController`
+    ///
     @objc func requestBadgeCount() {
         guard let siteID = storesManager.sessionManager.defaultStoreID else {
             DDLogError("# Error: Cannot fetch order count")
             return
         }
 
-        let action = OrderAction.countProcessingOrders(siteID: siteID) { [weak self] orderCount, error in
-            if error != nil {
-                return
+        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
+            if case let .failure(error) = result {
+                DDLogError("⛔️ Could not successfully fetch order statuses for siteID \(siteID): \(error)")
             }
-
-            self?.processBadgeCount(orderCount)
         }
 
         storesManager.dispatch(action)
     }
 
-    func processBadgeCount(_ orderCount: OrderCount?) {
+    /// Validate `OrderStatus` and trigger badge redraw
+    ///
+    func processBadgeCount(_ ordersStatus: OrderStatus?) {
         // Exit early if there is not data, or the count is zero
-        guard let orderCount = orderCount,
-            let processingCount = orderCount[OrderStatusEnum.processing.rawValue]?.total,
-            processingCount > 0 else {
+        guard let ordersStatus = ordersStatus,
+              ordersStatus.slug == OrderStatusEnum.processing.rawValue,
+              ordersStatus.total > 0 else {
             onBadgeReload?(nil)
             return
         }
 
-        onBadgeReload?(NumberFormatter.localizedOrNinetyNinePlus(processingCount))
+        onBadgeReload?(NumberFormatter.localizedOrNinetyNinePlus(ordersStatus.total))
     }
 
     func observeBadgeRefreshNotifications() {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -369,6 +369,9 @@ private extension MainTabBarController {
             return
         }
 
+        // Update view model with `siteID` to query correct Orders Status
+        viewModel.configureOrdersStatusesListener(for: siteID)
+
         // Initialize each tab's root view controller
         let dashboardViewController = createDashboardViewController(siteID: siteID)
         dashboardNavigationController.viewControllers = [dashboardViewController]


### PR DESCRIPTION
## Description

Previously `MainTabViewModel` used action to get amount of processing orders from network, process callback and display it. Action underneath saved data to cache but never used it. At network level it used action `countOrders` that is a duplicate of `retrieveOrderStatuses`.

This PR updates logic to listen on Core Data cache for `OrderStatus` change (to reuse fresh data from other `retrieveOrderStatuses` calls). It will still make own `retrieveOrderStatuses` requests to keep flow working in exact same way as previously. Unifying these actions will allow smarter caching and data reuse.

Unused actions, networking calls and models will be removed in a [separate PR](https://github.com/woocommerce/woocommerce-ios/pull/4252).

## Test

1. Launch app and observe correct badge number for processing orders
2. Make a new order from the web
3. If you're testing on a simulator (no push) - switch to orders tab to trigger a refresh
4. Check that badge count is updated

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
