### PR TITLE
[Mobile Payments] Fix link to Hardware in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please, remember to not add this information on your commits and PRs.
     - [Networking](docs/NETWORKING.md)
     - [Storage](docs/STORAGE.md)
     - [Yosemite](docs/YOSEMITE.md)
-    - [Hardware](HARDWARE.md)    
+    - [Hardware](docs/HARDWARE.md)    
 - Coding Guidelines
     - [Coding Style](docs/coding-style-guide.md)
     - [Naming Conventions](docs/naming-conventions.md)


### PR DESCRIPTION
Closes #4409 

An easy one to get the week started. 

Fix link to HARDWARE.md in README.md

## Changes
* Point the link to HARDWARE.md to the correct folder (`docs`)

## How to test
There isn't much to test.
* Navigate [to the branch in GitHub](https://github.com/woocommerce/woocommerce-ios/tree/fix/hardware-link)
* Find the link to Hardware in Documentation > Architecture.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
