### PR TITLE
[Mobile Payments] Set title of receipt preview

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/ReceiptViewController.swift
@@ -34,6 +34,7 @@ final class ReceiptViewController: UIViewController {
 
 private extension ReceiptViewController {
     func configureToolbar() {
+        title = Localization.title
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: .print,
                                                             style: .plain,
                                                             target: self,
@@ -52,5 +53,14 @@ private extension ReceiptViewController {
 
     @objc func printReceipt() {
         viewModel.printReceipt()
+    }
+}
+
+private extension ReceiptViewController {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Receipt",
+            comment: "The title of the view containing a receipt preview"
+        )
     }
 }


### PR DESCRIPTION
Closes #4357 

Add a title to the receipt preview.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/120701798-502ec600-c481-11eb-9865-3bb674ad9b8c.PNG" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/120701824-59b82e00-c481-11eb-8b00-73e5f9c15831.PNG" width="350"/> |

## Changes
* Set a title for ReceiptViewController

## How to test
* Navigate to an order that has been charged on the testing device (just as a reminder, receipts do not propagate across devices yet)
* Tap "See receipt"
* Notice the title of the preview.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
