### PR TITLE
Add-ons: Allow product encoding to continue after add-ons decoding fail

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -385,7 +385,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
         let menuOrder = try container.decode(Int.self, forKey: .menuOrder)
 
-        let addOns = try container.decodeIfPresent(ProductAddOnEnvelope.self, forKey: .metadata)?.revolve() ?? []
+        // In some isolated cases, it appears to be some malformed meta-data that causes this line to throw hence the whole product decoding to throw.
+        // Since add-ons are optional, `try?` will be used to prevent the whole decoding to stop.
+        // https://github.com/woocommerce/woocommerce-ios/issues/4205
+        let addOns = (try? container.decodeIfPresent(ProductAddOnEnvelope.self, forKey: .metadata)?.revolve()) ?? []
 
         self.init(siteID: siteID,
                   productID: productID,


### PR DESCRIPTION
# Why

#4279 fixed a crash when parsing add-ons with malformed metadata, but I just realized that while that prevents the crash, it also prevents the products list to successfully continue its decoding, which results in an empty screen for the user.

Since add-ons is an optional plugin and the feature is behind a beta toggle, this PR makes sure that even if the add-on encoding fails, the product encoding will continue.

# Testing steps
- Run the app and see that the product list is displayed normally.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
