### PR TITLE
Variations: Final touches

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.9
 -----
-
+- [*] Products: You can edit product attributes for variations right from the main product form. [https://github.com/woocommerce/woocommerce-ios/pull/4350]
 
 6.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -612,7 +612,7 @@ private extension DefaultProductFormTableViewModel {
 
         // No price warning row
         static let noPriceWarningTitle =
-            NSLocalizedString("Variations without price won’t be shown in your store",
+            NSLocalizedString("Add price to your variations to make them visible on your store",
                               comment: "Title of the no price warning row on Product Variation main screen when a variation is enabled without a price")
 
         // Downloadable files

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -360,7 +360,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 let variationsViewModel = ProductVariationsViewModel(formType: viewModel.formType)
-                let variationsViewController = ProductVariationsViewController(viewModel: variationsViewModel,
+                let variationsViewController = ProductVariationsViewController(initialViewController: self,
+                                                                               viewModel: variationsViewModel,
                                                                                product: originalProduct.product)
                 variationsViewController.onProductUpdate = { [viewModel] updatedProduct in
                     viewModel.updateProductVariations(from: updatedProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
@@ -22,7 +22,7 @@ private extension ProductVariationsTopBannerFactory {
     enum Localization {
         static let title = NSLocalizedString("Some variations do not have prices",
                                              comment: "Banner title in product variation list top banner when some variations do not have a price")
-        static let info = NSLocalizedString("Variations without price will not be shown in your store.",
+        static let info = NSLocalizedString("Add price to your variations to make them visible on your store",
                                             comment: "Banner caption in my store when the stats will be deprecated")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -110,14 +110,20 @@ final class ProductVariationsViewController: UIViewController {
     private let noticePresenter: NoticePresenter
     private let analytics: Analytics
 
+    /// ViewController that pushed `self`. Needed in order to go back to it when the first variation is created.
+    ///
+    private weak var initialViewController: UIViewController?
+
     /// Assign this closure to get notified when the underlying product changes due to new variations or new attributes.
     ///
     var onProductUpdate: ((Product) -> Void)?
 
-    init(viewModel: ProductVariationsViewModel,
+    init(initialViewController: UIViewController,
+         viewModel: ProductVariationsViewModel,
          product: Product,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          analytics: Analytics = ServiceLocator.analytics) {
+        self.initialViewController = initialViewController
         self.product = product
         self.viewModel = viewModel
         self.noticePresenter = noticePresenter
@@ -497,7 +503,7 @@ private extension ProductVariationsViewController {
         let editAttributeViewController = EditAttributesViewController(viewModel: editAttributesViewModel)
         editAttributeViewController.onVariationCreation = { [weak self] updatedProduct in
             self?.product = updatedProduct
-            navigationController.popViewController(animated: true)
+            self?.onFirstVariationCreated()
         }
         editAttributeViewController.onAttributesUpdate = { [weak self] updatedProduct in
             guard let self = self else { return }
@@ -523,6 +529,16 @@ private extension ProductVariationsViewController {
 
         let viewControllerToShow = allAttributes.isNotEmpty ? editAttributesViewController : self
         navigationController?.popToViewController(viewControllerToShow, animated: true)
+    }
+
+    /// Navigates back to the `initialViewController` if possible. If not possible, pop `self`.
+    ///
+    private func onFirstVariationCreated() {
+        guard let initialViewController = initialViewController else {
+            navigationController?.popViewController(animated: true)
+            return
+        }
+        navigationController?.popToViewController(initialViewController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -531,9 +531,11 @@ private extension ProductVariationsViewController {
         navigationController?.popToViewController(viewControllerToShow, animated: true)
     }
 
-    /// Navigates back to the `initialViewController` if possible. If not possible, pop `self`.
+    /// Presents a notice alerting that the variation was created and navigates back to the `initialViewController` if possible.
     ///
     private func onFirstVariationCreated() {
+        noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))
+
         guard let initialViewController = initialViewController else {
             navigationController?.popViewController(animated: true)
             return
@@ -745,5 +747,6 @@ private extension ProductVariationsViewController {
                                                         comment: "Instructions for the progress screen while generating a variation")
         static let generateVariationError = NSLocalizedString("The variation couldn't be generated.",
                                                               comment: "Error title when failing to generate a variation.")
+        static let variationCreated = NSLocalizedString("Variation created", comment: "Text for the notice after creating the first variation.")
     }
 }


### PR DESCRIPTION
closes #4313 

# Why

To make the variation flow simpler, we have extracted the product attributes section out of the variations list screen.

This PR adds some final details to conclude that piece of work.

# How

- Navigate back to the product form screen after creating the first variation.

- Show success notice after the first variation is created.

- Use the same copy for all of the "no price" warnings.

# Demo

https://user-images.githubusercontent.com/562080/120679147-7858fd80-c45e-11eb-9d56-75cbaa814e43.mov

# Testing Steps

- Launch the app and create a new variable product.
- Tap on the "Add variation" row and create your first variation.
- See that you are redirected back to the product form screen.
- See that the "Add variations" row is updated with the new variation information.
- See that there is a new "Variation Attributes" row.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
