### PR TITLE
[Mobile Payments] Set NSLocationDefaultAccuracyReduced to true

### DIFF
--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -66,7 +66,9 @@
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Bluetooth access is required in order to connect to supported card readers.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>This app uses Bluetooth to connect to supported card readers.</string>	
+	<string>This app uses Bluetooth to connect to supported card readers.</string>
+	<key>NSLocationDefaultAccuracyReduced</key>
+	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Noticons.ttf</string>


### PR DESCRIPTION
Closes #4316 

As suggested by Stripe, setting NSLocationDefaultAccuracyReduced to true would alter the location request performed by the Stripe Terminal SDK to reduce accuracy, which will not affect anything in terms of payments of authorizations.

## Changes
* Added NSLocationDefaultAccuracyReduced to Info.plist

## How to test
* Wait for CI. I will trigger a installable build as well to make sure everything is ok

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
