### PR TITLE
[Mobile Payments] Apply headline style to title in all modals

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -82,7 +82,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleTopTitle() {
-        topTitleLabel.applyBodyStyle()
+        topTitleLabel.applyHeadlineStyle()
     }
 
     func styleTopSubtitle() {


### PR DESCRIPTION
Closes #4331 

The cancel button will be tackled in #4364 

The fix is applied to al modals. To illustrate the change, I added just two screenshots.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/120698605-43a86e80-c47d-11eb-9124-c6fec8fd9414.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/120698607-44410500-c47d-11eb-8401-49e81ead597a.png" width="350"/> | 
| <img src="https://user-images.githubusercontent.com/2722505/120698642-4f943080-c47d-11eb-861d-3bf82414f6ae.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/120698644-4f943080-c47d-11eb-88e3-783c268288ee.png" width="350"/> | 


## Changes
* Apply headline style to modal title

## How to test
* Navigate to any part of the payment process that displays a modal (for example, connecting to a reader). Notice the style of the primary title



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
