### PR TITLE
[Mobile Payments] Add order number to payment intent description

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -157,18 +157,19 @@ private extension PaymentCaptureOrchestrator {
 
         return PaymentParameters(amount: orderTotal as Decimal,
                                                   currency: order.currency,
-                                                  receiptDescription: receiptDescription(),
+                                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                                   statementDescription: account?.statementDescriptor,
                                                   receiptEmail: order.billingAddress?.email,
                                                   metadata: metadata)
     }
 
-    func receiptDescription() -> String? {
+    func receiptDescription(orderNumber: String) -> String? {
         guard let storeName = ServiceLocator.stores.sessionManager.defaultSite?.name else {
             return nil
         }
 
         return String.localizedStringWithFormat(Localization.receiptDescription,
+                                                orderNumber,
                                                 storeName)
     }
 
@@ -179,9 +180,11 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Localization {
-        static let receiptDescription = NSLocalizedString("Receipt from %1$@",
-                                                             comment: "Message included in emailed receipts."
-                                                                + "Reads as: Receipt from @{store name}"
-                                                                + "Parameters: %1$@ - store name")
+        static let receiptDescription = NSLocalizedString("In-Person Payment for Order #%1$@ for %2$@",
+                                                          comment: "Message included in emailed receipts. "
+                                                            + "Reads as: In-Person Payment for "
+                                                            + "Order @{number} for @{store name} "
+                                                            + "Parameters: %1$@ - order number, "
+                                                            + "%2$@ - store name")
     }
 }


### PR DESCRIPTION
Closes #4206 

Changes:
- Adds `order.number` to the payment intent description
- Why not orderID? `order.number` is a comma-less string making it more suitable than the Int64 which, when localized, gains grouping commas)

To test:
- Complete a card present payment
- Open the internal WooCommerce Payments dashboard and ensure the transaction (when viewing as the merchant) shows the new description with the order number, i.e.:

<img width="1541" alt="ordernumber" src="https://user-images.githubusercontent.com/1595739/120714611-45bbfe80-c478-11eb-8ec4-7d85b8af1059.png">

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
