### PR TITLE
Shipping Labels: unit tests of view models in Carriers and Rates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
@@ -60,8 +60,8 @@ final class ShippingLabelCarriersViewModel: ObservableObject {
             let adultSignature = response.adultSignatureRequired.first { rate.title == $0.title }
 
             return ShippingLabelCarrierRowViewModel(selected: rate.title == selectedRate?.title,
-                                                    signatureSelected: selectedSignatureRate?.title == signature?.title,
-                                                    adultSignatureSelected: selectedAdultSignatureRate?.title == adultSignature?.title,
+                                                    signatureSelected: selectedSignatureRate?.title == signature?.title && signature != nil,
+                                                    adultSignatureSelected: selectedAdultSignatureRate?.title == adultSignature?.title && adultSignature != nil,
                                                     rate: rate,
                                                     signatureRate: signature,
                                                     adultSignatureRate: adultSignature) { [weak self] (rate, signature, adultSignature) in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF9DA4265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift */; };
 		45AF9DAA265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */; };
+		45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF9DAE265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift */; };
 		45B98E1F25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
 		45B9C63F23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45B9C63D23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib */; };
@@ -1762,6 +1763,7 @@
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		45AF9DA4265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersViewModelTests.swift; sourceTree = "<group>"; };
 		45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRowViewModelTests.swift; sourceTree = "<group>"; };
+		45AF9DAE265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelCarrierRate.swift; sourceTree = "<group>"; };
 		45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
 		45B9C63D23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPriceSettingsViewController.xib; sourceTree = "<group>"; };
@@ -4105,6 +4107,7 @@
 				57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */,
 				02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */,
 				023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */,
+				45AF9DAE265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift */,
 				57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */,
 			);
 			path = Mocks;
@@ -6797,6 +6800,7 @@
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
+				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				0215C6FC2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift in Sources */,
 				265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -560,6 +560,8 @@
 		45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
+		45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF9DA4265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift */; };
+		45AF9DAA265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */; };
 		45B98E1F25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
 		45B9C63F23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45B9C63D23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib */; };
@@ -1758,6 +1760,8 @@
 		45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductParentCategoriesViewController.xib; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
+		45AF9DA4265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersViewModelTests.swift; sourceTree = "<group>"; };
+		45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRowViewModelTests.swift; sourceTree = "<group>"; };
 		45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
 		45B9C63D23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPriceSettingsViewController.xib; sourceTree = "<group>"; };
@@ -3644,6 +3648,8 @@
 				4569D3F325DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift */,
 				45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */,
 				45DB7075261623410064A6CF /* ShippingLabelPackageDetailsViewModelTests.swift */,
+				45AF9DA4265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift */,
+				45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */,
 			);
 			path = "Create Shipping Label";
 			sourceTree = "<group>";
@@ -6958,6 +6964,7 @@
 				26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */,
 				020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */,
 				0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */,
+				45AF9DAA265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift in Sources */,
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
@@ -6986,6 +6993,7 @@
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
 				45DB706C26161F970064A6CF /* DecimalWooTests.swift in Sources */,
