### PR TITLE
[Mobile Payments] Ensure amounts in receipts always show two decimal numbers

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -75,7 +75,7 @@ public extension ReceiptRenderer {
                         <h1>\(receiptTitle)</h1>
                         <h3>\(Localization.amountPaidSectionTitle.uppercased())</h3>
                         <p>
-                            \(parameters.amount / 100) \(parameters.currency.uppercased())
+                            \(formattedAmount()) \(parameters.currency.uppercased())
                         </p>
                         <h3>\(Localization.datePaidSectionTitle.uppercased())</h3>
                         <p>
@@ -108,13 +108,15 @@ private extension ReceiptRenderer {
         addPrintFormatter(formatter, startingAtPageAt: 0)
     }
 
-    private func summaryTable() -> String {
+    private func formattedAmount() -> String {
         // We should use CurrencyFormatter instead for consistency
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
-        let amount = formatter.string(for: parameters.amount / 100) ?? ""
+        return formatter.string(for: parameters.amount / 100) ?? ""
+    }
 
+    private func summaryTable() -> String {
         var summaryContent = "<table>"
         for line in lines {
             summaryContent += "<tr><td>\(line.title) × \(line.quantity)</td><td>\(line.amount) \(parameters.currency.uppercased())</td></tr>"
@@ -125,7 +127,7 @@ private extension ReceiptRenderer {
                                     \(Localization.amountPaidSectionTitle)
                                 </td>
                                 <td>
-                                    \(amount) \(parameters.currency.uppercased())
+                                    \(formattedAmount()) \(parameters.currency.uppercased())
                                 </td>
                             </tr>
                             """

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -109,6 +109,12 @@ private extension ReceiptRenderer {
     }
 
     private func summaryTable() -> String {
+        // We should use CurrencyFormatter instead for consistency
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        let amount = formatter.string(for: parameters.amount / 100) ?? ""
+
         var summaryContent = "<table>"
         for line in lines {
             summaryContent += "<tr><td>\(line.title) × \(line.quantity)</td><td>\(line.amount) \(parameters.currency.uppercased())</td></tr>"
@@ -119,7 +125,7 @@ private extension ReceiptRenderer {
                                     \(Localization.amountPaidSectionTitle)
                                 </td>
                                 <td>
-                                    \(parameters.amount / 100) \(parameters.currency.uppercased())
+                                    \(amount) \(parameters.currency.uppercased())
                                 </td>
                             </tr>
                             """

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -48,15 +48,30 @@ public class ReceiptStore: Store {
 
 
 private extension ReceiptStore {
+    func generateLineItems(order: Order) -> [ReceiptLineItem] {
+        // We should use CurrencyFormatter instead for consistency
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+
+        return order.items.map { item in
+            ReceiptLineItem(
+                title: item.name,
+                quantity: item.quantity.description,
+                amount: formatter.string(from: item.price) ?? ""
+            )
+        }
+    }
+
     func print(order: Order, parameters: CardPresentReceiptParameters, completion: @escaping (PrintingResult) -> Void) {
-        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
+        let lineItems = generateLineItems(order: order)
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
         receiptPrinterService.printReceipt(content: content, completion: completion)
     }
 
     func generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
-        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
+        let lineItems = generateLineItems(order: order)
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
         let renderer = ReceiptRenderer(content: content)
@@ -84,7 +99,7 @@ private extension ReceiptStore {
     }
 
     func saveReceipt(order: Order, parameters: CardPresentReceiptParameters) {
-        let lineItems = order.items.map { ReceiptLineItem(title: $0.name, quantity: $0.quantity.description, amount: $0.price.stringValue)}
+        let lineItems = generateLineItems(order: order)
 
         let content = ReceiptContent(parameters: parameters, lineItems: lineItems)
 


### PR DESCRIPTION
Fixes #4250 

We now use a number formatter for receipt amounts. Ideally, we'd use the existing `CurrencyFormatter` but that's not available at the Hardware/Yosemite layer where the receipts are generated, so a simpler solution like this will work for now.

If there's a chance that we'll end up generating these in the backend, I don't think it's worth re-architecting things too much for this, considering we'll only support US stores for now.

## To test

Generate payment for an order with the amounts being integers, ensure the receipt shows `.00` for each line item and total amount.

![Screen Shot 2021-05-24 at 12 37 18](https://user-images.githubusercontent.com/8739/119338079-d718bd00-bc8f-11eb-9b6c-c1a7e6089e7b.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
