### PR TITLE
[Mobile Payments] Allow usage of simulated card reader on debug builds

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -68,10 +68,12 @@ extension StripeCardReaderService: CardReaderService {
 
         let config = DiscoveryConfiguration(
             discoveryMethod: .bluetoothProximity,
-            simulated: false
+            simulated: shouldUseSimulatedCardReader
         )
 
-        guard CBCentralManager.authorization != .denied else {
+        // If we're using the simulated reader, we don't want to check for Bluetooth permissions
+        // as the simulator won't have Bluetooth available.
+        guard shouldUseSimulatedCardReader || CBCentralManager.authorization != .denied else {
             throw CardReaderServiceError.bluetoothDenied
         }
 
@@ -503,5 +505,17 @@ private extension StripeCardReaderService {
 private extension StripeCardReaderService {
     func internalError(_ error: Error) {
         // Empty for now. Will be implemented later
+    }
+}
+
+// MARK: - Debugging configuration
+//
+private extension StripeCardReaderService {
+    var shouldUseSimulatedCardReader: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.arguments.contains("-simulate-stripe-card-reader")
+        #else
+        return false
+        #endif
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -124,6 +124,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-simulate-stripe-card-reader"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-force-crash-logging 1"
             isEnabled = "NO">
          </CommandLineArgument>


### PR DESCRIPTION
Fixes #4323

This makes possible to use a simulated card reader again, which was broken when we implemented Bluetooth authorization checks.

I introduce a new `-simulate-stripe-card-reader` launch argument that you can toggle when editing the scheme on Xcode:
![Screen Shot 2021-05-31 at 11 45 16](https://user-images.githubusercontent.com/8739/120174916-eeaef300-c205-11eb-8a2f-faf30eff1be6.png)

When the app uses the simulated reader, it won't check for bluetooth permissions.

## To test

1. On a device with bluetooth permission denied, and `-simulate-stripe-card-reader` disabled, trying to connect to a reader should show an error about Bluetooth permission.
2. On a device with bluetooth permission denied, and `-simulate-stripe-card-reader` enabled, trying to connect to a reader should let you connect to a simulated reader.
3. On a device with bluetooth permission allowed, and `-simulate-stripe-card-reader` disabled, trying to connect to a reader should let you to connect to a physical reader.
4. On a device with bluetooth permission allowed, and `-simulate-stripe-card-reader` enabled, trying to connect to a reader should let you connect to a simulated reader.
5. On a simulator with `-simulate-stripe-card-reader` disabled, trying to connect to a reader should show an error about Bluetooth not being available.
6. On a simulator with `-simulate-stripe-card-reader` enabled, trying to connect to a reader should let you connect to a simulated reader.

1 | 2 | 3 | 4 | 5 | 6 
-|-|-|-|-|-
![1](https://user-images.githubusercontent.com/8739/120176001-12bf0400-c207-11eb-8c05-34ce88dea292.png)|![2](https://user-images.githubusercontent.com/8739/120176008-1488c780-c207-11eb-82c9-81455294e849.png)|![3](https://user-images.githubusercontent.com/8739/120176010-15215e00-c207-11eb-8480-c67faa7d2346.png)|![4](https://user-images.githubusercontent.com/8739/120176013-15b9f480-c207-11eb-959f-d1f97392f2ee.png)|![5](https://user-images.githubusercontent.com/8739/120176298-66315200-c207-11eb-8f73-db5e3f1cdde6.png)|![6](https://user-images.githubusercontent.com/8739/120176017-16eb2180-c207-11eb-9d95-b9d9fc0daa75.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
