### PR TITLE
Shipping Labels: populated the total weight automatically in packages step

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -104,15 +104,18 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
             guard let self = self else { return }
             self.products = products
             self.itemsRows = self.generateItemsRows()
+            self.setTotalWeight()
         }, onProductVariationsReload: { [weak self] (productVariations) in
             guard let self = self else { return }
             self.productVariations = productVariations
             self.itemsRows = self.generateItemsRows()
+            self.setTotalWeight()
         })
 
         products = resultsControllers?.products ?? []
         productVariations = resultsControllers?.productVariations ?? []
         itemsRows = generateItemsRows()
+        setTotalWeight()
     }
 
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,
@@ -147,6 +150,31 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
             }
         }
         return itemsToFulfill
+    }
+
+    /// Set the total weight based on the weight of products and products variation inside the order items,
+    /// only if they are not virtual products.
+    ///
+    private func setTotalWeight() {
+        var tempTotalWeight: Double = 0
+
+        for item in orderItems {
+            let isVariation = item.variationID > 0
+            var product: Product?
+            var productVariation: ProductVariation?
+
+            if isVariation {
+                productVariation = productVariations.first { $0.productVariationID == item.variationID }
+            }
+            else {
+                product = products.first { $0.productID == item.productID }
+            }
+            if product?.virtual == false || productVariation?.virtual == false {
+                tempTotalWeight += Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
+            }
+        }
+
+        totalWeight = String(tempTotalWeight)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -156,6 +156,10 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// only if they are not virtual products.
     ///
     private func setTotalWeight() {
+        guard totalWeight.isEmpty else {
+            return
+        }
+
         var tempTotalWeight: Double = 0
 
         for item in orderItems {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -183,7 +183,7 @@ extension ShippingLabelPackageDetailsViewModel {
 
     // Return true if the done button in the package details screen should be enabled
     func isPackageDetailsDoneButtonEnabled() -> Bool {
-        return !selectedPackageID.isNilOrEmpty && totalWeight.isNotEmpty
+        return !selectedPackageID.isNilOrEmpty && totalWeight.isNotEmpty && Double(totalWeight) != 0 && Double(totalWeight) != nil
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -258,7 +258,44 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
     func test_totalWeight_returns_the_expected_value() {
         // Given
-        let expect = expectation(description: "totalWeight returns expected value")
+        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
+                     MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
+                     MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
+                     MockOrderItem.sampleItem(name: "Jeans",
+                                              productID: 49,
+                                              variationID: 49,
+                                              quantity: 1,
+                                              attributes: orderItemAttributes)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1"))
+        insert(ProductVariation.fake().copy(siteID: sampleSiteID,
+                                            productID: 49,
+                                            productVariationID: 49,
+                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
+
+
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: nil,
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "124.0")
+    }
+
+    func test_totalWeight_returns_the_expected_value_when_already_set() {
+        // Given
+        let expect = expectation(description: "totalWeight returns expected value when already set")
 
         let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
         let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
@@ -271,14 +308,6 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                               attributes: orderItemAttributes)]
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
-                                                             packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
-                                                             formatter: currencyFormatter,
-                                                             storageManager: storageManager,
-                                                             weightUnit: "kg")
-        XCTAssertEqual(viewModel.totalWeight, "0.0")
 
         // When
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123"))
@@ -289,9 +318,19 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                             productVariationID: 49,
                                             attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
 
+
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: "30",
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+        XCTAssertEqual(viewModel.totalWeight, "30")
+
         // Then
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertEqual(viewModel.totalWeight, "124.0")
+            XCTAssertEqual(viewModel.totalWeight, "30")
             expect.fulfill()
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -214,6 +214,48 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.isPackageDetailsDoneButtonEnabled())
     }
+
+    func test_totalWeight_returns_the_expected_value() {
+        // Given
+        let expect = expectation(description: "totalWeight returns expected value")
+
+        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
+                     MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
+                     MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
+                     MockOrderItem.sampleItem(name: "Jeans",
+                                              productID: 49,
+                                              variationID: 49,
+                                              quantity: 1,
+                                              attributes: orderItemAttributes)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: nil,
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+        XCTAssertEqual(viewModel.totalWeight, "0.0")
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1"))
+        insert(ProductVariation.fake().copy(siteID: sampleSiteID,
+                                            productID: 49,
+                                            productVariationID: 49,
+                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
+
+        // Then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            XCTAssertEqual(viewModel.totalWeight, "124.0")
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -215,6 +215,47 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isPackageDetailsDoneButtonEnabled())
     }
 
+    func test_isPackageDetailsDoneButtonEnabled_returns_the_expected_value_when_the_totalWeight_is_not_valid() {
+        // Given
+        let order = MockOrders().empty().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: nil,
+                                                             formatter: currencyFormatter,
+                                                             stores: stores,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+
+        // When
+        viewModel.totalWeight = "0"
+        viewModel.selectedPackageID = "sample-package"
+
+        // Then
+        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+
+        // When
+        viewModel.totalWeight = "0.0"
+
+        // Then
+        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+
+        // When
+        viewModel.totalWeight = "1..1"
+
+        // Then
+        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+
+        // When
+        viewModel.totalWeight = "test"
+
+        // Then
+        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+    }
+
     func test_totalWeight_returns_the_expected_value() {
         // Given
         let expect = expectation(description: "totalWeight returns expected value")


### PR DESCRIPTION
Fixes #4090 by fetching and populating the weight of the package for every item.

## Testing
1. Modify products and product variations by specifying different weights.
2. Create an order using these products, and make sure it satisfies the SL creation conditions.
3. Open the order in the app.
4. Click on Create Shipping Label.
5. Pass the origin and shipping addresses steps.
6. Open the package details screen.
7. Confirm that the shown "Total package weight" is the correct one.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/120478002-ae3da980-c3ac-11eb-9e92-7ef62c267cf6.png" width=300 />


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
