### PR TITLE
Shipping Labels: Add endpoint to update shipping label account settings

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -595,6 +595,51 @@ extension ShippingLabel {
     }
 }
 
+extension ShippingLabelAccountSettings {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        canManagePayments: CopiableProp<Bool> = .copy,
+        canEditSettings: CopiableProp<Bool> = .copy,
+        storeOwnerDisplayName: CopiableProp<String> = .copy,
+        storeOwnerUsername: CopiableProp<String> = .copy,
+        storeOwnerWpcomUsername: CopiableProp<String> = .copy,
+        storeOwnerWpcomEmail: CopiableProp<String> = .copy,
+        paymentMethods: CopiableProp<[ShippingLabelPaymentMethod]> = .copy,
+        selectedPaymentMethodID: CopiableProp<Int64> = .copy,
+        isEmailReceiptsEnabled: CopiableProp<Bool> = .copy,
+        paperSize: CopiableProp<ShippingLabelPaperSize> = .copy,
+        lastSelectedPackageID: CopiableProp<String> = .copy
+    ) -> ShippingLabelAccountSettings {
+        let siteID = siteID ?? self.siteID
+        let canManagePayments = canManagePayments ?? self.canManagePayments
+        let canEditSettings = canEditSettings ?? self.canEditSettings
+        let storeOwnerDisplayName = storeOwnerDisplayName ?? self.storeOwnerDisplayName
+        let storeOwnerUsername = storeOwnerUsername ?? self.storeOwnerUsername
+        let storeOwnerWpcomUsername = storeOwnerWpcomUsername ?? self.storeOwnerWpcomUsername
+        let storeOwnerWpcomEmail = storeOwnerWpcomEmail ?? self.storeOwnerWpcomEmail
+        let paymentMethods = paymentMethods ?? self.paymentMethods
+        let selectedPaymentMethodID = selectedPaymentMethodID ?? self.selectedPaymentMethodID
+        let isEmailReceiptsEnabled = isEmailReceiptsEnabled ?? self.isEmailReceiptsEnabled
+        let paperSize = paperSize ?? self.paperSize
+        let lastSelectedPackageID = lastSelectedPackageID ?? self.lastSelectedPackageID
+
+        return ShippingLabelAccountSettings(
+            siteID: siteID,
+            canManagePayments: canManagePayments,
+            canEditSettings: canEditSettings,
+            storeOwnerDisplayName: storeOwnerDisplayName,
+            storeOwnerUsername: storeOwnerUsername,
+            storeOwnerWpcomUsername: storeOwnerWpcomUsername,
+            storeOwnerWpcomEmail: storeOwnerWpcomEmail,
+            paymentMethods: paymentMethods,
+            selectedPaymentMethodID: selectedPaymentMethodID,
+            isEmailReceiptsEnabled: isEmailReceiptsEnabled,
+            paperSize: paperSize,
+            lastSelectedPackageID: lastSelectedPackageID
+        )
+    }
+}
+
 extension ShippingLabelAddress {
     public func copy(
         company: CopiableProp<String> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAccountSettings.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents Account Settings for Shipping Labels.
 ///
-public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable {
+public struct ShippingLabelAccountSettings: Equatable, GeneratedFakeable, GeneratedCopiable {
     /// Remote Site ID.
     public let siteID: Int64
 

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -27,6 +27,9 @@ public protocol ShippingLabelRemoteProtocol {
                               completion: @escaping (Result<ShippingLabelCarriersAndRates, Error>) -> Void)
     func loadShippingLabelAccountSettings(siteID: Int64,
                                           completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void)
+    func updateShippingLabelAccountSettings(siteID: Int64,
+                                            settings: ShippingLabelAccountSettings,
+                                            completion: @escaping (Result<Bool, Error>) -> Void)
     func checkCreationEligibility(siteID: Int64,
                                   orderID: Int64,
                                   canCreatePaymentMethod: Bool,
@@ -179,6 +182,23 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Updates account-level shipping label settings for a store.
+    /// - Parameters:
+    ///     - siteID: Remote ID of the site.
+    ///     - settings: The shipping label account settings to update remotely.
+    ///     - completion: Closure to be executed upon completion.
+    public func updateShippingLabelAccountSettings(siteID: Int64, settings: ShippingLabelAccountSettings, completion: @escaping (Result<Bool, Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.selectedPaymentMethodID: settings.selectedPaymentMethodID,
+            ParameterKey.emailReceipts: settings.isEmailReceiptsEnabled,
+            ParameterKey.paperSize: settings.paperSize.rawValue
+        ]
+        let path = Path.accountSettings
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = SuccessResultMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Checks eligibility for shipping label creation.
     /// - Parameters:
     ///     - siteID: Remote ID of the site.
@@ -226,5 +246,7 @@ private extension ShippingLabelRemote {
         static let originAddress = "origin"
         static let destinationAddress = "destination"
         static let packages = "packages"
+        static let selectedPaymentMethodID = "selected_payment_method_id"
+        static let emailReceipts = "email_receipts"
     }
 }

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -286,6 +286,41 @@ final class ShippingLabelRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
+    func test_updateShippingLabelAccountSettings_returns_true_on_success() throws {
+        // Given
+        let settings = ShippingLabelAccountSettings.fake().copy()
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "account/settings", filename: "generic_success")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.updateShippingLabelAccountSettings(siteID: self.sampleSiteID, settings: settings) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try result.get()
+        XCTAssertTrue(response)
+    }
+
+    func test_updateShippingLabelAccountSettings_returns_error_on_failure() throws {
+        // Given
+        let settings = ShippingLabelAccountSettings.fake().copy()
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "account/settings", filename: "generic_error")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.updateShippingLabelAccountSettings(siteID: self.sampleSiteID, settings: settings) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
+
     func test_checkCreationEligibility_returns_true_on_success() throws {
         // Given
         let orderID: Int64 = 321

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -60,4 +60,10 @@ public enum ShippingLabelAction: Action {
     ///
     case synchronizeShippingLabelAccountSettings(siteID: Int64,
                                                  completion: (Result<ShippingLabelAccountSettings, Error>) -> Void)
+
+    /// Updates account-level shipping label settings for a store.
+    ///
+    case updateShippingLabelAccountSettings(siteID: Int64,
+                                            settings: ShippingLabelAccountSettings,
+                                            completion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -199,7 +199,18 @@ private extension ShippingLabelStore {
     func updateShippingLabelAccountSettings(siteID: Int64,
                                             settings: ShippingLabelAccountSettings,
                                             completion: @escaping (Result<Bool, Error>) -> Void) {
-        remote.updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
+        remote.updateShippingLabelAccountSettings(siteID: siteID, settings: settings) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let success):
+                self.upsertShippingLabelAccountSettingsInBackground(siteID: siteID, accountSettings: settings) {
+                    completion(.success(success))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -67,6 +67,8 @@ public final class ShippingLabelStore: Store {
                                  completion: completion)
         case .synchronizeShippingLabelAccountSettings(let siteID, let completion):
             synchronizeShippingLabelAccountSettings(siteID: siteID, completion: completion)
+        case .updateShippingLabelAccountSettings(let siteID, let settings, let completion):
+            updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
         }
     }
 }
@@ -192,6 +194,12 @@ private extension ShippingLabelStore {
                 }
             }
         }
+    }
+
+    func updateShippingLabelAccountSettings(siteID: Int64,
+                                            settings: ShippingLabelAccountSettings,
+                                            completion: @escaping (Result<Bool, Error>) -> Void) {
+        remote.updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -43,6 +43,10 @@ final class MockShippingLabelRemote {
         let siteID: Int64
     }
 
+    private struct UpdateAccountSettingsResultKey: Hashable {
+        let siteID: Int64
+    }
+
     private struct CreationEligibilityResultKey: Hashable {
         let siteID: Int64
         let orderID: Int64
@@ -74,6 +78,9 @@ final class MockShippingLabelRemote {
 
     /// The results to return based on the given arguments in `loadShippingLabelAccountSettings`
     private var loadAccountSettings = [LoadAccountSettingsResultKey: Result<ShippingLabelAccountSettings, Error>]()
+
+    /// The results to return based on the given arguments in `updateShippingLabelAccountSettings`
+    private var updateAccountSettings = [UpdateAccountSettingsResultKey: Result<Bool, Error>]()
 
     /// The results to return based on the given arguments in `checkCreationEligibility`
     private var creationEligibilityResults = [CreationEligibilityResultKey: Result<ShippingLabelCreationEligibilityResponse, Error>]()
@@ -132,11 +139,19 @@ final class MockShippingLabelRemote {
         loadCarriersAndRatesResults[key] = result
     }
 
-    /// Set the value passed to the `completion` block if `createPackage` is called.
+    /// Set the value passed to the `completion` block if `loadShippingLabelAccountSettings` is called.
     func whenLoadShippingLabelAccountSettings(siteID: Int64,
                                        thenReturn result: Result<ShippingLabelAccountSettings, Error>) {
         let key = LoadAccountSettingsResultKey(siteID: siteID)
         loadAccountSettings[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `updateShippingLabelAccountSettings` is called.
+    func whenUpdateShippingLabelAccountSettings(siteID: Int64,
+                                                settings: ShippingLabelAccountSettings,
+                                                thenReturn result: Result<Bool, Error>) {
+        let key = UpdateAccountSettingsResultKey(siteID: siteID)
+        updateAccountSettings[key] = result
     }
 
     func whenCheckingCreationEligiblity(siteID: Int64,
@@ -262,6 +277,21 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = LoadAccountSettingsResultKey(siteID: siteID)
             if let result = self.loadAccountSettings[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func updateShippingLabelAccountSettings(siteID: Int64,
+                                            settings: ShippingLabelAccountSettings,
+                                            completion: @escaping (Result<Bool, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = UpdateAccountSettingsResultKey(siteID: siteID)
+            if let result = self.updateAccountSettings[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -638,6 +638,52 @@ final class ShippingLabelStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
+
+    // MARK: `updateShippingLabelAccountSettings`
+
+    func test_updateShippingLabelAccountSettings_returns_success_response() throws {
+        // Given
+        let settings = ShippingLabelAccountSettings.fake().copy()
+        let remote = MockShippingLabelRemote()
+        remote.whenUpdateShippingLabelAccountSettings(siteID: sampleSiteID,
+                                                      settings: settings,
+                                                      thenReturn: .success(true))
+        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = ShippingLabelAction.updateShippingLabelAccountSettings(siteID: self.sampleSiteID, settings: settings) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_updateShippingLabelAccountSettings_returns_error_on_failure() throws {
+        // Given
+        let settings = ShippingLabelAccountSettings.fake().copy()
+        let remote = MockShippingLabelRemote()
+        let expectedError = NetworkError.notFound
+        remote.whenUpdateShippingLabelAccountSettings(siteID: sampleSiteID,
+                                                      settings: settings,
+                                                      thenReturn: .failure(expectedError))
+        let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = ShippingLabelAction.updateShippingLabelAccountSettings(siteID: self.sampleSiteID, settings: settings) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
 }
 
 private extension ShippingLabelStoreTests {


### PR DESCRIPTION
Part of #4086 

## Description

After changing the payment method for shipping label purchases, we need to update the shipping label account settings remotely with those changes. The remote settings will then be used when making the purchase.

This PR adds support to the Networking and Yosemite layers for the endpoint used to update these settings (`POST /wc/v1/connect/account/settings`).

## Changes

* Adds `updateShippingLabelAccountSettings` to `ShippingLabelRemote` in the Networking layer. This takes the settings and sends the parameters that can be updated to remote.
* Adds  `updateShippingLabelAccountSettings` to `ShippingLabelAction` and `ShippingLabelStore` in the Yosemite layer. This updates the settings remotely and upserts the settings in Core Data when the remote update is successful.
* Makes `ShippingLabelAccountSettings` conform to `GeneratedCopiable` and adds a copiable method for use in unit tests.
* Updates Yosemite mocks in `MockShippingLabelRemote`.
* Adds Networking (Remote) unit tests and Yosemite (Store) unit tests.

## Testing

Check the code and confirm tests pass in CI (endpoint is not yet used in app).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.