### PR TITLE
[Mobile Payments] Update height of buttons in modal alert

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -68,6 +68,37 @@ extension UIButton {
         setBackgroundImage(disabledBackgroundImage, for: .disabled)
     }
 
+    /// Applies the Secondary Button Style: Solid BG, always light!
+    ///
+    func applySecondaryLightButtonStyle() {
+        contentEdgeInsets = Style.defaultEdgeInsets
+        layer.borderColor = UIColor.primaryButtonBorder.cgColor
+        layer.borderWidth = Style.defaultBorderWidth
+        layer.cornerRadius = Style.defaultCornerRadius
+        titleLabel?.applyHeadlineStyle()
+        enableMultipleLines()
+        titleLabel?.textAlignment = .center
+
+        setTitleColor(.black, for: .normal)
+        setTitleColor(.black, for: .highlighted)
+        setTitleColor(.buttonDisabledTitle, for: .disabled)
+
+        let normalBackgroundImage = UIImage.renderBackgroundImage(fill: .secondaryLightButtonBackground,
+                                                                  border: .secondaryLightButtonBackground)
+            .applyTintColorToiOS13(.secondaryLightButtonBackground)
+        setBackgroundImage(normalBackgroundImage, for: .normal)
+
+        let highlightedBackgroundImage = UIImage.renderBackgroundImage(fill: .primaryButtonDownBackground,
+                                                                       border: .primaryButtonDownBorder)
+            .applyTintColorToiOS13(.primaryButtonDownBackground)
+        setBackgroundImage(highlightedBackgroundImage, for: .highlighted)
+
+        let disabledBackgroundImage = UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
+                                                                    border: .buttonDisabledBorder)
+            .applyTintColorToiOS13(.buttonDisabledBorder) // Use border as tint color since the background is clear
+        setBackgroundImage(disabledBackgroundImage, for: .disabled)
+    }
+
     /// Applies the Link Button Style: Clear BG / Brand Text Color
     ///
     func applyLinkButtonStyle() {

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -224,6 +224,10 @@ extension UIColor {
         return .systemColor(.systemGray3)
     }
 
+    /// Secondary Light Button Background.
+    ///
+    static var secondaryLightButtonBackground: UIColor = .white
+
     /// Button Disabled Background.
     ///
     static var buttonDisabledBackground: UIColor {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -15,8 +15,8 @@ final class CardPresentPaymentsModalViewController: UIViewController {
     @IBOutlet private weak var bottomTitleLabel: UILabel!
     @IBOutlet private weak var bottomSubtitleLabel: UILabel!
 
-    @IBOutlet private weak var primaryButton: NUXButton!
-    @IBOutlet private weak var secondaryButton: NUXButton!
+    @IBOutlet private weak var primaryButton: UIButton!
+    @IBOutlet private weak var secondaryButton: UIButton!
     @IBOutlet weak var auxiliaryButton: UIButton!
 
     @IBOutlet private weak var imageView: UIImageView!
@@ -115,12 +115,13 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func stylePrimaryButton() {
-        primaryButton.isPrimary = true
+        primaryButton.applyPrimaryButtonStyle()
         primaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         primaryButton.titleLabel?.minimumScaleFactor = 0.5
     }
 
     func styleSecondaryButton() {
+        secondaryButton.applySecondaryLightButtonStyle()
         secondaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         secondaryButton.titleLabel?.minimumScaleFactor = 0.5
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -79,9 +79,9 @@
                                             <rect key="frame" x="16" y="20" width="280" height="170"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="50"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="50" id="Gcd-Af-CS9"/>
+                                                        <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                     <state key="normal" title="Primary Action Button">
@@ -92,9 +92,9 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                                    <rect key="frame" x="0.0" y="70" width="280" height="50"/>
+                                                    <rect key="frame" x="0.0" y="60" width="280" height="40"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="50" id="ju1-aE-m26"/>
+                                                        <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                     <state key="normal" title="Secondary Action Button">
@@ -105,7 +105,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="140" width="280" height="30"/>
+                                                    <rect key="frame" x="0.0" y="120" width="280" height="50"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -78,12 +78,12 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
                                             <rect key="frame" x="16" y="20" width="280" height="170"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
                                                     <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                     <state key="normal" title="Primary Action Button">
                                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </state>
@@ -91,12 +91,12 @@
                                                         <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
                                                     <rect key="frame" x="0.0" y="60" width="280" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                     <state key="normal" title="Secondary Action Button">
                                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </state>


### PR DESCRIPTION
Closes #4359 

The style of the alert button is deferred to #4364 

The new height of the buttons is applied to all the modal, but just to illustrate the changes, here are two screenshots:

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/120699897-0513b380-c47f-11eb-9c0a-009142f2041a.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/120699899-05ac4a00-c47f-11eb-8fdf-c7ecbe6c3130.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/120699945-1230a280-c47f-11eb-8e86-48f0fa90dee6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/120699947-12c93900-c47f-11eb-96f1-34eae935bc6b.png" width="350"/> |

## Changes
* Reduce the height of the action buttons to 40 px.

## How to test
* Navigate to a part of the payment collection flow that displays a modal alert, notice the height of the action buttons.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
