### PR TITLE
Add-ons: Give Feedback button in the announcement banner is trimmed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnTopBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/AddOns/OrderAddOnTopBanner.swift
@@ -88,7 +88,7 @@ private extension OrderAddOnTopBanner {
                                                    "For now, you’ll be able to see the add-ons for your orders. " +
                                                    "You can create and edit these add-ons in your web dashboard.",
                                                    comment: "Content of the banner notice in the add-ons view")
-        static let giveFeedback = NSLocalizedString("Give Feedback", comment: "Title of the button to give feedback about the add-ons feature")
+        static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the add-ons feature")
         static let dismiss = NSLocalizedString("Dismiss", comment: "Title of the button to dismiss the banner notice in the add-ons view")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -192,6 +192,7 @@ private extension TopBannerView {
         // Style buttons
         actionButtons.forEach { button in
             button.applyLinkButtonStyle()
+            button.titleLabel?.adjustsFontSizeToFitWidth = true
             button.backgroundColor = backgroundColor(for: viewModel.type)
             buttonsStackView.addArrangedSubview(button)
         }


### PR DESCRIPTION
fix #4280

# Why

It was reported that in Spanish, the "Give Feedback" button in the announcement banner for add-ons is trimmed. 

I wondered why other top banners that requested feedback(eg: Products) weren't getting trimmed in Spanish and I noticed that we were using different localized keys for them. "Give Feedback" vs "Give feedback"

I also wonder how we could mitigate this in the future, maybe using tools like [R.swift](https://github.com/mac-cain13/R.swift)? cc @AliSoftware 

# How

- Use the products banner "Give feedback" localized key for the add-ons top banner.

- Set top-banner button labels to auto shrink when needed. 

# Screenshots

Before | After
--- | ---
<img width="437" alt="before" src="https://user-images.githubusercontent.com/562080/119854505-bc845500-bed6-11eb-97e7-bb7cbbe3806a.png"> | <img width="441" alt="after" src="https://user-images.githubusercontent.com/562080/119854511-bdb58200-bed6-11eb-8c90-eba9dcf96f1f.png">

# Testing

**Prerequisites:** 
- Have your site with the add-ons plugin installed and with at least one order with add-ons.
- Enable the "Add-Ons" feature from the beta features screen in settings.

**Steps:** 
- Launch the app in an iPhone SE simulator in Spanish(Latin America) and navigate to the add-on order
- Tap on the "View Add-Ons" button.
- See that there is a "beta feature" banner
- See that the "Da tu opinión" text is not trimmed.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
