### PR TITLE
Fetch ScreenObject Swift package and use it in UI tests  for PrologueScreen 

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "trunk",
-          "revision": "68d92f082bf56358f5dba2021e1f5f81107d123e",
+          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
           "version": null
         }
       },

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "trunk",
-          "revision": "3d93c36483884db3fab88aea5c181ce75ceeac1d",
+          "revision": "d4ad399fb4777d390f359ce20865051320bf30b4",
           "version": null
         }
       },

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "ScreenObject",
+        "repositoryURL": "https://github.com/Automattic/ScreenObject",
+        "state": {
+          "branch": "trunk",
+          "revision": "3d93c36483884db3fab88aea5c181ce75ceeac1d",
+          "version": null
+        }
+      },
+      {
         "package": "SwiftUI-Shimmer",
         "repositoryURL": "https://github.com/markiv/SwiftUI-Shimmer",
         "state": {

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "trunk",
-          "revision": "d4ad399fb4777d390f359ce20865051320bf30b4",
+          "revision": "68d92f082bf56358f5dba2021e1f5f81107d123e",
           "version": null
         }
       },

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "trunk",
+          "branch": null,
           "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
-          "version": null
+          "version": "0.1.0"
         }
       },
       {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -8425,8 +8425,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = trunk;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
 			};
 		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -494,6 +494,8 @@
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
+		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
+		3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF22489267073AE008FFA87 /* ScreenObject */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -2668,6 +2670,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
+				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2676,6 +2679,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
+				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6210,6 +6214,9 @@
 				CCDC49D023FFFFF4003166BA /* PBXTargetDependency */,
 			);
 			name = WooCommerceUITests;
+			packageProductDependencies = (
+				3FF2247226706AA3008FFA87 /* ScreenObject */,
+			);
 			productName = WooCommerceUITests;
 			productReference = CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -6231,6 +6238,7 @@
 			name = WooCommerceScreenshots;
 			packageProductDependencies = (
 				247CE89B2583402A00F9D9D1 /* Embassy */,
+				3FF22489267073AE008FFA87 /* ScreenObject */,
 			);
 			productName = WooCommerceScreenshots;
 			productReference = F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */;
@@ -6315,6 +6323,7 @@
 			packageReferences = (
 				247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */,
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
+				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -8412,6 +8421,14 @@
 				minimumVersion = 4.1.2;
 			};
 		};
+		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/ScreenObject";
+			requirement = {
+				branch = trunk;
+				kind = branch;
+			};
+		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
@@ -8435,6 +8452,16 @@
 		263E38452641FF3400260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		3FF2247226706AA3008FFA87 /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
+		};
+		3FF22489267073AE008FFA87 /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
 		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -1,5 +1,6 @@
-import XCTest
 import Embassy
