### PR TITLE
[Mobile Payments] Remove payments feature flag

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -67,14 +67,12 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         }
         stores.dispatch(reviewAction)
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
-            group.enter()
-            let resetAction = CardPresentPaymentAction.reset
+        group.enter()
+        let resetAction = CardPresentPaymentAction.reset
 
-            stores.dispatch(resetAction)
+        stores.dispatch(resetAction)
 
-            group.leave()
-        }
+        group.leave()
 
         group.notify(queue: .main) {
             onCompletion()

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -5,8 +5,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .cardPresentPayments:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .largeTitles:
             return true
         case .shippingLabelsM2M3:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -10,10 +10,6 @@ enum FeatureFlag: Int {
     ///
     case barcodeScanner
 
-    /// Card Present Payments
-    ///
-    case cardPresentPayments
-
     /// Large titles on the main tabs
     ///
     case largeTitles

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -479,8 +479,7 @@ extension OrderDetailsViewModel {
                 self.dataSource.isEligibleForCardPresentPayment = false
             case .success(let account):
                 self.paymentsAccount = account
-                self.dataSource.isEligibleForCardPresentPayment = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) &&
-                    self.isOrderEligibleForCardPayment() && account.isCardPresentEligible
+                self.dataSource.isEligibleForCardPresentPayment = self.isOrderEligibleForCardPayment() && account.isCardPresentEligible
             }
 
             onCompletion?()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -133,8 +133,7 @@ private extension SettingsViewController {
             case .failure:
                 self.canCollectPayments = false
             case .success(let account):
-                self.canCollectPayments = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) &&
-                    account.isCardPresentEligible
+                self.canCollectPayments = account.isCardPresentEligible
             }
 
             onCompletion()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -388,10 +388,6 @@ private extension OrderDetailsViewController {
     }
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
-            return
-        }
-
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -158,11 +158,8 @@ class DefaultStoresManager: StoresManager {
     ///
     @discardableResult
     func deauthenticate() -> StoresManager {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) {
-            let resetAction = CardPresentPaymentAction.reset
-
-            ServiceLocator.stores.dispatch(resetAction)
-        }
+        let resetAction = CardPresentPaymentAction.reset
+        ServiceLocator.stores.dispatch(resetAction)
 
         state = DeauthenticatedState()
 


### PR DESCRIPTION
Closes #4287 

Remove local feature flag for mobile payments, just in case we need to submit a new build of 6.8 for review

## Changes
* Remove `cardPresentPayments` feature flag

## How to test

| Store gated into beta 1 | Store not gated into beta 1 |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/121750126-cf537800-cad9-11eb-9a32-d847fe284d70.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/121750142-d67a8600-cad9-11eb-9ce7-f4a3749d57c8.png" width="350"/> |
* Login to an account that has at least one store gated into the beta 1 of Card Present Payments
* Check that it is possible to capture a payment. The easiest way is navigating to Settings, and then checking that the Manage Card Reader entry is available
* Switch to a store not gated into the beta, or to an account without stores gated into the beta.
* Navigate to settings again, check there are no traces of "Manage Card Readers".


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
