### PR TITLE
[Mobile Payments] Beta: Request and parse the card_present_eligible flag

### DIFF
--- a/Networking/Networking/Model/WCPayAccount.swift
+++ b/Networking/Networking/Model/WCPayAccount.swift
@@ -37,8 +37,7 @@ public struct WCPayAccount: Decodable {
         self.defaultCurrency = defaultCurrency
         self.supportedCurrencies = supportedCurrencies
         self.country = country
-        /// Hardcoded until support for this property is available in WCPay
-        self.isCardPresentEligible = true
+        self.isCardPresentEligible = isCardPresentEligible
     }
 
     /// The public initializer for WCPay Account.

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -74,7 +74,7 @@ private extension WCPayRemote {
     enum AccountParameterValues {
         static let fieldValues: String = """
             status,has_pending_requirements,has_overdue_requirements,current_deadline,\
-            statement_descriptor,store_currencies,country
+            statement_descriptor,store_currencies,country,card_present_eligible
             """
     }
 


### PR DESCRIPTION
Closes #4241 

Changes:
- Include `card_present_eligible` in the list of fields we want the accounts endpoint to return to us
- Use the value from the account response

To test:
- Use WP CLI to set card_present_enabled to 0 ( p91TBi-5cf-p2 )
- Wait 2 hours or, use WCPay Dev Tools to clear the account cache in wp-admin
- Install and run this branch on your device
- Proceed to Settings
- Make sure Manage Card Reader does NOT appear (wait at least 10 seconds)
- Use WP CLI to set card_present_enabled to 1 
- Wait 2 hours or, use WCPay Dev Tools to clear the account cache in wp-admin
- Exit and re-enter Settings
- Make sure Manage Card Reader appears (this may take 5-10 seconds)
- Make sure you can pair a reader and disconnect
- Halt the app

Or, optionally, just toggle between two sites - one with this flag set and another without and ensure the settings menu updates appropriately.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
