### PR TITLE
[Mobile Payments] Show an alert if the app can't use Bluetooth

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -29,7 +29,7 @@ public protocol CardReaderService {
 
     /// Starts the service.
     /// That could imply, for example, that the reader discovery process starts
-    func start(_ configProvider: CardReaderConfigProvider)
+    func start(_ configProvider: CardReaderConfigProvider) throws
 
     /// Cancels the discovery process.
     func cancelDiscovery() -> Future <Void, Error>

--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -29,6 +29,9 @@ public enum CardReaderServiceError: Error {
 
     /// Error thrown while updating the reader firmware
     case softwareUpdate(underlyingError: UnderlyingError = .internalServiceError)
+
+    /// The user has denied the app permission to use Bluetooth
+    case bluetoothDenied
 }
 
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1,5 +1,6 @@
 import Combine
 import StripeTerminal
+import CoreBluetooth
 
 /// The adapter wrapping the Stripe Terminal SDK
 public final class StripeCardReaderService: NSObject {
@@ -62,13 +63,17 @@ extension StripeCardReaderService: CardReaderService {
 
     // MARK: - CardReaderService conformance. Commands
 
-    public func start(_ configProvider: CardReaderConfigProvider) {
+    public func start(_ configProvider: CardReaderConfigProvider) throws {
         setConfigProvider(configProvider)
 
         let config = DiscoveryConfiguration(
             discoveryMethod: .bluetoothProximity,
             simulated: false
         )
+
+        guard CBCentralManager.authorization != .denied else {
+            throw CardReaderServiceError.bluetoothDenied
+        }
 
         switchStatusToDiscovering()
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
@@ -1,0 +1,71 @@
+import UIKit
+import Yosemite
+
+/// Modal presented on error
+final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
+
+    /// The error returned by the stack
+    private let error: Error
+
+    /// A closure to execute when the primary button is tapped
+    private let primaryAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
+
+    let topTitle: String = Localization.connectionFailed
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.dismiss
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? {
+        switch error {
+        case CardReaderServiceError.bluetoothDenied:
+            return Localization.bluetoothDenied
+        default:
+            return nil
+        }
+    }
+
+    let bottomSubtitle: String? = nil
+
+    init(error: Error, primaryAction: @escaping () -> Void) {
+        self.error = error
+        self.primaryAction = primaryAction
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true, completion: {[weak self] in
+            self?.primaryAction()
+        })
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalScanningFailed {
+    enum Localization {
+        static let connectionFailed = NSLocalizedString(
+            "Reader connection failed",
+            comment: "Error message. Presented to users when finding a reader to connect to fails"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "Dismiss",
+            comment: "Button to dismiss the alert presented when finding a reader to connect to fails"
+        )
+
+        static let bluetoothDenied = NSLocalizedString(
+            "Bluetooth permission was denied",
+            comment: "Explanation in the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -11,6 +11,10 @@ final class CardReaderSettingsAlerts {
         setViewModelAndPresent(from: from, viewModel: scanningForReader(cancel: cancel))
     }
 
+    func scanningFailed(from: UIViewController, error: Error, close: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: scanningFailed(error: error, close: close))
+    }
+
     func connectingToReader(from: UIViewController) {
         setViewModelAndPresent(from: from, viewModel: connectingToReader())
     }
@@ -37,6 +41,10 @@ final class CardReaderSettingsAlerts {
 private extension CardReaderSettingsAlerts {
     func scanningForReader(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalScanningForReader(cancel: cancel)
+    }
+
+    func scanningFailed(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalScanningFailed(error: error, primaryAction: close)
     }
 
     func connectingToReader() -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -79,6 +79,8 @@ private extension CardReaderSettingsUnknownViewController {
             showConnectingModal()
         case .foundReader:
             showFoundReaderModal()
+        case .failed(let error):
+            showDiscoveryErrorModal(error: error)
         default:
             dismissAnyModal()
         }
@@ -98,6 +100,12 @@ private extension CardReaderSettingsUnknownViewController {
         }
 
         modalAlerts.scanningForReader(from: self, cancel: viewModel.cancelReaderDiscovery)
+    }
+
+    func showDiscoveryErrorModal(error: Error) {
+        modalAlerts.scanningFailed(from: self, error: error) { [weak self] in
+            self?.dismissAnyModal()
+        }
     }
 
     func showConnectingModal() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -23,7 +23,9 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     private var foundReader: CardReader?
 
     var discoveryState: CardReaderSettingsUnknownViewModelDiscoveryState = .notSearching
-    var foundReaderSerialNumber: String?
+    var foundReaderSerialNumber: String? {
+        foundReader?.serial
+    }
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
         self.didChangeShouldShow = didChangeShouldShow
@@ -56,20 +58,10 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         ServiceLocator.stores.dispatch(connectedAction)
     }
 
-    private func updateProperties() {
-        guard let foundReader = foundReader else {
-            foundReaderSerialNumber = nil
-            return
-        }
-
-        foundReaderSerialNumber = foundReader.serial
-    }
-
     /// Dispatch a request to start reader discovery
     ///
     func startReaderDiscovery() {
         discoveryState = .searching
-        updateProperties()
         didUpdate?()
 
         ServiceLocator.analytics.track(.cardReaderDiscoveryTapped)
@@ -80,7 +72,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             },
             onError: { [weak self] error in
                 self?.discoveryState = .failed(error)
-                self?.updateProperties()
                 self?.didUpdate?()
                 ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
             })
@@ -111,7 +102,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
 
         foundReader = cardReader
         discoveryState = .foundReader
-        updateProperties()
         didUpdate?()
     }
 
@@ -119,7 +109,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     ///
     func cancelReaderDiscovery() {
         discoveryState = .notSearching
-        updateProperties()
         didUpdate?()
 
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { _ in
@@ -136,7 +125,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         }
 
         discoveryState = .connectingToReader
-        updateProperties()
         didUpdate?()
 
         ServiceLocator.analytics.track(.cardReaderConnectionTapped)
@@ -161,7 +149,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     func continueSearch() {
         discoveryState = .searching
         foundReader = nil
-        updateProperties()
         didUpdate?()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -22,7 +22,11 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
 
     private var foundReader: CardReader?
 
-    var discoveryState: CardReaderSettingsUnknownViewModelDiscoveryState = .notSearching
+    var discoveryState: CardReaderSettingsUnknownViewModelDiscoveryState = .notSearching {
+        didSet {
+            didUpdate?()
+        }
+    }
     var foundReaderSerialNumber: String? {
         foundReader?.serial
     }
@@ -62,7 +66,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     ///
     func startReaderDiscovery() {
         discoveryState = .searching
-        didUpdate?()
 
         ServiceLocator.analytics.track(.cardReaderDiscoveryTapped)
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
@@ -72,7 +75,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             },
             onError: { [weak self] error in
                 self?.discoveryState = .failed(error)
-                self?.didUpdate?()
                 ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
             })
 
@@ -102,14 +104,12 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
 
         foundReader = cardReader
         discoveryState = .foundReader
-        didUpdate?()
     }
 
     /// Dispatch a request to cancel reader discovery
     ///
     func cancelReaderDiscovery() {
         discoveryState = .notSearching
-        didUpdate?()
 
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { _ in
         }
@@ -125,7 +125,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         }
 
         discoveryState = .connectingToReader
-        didUpdate?()
 
         ServiceLocator.analytics.track(.cardReaderConnectionTapped)
         let action = CardPresentPaymentAction.connect(reader: foundReader) { result in
@@ -149,7 +148,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     func continueSearch() {
         discoveryState = .searching
         foundReader = nil
-        didUpdate?()
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1184,6 +1184,7 @@
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
+		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2454,6 +2455,7 @@
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
+		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -5680,6 +5682,7 @@
 				D82BB3A926454F3300A82741 /* CardPresentModalProcessing.swift */,
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
+				E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 			);
@@ -6560,6 +6563,7 @@
 				D89CFF3A25B43BBB000E4683 /* WrongAccountErrorViewModel.swift in Sources */,
 				45C91CFE25E55A1200FD8812 /* ShippingLabelAddressTopBannerFactory.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
+				E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */,
 				D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */,
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -32,7 +32,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             }
         }.store(in: &cancellables)
 
-        readerService.start(MockTokenProvider())
+        try! readerService.start(MockTokenProvider())
         wait(for: [receivedReaders], timeout: Constants.expectationTimeout)
     }
 
@@ -68,7 +68,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
                 .fulfillOnCompletion(expectation: discoveredReaders)
         }.store(in: &cancellables)
 
-        readerService.start(MockTokenProvider())
+        try! readerService.start(MockTokenProvider())
         wait(for: [discoveredReaders], timeout: Constants.expectationTimeout)
     }
 
