### PR TITLE
[Mobile Payments] Add PaymentGatewayAccountStore

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 31054733262E36AB00C5C02B /* wcpay-payment-intent-error.json */; };
 		31104E142630DDA700587C1E /* wcpay-account-wrong-json.json in Resources */ = {isa = PBXBuildFile; fileRef = 31104E132630DDA700587C1E /* wcpay-account-wrong-json.json */; };
 		311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */; };
+		314703082670222500EF253A /* PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703072670222500EF253A /* PaymentGatewayAccount.swift */; };
 		3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE5F26129ADD00E566B9 /* wcpay-account-none.json */; };
 		3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE6326129B1300E566B9 /* wcpay-account-complete.json */; };
 		3158FE6826129CE200E566B9 /* wcpay-account-rejected-fraud.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE6726129CE200E566B9 /* wcpay-account-rejected-fraud.json */; };
@@ -655,6 +656,7 @@
 		31054733262E36AB00C5C02B /* wcpay-payment-intent-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-payment-intent-error.json"; sourceTree = "<group>"; };
 		31104E132630DDA700587C1E /* wcpay-account-wrong-json.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-wrong-json.json"; sourceTree = "<group>"; };
 		311976DF2602BD4B006AC56C /* SitePluginsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginsMapperTests.swift; sourceTree = "<group>"; };
+		314703072670222500EF253A /* PaymentGatewayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccount.swift; sourceTree = "<group>"; };
 		3158FE5F26129ADD00E566B9 /* wcpay-account-none.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-none.json"; sourceTree = "<group>"; };
 		3158FE6326129B1300E566B9 /* wcpay-account-complete.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-complete.json"; sourceTree = "<group>"; };
 		3158FE6726129CE200E566B9 /* wcpay-account-rejected-fraud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-rejected-fraud.json"; sourceTree = "<group>"; };
@@ -1440,6 +1442,7 @@
 				CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */,
 				B5BB1D1120A255EC00112D92 /* OrderStatusEnum.swift */,
 				267313302559CC930026F7EF /* PaymentGateway.swift */,
+				314703072670222500EF253A /* PaymentGatewayAccount.swift */,
 				743E84EB22171F4600FAC9D7 /* ShipmentTracking.swift */,
 				D823D90C2237784A00C90817 /* ShipmentTrackingProvider.swift */,
 				D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */,
@@ -2360,6 +2363,7 @@
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
+				314703082670222500EF253A /* PaymentGatewayAccount.swift in Sources */,
 				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,

--- a/Networking/Networking/Model/PaymentGatewayAccount.swift
+++ b/Networking/Networking/Model/PaymentGatewayAccount.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Represents a Payment Gateway Account.
+///
+public struct PaymentGatewayAccount {
+
+    /// Site identifier.
+    ///
+    public let siteID: Int64
+
+    public let status: String
+
+    public let hasPendingRequirements: Bool
+
+    public let hasOverdueRequirements: Bool
+
+    public let currentDeadline: Date?
+
+    public let statementDescriptor: String
+
+    public let defaultCurrency: String
+
+    public let supportedCurrencies: [String]
+
+    public let country: String
+
+    /// A boolean flag indicating if this Account is eligible for card present payments
+    public let isCardPresentEligible: Bool
+
+    /// Struct initializer
+    ///
+    public init(siteID: Int64,
+         status: String,
+         hasPendingRequirements: Bool,
+         hasOverdueRequirements: Bool,
+         currentDeadline: Date?,
+         statementDescriptor: String,
+         defaultCurrency: String,
+         supportedCurrencies: [String],
+         country: String,
+         isCardPresentEligible: Bool
+    ) {
+        self.siteID = siteID
+        self.status = status
+        self.hasPendingRequirements = hasPendingRequirements
+        self.hasOverdueRequirements = hasOverdueRequirements
+        self.currentDeadline = currentDeadline
+        self.statementDescriptor = statementDescriptor
+        self.defaultCurrency = defaultCurrency
+        self.supportedCurrencies = supportedCurrencies
+        self.country = country
+        self.isCardPresentEligible = isCardPresentEligible
+    }
+}

