### PR TITLE
Address validation banner now is shown at full height after tapping Done button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -163,7 +163,6 @@ private extension ShippingLabelAddressFormViewController {
 
         topBannerView.removeFromSuperview()
         tableView.tableHeaderView = nil
-        tableView.updateHeaderHeight()
     }
 
     func configureConfirmButton() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -52,13 +52,11 @@ final class ShippingLabelAddressFormViewController: UIViewController {
 
     /// Init
     ///
-    init(
-        siteID: Int64,
-        type: ShipType,
-        address: ShippingLabelAddress?,
-        validationError: ShippingLabelAddressValidationError?,
-        completion: @escaping Completion
-    ) {
+    init(siteID: Int64,
+         type: ShipType,
+         address: ShippingLabelAddress?,
+         validationError: ShippingLabelAddressValidationError?,
+         completion: @escaping Completion ) {
         viewModel = ShippingLabelAddressFormViewModel(siteID: siteID, type: type, address: address, validationError: validationError)
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
@@ -122,14 +120,6 @@ private extension ShippingLabelAddressFormViewController {
         registerTableViewCells()
 
         tableView.dataSource = self
-
-        // Configure header container view
-        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
-        headerContainer.addSubview(topStackView)
-        headerContainer.pinSubviewToSafeArea(topStackView)
-        topStackView.addArrangedSubview(topBannerView)
-
-        tableView.tableHeaderView = headerContainer
     }
 
     func registerTableViewCells() {
@@ -147,7 +137,32 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func updateTopBannerView() {
-        topBannerView.isHidden = !viewModel.shouldShowTopBannerView
+        if !viewModel.shouldShowTopBannerView {
+            hideTopBannerView()
+        }
+        else {
+            displayTopBannerView()
+        }
+    }
+
+    func displayTopBannerView() {
+        // Configure header container view
+        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
+        headerContainer.addSubview(topStackView)
+        headerContainer.pinSubviewToSafeArea(topStackView)
+        topStackView.addArrangedSubview(topBannerView)
+
+        tableView.tableHeaderView = headerContainer
+        tableView.updateHeaderHeight()
+    }
+
+    func hideTopBannerView() {
+        guard tableView.tableHeaderView != nil else {
+            return
+        }
+
+        topBannerView.removeFromSuperview()
+        tableView.tableHeaderView = nil
         tableView.updateHeaderHeight()
     }
 
@@ -475,9 +490,5 @@ private extension ShippingLabelAddressFormViewController {
                                                             comment: "Error in finding the address in the Shipping Label Address Validation in Apple Maps")
         static let phoneNumberErrorNotice = NSLocalizedString("The phone number is not valid or you can't call the customer from this device.",
             comment: "Error in calling the phone number of the customer in the Shipping Label Address Validation")
-    }
-
-    enum Constants {
-        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
 }


### PR DESCRIPTION
Fixes #4095

## Description
Previously, if you edit the address under shipping labels (using an address that can't be validated), and tap Done, the address validation banner only displays as a single line with the text cut off. Now will be shown at full height.

## Testing
1. Start with an order that has an address that can't be automatically validated. An easy way to test this is with an order that doesn't have a shipping address set at all.
2. On the Orders tab, open the order details.
3. Press the button "Create Shipping Label".
4. Press the button "Continue" in Create Shipping Label form, under the `Ship From` cell. Confirm the address.
5. Press the button "Continue" in Create Shipping Label form, under the `Ship To` cell. This should open a screen to edit the address, with the validation banner displayed as expected.
6. Enter the required address details, but again use an address that can't be automatically validated.
7. Tap Done. Notice that the address validation banner appears again, at full height.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
