### PR TITLE
[Mobile Payments] Improve UI to retry failed payments

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -13,7 +13,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     private let primaryAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .oneAction
+    let actionsMode: PaymentsModalActionsMode = .twoAction
 
     let topTitle: String = Localization.paymentFailed
 
@@ -25,7 +25,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let primaryButtonTitle: String? = Localization.tryAgain
 
-    let secondaryButtonTitle: String? = nil
+    let secondaryButtonTitle: String? = Localization.noThanks
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -47,7 +47,9 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
         })
     }
 
-    func didTapSecondaryButton(in viewController: UIViewController?) { }
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true, completion: nil)
+    }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
@@ -62,6 +64,11 @@ private extension CardPresentModalError {
         static let tryAgain = NSLocalizedString(
             "Try collecting payment again",
             comment: "Button to try to collect a payment again. Presented to users after a collecting a payment fails"
+        )
+
+        static let noThanks = NSLocalizedString(
+            "No thanks",
+            comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -33,8 +33,8 @@ final class CardPresentModalErrorTests: XCTestCase {
         XCTAssertNotNil(viewModel.primaryButtonTitle)
     }
 
-    func test_secondary_button_title_is_nil() {
-        XCTAssertNil(viewModel.secondaryButtonTitle)
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
     }
 
     func test_bottom_title_is_not_nil() {


### PR DESCRIPTION
Fixes #4227 

I started trying to add a "No thanks" button to the payment error alert, but soon noticed that the try again button was not working. I tested this with an order amount ending in `.75`, which simulates the payment being declined by the payment processor.

It looks like the retry operation was trying to cancel any payment in progress before starting again, but the callback method on `paymentCancellable.cancel` was not being called, presumably because the payment collection was completed successfully and the error came on the `processPayment` stage.

With this PR, the `paymentCancellable` is cleared when `collectPaymentMethod` completes, and `cancelPaymentIntent` will only cancel the payment intent if there is no `paymentCancellable` to cancel. The [documentation](https://stripe.com/docs/api/payment_intents/cancel) says:

> A PaymentIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, or requires_action.

In my testing, the active intent had the `requires_payment_method` status, which I understand it means we should be canceling it, but I still get confused around payment intents and collection, so I could use a second opinion here.

Besides that, I modified the alert to show the "No thanks" button to dismiss, now that the retry button would get you into an infinite loop.

<img src="https://user-images.githubusercontent.com/8739/120671147-647abf00-c491-11eb-9b2d-29af2d643d09.png" width="450">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