--- a/Networking/Networking/Model/PaymentGatewayAccount.swift
+++ b/Networking/Networking/Model/PaymentGatewayAccount.swift
@@ -8,6 +8,8 @@ public struct PaymentGatewayAccount {
     ///
     public let siteID: Int64
 
+    public let gatewayID: String
+
     public let status: String
 
     public let hasPendingRequirements: Bool
@@ -30,17 +32,19 @@ public struct PaymentGatewayAccount {
     /// Struct initializer
     ///
     public init(siteID: Int64,
-         status: String,
-         hasPendingRequirements: Bool,
-         hasOverdueRequirements: Bool,
-         currentDeadline: Date?,
-         statementDescriptor: String,
-         defaultCurrency: String,
-         supportedCurrencies: [String],
-         country: String,
-         isCardPresentEligible: Bool
-    ) {
+                gatewayID: String,
+                status: String,
+                hasPendingRequirements: Bool,
+                hasOverdueRequirements: Bool,
+                currentDeadline: Date?,
+                statementDescriptor: String,
+                defaultCurrency: String,
+                supportedCurrencies: [String],
+                country: String,
+                isCardPresentEligible: Bool
+        ) {
         self.siteID = siteID
+        self.gatewayID = gatewayID
         self.status = status
         self.hasPendingRequirements = hasPendingRequirements
         self.hasOverdueRequirements = hasOverdueRequirements

--- a/Networking/Networking/Model/WCPayAccount.swift
+++ b/Networking/Networking/Model/WCPayAccount.swift
@@ -1,6 +1,8 @@
 /// Represent a WCPay accont Entity.
 ///
 public struct WCPayAccount: Decodable {
+    public static let gatewayID = "woocommerce-payments"
+
     public let status: WCPayAccountStatusEnum
     public let hasPendingRequirements: Bool
     public let hasOverdueRequirements: Bool

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -523,7 +523,7 @@ public extension StorageType {
         return firstObject(ofType: SitePlugin.self, matching: predicate)
     }
 
-    /// Returns a payment gateway account with a specified `siteID`
+    /// Returns a payment gateway account with a specified `siteID` and `gatewayID`
     ///
     func loadPaymentGatewayAccount(siteID: Int64, gatewayID: String) -> PaymentGatewayAccount? {
         let predicate = \PaymentGatewayAccount.siteID == siteID && \PaymentGatewayAccount.gatewayID == gatewayID

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -525,7 +525,7 @@ public extension StorageType {
 
     /// Returns a payment gateway account with a specified `siteID`
     ///
-    func loadPaymentGatewayAccount(siteID: Int64) -> PaymentGatewayAccount? {
-        let predicate = \PaymentGatewayAccount.siteID == siteID
+    func loadPaymentGatewayAccount(siteID: Int64, gatewayID: String) -> PaymentGatewayAccount? {
+        let predicate = \PaymentGatewayAccount.siteID == siteID && \PaymentGatewayAccount.gatewayID == gatewayID
         return firstObject(ofType: PaymentGatewayAccount.self, matching: predicate)
     }}

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -6,6 +6,8 @@ class StorageTypeExtensionsTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 98765
 
+    private let sampleGatewayID: String = "woocommerce-payments"
+
     private var storageManager: StorageManagerType!
 
     private var storage: StorageType! {
@@ -1051,7 +1053,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         let account = storage.insertNewObject(ofType: PaymentGatewayAccount.self)
         account.country = "US"
         account.defaultCurrency = "USD"
-        account.gatewayID = "woocommerce-payments"
+        account.gatewayID = sampleGatewayID
         account.hasOverdueRequirements = false
         account.hasPendingRequirements = false
         account.isCardPresentEligible = true
@@ -1061,7 +1063,7 @@ class StorageTypeExtensionsTests: XCTestCase {
         account.supportedCurrencies = ["USD"]
 
         // When
-        let foundAccount = try XCTUnwrap(storage.loadPaymentGatewayAccount(siteID: sampleSiteID))
+        let foundAccount = try XCTUnwrap(storage.loadPaymentGatewayAccount(siteID: sampleSiteID, gatewayID: sampleGatewayID))
 
         // Then
         XCTAssertEqual(foundAccount, account)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -112,7 +112,7 @@ private extension SettingsViewController {
         tableView.delegate = self
     }
 
-    private func refreshResultsController() {
+    func refreshResultsController() {
         try? resultsController.performFetch()
         sites = resultsController.fetchedObjects
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -46,7 +46,7 @@ final class SettingsViewController: UIViewController {
 
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
-    private let resultsController: ResultsController<StorageSite> = {
+    private let sitesResultsController: ResultsController<StorageSite> = {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "isWooCommerceActive == YES")
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
@@ -57,6 +57,20 @@ final class SettingsViewController: UIViewController {
     /// Sites pulled from the results controlelr
     ///
     private var sites = [Yosemite.Site]()
+
+    /// Payment Gateway Account ResultsController
+    ///
+    private let gatewayAccountResultsController: ResultsController<StoragePaymentGatewayAccount> = {
+        let storageManager = ServiceLocator.storageManager
+        /// TODO - resolve how I want to manage the siteID here. Should I just fetch all gatewayAccounts and filter by siteID later perhaps?
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+
+        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
+    /// Accounts pulled from the results controller
+    ///
+    private var gatewayAccounts = [StoragePaymentGatewayAccount]()
 
     /// Store Picker Coordinator
     ///
@@ -71,11 +85,9 @@ final class SettingsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        checkAvailabilityForPayments() { [weak self] in
+        configureResultsControllers(onReload: { [weak self] in
             self?.refreshViewContent()
-        }
-
-        refreshResultsController()
+        })
         configureNavigation()
         configureMainView()
         configureTableView()
@@ -112,35 +124,35 @@ private extension SettingsViewController {
         tableView.delegate = self
     }
 
-    func refreshResultsController() {
-        try? resultsController.performFetch()
-        sites = resultsController.fetchedObjects
+    func configureResultsControllers(onReload: @escaping () -> Void) {
+        configureSiteResultsController(onReload: onReload)
+        configureAccountResultsController(onReload: onReload)
     }
 
-    func checkAvailabilityForPayments(onCompletion: @escaping () -> Void) {
-        guard let siteID = self.siteID else {
-            canCollectPayments = false
-            onCompletion()
+    private func configureSiteResultsController(onReload: @escaping () -> Void) {
+        try? sitesResultsController.performFetch()
+        sites = sitesResultsController.fetchedObjects
+    }
+
+    private func configureAccountResultsController(onReload: @escaping () -> Void) {
+        /// Bail early if the card present payments feature is disabled
+        ///
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
             return
         }
 
-        let action = WCPayAction.loadAccount(siteID: siteID) { [weak self] result in
+        gatewayAccountResultsController.onDidChangeContent = {
+            onReload()
+        }
+
+        gatewayAccountResultsController.onDidResetContent = { [weak self] in
             guard let self = self else {
                 return
             }
-
-            switch result {
-            case .failure:
-                self.canCollectPayments = false
-            case .success(let account):
-                self.canCollectPayments = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) &&
-                    account.isCardPresentEligible
-            }
-
-            onCompletion()
+            onReload()
         }
 
-        ServiceLocator.stores.dispatch(action)
+        try? gatewayAccountResultsController.performFetch()
     }
 
     func configureTableViewFooter() {
@@ -162,8 +174,29 @@ private extension SettingsViewController {
     }
 
     func refreshViewContent() {
+        refreshCanCollectPayment()
         configureSections()
         tableView.reloadData()
+    }
+
+    func refreshCanCollectPayment() {
+        /// Bail early if the card present payments feature is disabled
+        ///
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
+            canCollectPayments = false
+            return
+        }
+
+        canCollectPayments = false
+
+        /// At the moment, we only expect one gateway account, but in the futue we may have multiple gateway accounts
+        /// each capable of supporting card present payments, so let's do this right now
+        ///
+        for gatewayAccount in gatewayAccounts {
+            if gatewayAccount.isCardPresentEligible {
+                canCollectPayments = true
+            }
+        }
     }
 
     func configureSections() {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		26E5A08225A66868000DF8F6 /* ProductAttributeTermStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */; };
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
+		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxClassStore.swift */; };
@@ -296,9 +297,6 @@
 		D8652F8A2635A2E800350F37 /* WCPayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8652F892635A2E800350F37 /* WCPayAction.swift */; };
 		D8652F8E2635A2F800350F37 /* WCPayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8652F8D2635A2F800350F37 /* WCPayStore.swift */; };
 		D8652F922635A79500350F37 /* WCPayStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8652F912635A79500350F37 /* WCPayStoreTests.swift */; };
-		D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */; };
-		D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */; };
-		D8736B7322F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */; };
 		D87F27DB25E7E8EA006EC8C9 /* MockCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F27DA25E7E8EA006EC8C9 /* MockCardReader.swift */; };
 		D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F614922657A690031A13B /* AppSettingsAction.swift */; };
 		D87F614C22657B150031A13B /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F614B22657B150031A13B /* AppSettingsStore.swift */; };
@@ -487,6 +485,7 @@
 		26E5A08125A66868000DF8F6 /* ProductAttributeTermStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStore.swift; sourceTree = "<group>"; };
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -649,9 +648,6 @@
 		D8652F892635A2E800350F37 /* WCPayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayAction.swift; sourceTree = "<group>"; };
 		D8652F8D2635A2F800350F37 /* WCPayStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayStore.swift; sourceTree = "<group>"; };
 		D8652F912635A79500350F37 /* WCPayStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayStoreTests.swift; sourceTree = "<group>"; };
-		D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
-		D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
-		D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		D87F27DA25E7E8EA006EC8C9 /* MockCardReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardReader.swift; sourceTree = "<group>"; };
 		D87F614922657A690031A13B /* AppSettingsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsAction.swift; sourceTree = "<group>"; };
 		D87F614B22657B150031A13B /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
@@ -1052,6 +1048,7 @@
 				D8C11A5522DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift */,
 				CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */,
 				261CF1C8255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift */,
+				312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */,
 				749375032249691D007D85D1 /* Product+ReadOnlyConvertible.swift */,
 				266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */,
 				2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */,
@@ -1692,6 +1689,7 @@
 				247CE7D42582E1FD00F9D9D1 /* ScreenshotStoresManager.swift in Sources */,
 				B5BC736520D1A98500B5B6FA /* AccountStore.swift in Sources */,
 				247CE8562583269900F9D9D1 /* MockProductActionHandler.swift in Sources */,
+				312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */,
 				2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */,
 				247CE8382582F21700F9D9D1 /* MockNotificationCountActionHandler.swift in Sources */,
 				02FF056523DE9C8B0058E6E7 /* MediaStore.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
 		3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703092670295300EF253A /* PaymentGatewayAccountStore.swift */; };
+		3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxClassStore.swift */; };
@@ -490,6 +491,7 @@
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
 		314703092670295300EF253A /* PaymentGatewayAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStore.swift; sourceTree = "<group>"; };
+		3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayAccount+PaymentGatewayAccount.swift"; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -1429,6 +1431,7 @@
 			isa = PBXGroup;
 			children = (
 				D8652E1F26303D4800350F37 /* PaymentIntent+ReceiptParameters.swift */,
+				3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */,
 			);
 			path = Payments;
 			sourceTree = "<group>";
@@ -1789,6 +1792,7 @@
 				247CE8442582F3BB00F9D9D1 /* MockSettingActionHandler.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */,
+				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
 				02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */,
 				0212AC5E242C67FA00C51F6C /* ProductsSortOrder.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
+		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
+		3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703092670295300EF253A /* PaymentGatewayAccountStore.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxClassStore.swift */; };
@@ -486,6 +488,8 @@
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
+		314703092670295300EF253A /* PaymentGatewayAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStore.swift; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -1160,6 +1164,7 @@
 				7499936520EFBC7200CF01CD /* OrderNoteStore.swift */,
 				CE3B7AD62225ECA90050FE4B /* OrderStatusStore.swift */,
 				261CF1F0255B389F0090D8D3 /* PaymentGatewayStore.swift */,
+				314703092670295300EF253A /* PaymentGatewayAccountStore.swift */,
 				749374FD2249601F007D85D1 /* ProductStore.swift */,
 				45ED6095257E7472007B4AC6 /* ProductAttributeStore.swift */,
 				D831E2E1230E3513000037D0 /* ProductReviewStore.swift */,
@@ -1383,6 +1388,7 @@
 				7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */,
 				CE3B7AD42225EBF10050FE4B /* OrderStatusAction.swift */,
 				261CF1EC255B37B40090D8D3 /* PaymentGatewayAction.swift */,
+				3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */,
 				749374FF2249605E007D85D1 /* ProductAction.swift */,
 				45ED6091257E72F4007B4AC6 /* ProductAttributeAction.swift */,
 				26E5A07D25A6640E000DF8F6 /* ProductAttributeTermAction.swift */,
@@ -1748,6 +1754,7 @@
 				45AB8B1724AA4B3D00B5B36E /* ProductTagStore.swift in Sources */,
 				247CE8342582F20100F9D9D1 /* MockAppSettingsActionHandler.swift in Sources */,
 				025CA2CA238F515600B05C81 /* ProductShippingClassStore.swift in Sources */,
+				3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */,
 				74937508224985BB007D85D1 /* ProductDimensions+ReadOnlyConvertible.swift in Sources */,
 				CC2C036C262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift in Sources */,
 				45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */,
@@ -1792,6 +1799,7 @@
 				CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */,
 				74D42DBC221C983F00B4977D /* ShipmentTracking+ReadOnlyConvertible.swift in Sources */,
 				247CE87A258332B400F9D9D1 /* MockNotificationActionHandler.swift in Sources */,
+				3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */,
 				025CA2CE238F53CB00B05C81 /* ProductShippingClass+ReadOnlyConvertible.swift in Sources */,
 				247CE86225832B1600F9D9D1 /* MockRefundActionHandler.swift in Sources */,
 				26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
 		3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703092670295300EF253A /* PaymentGatewayAccountStore.swift */; };
 		3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */; };
