### PR TITLE
Add-ons: Show "View Add-Ons" button in product list from order product detail.

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -6,9 +6,9 @@ import Yosemite
 ///
 struct AddOnCrossreferenceUseCase {
 
-    /// Order item with unknown attributes
+    /// All of the order item attributes
     ///
-    private let orderItem: AggregateOrderItem
+    private let orderItemAttributes: [OrderItemAttribute]
 
     /// Product entity with known addOns that matches the order item.
     ///
@@ -18,8 +18,8 @@ struct AddOnCrossreferenceUseCase {
     ///
     private let addOnGroups: [AddOnGroup]
 
-    init(orderItem: AggregateOrderItem, product: Product, addOnGroups: [AddOnGroup]) {
-        self.orderItem = orderItem
+    init(orderItemAttributes: [OrderItemAttribute], product: Product, addOnGroups: [AddOnGroup]) {
+        self.orderItemAttributes = orderItemAttributes
         self.product = product
         self.addOnGroups = addOnGroups
     }
@@ -27,7 +27,7 @@ struct AddOnCrossreferenceUseCase {
     /// Returns the attributes of an `orderItem` that are `addOns` by cross-referencing the attribute name with the add-on name.
     ///
     func addOnsAttributes() -> [OrderItemAttribute] {
-        orderItem.attributes.filter { attribute in
+        orderItemAttributes.filter { attribute in
             let addOnName = extractAddOnName(from: attribute)
             return addOnNameExistsInProductAddOns(addOnName) || addOnNameExistsInGlobalAddOns(addOnName)
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -756,7 +756,7 @@ private extension OrderDetailsDataSource {
         guard let product = products.first(where: { $0.productID == item.productID }), showAddOns else {
             return []
         }
-        return AddOnCrossreferenceUseCase(orderItem: item, product: product, addOnGroups: addOnGroups).addOnsAttributes()
+        return AddOnCrossreferenceUseCase(orderItemAttributes: item.attributes, product: product, addOnGroups: addOnGroups).addOnsAttributes()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -24,6 +24,22 @@ final class PickListTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var skuLabel: UILabel!
 
+    /// The stack view grouping add on information.
+    ///
+    @IBOutlet private var viewAddOnsStackView: UIStackView!
+
+    /// The label indicating that there are add-ons available.
+    ///
+    @IBOutlet private var viewAddOnsLabel: UILabel!
+
+    /// The chevron indicator next to the viewAddOns label.
+    ///
+    @IBOutlet private var viewAddOnsIndicator: UIImageView!
+
+    /// Assign this closure to be notified when the "View Add-ons" button is tapped.
+    ///
+    var onViewAddOnsTouchUp: (() -> Void)?
+
     /// Product Name
     ///
     var name: String? {
@@ -74,6 +90,7 @@ final class PickListTableViewCell: UITableViewCell {
         setupNameLabel()
         setupQuantityLabel()
         setupSkuLabel()
+        setupAddOnViews()
     }
 
     override func prepareForReuse() {
@@ -102,6 +119,7 @@ extension PickListTableViewCell {
         }
 
         sku = skuText
+        viewAddOnsStackView.isHidden = !item.hasAddOns
     }
 }
 
@@ -138,5 +156,30 @@ private extension PickListTableViewCell {
         skuLabel.applySecondaryFootnoteStyle()
         skuLabel?.isHidden = false
         skuLabel?.text = ""
+    }
+
+    func setupAddOnViews() {
+        viewAddOnsStackView.layoutMargins = .init(top: 4, left: 0, bottom: 4, right: 0) // Increase touch area
+        viewAddOnsStackView.isLayoutMarginsRelativeArrangement = true
+        viewAddOnsStackView.spacing = 2
+
+        viewAddOnsLabel.applySubheadlineStyle()
+        viewAddOnsLabel.text = Localization.viewAddOns
+
+        viewAddOnsIndicator.image = .chevronImage
+        viewAddOnsIndicator.tintColor = .systemGray
+
+        let tapRecognizer = UITapGestureRecognizer()
+        tapRecognizer.on { [weak self] _ in
+            self?.onViewAddOnsTouchUp?()
+        }
+        viewAddOnsStackView.addGestureRecognizer(tapRecognizer)
+    }
+}
+
+// MARK: Localization
+private extension PickListTableViewCell {
+    enum Localization {
+        static let viewAddOns = NSLocalizedString("View Add-Ons", comment: "Title of the button on the order details product list item to navigate to add-ons")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -112,6 +112,7 @@ extension PickListTableViewCell {
                                                        completion: nil)
         name = item.name
         quantity = item.quantity
+        viewAddOnsStackView.isHidden = !item.hasAddOns
 
         guard let skuText = item.sku else {
             skuLabel.isHidden = true
@@ -119,7 +120,6 @@ extension PickListTableViewCell {
         }
 
         sku = skuText
-        viewAddOnsStackView.isHidden = !item.hasAddOns
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,26 +17,26 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p6h-Fq-FjW">
-                        <rect key="frame" x="15" y="19" width="44" height="44"/>
+                        <rect key="frame" x="16" y="19" width="44" height="44"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="44" id="9vH-gW-wOd"/>
                             <constraint firstAttribute="height" constant="44" id="hcJ-qM-Kx2"/>
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="En5-gn-p39">
-                        <rect key="frame" x="75" y="19" width="230" height="85"/>
+                        <rect key="frame" x="76" y="19" width="228" height="85"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HX7-V5-bhX">
-                                <rect key="frame" x="0.0" y="0.0" width="230" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="228" height="20.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Title Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14R-zK-tgC">
-                                        <rect key="frame" x="0.0" y="0.0" width="190.5" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="188.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="893" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pPE-SE-pY7">
-                                        <rect key="frame" x="198.5" y="0.0" width="31.5" height="50"/>
+                                        <rect key="frame" x="196.5" y="0.0" width="31.5" height="20.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="bIk-vq-m2l"/>
                                         </constraints>
@@ -58,11 +57,35 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SKU" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7JH-rt-n9v">
-                                <rect key="frame" x="0.0" y="69" width="230" height="16"/>
+                                <rect key="frame" x="0.0" y="24.5" width="228" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ngn-rC-j3r">
+                                <rect key="frame" x="0.0" y="44.5" width="228" height="40.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="View Add-ons" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G8y-LH-fQJ">
+                                        <rect key="frame" x="0.0" y="12.5" width="85" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ek2-Tw-6Ql">
+                                        <rect key="frame" x="89" y="10.5" width="20" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="DgF-qN-Syn"/>
+                                            <constraint firstAttribute="width" secondItem="ek2-Tw-6Ql" secondAttribute="height" multiplier="1:1" id="eOC-ET-P1c"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAz-wP-wDU" userLabel="spacer">
+                                        <rect key="frame" x="113" y="0.0" width="115" height="40.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
                     </stackView>
                 </subviews>
@@ -82,6 +105,9 @@
                 <outlet property="productImageView" destination="p6h-Fq-FjW" id="bIw-1F-5GW"/>
                 <outlet property="quantityLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="skuLabel" destination="7JH-rt-n9v" id="U07-2n-W3b"/>
+                <outlet property="viewAddOnsIndicator" destination="ek2-Tw-6Ql" id="ech-iY-aT2"/>
+                <outlet property="viewAddOnsLabel" destination="G8y-LH-fQJ" id="N3a-fe-FyU"/>
+                <outlet property="viewAddOnsStackView" destination="ngn-rC-j3r" id="KqR-8Q-Dfj"/>
             </connections>
             <point key="canvasLocation" x="62" y="96.5"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -71,10 +71,11 @@ extension ProductListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = itemAtIndexPath(indexPath)
         let product = lookUpProduct(by: item.productOrVariationID)
+        let showAddOnsButton = shouldShowDisplayAddOnButton(item: item, product: product)
         let itemViewModel = ProductDetailsCellViewModel(item: item,
                                                         currency: viewModel.order.currency,
                                                         product: product,
-                                                        hasAddOns: false)
+                                                        hasAddOns: showAddOnsButton)
         let cell = tableView.dequeueReusableCell(PickListTableViewCell.self, for: indexPath)
         cell.selectionStyle = .default
         cell.configure(item: itemViewModel, imageService: imageService)
@@ -118,6 +119,18 @@ private extension ProductListViewController {
 
     func lookUpProduct(by productID: Int64) -> Product? {
         return products?.filter({ $0.productID == productID }).first
+    }
+
+    /// Returns `true` if the add-on feature is enabled and if the order item has add-ons associated with it.
+    ///
+    func shouldShowDisplayAddOnButton(item: OrderItem, product: Product?) -> Bool {
+        guard let product = product, viewModel.dataSource.showAddOns else {
+            return false
+        }
+
+        let globalAddOns = viewModel.dataSource.addOnGroups
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: item.attributes, product: product, addOnGroups: globalAddOns)
+        return useCase.addOnsAttributes().isNotEmpty
     }
 
     /// Displays the product details screen for the provided OrderItem

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -71,7 +71,7 @@ extension ProductListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = itemAtIndexPath(indexPath)
         let product = lookUpProduct(by: item.productOrVariationID)
-        let addOns = itemAddOnsAttributes(item: item, product: product)
+        let addOns = itemAddOnsAttributes(item: item)
         let itemViewModel = ProductDetailsCellViewModel(item: item,
                                                         currency: viewModel.order.currency,
                                                         product: product,
@@ -127,8 +127,8 @@ private extension ProductListViewController {
     /// Returns the item attributes that can be identified as add-ons attributes.
     /// If the "view add-ons" feature is disabled an empty array will be returned.
     ///
-    func itemAddOnsAttributes(item: OrderItem, product: Product?) -> [OrderItemAttribute] {
-        guard let product = product, viewModel.dataSource.showAddOns else {
+    func itemAddOnsAttributes(item: OrderItem) -> [OrderItemAttribute] {
+        guard let product = lookUpProduct(by: item.productID), viewModel.dataSource.showAddOns else {
             return []
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/AddOns/AddOnCrossreferenceTests.swift
@@ -9,12 +9,12 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOn_attributes_are_correctly_filtered_against_product_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
             OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
             OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
             OrderItemAttribute(metaID: 4, name: "NotOnProduct ($7.00)", value: ""),
-        ])
+        ]
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Fast Delivery"),
             ProductAddOn.fake().copy(name: "Topping"),
@@ -22,7 +22,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -34,15 +34,15 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOn_attributes_with_special_characters_in_name_are_correctly_filtered_against_product_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 3, name: "Fast (really) Delivery (fast) ($7.00)", value: ""),
-        ])
+        ]
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Fast (really) Delivery (fast)"),
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -53,15 +53,15 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOn_attributes_with_no_price_in_name_are_correctly_filtered_against_product_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 3, name: "Engraving", value: ""),
-        ])
+        ]
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Engraving"),
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -72,16 +72,16 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOnAttributes_is_empty_when_product_does_not_have_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
             OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
             OrderItemAttribute(metaID: 3, name: "Fast Delivery (%7.00)", value: ""),
             OrderItemAttribute(metaID: 4, name: "NotOnProduct (%7.00)", value: ""),
-        ])
+        ]
         let product = Product.fake()
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -90,7 +90,6 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOnAttributes_is_empty_when_orderItem_does_not_have_attributes() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem()
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Fast Delivery"),
             ProductAddOn.fake().copy(name: "Topping"),
@@ -98,7 +97,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ])
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: [])
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: [], product: product, addOnGroups: [])
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -107,11 +106,11 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOn_attributes_are_correctly_filtered_against_global_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
             OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
             OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: "")
