### PR TITLE
[Mobile Payments] Scale down button labels when text doesn't fit

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -116,14 +116,19 @@ private extension CardPresentPaymentsModalViewController {
 
     func stylePrimaryButton() {
         primaryButton.isPrimary = true
+        primaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        primaryButton.titleLabel?.minimumScaleFactor = 0.5
     }
 
     func styleSecondaryButton() {
-
+        secondaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        secondaryButton.titleLabel?.minimumScaleFactor = 0.5
     }
 
     func styleAuxiliaryButton() {
         auxiliaryButton.applyLinkButtonStyle()
+        auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
     }
 
     func populateContent() {


### PR DESCRIPTION
Fixes #4222 

Similar to #4326, this allows the buttons in modals to reduce the font size by 50% at most so that the text can fit. I didn't see a way to do this for buttons directly from Interface Builder, so I did it with code.

## To test

To test this, I modified one of the modals to have some sample long text in the buttons. Then also tested the original payment failed modal in #4222 .

![4222](https://user-images.githubusercontent.com/8739/120462745-80039e00-c39b-11eb-936b-5e8ae33ed26b.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
