### PR TITLE
[Mobile Payments] Restart reader discovery when tapping "Keep Searching"

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -121,7 +121,7 @@ extension StripeCardReaderService: CardReaderService {
             self?.discoveryCancellable?.cancel { [weak self] error in
                 // Horrible, terrible workaround.
                 // And yet, it is the classic "dispatch to the next run cycle".
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     guard let error = error else {
                         self?.switchStatusToIdle()
                         return promise(.success(()))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -81,6 +81,8 @@ private extension CardReaderSettingsUnknownViewController {
             showFoundReaderModal()
         case .failed(let error):
             showDiscoveryErrorModal(error: error)
+        case .cancellingSearch:
+            showSearchingModal()
         default:
             dismissAnyModal()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -81,7 +81,7 @@ private extension CardReaderSettingsUnknownViewController {
             showFoundReaderModal()
         case .failed(let error):
             showDiscoveryErrorModal(error: error)
-        case .cancellingSearch:
+        case .restartingSearch:
             showSearchingModal()
         default:
             dismissAnyModal()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -146,7 +146,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     /// we will restart the discovery process again
     func continueSearch() {
         foundReader = nil
-        discoveryState = .cancellingSearch
+        discoveryState = .restartingSearch
         cancelReaderDiscovery { [weak self] in
             self?.startReaderDiscovery()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -7,7 +7,7 @@ enum CardReaderSettingsUnknownViewModelDiscoveryState {
     case failed(Error)
     case foundReader
     case connectingToReader
-    case cancellingSearch
+    case restartingSearch
 }
 
 final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -148,16 +148,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         foundReader = nil
         discoveryState = .cancellingSearch
         cancelReaderDiscovery { [weak self] in
-            // Horrible, terrible workaround.
-            // And yet, it is the classic "dispatch to the next run cycle".
-            // It looks like the Terminal SDK signals that the discovery process has
-            // been cancelled when the SDK has not completely transitioned to an idle state.
-            // If we call startReaderDiscovery inmediately, the SDK will fire an error
-            // because the reader is busy with the first discovery operation (the one that
-            // it has signaled as cancelled)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self?.startReaderDiscovery()
-            }
+            self?.startReaderDiscovery()
         }
     }
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -94,7 +94,6 @@ private extension CardPresentPaymentStore {
                     case .failure(let error):
                         onError(error)
                     }
-                    print("completion")
                 },
                 receiveValue: onReaderDiscovered
             ))


### PR DESCRIPTION
Closes #4338

This is the continuation to #4334. If that PR took care of the UI side of the issue with the "Keep Searching" button, this PR, after discussing the scope for the "Keep Searching" button for beta 1 (p91TBi-5fB-p2#comment-4849) introduces the following change:

## Changes
* Keep Searching now triggers a restart of the reader discovery process. That means that it first cancel the previous discovery, and then starts a new one. Which has turned out to be fun because there seems to be something a bit off in the Terminal SDK hen it comes to discovery cancellation: the completion block that signals that cancellation is completed seems to be executed before the SDK has actually transitioned to an idle state.
* I added a good old "dispatch to the next cycle" to what happens when the Terminal SDK executes the completion block for the cancellation of the discovery process. There might be a more Combine-est way to do that, but I have no shame 🤷🏼 

## How to test
This one is tricky because I have only one reader. I assume that if it works with one reader, it does not matter which reader it is.

Testing requires:

1. Setting up a store for Card Present Payment Testing (also P91TBi-4BH-p2 for more specific instructions)
2. WCPay 2.4.0

It should not matter if this is tested on device or on the simulator, but it would be better to test on device and with an actual reader.

1. Navigate to Settings > Manage Card Readers
2. Tap Connect to Card Reader
3. When a reader is discovered, tap Keep Searching. 
4. The modal UI should transition to the "searching readers" state
5. After a while, the app should find a new reader
6. At this point, tap either Connect (and the app should connect to the reader, and it should be possible to capture a payment) or Keep Searching again, which would take you back to step 4
7. At any moment in the process, feel free to tap Cancel and start again. Things should still work
8. Also, once a connection to a reader is completed, try disconnecting from it and going back to step 2.

Fun times.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
