### PR TITLE
Update Fastlane's snapshot integration to version 1.25

### DIFF
--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -227,7 +227,7 @@ open class Snapshot: NSObject {
         #if os(OSX)
             let homeDir = URL(fileURLWithPath: NSHomeDirectory())
             return homeDir.appendingPathComponent(cachePath)
-        #elseif arch(i386) || arch(x86_64)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
             guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
                 throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
@@ -302,4 +302,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.24]
+// SnapshotHelperVersion [1.25]


### PR DESCRIPTION
See https://github.com/Automattic/simplenote-ios/pull/1316

For testing, I run `bundle install && bundle exec fastlane take_screenshots devices:'iPhone 11 Pro Max' languages:en-US`. But, I got stuck on a "start the device; can't start the device; try again" loop which kept going till it failed.

I'm not sure the issue is due to this change. Keen to know how that works on your end @jkmassel.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.