### PR TITLE
[Mobile Payments] Observe connected readers correctly when initiating payment

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -533,7 +533,7 @@ extension OrderDetailsViewModel {
     /// Returns a publisher that emits an initial value if there is no reader connected and completes as soon as a
     /// reader connects.
     func cardReaderAvailable(onCompletion: @escaping (AnyPublisher<[CardReader], Never>) -> Void) {
-        let action = CardPresentPaymentAction.isReadyToCollectPayment { publisher in
+        let action = CardPresentPaymentAction.checkCardReaderConnected { publisher in
             onCompletion(publisher)
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 import Gridicons
 import Yosemite
 import MessageUI
+import Combine
 
 final class OrderDetailsViewModel {
     private let paymentOrchestrator = PaymentCaptureOrchestrator()
@@ -527,6 +528,21 @@ extension OrderDetailsViewModel {
         }
 
         stores.dispatch(deleteTrackingAction)
+    }
+
+    /// Returns a publisher that emits an initial value if there is no reader connected and completes as soon as a
+    /// reader connects.
+    func cardReaderAvailable() -> AnyPublisher<[CardReader], Never> {
+        ServiceLocator.cardReaderService.connectedReaders
+            // We only emit values when there is no reader connected, including an initial value
+            .prefix(while: { cardReaders in
+                cardReaders.count == 0
+            })
+            // Remove duplicates since we don't want to present the connection modal twice
+            .removeDuplicates()
+            // Beyond this point, the publisher should emit an empty initial value once
+            // and then finish when a reader is connected.
+            .eraseToAnyPublisher()
     }
 
     /// We are passing the ReceiptParameters as part of the completon block

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -532,12 +532,16 @@ extension OrderDetailsViewModel {
 
     /// Returns a publisher that emits an initial value if there is no reader connected and completes as soon as a
     /// reader connects.
-    func cardReaderAvailable(onCompletion: @escaping (AnyPublisher<[CardReader], Never>) -> Void) {
-        let action = CardPresentPaymentAction.checkCardReaderConnected { publisher in
-            onCompletion(publisher)
-        }
+    func cardReaderAvailable() -> AnyPublisher<[CardReader], Never> {
+        Future<AnyPublisher<[CardReader], Never>, Never> { [stores] promise in
+            let action = CardPresentPaymentAction.checkCardReaderConnected(onCompletion: { publisher in
+                promise(.success(publisher))
+            })
 
-        stores.dispatch(action)
+            stores.dispatch(action)
+        }
+        .switchToLatest()
+        .eraseToAnyPublisher()
     }
 
     /// We are passing the ReceiptParameters as part of the completon block

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -529,12 +529,6 @@ extension OrderDetailsViewModel {
         stores.dispatch(deleteTrackingAction)
     }
 
-    func isReadyToCollectPayment(onCompletion: @escaping (Bool) -> Void) {
-        let checkConnectedAction = CardPresentPaymentAction.isReadyToCollectPayment(onCompletion: onCompletion)
-
-        ServiceLocator.stores.dispatch(checkConnectedAction)
-    }
-
     /// We are passing the ReceiptParameters as part of the completon block
     /// We do so at this point for testing purposes.
     /// When we implement persistance, the receipt metadata would be persisted

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -532,17 +532,12 @@ extension OrderDetailsViewModel {
 
     /// Returns a publisher that emits an initial value if there is no reader connected and completes as soon as a
     /// reader connects.
-    func cardReaderAvailable() -> AnyPublisher<[CardReader], Never> {
-        ServiceLocator.cardReaderService.connectedReaders
-            // We only emit values when there is no reader connected, including an initial value
-            .prefix(while: { cardReaders in
-                cardReaders.count == 0
-            })
-            // Remove duplicates since we don't want to present the connection modal twice
-            .removeDuplicates()
-            // Beyond this point, the publisher should emit an empty initial value once
-            // and then finish when a reader is connected.
-            .eraseToAnyPublisher()
+    func cardReaderAvailable(onCompletion: @escaping (AnyPublisher<[CardReader], Never>) -> Void) {
+        let action = CardPresentPaymentAction.isReadyToCollectPayment { publisher in
+            onCompletion(publisher)
+        }
+
+        stores.dispatch(action)
     }
 
     /// We are passing the ReceiptParameters as part of the completon block

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -580,30 +580,17 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
-        viewModel.cardReaderAvailable { [weak self] publisher in
-            self?.cardReaderAvailableSubscription = publisher
-                        .sink(
-                            receiveCompletion: { [weak self] result in
-                                self?.dismiss(animated: false, completion: {
-                                    self?.collectPaymentForCurrentOrder()
-                                })
-                                self?.cardReaderAvailableSubscription = nil
-                            },
-                            receiveValue: { [weak self] _ in
-                                self?.connectToCardReader()
-                            })
-        }
-//        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
-//            .sink(
-//                receiveCompletion: { [weak self] result in
-//                    self?.dismiss(animated: false, completion: {
-//                        self?.collectPaymentForCurrentOrder()
-//                    })
-//                    self?.cardReaderAvailableSubscription = nil
-//                },
-//                receiveValue: { [weak self] _ in
-//                    self?.connectToCardReader()
-//                })
+        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
+            .sink(
+                receiveCompletion: { [weak self] result in
+                    self?.dismiss(animated: false, completion: {
+                        self?.collectPaymentForCurrentOrder()
+                    })
+                    self?.cardReaderAvailableSubscription = nil
+                },
+                receiveValue: { [weak self] _ in
+                    self?.connectToCardReader()
+                })
     }
 
     private func collectPaymentForCurrentOrder() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -580,17 +580,30 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
-        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
-            .sink(
-                receiveCompletion: { [weak self] result in
-                    self?.dismiss(animated: false, completion: {
-                        self?.collectPaymentForCurrentOrder()
-                    })
-                    self?.cardReaderAvailableSubscription = nil
-                },
-                receiveValue: { [weak self] _ in
-                    self?.connectToCardReader()
-                })
+        viewModel.cardReaderAvailable { [weak self] publisher in
+            self?.cardReaderAvailableSubscription = publisher
+                        .sink(
+                            receiveCompletion: { [weak self] result in
+                                self?.dismiss(animated: false, completion: {
+                                    self?.collectPaymentForCurrentOrder()
+                                })
+                                self?.cardReaderAvailableSubscription = nil
+                            },
+                            receiveValue: { [weak self] _ in
+                                self?.connectToCardReader()
+                            })
+        }
+//        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
+//            .sink(
+//                receiveCompletion: { [weak self] result in
+//                    self?.dismiss(animated: false, completion: {
+//                        self?.collectPaymentForCurrentOrder()
+//                    })
+//                    self?.cardReaderAvailableSubscription = nil
+//                },
+//                receiveValue: { [weak self] _ in
+//                    self?.connectToCardReader()
+//                })
     }
 
     private func collectPaymentForCurrentOrder() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -580,15 +580,7 @@ private extension OrderDetailsViewController {
     }
 
     @objc private func collectPayment(at: IndexPath) {
-        cardReaderAvailableSubscription = ServiceLocator.cardReaderService.connectedReaders
-            // We only emit values when there is no reader connected, including an initial value
-            .prefix(while: { cardReaders in
-                cardReaders.count == 0
-            })
-            // Remove duplicates since we don't want to present the connection modal twice
-            .removeDuplicates()
-            // Beyond this point, the publisher should emit an empty initial value once
-            // and then finish when a reader is connected.
+        cardReaderAvailableSubscription = viewModel.cardReaderAvailable()
             .sink(
                 receiveCompletion: { [weak self] result in
                     self?.dismiss(animated: false, completion: {

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -61,5 +61,6 @@ public enum CardPresentPaymentAction: Action {
     /// 3. Reset all status indicators
     case reset
 
+    /// Checks if a reader is connected
     case checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -57,7 +57,4 @@ public enum CardPresentPaymentAction: Action {
     /// 2. Clear all credentials, cached data
     /// 3. Reset all status indicators
     case reset
-
-    /// Checks if the store is ready to collect a payment
-    case isReadyToCollectPayment(onCompletion: (Bool) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -61,5 +61,5 @@ public enum CardPresentPaymentAction: Action {
     /// 3. Reset all status indicators
     case reset
 
-    case isReadyToCollectPayment(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
+    case checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -1,5 +1,8 @@
 // MARK: - CardPresentPaymentAction: Defines all of the Actions supported by the CardPresentPaymentStore.
 //
+
+import Combine
+
 public enum CardPresentPaymentAction: Action {
     /// Start the Card Reader discovery process.
     ///
@@ -57,4 +60,6 @@ public enum CardPresentPaymentAction: Action {
     /// 2. Clear all credentials, cached data
     /// 3. Reset all status indicators
     case reset
+
+    case isReadyToCollectPayment(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -65,8 +65,8 @@ public final class CardPresentPaymentStore: Store {
             startCardReaderUpdate(onProgress: progress, onCompletion: completion)
         case .reset:
             reset()
-        case .isReadyToCollectPayment(onCompletion: let completion):
-            isReadyToCollectPayment(onCompletion: completion)
+        case .checkCardReaderConnected(onCompletion: let completion):
+            checkCardReaderConnected(onCompletion: completion)
         }
     }
 }
@@ -239,7 +239,7 @@ private extension CardPresentPaymentStore {
             ))
     }
 
-    func isReadyToCollectPayment(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {
+    func checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {
         let publisher = cardReaderService.connectedReaders
                      // We only emit values when there is no reader connected, including an initial value
                      .prefix(while: { cardReaders in

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -241,15 +241,15 @@ private extension CardPresentPaymentStore {
 
     func checkCardReaderConnected(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {
         let publisher = cardReaderService.connectedReaders
-                     // We only emit values when there is no reader connected, including an initial value
-                     .prefix(while: { cardReaders in
-                         cardReaders.count == 0
-                     })
-                     // Remove duplicates since we don't want to present the connection modal twice
-                     .removeDuplicates()
-                     // Beyond this point, the publisher should emit an empty initial value once
-                     // and then finish when a reader is connected.
-                     .eraseToAnyPublisher()
+            // We only emit values when there is no reader connected, including an initial value
+            .prefix(while: { cardReaders in
+                cardReaders.count == 0
+            })
+            // Remove duplicates since we don't want to present the connection modal twice
+            .removeDuplicates()
+            // Beyond this point, the publisher should emit an empty initial value once
+            // and then finish when a reader is connected.
+            .eraseToAnyPublisher()
 
         onCompletion(publisher)
     }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -65,6 +65,8 @@ public final class CardPresentPaymentStore: Store {
             startCardReaderUpdate(onProgress: progress, onCompletion: completion)
         case .reset:
             reset()
+        case .isReadyToCollectPayment(onCompletion: let completion):
+            isReadyToCollectPayment(onCompletion: completion)
         }
     }
 }
@@ -235,6 +237,21 @@ private extension CardPresentPaymentStore {
                         },
                         receiveValue: { _ in }
             ))
+    }
+
+    func isReadyToCollectPayment(onCompletion: (AnyPublisher<[CardReader], Never>) -> Void) {
+        let publisher = cardReaderService.connectedReaders
+                     // We only emit values when there is no reader connected, including an initial value
+                     .prefix(while: { cardReaders in
+                         cardReaders.count == 0
+                     })
+                     // Remove duplicates since we don't want to present the connection modal twice
+                     .removeDuplicates()
+                     // Beyond this point, the publisher should emit an empty initial value once
+                     // and then finish when a reader is connected.
+                     .eraseToAnyPublisher()
+
+        onCompletion(publisher)
     }
 }
 


### PR DESCRIPTION
Fixes #4220
Fixes #4224 

## Why

As mentioned on https://github.com/woocommerce/woocommerce-ios/issues/4224#issuecomment-847713764, the previous implementation was not canceling the subscription to `connectedReaders`, and callbacks for (dis)connection were getting triggered, even if there was no attempt to collect payment in progress

## How

We still don't have a good way to have Yosemite expose publishers, and the UI needs to have access to the subscription so it can cancel it when the modal is dismissed.

For now, I have the view model talk get the `connectedReaders` publisher directly from the card service through `ServiceLocator`. Now `OrderDetailsViewModel.cardReaderAvailable()` exposes a publisher to the view controller that guarantees an initial empty value if there is no reader connected, and a completion when a reader is finally connected.

The View Controller can update the UI accordingly with these two cases, and also cancel the observation if the user dismisses the reader connection modal.

## To test

I added a couple `.print()` operators at the start and end of the operator chain in `OrderDetailsViewModel.cardReaderAvailable()` to verify that the subscription lifecycle was what I expected.

1. Go to an order, tap on Collect Payment, a modal should be presented asking to connect a reader.
2. Dismiss the modal. The subscription to the publisher should be canceled.
3. Tap on Collect Payment, and connect a reader. The "Reader is ready" alert should be visible.
4. Cancel payment.
5. Turn off the reader. Nothing should happen
6. Turn on the reader.
7. Tap on collect payment, and connect a reader. The "Reader is ready" alert should be visible.
8. Tap your card. The payment should complete correctly.
9. Find another order, tap Collect Payment. The "Reader is ready" alert should be visible without prompting to connect a reader.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
