### PR TITLE
[Mobile Payment] Add transformer for currency string array

### DIFF
--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 52.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 52.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="statementDescriptor" optional="YES" attributeType="String"/>
         <attribute name="status" optional="YES" attributeType="String"/>
-        <attribute name="supportedCurrencies" optional="YES" attributeType="Transformable"/>
+        <attribute name="supportedCurrencies" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
     </entity>
     <entity name="Product" representedClassName="Product" syncable="YES">
         <attribute name="averageRating" attributeType="String"/>


### PR DESCRIPTION
Fixes #4388 

Changes:
- Newbie mistake - did not know that an explicit setting of the `Transformer` (to `NSSecureUnarchiveFromData`) and `Custom Class` `[String]` was needed for transformation of `String` Arrays

To test:
- Ensure the warning in the reference issue no longer appears
- Ensure all StorageTests pass

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
