### PR TITLE
Guard against invalid json objects when parsing product add-ons

### DIFF
--- a/Networking/Networking/Model/Product/ProductAddOnEnvelope.swift
+++ b/Networking/Networking/Model/Product/ProductAddOnEnvelope.swift
@@ -71,7 +71,21 @@ internal struct ProductAddOnEnvelope: Decodable {
     /// Converts an addOnJsonObject(`Dictionary`) to a `ProductAddOn` entity.
     ///
     private func decode(addOnJsonObject: AnyDictionary, using decoder: JSONDecoder) throws -> ProductAddOn {
+        // It appears to be unexpected crashes when parsing some JSON objects that are not handled inside subsequent `try JSONSerialization.data` call.
+        // https://github.com/woocommerce/woocommerce-ios/issues/4205
+        guard JSONSerialization.isValidJSONObject(addOnJsonObject) else {
+            throw ProductAddOnEnvelopeError.invalidJsonObject(addOnJsonObject)
+        }
+
         let jsonData = try JSONSerialization.data(withJSONObject: addOnJsonObject, options: .fragmentsAllowed)
         return try decoder.decode(ProductAddOn.self, from: jsonData)
     }
+}
+
+/// Custom errors that can happen during the `ProductAddOnEnvelope` decoding.
+///
+public enum ProductAddOnEnvelopeError: Error {
+    /// Represents an error when a `add-on JSON object` can't be converted to `JSON data`.
+    ///
+    case invalidJsonObject([String: Any])
 }


### PR DESCRIPTION
closes #4205 

# Why

There appears to be some crashes -WOOCOMMERCE-IOS-1CZD- (Only happening to 2 users so far) when parsing add-ons from the product metadata.

I couldn't replicate the crash, but the crash log indicates that it happens on some kind of json write
``` 
Invalid type in JSON write (__SwiftValue) - ProductAddOnEnvelope.revolve
``` 

My guess is that the call where we map a product-metadada json object to a `ProductAddOn` entity is not handling well a particularly mal-formed JSON object and crashing without proper error handling.
```swift
try JSONSerialization.data(withJSONObject: addOnJsonObject, options: .fragmentsAllowed)
```

# How

My solution consists in asking `JSONSerialization` if the JSON object is valid and throwing a custom error if it isn't.

```swift
guard JSONSerialization.isValidJSONObject(addOnJsonObject) else {
     throw ProductAddOnEnvelopeError.invalidJsonObject(addOnJsonObject)
}
```

This error is then logged onto tracks where we can monitor for the malformed JSON.
https://github.com/woocommerce/woocommerce-ios/blob/3115f4c5e1a05c646f957e594cdc75a345de1a88/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift#L724-L727

# Testing Steps
None, as we can't reproduce the error.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
