### PR TITLE
Merge release/6.8 into develop – Release Notes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
-    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+    fastlane-plugin-wpmreleasetoolkit (1.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -228,7 +228,6 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -237,8 +236,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.5)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.1)
   rake
   rmagick (~> 3.2.0)
   xcode-install

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,11 +57,11 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v6.7-whats-new"
+msgctxt "v6.8-whats-new"
 msgid ""
-"If you are using the WooCommerce Product Add-ons extension (made by WooCommerce) and have been wanting to see those details when viewing an order, wait no longer! We have added experimental support to the app to show those add-ons in orders. To give it a try, head on over to Experimental Features in Settings to enable it. Please send us your feedback on your experience!\n"
+"You can now create and edit a virtual product directly from the product details screen!\n"
 "\n"
-"We’re also moving to support iOS 14 or later only with the next release after this one. To continue receiving updates to the WooCommerce app, please upgrade your device to iOS 14.\n"
+"Please note that iOS 13 is no longer supported. Only iOS 14 and later versions will be supported going forward.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,3 +1,3 @@
-If you are using the WooCommerce Product Add-ons extension (made by WooCommerce) and have been wanting to see those details when viewing an order, wait no longer! We have added experimental support to the app to show those add-ons in orders. To give it a try, head on over to Experimental Features in Settings to enable it. Please send us your feedback on your experience!
+You can now create and edit a virtual product directly from the product details screen!
 
-We’re also moving to support iOS 14 or later only with the next release after this one. To continue receiving updates to the WooCommerce app, please upgrade your device to iOS 14.
+Please note that iOS 13 is no longer supported. Only iOS 14 and later versions will be supported going forward.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,26 +17,12 @@ def get_required_env(key)
   ENV[key]
 end
 
-def check_toolkit_update
-  plugin_name = 'fastlane-plugin-wpmreleasetoolkit'
-  UI.message('Checking for new version of the release toolkit...')
-  sh('bundle', 'outdated', plugin_name, '--porcelain') do |status, _, _|
-    break if status.success?
-
-    UI.important('The Release Toolkit you are using seems to be outdated. We suggest you to update to the latest version ASAP.')
-    if UI.interactive? && UI.confirm("Run \`bundle update #{plugin_name}\` now?")
-      sh('bundle', 'update', plugin_name)
-      UI.abort_with_message!("#{plugin_name} updated. Please restart your previous invocation of the \`#{lane_context[SharedValues::LANE_NAME]}\` lane to use the new toolkit.")
-    end
-  end
-end
-
 before_all do |lane|
   # Skip these checks/steps for test lane (not needed for testing)
   next if lane == :test_without_building
 
   # Ensure we use the latest version of the toolkit
-  check_toolkit_update unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
+  check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
 
   # Check that the env files exist
   unless is_ci || File.file?(USER_ENV_FILE_PATH)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.1'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
* Just updated the release notes with the copy wrangled in concert with marketing – see p91TBi-5fe-p2#comment-4904
* Also took the occasion to update to latest release toolkit and its update-check feature

⚠️ Note: this needs to be merged before this weekend so those updated Release Notes are picked up when we send strings to our translation vendor.