### PR TITLE
[Mobile Payments] Improve Bluetooth permission error

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
@@ -10,18 +10,18 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     /// A closure to execute when the primary button is tapped
     private let primaryAction: () -> Void
 
-    let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .oneAction
+    let textMode: PaymentsModalTextMode = .fullInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
 
-    let topTitle: String = Localization.connectionFailed
+    let topTitle: String = Localization.bluetoothRequired
 
     var topSubtitle: String? = nil
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.dismiss
+    let primaryButtonTitle: String? = Localization.openDeviceSettings
 
-    let secondaryButtonTitle: String? = nil
+    let secondaryButtonTitle: String? = Localization.dismiss
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -42,21 +42,31 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(targetURL)
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true, completion: {[weak self] in
             self?.primaryAction()
         })
     }
-
-    func didTapSecondaryButton(in viewController: UIViewController?) { }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
 private extension CardPresentModalScanningFailed {
     enum Localization {
-        static let connectionFailed = NSLocalizedString(
-            "Reader connection failed",
-            comment: "Error message. Presented to users when finding a reader to connect to fails"
+        static let bluetoothRequired = NSLocalizedString(
+            "Bluetooth permission required",
+            comment: "Title of the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions"
+        )
+
+        static let openDeviceSettings = NSLocalizedString(
+            "Open Device Settings",
+            comment: "Opens iOS's Device Settings for the app"
         )
 
         static let dismiss = NSLocalizedString(
@@ -65,7 +75,7 @@ private extension CardPresentModalScanningFailed {
         )
 
         static let bluetoothDenied = NSLocalizedString(
-            "Bluetooth permission was denied",
+            "This app needs permission to access Bluetooth to connect to a card reader, please change the privacy settings if you wish to allow this.",
             comment: "Explanation in the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions")
     }
 }


### PR DESCRIPTION
Part of #4232 
A continuation of #4289 

As suggested by @allendav in https://github.com/woocommerce/woocommerce-ios/pull/4289#issuecomment-849094781, this improves the messaging around Bluetooth permissions a bit, adding an explanation and a direct action to open device settings.

The primary button shows clipped text in Spanish, but we'll handle that in #4222
Spanish | English
-|-
![Screen Shot 2021-05-27 at 10 01 14](https://user-images.githubusercontent.com/8739/119789356-47635080-bed3-11eb-9523-8d4f1654c74a.png) | ![Screen Shot 2021-05-27 at 10 04 03](https://user-images.githubusercontent.com/8739/119789368-49c5aa80-bed3-11eb-9e25-040e480edfee.png)

## To test

I tested this applying the fix in #4292 to see the full message, but I'm not including that code in this PR.

1. Go to System Settings > Woo, and disable Bluetooth
2. Back in the Woo app, try to connect to a reader
3. An alert showing an error should display.
4. Tapping dismiss should close the alert. Tapping Open Device Settings should take you to the Woo iOS settings where you can enable bluetooth

It seems that when you toggle the Bluetooth permission setting and come back to the app, iOS kills the app and relaunches it. I would have tried to detect the state when the app becomes active again, but there's no point in doing that if it will get killed. It doesn't seem like we support UIKit's state preservation either?

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
