### PR TITLE
Set ALWAYS_EMBED_SWIFT_STANDRD_LIBRARIES for HardwareTests as inherited

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -1010,7 +1010,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1CC96A71F2937BCB7432766F /* Pods-HardwareTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
@@ -1031,7 +1031,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C61D1642BE09D1A1AD6AA9FA /* Pods-HardwareTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
@@ -1138,7 +1138,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB2B86965868C0EC25910D7D /* Pods-HardwareTests.release-alpha.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;


### PR DESCRIPTION
Not ticket for this one. A quick hot fix to a misconfiguration on the build settings of the HardawareTests target.

I don't understand why we are seeing this now, but hey, it is what it is 🤷🏼 

## Changes
* Set ALWAYS_EMBED_SWIFT_STANDRD_LIBRARIES, for the HardwareTests target, to ${inherited}, to mimic the configuration of other testing targets.

## How to test
* Wait for CI to give the ✅ 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
