### PR TITLE
Hack Week: improve the loading state in the Order Detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.9
 -----
-- [*] Order Detail: now we display a loader on top, to communicate that the order detail view has not yet been fully loaded.
+- [*] Order Detail: now we display a loader on top, to communicate that the order detail view has not yet been fully loaded. [https://github.com/woocommerce/woocommerce-ios/pull/4396]
 
 6.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.9
 -----
-
+- [*] Order Detail: now we display a loader on top, to communicate that the order detail view has not yet been fully loaded.
 
 6.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -53,10 +53,6 @@ final class OrderDetailsViewController: UIViewController {
     ///
     private var cardReaderAvailableSubscription: Combine.Cancellable? = nil
 
-    /// Loading view displayed while the order is loading
-    ///
-    private let loadingView = LoadingView(waitMessage: "Order is loading...")
-
     // MARK: - View Lifecycle
 
     /// Create an instance of `Self` from its corresponding storyboard.
@@ -76,7 +72,6 @@ final class OrderDetailsViewController: UIViewController {
         configureEntityListener()
         configureViewModel()
         updateTopBannerView()
-        loadingView.showLoader(in: view)
 
         // FIXME: this is a hack. https://github.com/woocommerce/woocommerce-ios/issues/1779
         reloadTableViewSectionsAndData()
@@ -84,8 +79,10 @@ final class OrderDetailsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        programaticallyBeginRefreshing()
         syncEverything { [weak self] in
-            self?.loadingView.hideLoader()
+            self?.refreshControl.endRefreshing()
         }
     }
 
@@ -276,7 +273,7 @@ private extension OrderDetailsViewController {
 
 // MARK: - Action Handlers
 //
-extension OrderDetailsViewController {
+private extension OrderDetailsViewController {
 
     @objc func pullToRefresh() {
         ServiceLocator.analytics.track(.orderDetailPulledToRefresh)
@@ -286,6 +283,14 @@ extension OrderDetailsViewController {
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             self?.refreshControl.endRefreshing()
         }
+    }
+
+    /// Programmatically show the loader above the tableview.
+    ///
+    func programaticallyBeginRefreshing() {
+        refreshControl.beginRefreshing()
+        let offsetPoint = CGPoint(x: 0, y: -refreshControl.frame.size.height)
+        tableView.setContentOffset(offsetPoint, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -10,9 +10,22 @@ import Combine
 //
 final class OrderDetailsViewController: UIViewController {
 
+    /// Main Stack View, that contains all the other views of the screen
+    ///
+    @IBOutlet private weak var stackView: UIStackView!
+
     /// Main TableView.
     ///
     @IBOutlet private weak var tableView: UITableView!
+
+    /// The top loader view, that will be embedded inside the stackview, on top of the tableview, while the screen is loading its
+    /// content for the first time.
+    ///
+    private var topLoaderView: TopLoaderView = {
+        let loaderView: TopLoaderView = TopLoaderView.instantiateFromNib()
+        loaderView.setBody(Localization.Generic.topLoaderBannerDescription)
+        return loaderView
+    }()
 
     /// Pull To Refresh Support.
     ///
@@ -66,6 +79,7 @@ final class OrderDetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigation()
+        configureTopLoaderView()
         configureTableView()
         registerTableViewCells()
         registerTableViewHeaderFooters()
@@ -79,10 +93,8 @@ final class OrderDetailsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        programaticallyBeginRefreshing()
         syncEverything { [weak self] in
-            self?.refreshControl.endRefreshing()
+            self?.topLoaderView.isHidden = true
         }
     }
 
@@ -106,6 +118,11 @@ final class OrderDetailsViewController: UIViewController {
 // MARK: - TableView Configuration
 //
 private extension OrderDetailsViewController {
+
+    /// Setup: TopLoaderView
+    func configureTopLoaderView() {
+        stackView.insertArrangedSubview(topLoaderView, at: 0)
+    }
 
     /// Setup: TableView
     ///
@@ -283,14 +300,6 @@ private extension OrderDetailsViewController {
             NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             self?.refreshControl.endRefreshing()
         }
-    }
-
-    /// Programmatically show the loader above the tableview.
-    ///
-    func programaticallyBeginRefreshing() {
-        refreshControl.beginRefreshing()
-        let offsetPoint = CGPoint(x: 0, y: -refreshControl.frame.size.height)
-        tableView.setContentOffset(offsetPoint, animated: true)
     }
 }
 
@@ -937,6 +946,11 @@ private extension OrderDetailsViewController {
     }
 
     enum Localization {
+        enum Generic {
+            static let topLoaderBannerDescription = NSLocalizedString("Loading content",
+                                                                      comment: "Description of the loading banner in Order Detail when loaded for the first time")
+        }
+
         enum ShippingLabelMoreMenu {
             static let cancelAction = NSLocalizedString("Cancel", comment: "Cancel the shipping label more menu action sheet")
             static let requestRefundAction = NSLocalizedString("Request a Refund",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -948,7 +948,7 @@ private extension OrderDetailsViewController {
     enum Localization {
         enum Generic {
             static let topLoaderBannerDescription = NSLocalizedString("Loading content",
-                                                                      comment: "Description of the loading banner in Order Detail when loaded for the first time")
+                                                                      comment: "Text of the loading banner in Order Detail when loaded for the first time")
         }
 
         enum ShippingLabelMoreMenu {

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,25 +15,31 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hBh-xf-Cby">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UvB-Se-4t8">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
-                                <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <connections>
-                                    <outlet property="delegate" destination="IgL-pI-DQK" id="z2y-Op-rg4"/>
-                                </connections>
-                            </tableView>
+                                <subviews>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hBh-xf-Cby">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                                        <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <connections>
+                                            <outlet property="delegate" destination="IgL-pI-DQK" id="z2y-Op-rg4"/>
+                                        </connections>
+                                    </tableView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="wvX-aq-v2S"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="hBh-xf-Cby" firstAttribute="top" secondItem="wvX-aq-v2S" secondAttribute="top" id="336-TT-5Dd"/>
-                            <constraint firstAttribute="trailing" secondItem="hBh-xf-Cby" secondAttribute="trailing" id="FQp-iN-6oS"/>
-                            <constraint firstItem="wvX-aq-v2S" firstAttribute="bottom" secondItem="hBh-xf-Cby" secondAttribute="bottom" id="MGb-D6-I2u"/>
-                            <constraint firstItem="hBh-xf-Cby" firstAttribute="leading" secondItem="BSM-Pn-wcY" secondAttribute="leading" id="zxy-1j-4Gg"/>
+                            <constraint firstItem="UvB-Se-4t8" firstAttribute="top" secondItem="wvX-aq-v2S" secondAttribute="top" id="4Ub-DZ-ghw"/>
+                            <constraint firstItem="wvX-aq-v2S" firstAttribute="trailing" secondItem="UvB-Se-4t8" secondAttribute="trailing" id="5yv-ks-XxC"/>
+                            <constraint firstItem="UvB-Se-4t8" firstAttribute="leading" secondItem="wvX-aq-v2S" secondAttribute="leading" id="gCC-dv-e72"/>
+                            <constraint firstItem="wvX-aq-v2S" firstAttribute="bottom" secondItem="UvB-Se-4t8" secondAttribute="bottom" id="r2l-mN-F5h"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="stackView" destination="UvB-Se-4t8" id="wvx-Df-1xq"/>
                         <outlet property="tableView" destination="hBh-xf-Cby" id="36b-Gi-HZa"/>
                     </connections>
                 </viewController>
@@ -78,6 +83,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TopLoaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TopLoaderView.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// A view with a loader on the left side, and a text on the right, useful for showing that there is some content that is still loading.
+/// Used on top of the Order Detail screen.
+///
+final class TopLoaderView: UIView {
+
+    @IBOutlet private weak var stackView: UIStackView!
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet private weak var body: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        customizeView()
+        customizeIndicator()
+        customizeLabels()
+    }
+
+    func setBody(_ text: String) {
+        self.body.text = text
+    }
+}
+
+private extension TopLoaderView {
+    func customizeView() {
+        backgroundColor = .black
+    }
+
+    func customizeIndicator() {
+        activityIndicator.startAnimating()
+        activityIndicator.color = .white
+    }
+
+    func customizeLabels() {
+        body.applySubheadlineStyle()
+        body.textColor = .white
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TopLoaderView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TopLoaderView.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="328-Nc-ZYG" customClass="TopLoaderView" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="UdD-Tg-nUz">
+                    <rect key="frame" x="16" y="0.0" width="343" height="44"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="rS4-bs-UuN">
+                            <rect key="frame" x="0.0" y="0.0" width="20" height="44"/>
+                        </activityIndicatorView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XH3-ML-t8o">
+                            <rect key="frame" x="36" y="0.0" width="307" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="VXL-71-Fte"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="T5Y-jZ-uDC"/>
+            <constraints>
+                <constraint firstItem="UdD-Tg-nUz" firstAttribute="top" secondItem="328-Nc-ZYG" secondAttribute="top" id="7PD-Jk-eIx"/>
+                <constraint firstAttribute="bottom" secondItem="UdD-Tg-nUz" secondAttribute="bottom" id="7zQ-q1-Uge"/>
+                <constraint firstItem="UdD-Tg-nUz" firstAttribute="leading" secondItem="328-Nc-ZYG" secondAttribute="leading" constant="16" id="gzu-8L-pap"/>
+                <constraint firstAttribute="trailing" secondItem="UdD-Tg-nUz" secondAttribute="trailing" constant="16" id="rHy-To-Yyb"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="activityIndicator" destination="rS4-bs-UuN" id="NNz-70-MQq"/>
+                <outlet property="body" destination="XH3-ML-t8o" id="UQo-xG-tvx"/>
+                <outlet property="stackView" destination="UdD-Tg-nUz" id="26C-DJ-Q8Q"/>
+            </connections>
+            <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -577,6 +577,8 @@
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EB92603F632006CDFB8 /* MapsHelper.swift */; };
 		45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45977EBF2604C167006CDFB8 /* PhoneHelper.swift */; };
+		459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DB7D42673721300E2CAD2 /* TopLoaderView.swift */; };
+		459DB7E2267372ED00E2CAD2 /* TopLoaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 459DB7E1267372ED00E2CAD2 /* TopLoaderView.xib */; };
 		45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */; };
 		45A0E4CC2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */; };
 		45A0E4D32566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */; };
@@ -1850,6 +1852,8 @@
 		4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		45977EB92603F632006CDFB8 /* MapsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapsHelper.swift; sourceTree = "<group>"; };
 		45977EBF2604C167006CDFB8 /* PhoneHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneHelper.swift; sourceTree = "<group>"; };
+		459DB7D42673721300E2CAD2 /* TopLoaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLoaderView.swift; sourceTree = "<group>"; };
+		459DB7E1267372ED00E2CAD2 /* TopLoaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TopLoaderView.xib; sourceTree = "<group>"; };
 		45A0E4C92566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfLinkedProductsTableViewCell.swift; sourceTree = "<group>"; };
 		45A0E4CA2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberOfLinkedProductsTableViewCell.xib; sourceTree = "<group>"; };
 		45A0E4D22566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsViewModelTests.swift; sourceTree = "<group>"; };
@@ -5578,6 +5582,8 @@
 				020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */,
 				4512055024655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift */,
 				4512055124655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib */,
+				459DB7D42673721300E2CAD2 /* TopLoaderView.swift */,
+				459DB7E1267372ED00E2CAD2 /* TopLoaderView.xib */,
 				CE35F1192343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift */,
 				CE35F11A2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.xib */,
 				CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */,
@@ -6153,6 +6159,7 @@
 				450C2CBB24D3127500D570DD /* ProductReviewsTableViewCell.xib in Resources */,
 				02DD81FC242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.xib in Resources */,
 				45E9A6E524DAE1EA00A600E8 /* ProductReviewsViewController.xib in Resources */,
+				459DB7E2267372ED00E2CAD2 /* TopLoaderView.xib in Resources */,
 				2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */,
 				02E6B97923853D81000A36F0 /* TitleAndValueTableViewCell.xib in Resources */,
 				CE37C04522984E81008DCB39 /* PickListTableViewCell.xib in Resources */,
@@ -6576,6 +6583,7 @@
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
+				459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */,
 				02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */,
 				0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,


### PR DESCRIPTION
As discussed here p91TBi-5f1, we'd like to improve the loading state of the Order Detail screen.
So, I implemented the solution proposed by @Garance91540 here: p91TBi-5f1#comment-4949.

One of the main issues that we want to solve, is to communicate to our users, displaying a refresh control on top of the table view, that the screen is still loading its content.

## Testing
#### Case 1
1. Open an Order Detail.
2. You should see the detail of the order, and an activity indicator on top (the same we use for the pull to refresh action).
3. The activity indicator should be hidden when all the requests finish.
4. The pull to refresh action should work like before.
5. If you try to open a sub-screen starting from Order Detail when you do a "pop" action, you should see the indicator at the top again.

#### Case 2
1. Open an Order Detail.
2. Open a sub-screen starting from Order Detail (like tapping "View Billing Information") 
3. Tap back.
4. You should see the indicator at the top again, while we are refreshing the data.


## Video

https://user-images.githubusercontent.com/495617/121526997-3bf74580-c9fa-11eb-80df-62cd1830a20f.mp4





Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
