### PR TITLE
[Mobile Payments] Ensure we don't start another reader discovery process until the previous one is fully canceled

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -24,6 +24,9 @@ public final class StripeCardReaderService: NSObject {
     private var pendingSoftwareUpdate: ReaderSoftwareUpdate?
 
     private var activePaymentIntent: StripeTerminal.PaymentIntent? = nil
+
+    /// A lock to ensure that the service only initiates or cancels a discovery process at the same time
+    private let discoveryLock = NSLock()
 }
 
 
@@ -77,9 +80,18 @@ extension StripeCardReaderService: CardReaderService {
             throw CardReaderServiceError.bluetoothDenied
         }
 
-        switchStatusToDiscovering()
-
         Terminal.shared.delegate = self
+
+        // We're now ready to start discovery, but first we'll check that we're not starting or canceling
+        // another discovery process.
+        // If we can't grab a lock quickly, let's fail rather than wait indefinitely
+        guard discoveryLock.lock(before: Date().addingTimeInterval(1)) else {
+            throw CardReaderServiceError.discovery(underlyingError: .busy)
+        }
+        // We only want to lock while we start the process to make sure another start or cancel doesn't collide.
+        // The lock is released when we return from this method, when it will be OK to call cancel.
+        defer { discoveryLock.unlock() }
+        switchStatusToDiscovering()
 
         /**
          * https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)discoverReaders:delegate:completion:
@@ -108,8 +120,17 @@ extension StripeCardReaderService: CardReaderService {
              * discovering mode before attempting a cancellation
              *
              */
