### PR TITLE
[Mobile Payments] Only show the option to email a receipt if the device can send email

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+/// Modal presented when the payment has been collected successfully
+final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewModel {
+
+    /// Amount charged
+    private let amount: String
+
+    /// Closure to execute when primary button is tapped
+    private let printReceiptAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .noBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String = Localization.paymentSuccessful
+
+    var topSubtitle: String? {
+        amount
+    }
+
+    let image: UIImage = .celebrationImage
+
+    let primaryButtonTitle: String? = Localization.printReceipt
+
+    let secondaryButtonTitle: String? = Localization.noThanks
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    init(amount: String, printReceipt: @escaping () -> Void) {
+        self.amount = amount
+        self.printReceiptAction = printReceipt
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.printReceiptAction()
+        })
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true)
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {}
+}
+
+private extension CardPresentModalSuccessWithoutEmail {
+    enum Localization {
+        static let paymentSuccessful = NSLocalizedString(
+            "Payment successful",
+            comment: "Label informing users that the payment succeeded. Presented to users when a payment is collected"
+        )
+
+        static let printReceipt = NSLocalizedString(
+            "Print receipt",
+            comment: "Button to print receipts. Presented to users after a payment has been successfully collected"
+        )
+
+        static let noThanks = NSLocalizedString(
+            "No thanks",
+            comment: "Button to dismiss modal overlay. Presented to users after a payment has been successfully collected"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -1,3 +1,4 @@
+import MessageUI
 import UIKit
 import WordPressUI
 
@@ -88,7 +89,11 @@ private extension OrderDetailsPaymentAlerts {
     }
 
     func successViewModel(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalSuccess(amount: amount, printReceipt: printReceipt, emailReceipt: emailReceipt)
+        if MFMailComposeViewController.canSendMail() {
+            return CardPresentModalSuccess(amount: amount, printReceipt: printReceipt, emailReceipt: emailReceipt)
+        } else {
+            return CardPresentModalSuccessWithoutEmail(amount: amount, printReceipt: printReceipt)
+        }
     }
 
     func errorViewModel(amount: String, error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
+		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
@@ -2465,6 +2466,7 @@
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
+		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
@@ -5690,6 +5692,7 @@
 				D8815B0026385E3F00EDAD62 /* CardPresentModalTapCard.swift */,
 				D8815B062638606B00EDAD62 /* CardPresentModalRemoveCard.swift */,
 				D8815B0C263861A400EDAD62 /* CardPresentModalSuccess.swift */,
+				E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */,
 				D8815B122638686200EDAD62 /* CardPresentModalError.swift */,
 				D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */,
 				D85806282642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift */,
@@ -7061,6 +7064,7 @@
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
+				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1190,6 +1190,7 @@
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
+		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
@@ -2467,6 +2468,7 @@
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
+		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
@@ -5599,6 +5601,7 @@
 				D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */,
 				D802547726551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift */,
 				D802547C26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift */,
+				E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */,
 				D80254812655267A001B2CC1 /* CardPresentModalErrorTests.swift */,
 				D802548626552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift */,
 				D802548B26552F41001B2CC1 /* CardPresentModalProcessingTests.swift */,
@@ -7275,6 +7278,7 @@
 				0236BCA425087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift in Sources */,
 				0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
+				E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
 				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
+    private var viewModel: CardPresentModalSuccessWithoutEmail!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalSuccessWithoutEmail(amount: Expectations.amount, printReceipt: closures.printReceipt())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_provides_expected_title() {
+        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_nil() {
+        XCTAssertNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: UIViewController())
+
+        XCTAssertTrue(closures.didTapPrint)
+    }
+}
+
+
+private extension CardPresentModalSuccessWithoutEmailTests {
+    enum Expectations {
+        static var amount = "amount"
+        static var image = UIImage.celebrationImage
+    }
+}
+
+
+private final class Closures {
+    var didTapPrint = false
+
+    func printReceipt() -> () -> Void {
+        return { [weak self] in
+            self?.didTapPrint = true
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4225 

This will check whether the device can send mail before showing the option to email a receipt, which would silently fail before.

Instead of adding more complicated logic to `CardPresentModalSuccess`, I've created a new `CardPresentModalSuccessWithoutEmail` with two buttons.

## To test

The easiest way to test this is to go to System Settings > Mail, and temporarily disable all your email accounts. Then try to collect a payment. At the end of the successful payment, it should look like this:

With email available | With no email
-|-
![Screen Shot 2021-06-01 at 12 02 53](https://user-images.githubusercontent.com/8739/120306277-fc31af00-c2d1-11eb-9a9d-0d32dbba994e.png)|![Screen Shot 2021-06-01 at 12 02 17](https://user-images.githubusercontent.com/8739/120306328-09e73480-c2d2-11eb-98d0-c03c57fc967c.png)

The "No thanks" button should dismiss the modal in both cases, and the "Email receipt" should show the email composer with the receipt:

<img src="https://user-images.githubusercontent.com/8739/120306458-2b482080-c2d2-11eb-83b1-8835da8aa8e1.png" width="400">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