+		31BF226526715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BF226426715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
 		45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45010692239A6C9F00E24722 /* TaxClassStore.swift */; };
@@ -492,6 +493,7 @@
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
 		314703092670295300EF253A /* PaymentGatewayAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStore.swift; sourceTree = "<group>"; };
 		3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayAccount+PaymentGatewayAccount.swift"; sourceTree = "<group>"; };
+		31BF226426715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStoreTests.swift; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -1210,6 +1212,7 @@
 				7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */,
 				7455262F22305F88003F8932 /* OrderStatusStoreTests.swift */,
 				261CF2C6255C445A0090D8D3 /* PaymentGatewayStoreTests.swift */,
+				31BF226426715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift */,
 				744914F6224AD2AF00546DE4 /* ProductStoreTests.swift */,
 				4552073C25811B4E001CF873 /* ProductAttributeStoreTests.swift */,
 				D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */,
@@ -1898,6 +1901,7 @@
 				02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */,
 				B53A56A0211245E0000776C9 /* MockStorageManager+Sample.swift in Sources */,
 				453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */,
+				31BF226526715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift in Sources */,
 				744914F7224AD2AF00546DE4 /* ProductStoreTests.swift in Sources */,
 				0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */,
 				578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
@@ -4,7 +4,13 @@ import Networking
 /// Defines all of the `actions` supported by the `PaymentGatewayAccountStore`.
 ///
 public enum PaymentGatewayAccountAction: Action {
-    /// Retrieves and stores payment gateway accounts for the provided `siteID`
+    /// Retrieves and stores payment gateway account(s) for the provided `siteID`
     ///
-    case loadAccounts(siteID: Int64, onCompletion: (Result<[PaymentGatewayAccount], Error>) -> Void)
+    case loadAccounts(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Captures a payment intent ID, associated to an order and site
+    case captureOrderPayment(siteID: Int64,
+                             orderID: Int64,
+                             paymentIntentID: String,
+                             completion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Networking
+
+/// Defines all of the `actions` supported by the `PaymentGatewayAccountStore`.
+///
+public enum PaymentGatewayAccountAction: Action {
+    /// Retrieves and stores payment gateway accounts for the provided `siteID`
+    ///
+    case loadAccounts(siteID: Int64, onCompletion: (Result<[PaymentGatewayAccount], Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -118,7 +118,7 @@ public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias WCPayAccount = Networking.WCPayAccount
-
+public typealias WCPayAccountStatusEnum = Networking.WCPayAccountStatusEnum
 
 // MARK: - Exported Storage Symbols
 
@@ -137,6 +137,7 @@ public typealias StorageOrderStatsV4Interval = Storage.OrderStatsV4Interval
 public typealias StorageOrderStatsV4Totals = Storage.OrderStatsV4Totals
 public typealias StorageOrderStatus = Storage.OrderStatus
 public typealias StoragePaymentGateway = Storage.PaymentGateway
+public typealias StoragePaymentGatewayAccount = Storage.PaymentGatewayAccount
 public typealias StoragePreselectedProvider = Storage.PreselectedProvider
 public typealias StorageProduct = Storage.Product
 public typealias StorageProductAddOn = Storage.ProductAddOn

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -42,6 +42,7 @@ public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval
 public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
 public typealias PaymentGateway = Networking.PaymentGateway
+public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product
 public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption

--- a/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
+++ b/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
@@ -1,0 +1,21 @@
+import Hardware
+
+public extension WCPayAccount {
+    /// Maps a WCPayAccount into the PaymentGatewayAccount struct
+    ///
+    func toPaymentGatewayAccount(siteID: Int64) -> PaymentGatewayAccount { // TODO can we add siteID to WCPayAccount?
+        return PaymentGatewayAccount(
+            siteID: siteID,
+            gatewayID: "woocommerce-payments", // TODO constant/enum
+            status: status.rawValue,
+            hasPendingRequirements: hasPendingRequirements,
+            hasOverdueRequirements: hasOverdueRequirements,
+            currentDeadline: currentDeadline,
+            statementDescriptor: statementDescriptor,
+            defaultCurrency: defaultCurrency,
+            supportedCurrencies: supportedCurrencies,
+            country: country,
+            isCardPresentEligible: isCardPresentEligible
+        )
+    }
+}

--- a/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
+++ b/Yosemite/Yosemite/Model/Payments/WCPayAccount+PaymentGatewayAccount.swift
@@ -6,7 +6,7 @@ public extension WCPayAccount {
     func toPaymentGatewayAccount(siteID: Int64) -> PaymentGatewayAccount { // TODO can we add siteID to WCPayAccount?
         return PaymentGatewayAccount(
             siteID: siteID,
-            gatewayID: "woocommerce-payments", // TODO constant/enum
+            gatewayID: WCPayAccount.gatewayID,
             status: status.rawValue,
             hasPendingRequirements: hasPendingRequirements,
             hasOverdueRequirements: hasOverdueRequirements,

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -9,6 +9,8 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
     ///
     public func update(with paymentGatewayAccount: Yosemite.PaymentGatewayAccount) {
         status = paymentGatewayAccount.status
+        siteID = paymentGatewayAccount.siteID
+        gatewayID = paymentGatewayAccount.gatewayID
         hasPendingRequirements = paymentGatewayAccount.hasPendingRequirements
         hasOverdueRequirements = paymentGatewayAccount.hasOverdueRequirements
         currentDeadline = paymentGatewayAccount.currentDeadline

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -25,6 +25,7 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
         let accountStatus = Yosemite.WCPayAccountStatusEnum.init(rawValue: status)
 
         return PaymentGatewayAccount(siteID: siteID,
+                                     gatewayID: gatewayID,
                                      status: accountStatus.rawValue,
                                      hasPendingRequirements: hasPendingRequirements,
                                      hasOverdueRequirements: hasOverdueRequirements,

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Storage
+
+// MARK: - PaymentGatewayAccount: ReadOnlyConvertible
+//
+extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
+
+    /// Updates the `Storage.PaymentGatewayAccount` from the ReadOnly type.
+    ///
+    public func update(with paymentGatewayAccount: Yosemite.WCPayAccount) {
+        status = paymentGatewayAccount.status.rawValue
+        hasPendingRequirements = paymentGatewayAccount.hasPendingRequirements
+        hasOverdueRequirements = paymentGatewayAccount.hasOverdueRequirements
+        currentDeadline = paymentGatewayAccount.currentDeadline
+        statementDescriptor = paymentGatewayAccount.statementDescriptor
+        defaultCurrency = paymentGatewayAccount.defaultCurrency
+        supportedCurrencies = paymentGatewayAccount.supportedCurrencies
+        country = paymentGatewayAccount.country
+        isCardPresentEligible = paymentGatewayAccount.isCardPresentEligible
+    }
+
+    /// Returns a ReadOnly version for Yosemite.
+    ///
+    public func toReadOnly() -> Yosemite.WCPayAccount {
+        let accountStatus = Yosemite.WCPayAccountStatusEnum.init(rawValue: status)
+
+        return WCPayAccount(status: accountStatus,
+                     hasPendingRequirements: hasPendingRequirements,
+                     hasOverdueRequirements: hasOverdueRequirements,
+                     currentDeadline: currentDeadline,
+                     statementDescriptor: statementDescriptor,
+                     defaultCurrency: defaultCurrency,
+                     supportedCurrencies: supportedCurrencies,
+                     country: country,
+                     isCardPresentEligible: isCardPresentEligible)
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -7,8 +7,8 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
 
     /// Updates the `Storage.PaymentGatewayAccount` from the ReadOnly type.
     ///
-    public func update(with paymentGatewayAccount: Yosemite.WCPayAccount) {
-        status = paymentGatewayAccount.status.rawValue
+    public func update(with paymentGatewayAccount: Yosemite.PaymentGatewayAccount) {
+        status = paymentGatewayAccount.status
         hasPendingRequirements = paymentGatewayAccount.hasPendingRequirements
         hasOverdueRequirements = paymentGatewayAccount.hasOverdueRequirements
         currentDeadline = paymentGatewayAccount.currentDeadline
@@ -21,17 +21,18 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
 
     /// Returns a ReadOnly version for Yosemite.
     ///
-    public func toReadOnly() -> Yosemite.WCPayAccount {
+    public func toReadOnly() -> Yosemite.PaymentGatewayAccount {
         let accountStatus = Yosemite.WCPayAccountStatusEnum.init(rawValue: status)
 
-        return WCPayAccount(status: accountStatus,
-                     hasPendingRequirements: hasPendingRequirements,
-                     hasOverdueRequirements: hasOverdueRequirements,
-                     currentDeadline: currentDeadline,
-                     statementDescriptor: statementDescriptor,
-                     defaultCurrency: defaultCurrency,
-                     supportedCurrencies: supportedCurrencies,
-                     country: country,
-                     isCardPresentEligible: isCardPresentEligible)
+        return PaymentGatewayAccount(siteID: siteID,
+                                     status: accountStatus.rawValue,
+                                     hasPendingRequirements: hasPendingRequirements,
+                                     hasOverdueRequirements: hasOverdueRequirements,
+                                     currentDeadline: currentDeadline,
+                                     statementDescriptor: statementDescriptor,
+                                     defaultCurrency: defaultCurrency,
+                                     supportedCurrencies: supportedCurrencies,
+                                     country: country,
+                                     isCardPresentEligible: isCardPresentEligible)
     }
 }

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Networking
+import Storage
+
+/// Implements `PaymentGatewayAccountAction` actions
+///
+public final class PaymentGatewayAccountStore: Store {
+
+    /// For now, we only have one remote we support - the WCPay remote - to get an account
+    /// In the future we'll want to allow this store to support other remotes
+    ///
+    private let remote: WCPayRemote
+
+    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.remote = WCPayRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: PaymentGatewayAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? PaymentGatewayAccountAction else {
+            assertionFailure("PaymentGatewayAccountAction received an unsupported action")
+            return
+        }
+
+        switch action {
+        case let .loadAccounts(siteID, onCompletion):
+            loadAccounts(siteID: siteID, onCompletion: onCompletion)
+        }
+    }
+}
+
+// MARK: Storage Methods
+private extension PaymentGatewayAccountStore {
+
+    func loadAccounts(siteID: Int64, onCompletion: (Result<[PaymentGatewayAccount], Error>) -> Void) {
+        // Make it work similar to RefundStore.swift retrieveRefunds
+        // hits up the WCPayRemote to get the account
+        // deletes the stored account if it isn’t found
+        // converts the WCPayAccount to a PaymentGatewayAccount (using the extension above)
+        // upserts the PaymentGatewayAccount account if it is found
+    }
+
+    // Add deleteStoredAccounts to it similar to deleteStaleRefunds
+    // Add upsertStoredAccountsInBackground to it similar to upsertStoredRefundsInBackground
+}

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -65,7 +65,7 @@ private extension PaymentGatewayAccountStore {
                 onCompletion(.success(()))
                     return
             case .failure(let error):
-                self.deleteStaleAccount(siteID: siteID, gatewayID: "woocommerce-payments") // TODO make a constant/enum
+                self.deleteStaleAccount(siteID: siteID, gatewayID: WCPayAccount.gatewayID)
                 onCompletion(.failure(error))
                 return
             }

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -31,18 +31,27 @@ public final class PaymentGatewayAccountStore: Store {
         }
 
         switch action {
-        case let .loadAccounts(siteID, onCompletion):
-            loadAccounts(siteID: siteID, onCompletion: onCompletion)
+        case .loadAccounts(let siteID, let onCompletion):
+            loadAccounts(siteID: siteID,
+                         onCompletion: onCompletion)
+        case .captureOrderPayment(let siteID,
+                                  let orderID,
+                                  let paymentIntentID,
+                                  let onCompletion):
+            captureOrderPayment(siteID: siteID,
+                                orderID: orderID,
+                                paymentIntentID: paymentIntentID,
+                                onCompletion: onCompletion)
         }
     }
 }
 
-// MARK: Storage Methods
+// MARK: Networking Methods
 private extension PaymentGatewayAccountStore {
-
-    func loadAccounts(siteID: Int64, onCompletion: @escaping (Result<[PaymentGatewayAccount], Error>) -> Void) {
-
-        /// The only accounts we know about right now are WCPayAccounts
+    func loadAccounts(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        /// The only plugin we support payment gateway accounts for right now is WooCommerce Payments.
+        /// And there is only one account per site for that plugin.  In the future we will need to support remotes for
+        /// other plugins and it might be possible for there to be multiple accounts for a single site then.
         ///
         remote.loadAccount(for: siteID) { [weak self] result in
             guard let self = self else {
@@ -53,17 +62,43 @@ private extension PaymentGatewayAccountStore {
             case .success(let wcpayAccount):
                 let account = wcpayAccount.toPaymentGatewayAccount(siteID: siteID)
                 self.upsertStoredAccountInBackground(readonlyAccount: account)
-                onCompletion(.success([account]))
+                onCompletion(.success(()))
                     return
             case .failure(let error):
                 self.deleteStaleAccount(siteID: siteID, gatewayID: "woocommerce-payments") // TODO make a constant/enum
                 onCompletion(.failure(error))
                 return
             }
-
         }
     }
 
+    func captureOrderPayment(siteID: Int64,
+                             orderID: Int64,
+                             paymentIntentID: String,
+                             onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        /// The only plugin we support capturing payments with right now is WooCommerce Payments.
+        /// In the future we will need to support remotes for other plugins.
+        ///
+        remote.captureOrderPayment(for: siteID, orderID: orderID, paymentIntentID: paymentIntentID, completion: { result in
+            switch result {
+            case .success(let intent):
+                guard intent.status == .succeeded else {
+                    DDLogDebug("Unexpected payment intent status \(intent.status) after attempting capture")
+                    onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+                    return
+                }
+
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
+                return
+            }
+        })
+    }
+}
+
+// MARK: Storage Methods
+private extension PaymentGatewayAccountStore {
     func upsertStoredAccountInBackground(readonlyAccount: PaymentGatewayAccount) {
         let storage = storageManager.viewStorage
         let storageAccount = storage.loadPaymentGatewayAccount(siteID: readonlyAccount.siteID, gatewayID: readonlyAccount.gatewayID) ??

--- a/Yosemite/YosemiteTests/Stores/PaymentGatewayAccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/PaymentGatewayAccountStoreTests.swift
@@ -91,14 +91,13 @@ final class PaymentGatewayAccountStoreTests: XCTestCase {
 
         XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
 
-        // TODO This doesn't find the storageAccount. Why not?
-        // let storageAccount = viewStorage.loadPaymentGatewayAccount(
-        //    siteID: sampleSiteID,
-        //    gatewayID: WCPayAccount.gatewayID
-        //)
+        let storageAccount = viewStorage.loadPaymentGatewayAccount(
+            siteID: sampleSiteID,
+            gatewayID: WCPayAccount.gatewayID
+        )
 
-        // TODO Figure out why the storageAccount lacks siteID and gatewayID here but everything else is fine
-        let storageAccount = viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self)
+        XCTAssert(storageAccount?.siteID == sampleSiteID)
+        XCTAssert(storageAccount?.gatewayID == WCPayAccount.gatewayID)
         XCTAssert(storageAccount?.status == "complete")
     }
 
@@ -120,7 +119,7 @@ final class PaymentGatewayAccountStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    /// Verifies that the store hits the network when capturing a payment ID, and that propagates sucess.
+    /// Verifies that the store hits the network when capturing a payment ID, and that propagates success.
     ///
     func test_capturePaymentID_returns_expected_data() throws {
         let store = PaymentGatewayAccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)

--- a/Yosemite/YosemiteTests/Stores/PaymentGatewayAccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/PaymentGatewayAccountStoreTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import TestKit
+
+@testable import Yosemite
+@testable import Networking
+@testable import Storage
+
+/// PaymentGatewayStore Unit Tests
+///
+final class PaymentGatewayAccountStoreTests: XCTestCase {
+
+    /// Mock Dispatcher
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock Network
+    ///
+    private var network: MockNetwork!
+
+    /// Convenience Property: Returns the StorageType associated with the main thread.
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID: Int64 = 999
+
+    /// Testing OrderID
+    ///
+    private let sampleOrderID: Int64 = 560
+
+    /// Testing PaymentIntentID
+    ///
+    private let samplePaymentIntentID: String = "p_idREDACTED"
+
+    // MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        dispatcher = nil
+        storageManager = nil
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    /// Verifies that the PaymentGatewayAccountStore hits the network when loading a WCPay Account, propagates errors and places nothing in storage.
+    ///
+    func test_loadAccounts_returns_error_on_failure() throws {
+        let store = PaymentGatewayAccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectation = self.expectation(description: "Load Account error response")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "generic_error")
+
+        let action = PaymentGatewayAccountAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
+            XCTAssertTrue(result.isFailure)
+            expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        XCTAssertNil(viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self, matching: nil))
+    }
+
+    /// Verifies that the PaymentGatewayAccountStore hits the network when loading a WCPay Account, propagates success and upserts the account into storage.
+    ///
+    func test_loadAccounts_returns_expected_data() throws {
+        let store = PaymentGatewayAccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectation = self.expectation(description: "Load Account fetch response")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts", filename: "wcpay-account-complete")
+        let action = PaymentGatewayAccountAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
+
+        // TODO This doesn't find the storageAccount. Why not?
+        // let storageAccount = viewStorage.loadPaymentGatewayAccount(
+        //    siteID: sampleSiteID,
+        //    gatewayID: WCPayAccount.gatewayID
+        //)
+
+        // TODO Figure out why the storageAccount lacks siteID and gatewayID here but everything else is fine
+        let storageAccount = viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self)
+        XCTAssert(storageAccount?.status == "complete")
+    }
+
+    /// Verifies that the store hits the network when capturing a payment ID, and that propagates errors.
+    ///
+    func test_capturePaymentID_returns_error_on_failure() throws {
+        let store = PaymentGatewayAccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectation = self.expectation(description: "Capture Payment Intent error response")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment", filename: "generic_error")
+        let action = PaymentGatewayAccountAction.captureOrderPayment(siteID: sampleSiteID,
+                                                                     orderID: sampleOrderID,
+                                                                     paymentIntentID: samplePaymentIntentID,
+                                                                     completion: { result in
+                                                                        XCTAssertTrue(result.isFailure)
+                                                                        expectation.fulfill()
+                                                                     })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that the store hits the network when capturing a payment ID, and that propagates sucess.
+    ///
+    func test_capturePaymentID_returns_expected_data() throws {
+        let store = PaymentGatewayAccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectation = self.expectation(description: "Load Account fetch response")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+        let action = PaymentGatewayAccountAction.captureOrderPayment(siteID: sampleSiteID,
+                                                                     orderID: sampleOrderID,
+                                                                     paymentIntentID: samplePaymentIntentID,
+                                                                     completion: { result in
+                                                                        XCTAssertTrue(result.isSuccess)
+                                                                        expectation.fulfill()
+                                                                     })
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}


### PR DESCRIPTION
Partially addresses #4314

This PR builds on #4349 (which added PaymentGatewayAccount to CoreData).

This PR adds a new store - PaymentGatewayAccountStore - that knows how to get PaymentGatewayAccounts from Storage and convert WCPayAccounts from the WCPayRemote into them.

A subsequent PR will change SettingsViewController and OrderDetails to use a PaymentGatewayAccount ResultsController, this store, and remove the WCPayStore

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
