### PR TITLE
[Mobile Payments] Improve user facing errors

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -34,6 +34,34 @@ public enum CardReaderServiceError: Error {
     case bluetoothDenied
 }
 
+extension CardReaderServiceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .connection(let underlyingError):
+            return underlyingError.errorDescription
+        case .discovery(let underlyingError):
+            return underlyingError.errorDescription
+        case .disconnection(let underlyingError):
+            return underlyingError.errorDescription
+        case .intentCreation(let underlyingError):
+            return underlyingError.errorDescription
+        case .paymentMethodCollection(let underlyingError):
+            return underlyingError.errorDescription
+        case .paymentCapture(let underlyingError):
+            return underlyingError.errorDescription
+        case .paymentCancellation(let underlyingError):
+            return underlyingError.errorDescription
+        case .softwareUpdate(let underlyingError):
+            return underlyingError.errorDescription
+        case .bluetoothDenied:
+            return NSLocalizedString(
+                "This app needs permission to access Bluetooth to connect to a card reader, please change the privacy settings if you wish to allow this.",
+                comment: "Explanation in the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions"
+            )
+        }
+    }
+}
+
 
 /// Underlying error. Models the specific error that made a given
 /// interaction with the SDK fail.

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
@@ -26,12 +26,7 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     let auxiliaryButtonTitle: String? = nil
 
     var bottomTitle: String? {
-        switch error {
-        case CardReaderServiceError.bluetoothDenied:
-            return Localization.bluetoothDenied
-        default:
-            return nil
-        }
+        error.localizedDescription
     }
 
     let bottomSubtitle: String? = nil
@@ -73,9 +68,4 @@ private extension CardPresentModalScanningFailed {
             "Dismiss",
             comment: "Button to dismiss the alert presented when finding a reader to connect to fails"
         )
-
-        static let bluetoothDenied = NSLocalizedString(
-            "This app needs permission to access Bluetooth to connect to a card reader, please change the privacy settings if you wish to allow this.",
-            comment: "Explanation in the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions")
-    }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
@@ -68,4 +68,5 @@ private extension CardPresentModalScanningFailed {
             "Dismiss",
             comment: "Button to dismiss the alert presented when finding a reader to connect to fails"
         )
+    }
 }


### PR DESCRIPTION
Fixes #4235

We already had plenty of localized descriptions for the underlying errors, but since `CardReaderServiceError` didn't conform to `LocalizedError` itself those weren't actually used.

This customizes the localized descriptions for `CardReaderServiceError`, defining a new one for the bluetooth permissions error, and otherwise propagating the underlying error's description

We might call #4303 solved with this, although for location denied we should do like we did in #4302 and show a custom modal taking the user to settings directly.

## To test

Make a payment fail. I've tried a few scenarios:

1. Location disabled
2. Leave the card inside the reader and make a second payment
3. Use an amount ending in `.75`

![Screen Shot 2021-05-27 at 16 52 28](https://user-images.githubusercontent.com/8739/119849679-1dc71b00-bf0d-11eb-8254-537085660947.png) | ![Screen Shot 2021-05-27 at 16 53 03](https://user-images.githubusercontent.com/8739/119849690-20297500-bf0d-11eb-824f-ed6bad9ef336.png) | ![Screen Shot 2021-05-27 at 16 53 09](https://user-images.githubusercontent.com/8739/119849693-20c20b80-bf0d-11eb-94fc-838270c547c6.png)
-|-|-



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