-        ])
+        ]
         let product = Product.fake()
         let addOnGroups = [
             AddOnGroup.fake().copy(addOns: [ProductAddOn.fake().copy(name: "Fast Delivery")]),
@@ -119,7 +118,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ]
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: addOnGroups)
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: addOnGroups)
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then
@@ -131,12 +130,12 @@ class AddOnCrossreferenceTests: XCTestCase {
 
     func tests_addOn_attributes_are_correctly_filtered_against_product_addOns_and_global_addOns() {
         // Given
-        let orderItem = MockAggregateOrderItem.emptyItem().copy(attributes: [
+        let orderItemAttributes = [
             OrderItemAttribute(metaID: 1, name: "Topping ($3.00)", value: ""),
             OrderItemAttribute(metaID: 2, name: "Random Attribute 1", value: ""),
             OrderItemAttribute(metaID: 3, name: "Fast Delivery ($7.00)", value: ""),
             OrderItemAttribute(metaID: 4, name: "Gift Wrapping ($7.00)", value: ""),
-        ])
+        ]
         let product = Product.fake().copy(addOns: [
             ProductAddOn.fake().copy(name: "Fast Delivery"),
             ProductAddOn.fake().copy(name: "Topping"),
@@ -148,7 +147,7 @@ class AddOnCrossreferenceTests: XCTestCase {
         ]
 
         // When
-        let useCase = AddOnCrossreferenceUseCase(orderItem: orderItem, product: product, addOnGroups: addOnGroups)
+        let useCase = AddOnCrossreferenceUseCase(orderItemAttributes: orderItemAttributes, product: product, addOnGroups: addOnGroups)
         let addOnsAttributes = useCase.addOnsAttributes()
 
         // Then


### PR DESCRIPTION
part of #4271 

# Why

It was reported that tapping on the "details" button from a completed|on-hold order navigates to the item list but those item does not show any add-on information.

This PR makes sure to show the "view add-on" in that screen button for products that have associated add-ons

# How

- Update `AddOnCrossreferenceUseCase` to accept an `[OrderItemAttributes]` instead of `AggregatedOrderItem`. This is needed to be able to reuse `AddOnCrossreferenceUseCase` from `ProductListViewController` where we only have an `OrderItem` type.

- Update `PickListTableViewCell` to include the `View Add-ons` button

- Update `ProductListViewController` to use `AddOnCrossreferenceUseCase` to determine if an item has add-ons and populate the cell view model appropriately.

# Demo

**Before**
https://user-images.githubusercontent.com/562080/119728758-70cf9e00-be39-11eb-9ff5-d89d158a7fb5.mov 

**After**
https://user-images.githubusercontent.com/562080/119728769-72996180-be39-11eb-9b21-3357385d682c.mov

# Testing

**Prerequisites:** 
- Have your site with the add-ons plugin installed and with at least one order with add-ons.
- Enable the "Add-Ons" feature from the beta features screen in settings.

**Steps:**
- Launch the app and navigate to the add-on order
- Mark that order as "complete" or as "on-hold".
- Tap on the "Details" button below the product list.
- See that the next screen has the "View add-ons" button in the appropriate items
- See that the button navigates properly to the add-ons screen.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
