### PR TITLE
Updated CTA with `Print Shipping Label`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 6.9
 -----
 - [*] Products: You can edit product attributes for variations right from the main product form. [https://github.com/woocommerce/woocommerce-ios/pull/4350]
-- [*] Improved CTA. "Print Shipping Label" instead of "Reprint Shipping Label".
+- [*] Improved CTA. "Print Shipping Label" instead of "Reprint Shipping Label". [https://github.com/woocommerce/woocommerce-ios/pull/4394]
 
 6.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.9
 -----
 - [*] Products: You can edit product attributes for variations right from the main product form. [https://github.com/woocommerce/woocommerce-ios/pull/4350]
+- [*] Improved CTA. "Print Shipping Label" instead of "Reprint Shipping Label".
 
 6.8
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1175,7 +1175,7 @@ extension OrderDetailsDataSource {
         static let netAmount = NSLocalizedString("Net Payment", comment: "The title for the net amount paid cell")
         static let collectPayment = NSLocalizedString("Collect Payment", comment: "Text on the button that starts collecting a card present payment.")
         static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
-        static let reprintShippingLabel = NSLocalizedString("Reprint Shipping Label", comment: "Text on the button that reprints a shipping label")
+        static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
         static let seeReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Reprint Shipping Label/ReprintShippingLabelViewController.swift
@@ -257,8 +257,8 @@ private extension ReprintShippingLabelViewController {
     }
 
     enum Localization {
-        static let navigationBarTitle = NSLocalizedString("Reprint Shipping Label",
-                                                          comment: "Navigation bar title to reprint a shipping label")
+        static let navigationBarTitle = NSLocalizedString("Print Shipping Label",
+                                                          comment: "Navigation bar title to print a shipping label")
         static let reprintButtonTitle = NSLocalizedString("Print Shipping Label",
                                                           comment: "Button title to generate a shipping label document for printing")
         static let paperSizeSelectorTitle = NSLocalizedString("Paper Size", comment: "Title of the paper size selector row for reprinting a shipping label")


### PR DESCRIPTION
Fixes #4393 

## Description
Updated the CTA in the Order Details screen to “Print shipping label”, because currently we can’t detect if a label has been printed in the app, so it is weird to display “Reprint shipping label”.


## Screenshots
| Updated the Shipping Label CTA in Order Detail Screen            |  Title of the screen for printing the shipping label |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-09 at 15 32 04](https://user-images.githubusercontent.com/495617/121364526-26b9e280-c938-11eb-94c4-b8e5cf7c8c6c.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-09 at 15 32 07](https://user-images.githubusercontent.com/495617/121364538-29b4d300-c938-11eb-8bb2-a21efba15788.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