+import ScreenObject
+import XCTest
 
 class WooCommerceScreenshots: XCTestCase {
 
@@ -129,6 +130,21 @@ class WooCommerceScreenshots: XCTestCase {
 fileprivate var screenshotCount = 0
 
 extension BaseScreen {
+
+    @discardableResult
+    func thenTakeScreenshot(named title: String) -> Self {
+        screenshotCount += 1
+
+        let mode = isDarkMode ? "dark" : "light"
+        let filename = "\(screenshotCount)-\(mode)-\(title)"
+
+        snapshot(filename)
+
+        return self
+    }
+}
+
+extension ScreenObject {
 
     @discardableResult
     func thenTakeScreenshot(named title: String) -> Self {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -7,15 +7,19 @@ private struct ElementStringIDs {
 }
 
 final class PrologueScreen: ScreenObject {
-    private let continueButton: XCUIElement
-    private let siteAddressButton: XCUIElement
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons[ElementStringIDs.continueButton]
+    }
+    private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons[ElementStringIDs.siteAddressButton]
+    }
+
+    private var continueButton: XCUIElement { expectedElement }
+    private var siteAddressButton: XCUIElement { siteAddressButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]
-        siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
-
         try super.init(
-            probeElementGetter: { $0.buttons[ElementStringIDs.continueButton] },
+            expectedElementGetter: { $0.buttons[ElementStringIDs.continueButton] },
             app: app
         )
     }

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import ScreenObject
 import XCTest
 
 private struct ElementStringIDs {
@@ -6,15 +6,18 @@ private struct ElementStringIDs {
     static let siteAddressButton = "Prologue Self Hosted Button"
 }
 
-final class PrologueScreen: BaseScreen {
+final class PrologueScreen: ScreenObject {
     private let continueButton: XCUIElement
     private let siteAddressButton: XCUIElement
 
-    init() {
+    init(app: XCUIApplication = XCUIApplication()) throws {
         continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]
         siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
 
-        super.init(element: continueButton)
+        try super.init(
+            probeElementGetter: { $0.buttons[ElementStringIDs.continueButton] },
+            app: app
+        )
     }
 
     func selectContinueWithWordPress() -> GetStartedScreen {
@@ -27,9 +30,5 @@ final class PrologueScreen: BaseScreen {
         siteAddressButton.tap()
 
         return LoginSiteAddressScreen()
-    }
-
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
     }
 }

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -39,7 +39,7 @@ final class SettingsScreen: BaseScreen {
             logOutAlert.buttons.element(boundBy: 1).tap()
         }
 
-        return PrologueScreen()
+        return try! PrologueScreen()
     }
 }
 

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -27,7 +27,7 @@ final class SettingsScreen: BaseScreen {
     }
 
     @discardableResult
-    func logOut() -> PrologueScreen {
+    func logOut() throws -> PrologueScreen {
         logOutButton.tap()
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
@@ -39,7 +39,7 @@ final class SettingsScreen: BaseScreen {
             logOutAlert.buttons.element(boundBy: 1).tap()
         }
 
-        return try! PrologueScreen()
+        return try PrologueScreen()
     }
 }
 

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -13,7 +13,7 @@ final class LoginTests: XCTestCase {
 
     // Login with Store Address and log out.
     func test_site_address_login_logout() {
-        let prologue = PrologueScreen().selectSiteAddress()
+        let prologue = try! PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -26,12 +26,12 @@ final class LoginTests: XCTestCase {
             .logOut()
 
 
-        XCTAssert(prologue.isLoaded())
+        XCTAssert(prologue.isLoaded)
     }
 
     //Login with WordPress.com account and log out
     func test_WordPress_login_logout() {
-        let prologue = PrologueScreen().selectContinueWithWordPress()
+        let prologue = try! PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
@@ -42,11 +42,11 @@ final class LoginTests: XCTestCase {
             .verifySelectedStoreDisplays(storeName: TestCredentials.storeName, siteUrl: TestCredentials.siteUrl)
             .logOut()
 
-        XCTAssert(prologue.isLoaded())
+        XCTAssert(prologue.isLoaded)
     }
 
     func test_WordPress_unsuccessfull_login() {
-        _ = PrologueScreen().selectContinueWithWordPress()
+        _ = try! PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -12,8 +12,8 @@ final class LoginTests: XCTestCase {
     }
 
     // Login with Store Address and log out.
-    func test_site_address_login_logout() {
-        let prologue = try! PrologueScreen().selectSiteAddress()
+    func test_site_address_login_logout() throws {
+        let prologue = try PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -30,8 +30,8 @@ final class LoginTests: XCTestCase {
     }
 
     //Login with WordPress.com account and log out
-    func test_WordPress_login_logout() {
-        let prologue = try! PrologueScreen().selectContinueWithWordPress()
+    func test_WordPress_login_logout() throws {
+        let prologue = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
@@ -45,8 +45,8 @@ final class LoginTests: XCTestCase {
         XCTAssert(prologue.isLoaded)
     }
 
-    func test_WordPress_unsuccessfull_login() {
-        _ = try! PrologueScreen().selectContinueWithWordPress()
+    func test_WordPress_unsuccessfull_login() throws {
+        _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()


### PR DESCRIPTION
This adds the new [`ScreenObject`](https://github.com/Automattic/ScreenObject) Swift package to the project and uses it instead of `BaseScreen` in the `PrologueScreen`. I picked that screen because it was part touched in the login tests flow which we are currently working on (so there's fresher knowledge of them).

To test, run the `LoginTests` `XCTestCase` from the WooCommerceScreenshots scheme with the mocks (`rake mocks`) running on the terminal, it should build and pass.

I also run the UI tests in CI and they passed.

<img width="1039" alt="Screen Shot 2021-06-15 at 9 14 55 pm" src="https://user-images.githubusercontent.com/1218433/122043533-c850a080-ce1e-11eb-9b3e-023dd593741d.png">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---

~~This PR is still a draft, but I would appreciate your [30% feedback](https://www.linkedin.com/pulse/5-30-90-feedback-why-matters-manley-/) on it.~~
