### PR TITLE
[Mobile Payments] Update copy for scanning for reader modal

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -47,7 +47,7 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let instruction = NSLocalizedString(
-            "Turn on your reader by pressing its power button",
+            "Press the power button of your reader until you see a flashing blue light",
             comment: "Label within the modal dialog that appears when searching for a card reader"
         )
 


### PR DESCRIPTION
Fixes #4366

Updates the modal copy to match the design:

Before | After
-|-
![Screen Shot 2021-06-14 at 11 50 18](https://user-images.githubusercontent.com/8739/121875246-86cdd180-cd08-11eb-8035-fb61b399e223.png)|![Screen Shot 2021-06-14 at 11 51 55](https://user-images.githubusercontent.com/8739/121875253-88979500-cd08-11eb-8a89-59bf28484f66.png)

## To test

Go to settings > Manage Card Readers and tap on Connect Card Reader

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
