### PR TITLE
[Mobile Payments] Add currency to order total in modals when capturing a payment

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -594,9 +594,14 @@ private extension OrderDetailsViewController {
     }
 
     private func collectPaymentForCurrentOrder() {
+        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        let currencyCode = ServiceLocator.currencySettings.currencyCode
+        let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let value = currencyFormatter.formatAmount(viewModel.order.total, with: unit) ?? ""
+
         paymentAlerts.readerIsReady(from: self,
                                     title: viewModel.collectPaymentFrom,
-                                    amount: viewModel.order.total)
+                                    amount: value)
 
         ServiceLocator.analytics.track(.collectPaymentTapped)
         viewModel.collectPayment { [weak self] readerEventMessage in


### PR DESCRIPTION
Closes #4356 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/121946323-d0c3b100-cd22-11eb-967a-f1b32cbf1a9a.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/121946450-f18c0680-cd22-11eb-94bd-bab4ed750c31.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/121946325-d0c3b100-cd22-11eb-8a8f-cdaba0b5cf58.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/121946451-f18c0680-cd22-11eb-9174-2301cd30929c.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/121946327-d15c4780-cd22-11eb-91af-6d807916d192.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/121946452-f2249d00-cd22-11eb-8f2a-e48c79c06d4d.png" width="350"/> |

## Changes
Format the total amount being charged using the store currency settings. 

## How to test
* Attempt to charge an order. 
* Notice the amount, and I the amount includes the currency.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
