### PR TITLE
[Mobile Payments] Fix Tapping "Keep Searching" when discovering readers dismisses the modal and nothing else happens

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
@@ -35,13 +35,13 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        connectAction()
-        viewController?.dismiss(animated: true, completion: nil)
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.connectAction()
+        })
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         continueSearchAction()
-        viewController?.dismiss(animated: true, completion: nil)
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalFoundReaderTests.swift
@@ -49,7 +49,7 @@ final class CardPresentModalFoundReaderTests: XCTestCase {
     }
 
     func test_primary_button_action_calls_closure() {
-        viewModel.didTapPrimaryButton(in: nil)
+        viewModel.didTapPrimaryButton(in: UIViewController())
 
         XCTAssertTrue(closures.didTapConnect)
     }


### PR DESCRIPTION
Closes #4330 

This is an issue I found today while taking screenshots for the UI review.

In a nutshell, the "Keep Searching" functionality when discovering readers does not work, partially because a UI glitch, and partially because it is not fully implemented.

This PR solves the UI side of it. #4333 should take care of the rest.


https://user-images.githubusercontent.com/2722505/120240903-b6240f00-c22f-11eb-8f59-d870f1dc5195.MP4

## Changes
* Call completion block on primary block after dismissal has been completed.
* Do not dismiss on secondary button. That makes possible to launch the discovery UI again.

## How to test
* Build and run on device.
* Navigate to settings > Manage Card Readers
* Tap Connect Card Reader
* When a reader is found, tap "Keep Searching"
* A new modal "searching readers would be presented". This is the correct UI, but it is not actually searching for other readers (that's what #4333 should solve)
* Tap Cancel in the modal.
* Tap Connect Card Reader again.
* When a new card reader is discovered, tap "Connect" and it should work


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