@@ -105,7 +105,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             }
         }.store(in: &self.cancellables)
 
-        readerService.start(MockTokenProvider())
+        try! readerService.start(MockTokenProvider())
         wait(for: [discoveredReaders, connectedToReader, connectedreaderIsPublished], timeout: Constants.expectationTimeout)
     }
 }

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -76,7 +76,11 @@ public final class CardPresentPaymentStore: Store {
 //
 private extension CardPresentPaymentStore {
     func startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: @escaping (_ readers: [CardReader]) -> Void, onError: @escaping (Error) -> Void) {
-        cardReaderService.start(WCPayTokenProvider(siteID: siteID, remote: self.remote))
+        do {
+            try cardReaderService.start(WCPayTokenProvider(siteID: siteID, remote: self.remote))
+        } catch {
+            return onError(error)
+        }
 
         // Over simplification. This is the point where we would receive
         // new data via the CardReaderService's stream of discovered readers

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -55,7 +55,7 @@ final class MockCardReaderService: CardReaderService {
 
     }
 
-    func start(_ configProvider: CardReaderConfigProvider) {
+    func start(_ configProvider: CardReaderConfigProvider) throws {
         didHitStart = true
         didReceiveAConfigurationProvider = true
 


### PR DESCRIPTION
Fixes #4232

Currently, tapping on Connect reader will attempt to start discovery even if the user has declined the Bluetooth permission. The stripe SDK would return an error, but we weren't handling errors at all in discovery.

This PR introduces a new alert to show any errors related to discovery, although it will only show a detailed message for Bluetooth permission errors.

## How

Initially I tried to have the service call `switchStatusToFault` and pretend there was an error coming from the API. However, the permission check is synchronous, so doing that would send a failed completion to `discoveredReaders` before the store had subscribed to it, and it would re-initialize it, so when the store subscribed, it would have the initial empty value.

Instead of trying to fit this into the Combine flow, I made the call to `start` throw an error.

I also took the opportunity to simplify a couple things for state management in `CardReaderSettingsUnknownViewModel`.

## To test

1. Go to System Settings > Woo, and disable Bluetooth
2. Back in the Woo app, try to connect to a reader
3. An alert showing an error should display:

<img width="400" src="https://user-images.githubusercontent.com/8739/119680499-86e15c80-be41-11eb-94a4-e5aa7c223f8a.png">

Any other error would also display the alert without the explanation. For instance, with the reader powered off and bluetooth available, start reader discovery, then enable airplane mode:

<img width="400" src="https://user-images.githubusercontent.com/8739/119682655-58fd1780-be43-11eb-8210-05c847bdaae3.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