-            guard self?.discoveryStatusSubject.value == .discovering else {
+            guard let self = self,
+                  let discoveryCancellable = self.discoveryCancellable,
+                  self.discoveryStatusSubject.value == .discovering else {
                 return promise(.success(()))
+            }
+
+            // If all the previous checks are ok, and we are going to definitely cancel an existing
+            // cancelable, then we attempt to grab a lock on the discovery process.
+            // If it's not possible, then another start or cancel might be in progress, so we'll fail right away.
+            guard self.discoveryLock.lock(before: Date().addingTimeInterval(1)) else {
+                return promise(.failure(CardReaderServiceError.discovery(underlyingError: .busy)))
             }
 
             // The completion block for cancel, apparently, is called when
@@ -118,10 +139,12 @@ extension StripeCardReaderService: CardReaderService {
             // to start a second operation on the card reader.
             // (for example, starting an operation after discovery has been cancelled)
             //
-            self?.discoveryCancellable?.cancel { [weak self] error in
+            discoveryCancellable.cancel { [discoveryLock = self.discoveryLock, weak self] error in
                 // Horrible, terrible workaround.
                 // And yet, it is the classic "dispatch to the next run cycle".
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [discoveryLock] in
+                    // When we're done with the completion, we let go of the discovery lock
+                    defer { discoveryLock.unlock() }
                     guard let error = error else {
                         self?.switchStatusToIdle()
                         return promise(.success(()))

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequired.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequired.swift
@@ -2,7 +2,7 @@ import UIKit
 import Yosemite
 
 /// Modal presented on error
-final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
+final class CardPresentModalBluetoothRequired: CardPresentPaymentsModalViewModel {
 
     /// The error returned by the stack
     private let error: Error
@@ -11,17 +11,17 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     private let primaryAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .fullInfo
-    let actionsMode: PaymentsModalActionsMode = .oneAction
+    let actionsMode: PaymentsModalActionsMode = .twoAction
 
-    let topTitle: String = Localization.title
+    let topTitle: String = Localization.bluetoothRequired
 
     var topSubtitle: String? = nil
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.dismiss
+    let primaryButtonTitle: String? = Localization.openDeviceSettings
 
-    let secondaryButtonTitle: String? = nil
+    let secondaryButtonTitle: String? = Localization.dismiss
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -37,21 +37,31 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(targetURL)
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
         viewController?.dismiss(animated: true, completion: {[weak self] in
             self?.primaryAction()
         })
     }
 
-    func didTapSecondaryButton(in viewController: UIViewController?) { }
-
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-private extension CardPresentModalScanningFailed {
+private extension CardPresentModalBluetoothRequired {
     enum Localization {
-        static let title = NSLocalizedString(
-            "Connecting reader failed",
-            comment: "Title of the alert presented when the user tries to connect a Bluetooth card reader and it fails"
+        static let bluetoothRequired = NSLocalizedString(
+            "Bluetooth permission required",
+            comment: "Title of the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions"
+        )
+
+        static let openDeviceSettings = NSLocalizedString(
+            "Open Device Settings",
+            comment: "Opens iOS's Device Settings for the app"
         )
 
         static let dismiss = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -1,5 +1,5 @@
 import UIKit
-import Hardware
+import Yosemite
 import WordPressUI
 
 /// A layer of indirection between our card reader settings view controllers and the modal alerts

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Hardware
 import WordPressUI
 
 /// A layer of indirection between our card reader settings view controllers and the modal alerts
@@ -44,7 +45,12 @@ private extension CardReaderSettingsAlerts {
     }
 
     func scanningFailed(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalScanningFailed(error: error, primaryAction: close)
+        switch error {
+        case CardReaderServiceError.bluetoothDenied:
+            return CardPresentModalBluetoothRequired(error: error, primaryAction: close)
+        default:
+            return CardPresentModalScanningFailed(error: error, primaryAction: close)
+        }
     }
 
     func connectingToReader() -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1192,6 +1192,7 @@
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
+		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2470,6 +2471,7 @@
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
+		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -5703,6 +5705,7 @@
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
 				E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */,
+				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
@@ -6706,6 +6709,7 @@
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
+				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */,
 				0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1191,6 +1191,8 @@
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
+		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
+		E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
@@ -2470,6 +2472,8 @@
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
+		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
+		E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequiredTests.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
@@ -5610,6 +5614,8 @@
 				D802549026552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift */,
 				D8025495265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift */,
 				D802549A265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift */,
+				E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */,
+				E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7118,6 +7124,7 @@
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */,
+				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
@@ -7193,6 +7200,7 @@
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
+				E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */,
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequiredTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequiredTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalBluetoothRequiredTests: XCTestCase {
+    private var viewModel: CardPresentModalBluetoothRequired!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalBluetoothRequired(error: Expectations.error, primaryAction: closures.primaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+}
+
+
+private extension CardPresentModalBluetoothRequiredTests {
+    enum Expectations {
+        static let image = UIImage.paymentErrorImage
+        static let error = MockError()
+    }
+
+    final class MockError: Error {
+        var localizedDescription: String {
+            "description"
+        }
+    }
+}
+
+
+private final class Closures {
+    var didTapPrimary = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapPrimary = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalScanningFailedTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalScanningFailedTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalScanningFailedTests: XCTestCase {
+    private var viewModel: CardPresentModalScanningFailed!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalScanningFailed(error: Expectations.error, primaryAction: closures.primaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_nil() {
+        XCTAssertNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_bottom_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+}
+
+
+private extension CardPresentModalScanningFailedTests {
+    enum Expectations {
+        static let image = UIImage.paymentErrorImage
+        static let error = MockError()
+    }
+
+    final class MockError: Error {
+        var localizedDescription: String {
+            "description"
+        }
+    }
+}
+
+
+private final class Closures {
+    var didTapPrimary = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapPrimary = true
+        }
+    }
+}


### PR DESCRIPTION
Part of #4338 

After #4339, I started noticing that sometimes if you start discovering readers and cancel, the app gets into a broken state where it says it can't start discovering readers because it's already discovering readers. On top of that, the error alert had "Bluetooth permission required" as the title.

To reproduce the issue, it's a bit hit and miss, but cancel a search in progress and try to start a new one within a second.

https://user-images.githubusercontent.com/8739/120641526-fa075600-c473-11eb-9adb-ea52d8d89c58.mp4

## How

#4339 introduced a delayed call to completion to give `StripeTerminal` enough time to clean up its internal state. However, the UI doesn't wait for this and optimistically dismisses the modal immediately, leaving the option to tap on "Connect Card Reader" while the previous cancelation is still in progress.

Internally, the discovery cancelation happens fairly quickly, but since we have a 1 second delay, you can reach a scenario where the user taps start, the discovery process starts successfully because Stripe's internal state is cleared already, and then a second later, the completion block for cancelation triggers and sets the service's state to `idle`.

To avoid this issue, I've introduced a lock to make sure we only start a process if we're not canceling one, and vice versa. Instead of waiting indefinitely, there's a 1 second timeout, so there's still a chance of the app complaining that it's busy if the user tries to start too quickly, but at least dismissing that alert and trying again will work.

Finally, I've updated the modal alerts to handle Bluetooth permissions and other errors separately.

Bluetooth error | Other error
-|-
![Screen Shot 2021-06-03 at 14 07 16](https://user-images.githubusercontent.com/8739/120642306-04761f80-c475-11eb-9b39-98d4c21ba70f.png)|![Screen Shot 2021-06-03 at 14 06 46](https://user-images.githubusercontent.com/8739/120642246-f2947c80-c474-11eb-9369-951c1d38e59c.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
