### PR TITLE
[Mobile Payments] Fix Email receipt not being presented 

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -47,7 +47,6 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        emailReceiptAction()
         viewController?.dismiss(animated: true, completion: { [weak self] in
             self?.emailReceiptAction()
         })

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -48,7 +48,9 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         emailReceiptAction()
-        viewController?.dismiss(animated: false)
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.emailReceiptAction()
+        })
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -56,7 +56,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
     }
 
     func test_secondary_button_action_calls_closure() {
-        viewModel.didTapSecondaryButton(in: nil)
+        viewModel.didTapSecondaryButton(in: UIViewController())
 
         XCTAssertTrue(closures.didTapEmail)
     }


### PR DESCRIPTION
Closes #4272 

⚠️ This PR is against the feature branch implementing support for Card Present Payments, not against develop ⚠️


https://user-images.githubusercontent.com/2722505/119479732-f14dac00-bd1e-11eb-938e-a68fa9582f63.MP4


## Changes
* Call "email receipt action" after the modal has been completely dismissed. I have no idea why this used to work before the way it was.


## How to test
Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. WCPay 2.4.0
3. The site being enrolled into the beta (p91TBi-5cf-p2)

* Checkout the branch
* Connect to a reader
* Navigate to an eligible order. Tap "Collect Payment" and complete the payment collection process
* When prompted, tap "Email receipt"
Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
