### PR TITLE
Move release note for virtual product creation to 6.8 release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,11 +8,11 @@
 -----
 
 - [***] Dropped iOS 13 support. From now we support iOS 14 and later. [https://github.com/woocommerce/woocommerce-ios/pull/4209]
+- [**] Products: Added the option to create and edit a virtual product directly from the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/4214]
 
 6.7
 -----
 - [**] Add-Ons: Order add-ons are now available as a beta feature. To try it, enable it from settings! [https://github.com/woocommerce/woocommerce-ios/pull/4119]
-- [**] Products: Added the option to create and edit a virtual product directly from the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/4214]
 
 6.6
 -----


### PR DESCRIPTION
The change in https://github.com/woocommerce/woocommerce-ios/pull/4214 was part of release 6.8, but I accidentally put the release note under 6.7. This moves the release note to 6.8 to ensure these release notes are accurate, for future reference. (The release notes going out with the 6.8 release are already updated, internal ref: p91TBi-5fe-p2.)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.