### PR TITLE
Include attributes for aggregating order items

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+7.0
+-----
+- [*] Fix: Orders for a variable product with different configurations of a single variation will now show each order item separately. [https://github.com/woocommerce/woocommerce-ios/pull/4416]
+
+
 6.9
 -----
 - [*] Order Detail: now we display a loader on top, to communicate that the order detail view has not yet been fully loaded. [https://github.com/woocommerce/woocommerce-ios/pull/4396]

--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -65,6 +65,7 @@ extension AggregateOrderItem: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(productID)
         hasher.combine(variationID)
+        hasher.combine(attributes)
     }
 }
 


### PR DESCRIPTION
Fixes #4412

In #4412, it was reported that when a customer orders multiple items of a variable product but with different attributes, the app only displays that variation once in the Order Details.

I think the main cause is that we are aggregating order items based only on product and variation ID so, if there are multiple items of the same product with a single variation, but different attributes, they will be grouped as one.

The fix for this seems pretty simple, which makes me wonder if there is a lot more to it that I'm missing, so please review accordingly. I'm not too familiar with this area of the app yet.

## To test

Follow the steps in #4412:


1. Create a variable product.
2. Add “Color” as an attribute with “Blue|Green|Yellow” as the values.
3. Create a single variation of that variable product. Choose “Any” as the attribute option.
4. Create a single order for the product.
    - Add 1 Blue
    - Add 2 Green
    - Add 5 Yellow
5. Check out and submit the order.
6. In the app, view the order. It should show three different items, one for each color purchased.

On the web:

![Screen Shot 2021-06-15 at 09 43 35](https://user-images.githubusercontent.com/8739/122014484-7af11680-cdbf-11eb-84eb-018fa1efca3e.png)

Before | After
-|-
![Screen Shot 2021-06-15 at 09 44 15](https://user-images.githubusercontent.com/8739/122014512-83495180-cdbf-11eb-9d9a-631d9a417643.png)|![Screen Shot 2021-06-15 at 09 44 59](https://user-images.githubusercontent.com/8739/122014520-85131500-cdbf-11eb-98fe-292980a40158.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