+				45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import Yosemite
+
+/// Mock for `ShippingLabelCarrierRate`
+///
+final class MockShippingLabelCarrierRate {
+
+    static func makeRate(title: String = "USPS - Parcel Select Mail",
+                         rate: Double = 40.060000000000002) -> ShippingLabelCarrierRate {
+        return ShippingLabelCarrierRate(title: title,
+                                        insurance: 0,
+                                        retailRate: rate,
+                                        rate: rate,
+                                        rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                        serviceID: "ParcelSelect",
+                                        carrierID: "usps",
+                                        shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
+                                        hasTracking: true,
+                                        isSelected: false,
+                                        isPickupFree: true,
+                                        deliveryDays: 2,
+                                        deliveryDateGuaranteed: false)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
@@ -4,4 +4,96 @@ import Yosemite
 
 final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
 
+    func test_properties_returns_expected_values() {
+        // Given
+        let viewModel = ShippingLabelCarrierRowViewModel(selected: true,
+                                                         signatureSelected: true,
+                                                         adultSignatureSelected: false,
+                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
+                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33)) { (_, _, _) in
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.selected, true)
+        XCTAssertEqual(viewModel.signatureSelected, true)
+        XCTAssertEqual(viewModel.adultSignatureSelected, false)
+        XCTAssertEqual(viewModel.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(viewModel.subtitle, "2 business days")
+        XCTAssertEqual(viewModel.price, "$40.33")
+        XCTAssertEqual(viewModel.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(viewModel.extraInfo, "Includes USPS tracking, Eligible for free pickup")
+        XCTAssertEqual(viewModel.displaySignatureRequired, true)
+        XCTAssertEqual(viewModel.displayAdultSignatureRequired, true)
+        XCTAssertEqual(viewModel.signatureRequiredText, "Signature required (+$5.66)")
+        XCTAssertEqual(viewModel.adultSignatureRequiredText, "Adult signature required (+$11.00)")
+    }
+
+    func test_handleSelection_return_expected_values() throws {
+        // Given
+        let expectedRate: ShippingLabelCarrierRate = waitFor { promise in
+        let viewModel = ShippingLabelCarrierRowViewModel(selected: false,
+                                                         signatureSelected: false,
+                                                         adultSignatureSelected: false,
+                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
+                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33)) { (rate, _, _) in
+            promise(rate)
+        }
+            // When
+            viewModel.handleSelection()
+        }
+
+
+
+        // Then
+        let rate = try XCTUnwrap(expectedRate)
+        XCTAssertEqual(rate, MockShippingLabelCarrierRate.makeRate(rate: 40.33))
+    }
+
+    func test_handleSignatureSelection_return_expected_values() throws {
+        // Given
+        let expectedRate: ShippingLabelCarrierRate? = waitFor { promise in
+        let viewModel = ShippingLabelCarrierRowViewModel(selected: false,
+                                                         signatureSelected: false,
+                                                         adultSignatureSelected: false,
+                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
+                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33)) { (rate, signatureRate, _) in
+            promise(signatureRate)
+        }
+            // When
+            viewModel.handleSignatureSelection()
+        }
+
+
+
+        // Then
+        let rate = try XCTUnwrap(expectedRate)
+        XCTAssertEqual(rate, MockShippingLabelCarrierRate.makeRate(rate: 45.99))
+    }
+
+    func test_handleAdultSignatureSelection_return_expected_values() throws {
+        // Given
+        let expectedRate: ShippingLabelCarrierRate? = waitFor { promise in
+        let viewModel = ShippingLabelCarrierRowViewModel(selected: false,
+                                                         signatureSelected: false,
+                                                         adultSignatureSelected: false,
+                                                         rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
+                                                         signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
+                                                         adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33)) { (rate,
+                                                                                                                                    _,
+                                                                                                                                    adultSignatureRate) in
+            promise(adultSignatureRate)
+        }
+            // When
+            viewModel.handleAdultSignatureSelection()
+        }
+
+
+
+        // Then
+        let rate = try XCTUnwrap(expectedRate)
+        XCTAssertEqual(rate, MockShippingLabelCarrierRate.makeRate(rate: 51.33))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class ShippingLabelCarriersViewModelTests: XCTestCase {
+
+    func test_rows_generation_returns_expected_data() {
+        // Given
+        let viewModel = ShippingLabelCarriersViewModel(order: MockOrders().sampleOrder(),
+                                                       originAddress: MockShippingLabelAddress.sampleAddress(),
+                                                       destinationAddress: MockShippingLabelAddress.sampleAddress(),
+                                                       packages: [])
+        XCTAssertEqual(viewModel.rows.count, 0)
+
+        // When
+        viewModel.generateRows(response: sampleShippingLabelCarriersAndRates())
+
+        // Then
+        let row = viewModel.rows.first
+        XCTAssertEqual(row?.selected, false)
+        XCTAssertEqual(row?.signatureSelected, false)
+        XCTAssertEqual(row?.adultSignatureSelected, false)
+        XCTAssertEqual(row?.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(row?.subtitle, "2 business days")
+        XCTAssertEqual(row?.price, "$40.06")
+        XCTAssertEqual(row?.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(row?.extraInfo, "Includes USPS tracking, Eligible for free pickup")
+        XCTAssertEqual(row?.displaySignatureRequired, true)
+        XCTAssertEqual(row?.displayAdultSignatureRequired, true)
+        XCTAssertEqual(row?.signatureRequiredText, "Signature required (+$5.00)")
+        XCTAssertEqual(row?.adultSignatureRequiredText, "Adult signature required (+$10.00)")
+
+        let row2 = viewModel.rows.last
+        XCTAssertEqual(row2?.selected, false)
+        XCTAssertEqual(row2?.signatureSelected, false)
+        XCTAssertEqual(row2?.adultSignatureSelected, false)
+        XCTAssertEqual(row2?.title, "UPS")
+        XCTAssertEqual(row2?.subtitle, "2 business days")
+        XCTAssertEqual(row2?.price, "$40.06")
+        XCTAssertEqual(row2?.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(row2?.extraInfo, "Includes USPS tracking, Eligible for free pickup")
+        XCTAssertEqual(row2?.displaySignatureRequired, false)
+        XCTAssertEqual(row2?.displayAdultSignatureRequired, false)
+        XCTAssertEqual(row2?.signatureRequiredText, "")
+        XCTAssertEqual(row2?.adultSignatureRequiredText, "")
+    }
+}
+
+private extension ShippingLabelCarriersViewModelTests {
+    func sampleShippingLabelCarriersAndRates() -> ShippingLabelCarriersAndRates {
+        return ShippingLabelCarriersAndRates(defaultRates: [sampleCarrierRate(), sampleCarrierRate(title: "UPS")],
+                                             signatureRequired: [sampleSignatureRate()],
+                                             adultSignatureRequired: [sampleAdultSignatureRate()])
+    }
+
+    func sampleCarrierRate(title: String = "USPS - Parcel Select Mail") -> ShippingLabelCarrierRate {
+        let rate = ShippingLabelCarrierRate(title: title,
+                                            insurance: 0,
+                                            retailRate: 40.060000000000002,
+                                            rate: 40.060000000000002,
+                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                            serviceID: "ParcelSelect",
+                                            carrierID: "usps",
+                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
+                                            hasTracking: true,
+                                            isSelected: false,
+                                            isPickupFree: true,
+                                            deliveryDays: 2,
+                                            deliveryDateGuaranteed: false)
+
+        return rate
+    }
+
+    func sampleSignatureRate() -> ShippingLabelCarrierRate {
+        let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                            insurance: 0,
+                                            retailRate: 45.060000000000002,
+                                            rate: 45.060000000000002,
+                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                            serviceID: "ParcelSelect",
+                                            carrierID: "usps",
+                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
+                                            hasTracking: true,
+                                            isSelected: false,
+                                            isPickupFree: true,
+                                            deliveryDays: 2,
+                                            deliveryDateGuaranteed: false)
+
+        return rate
+    }
+
+    func sampleAdultSignatureRate() -> ShippingLabelCarrierRate {
+        let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                            insurance: 0,
+                                            retailRate: 50.060000000000002,
+                                            rate: 50.060000000000002,
+                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
+                                            serviceID: "ParcelSelect",
+                                            carrierID: "usps",
+                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
+                                            hasTracking: true,
+                                            isSelected: false,
+                                            isPickupFree: true,
+                                            deliveryDays: 2,
+                                            deliveryDateGuaranteed: false)
+
+        return rate
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
@@ -48,62 +48,10 @@ final class ShippingLabelCarriersViewModelTests: XCTestCase {
 
 private extension ShippingLabelCarriersViewModelTests {
     func sampleShippingLabelCarriersAndRates() -> ShippingLabelCarriersAndRates {
-        return ShippingLabelCarriersAndRates(defaultRates: [sampleCarrierRate(), sampleCarrierRate(title: "UPS")],
-                                             signatureRequired: [sampleSignatureRate()],
-                                             adultSignatureRequired: [sampleAdultSignatureRate()])
-    }
-
-    func sampleCarrierRate(title: String = "USPS - Parcel Select Mail") -> ShippingLabelCarrierRate {
-        let rate = ShippingLabelCarrierRate(title: title,
-                                            insurance: 0,
-                                            retailRate: 40.060000000000002,
-                                            rate: 40.060000000000002,
-                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
-                                            serviceID: "ParcelSelect",
-                                            carrierID: "usps",
-                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
-                                            hasTracking: true,
-                                            isSelected: false,
-                                            isPickupFree: true,
-                                            deliveryDays: 2,
-                                            deliveryDateGuaranteed: false)
-
-        return rate
-    }
-
-    func sampleSignatureRate() -> ShippingLabelCarrierRate {
-        let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                            insurance: 0,
-                                            retailRate: 45.060000000000002,
-                                            rate: 45.060000000000002,
-                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
-                                            serviceID: "ParcelSelect",
-                                            carrierID: "usps",
-                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
-                                            hasTracking: true,
-                                            isSelected: false,
-                                            isPickupFree: true,
-                                            deliveryDays: 2,
-                                            deliveryDateGuaranteed: false)
-
-        return rate
-    }
-
-    func sampleAdultSignatureRate() -> ShippingLabelCarrierRate {
-        let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                            insurance: 0,
-                                            retailRate: 50.060000000000002,
-                                            rate: 50.060000000000002,
-                                            rateID: "rate_a8a29d5f34984722942f466c30ea27ef",
-                                            serviceID: "ParcelSelect",
-                                            carrierID: "usps",
-                                            shipmentID: "shp_e0e3c2f4606c4b198d0cbd6294baed56",
-                                            hasTracking: true,
-                                            isSelected: false,
-                                            isPickupFree: true,
-                                            deliveryDays: 2,
-                                            deliveryDateGuaranteed: false)
-
-        return rate
+        return ShippingLabelCarriersAndRates(defaultRates: [MockShippingLabelCarrierRate.makeRate(), MockShippingLabelCarrierRate.makeRate(title: "UPS")],
+                                             signatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "UPS",
+                                                                                                       rate: 45.060000000000002)],
+                                             adultSignatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "UPS",
+                                                                                                            rate: 50.060000000000002)])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
@@ -49,9 +49,9 @@ final class ShippingLabelCarriersViewModelTests: XCTestCase {
 private extension ShippingLabelCarriersViewModelTests {
     func sampleShippingLabelCarriersAndRates() -> ShippingLabelCarriersAndRates {
         return ShippingLabelCarriersAndRates(defaultRates: [MockShippingLabelCarrierRate.makeRate(), MockShippingLabelCarrierRate.makeRate(title: "UPS")],
-                                             signatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "UPS",
+                                             signatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "USPS - Parcel Select Mail",
                                                                                                        rate: 45.060000000000002)],
-                                             adultSignatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "UPS",
+                                             adultSignatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "USPS - Parcel Select Mail",
                                                                                                             rate: 50.060000000000002)])
     }
 }


### PR DESCRIPTION
Part of #4085

## Description
This PR implements the unit tests of the view models used in Carriers and Rates.
Before merging this PR in `develop`, we should make sure that https://github.com/woocommerce/woocommerce-ios/pull/4274 was merged first.

## Testing
- Just CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
