### PR TITLE
Refactor SettingsAction to use Result

### DIFF
--- a/Networking/Networking/Remote/SiteAPIRemote.swift
+++ b/Networking/Networking/Remote/SiteAPIRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// Site API: Remote Endpoints
@@ -13,7 +12,7 @@ public class SiteAPIRemote: Remote {
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadAPIInformation(for siteID: Int64, completion: @escaping (Swift.Result<SiteAPI, Error>) -> Void) {
+    public func loadAPIInformation(for siteID: Int64, completion: @escaping (Result<SiteAPI, Error>) -> Void) {
         let path = String()
         let parameters = [ParameterKeys.fields: ParameterValues.fieldValues]
         let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/Networking/Remote/SiteAPIRemote.swift
+++ b/Networking/Networking/Remote/SiteAPIRemote.swift
@@ -13,7 +13,7 @@ public class SiteAPIRemote: Remote {
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadAPIInformation(for siteID: Int64, completion: @escaping (SiteAPI?, Error?) -> Void) {
+    public func loadAPIInformation(for siteID: Int64, completion: @escaping (Swift.Result<SiteAPI, Error>) -> Void) {
         let path = String()
         let parameters = [ParameterKeys.fields: ParameterValues.fieldValues]
         let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/NetworkingTests/Remote/SiteAPIRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteAPIRemoteTests.swift
@@ -22,34 +22,39 @@ class SiteAPIRemoteTests: XCTestCase {
 
     /// Verifies that loadAPIInformation properly parses the sample response.
     ///
-    func testLoadGeneralSettingsProperlyReturnsParsedSettings() {
+    func test_loadAPIInformation_properly_returns_parsed_settings() throws {
+        // Given
         let remote = SiteAPIRemote(network: network)
-        let expectation = self.expectation(description: "Load site API information")
-
         network.simulateResponse(requestUrlSuffix: "", filename: "site-api")
-        remote.loadAPIInformation(for: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(siteAPI)
-            XCTAssertEqual(siteAPI?.siteID, self.sampleSiteID)
-            XCTAssertEqual(siteAPI?.highestWooVersion, WooAPIVersion.mark3)
-            expectation.fulfill()
+
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            remote.loadAPIInformation(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let siteAPI = try result.get()
+        XCTAssertEqual(siteAPI.siteID, sampleSiteID)
+        XCTAssertEqual(siteAPI.highestWooVersion, WooAPIVersion.mark3)
     }
 
     /// Verifies that loadAPIInformation properly relays Networking Layer errors.
     ///
-    func testLoadGeneralSettingsProperlyRelaysNetworkingErrors() {
+    func test_loadAPIInformation_properly_relays_networking_errors() {
+        // Given
         let remote = SiteAPIRemote(network: network)
-        let expectation = self.expectation(description: "Load site API information contains errors")
 
-        remote.loadAPIInformation(for: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(siteAPI)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            remote.loadAPIInformation(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -420,13 +420,13 @@ private extension StorePickerViewController {
     ///
     func displaySiteWCRequirementWarningIfNeeded(siteID: Int64, siteName: String) {
         updateActionButtonAndTableState(animating: true, enabled: false)
-        RequirementsChecker.checkMinimumWooVersion(for: siteID) { [weak self] (result, error) in
+        RequirementsChecker.checkMinimumWooVersion(for: siteID) { [weak self] result in
             switch result {
-            case .validWCVersion:
+            case .success(.validWCVersion):
                 self?.updateUIForValidSite()
-            case .invalidWCVersion:
+            case .success(.invalidWCVersion):
                 self?.updateUIForInvalidSite(named: siteName)
-            case .empty, .error:
+            case .failure:
                 self?.updateUIForEmptyOrErroredSite(named: siteName, with: siteID)
             }
         }

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -15,15 +15,6 @@ enum RequirementCheckResult: Int, CaseIterable {
     /// The installed version of WC is NOT valid
     ///
     case invalidWCVersion
-
-    /// The response returned from the server successfully however it was empty or missing information
-    /// that prevents us from verifing the WC version
-    ///
-    case empty
-
-    /// The request to the server timed out or resulted in an error
-    ///
-    case error
 }
 
 
@@ -51,12 +42,9 @@ class RequirementsChecker {
             return
         }
 
-        checkMinimumWooVersion(for: siteID) { (result, error) in
-            switch result {
-            case .invalidWCVersion:
+        checkMinimumWooVersion(for: siteID) { result in
+            if case .success(.invalidWCVersion) = result {
                 displayWCVersionAlert()
-            default:
-                break
             }
         }
     }
@@ -64,11 +52,9 @@ class RequirementsChecker {
     /// This function simply checks the provided site's API version. No warning will be displayed to the user.
     ///
     /// - parameter siteID: The SiteID to perform a version check on
-    /// - parameter onCompletion: Closure to be executed upon completion
-    /// - parameter result: Closure param that is the result of the requirement check
-    /// - parameter error: Closure param that is any error that occured while checking the WC version
+    /// - parameter onCompletion: Closure to be executed upon completion with the result of the requirement check
     ///
-    static func checkMinimumWooVersion(for siteID: Int64, onCompletion: ((_ result: RequirementCheckResult, _ error: Error?) -> Void)? = nil) {
+    static func checkMinimumWooVersion(for siteID: Int64, onCompletion: ((Result<RequirementCheckResult, Error>) -> Void)? = nil) {
         let action = retrieveSiteAPIAction(siteID: siteID, onCompletion: onCompletion)
         ServiceLocator.stores.dispatch(action)
     }
@@ -90,24 +76,19 @@ private extension RequirementsChecker {
 
     /// Returns a `SettingAction.retrieveSiteAPI` action
     ///
-    static func retrieveSiteAPIAction(siteID: Int64, onCompletion: ((RequirementCheckResult, Error?) -> Void)? = nil) -> SettingAction {
-        return SettingAction.retrieveSiteAPI(siteID: siteID) { (siteAPI, error) in
-            guard error == nil else {
+    static func retrieveSiteAPIAction(siteID: Int64, onCompletion: ((Result<RequirementCheckResult, Error>) -> Void)? = nil) -> SettingAction {
+        return SettingAction.retrieveSiteAPI(siteID: siteID) { result in
+            switch result {
+            case .success(let siteAPI):
+                if siteAPI.highestWooVersion == .mark3 {
+                    onCompletion?(.success(.validWCVersion))
+                } else {
+                    DDLogWarn("⚠️ WC version older than v3.5 — highest API version: \(siteAPI.highestWooVersion.rawValue) for siteID: \(siteAPI.siteID)")
+                    onCompletion?(.success(.invalidWCVersion))
+                }
+            case .failure(let error):
                 DDLogError("⛔️ An error occurred while fetching API info for siteID \(siteID): \(String(describing: error))")
-                onCompletion?(.error, error)
-                return
-            }
-            guard let siteAPI = siteAPI else {
-                DDLogWarn("⚠️ Empty or invalid response while fetching API info for siteID \(siteID))")
-                onCompletion?(.empty, nil)
-                return
-            }
-
-            if siteAPI.highestWooVersion == .mark3 {
-                onCompletion?(.validWCVersion, nil)
-            } else {
-                DDLogWarn("⚠️ WC version older than v3.5 — highest API version: \(siteAPI.highestWooVersion.rawValue) for siteID: \(siteAPI.siteID)")
-                onCompletion?(.invalidWCVersion, nil)
+                onCompletion?(.failure(error))
             }
         }
     }

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -16,5 +16,5 @@ public enum SettingAction: Action {
 
     /// Retrieves the site API details (used to determine the WC version)
     ///
-    case retrieveSiteAPI(siteID: Int64, onCompletion: (SiteAPI?, Error?) -> Void)
+    case retrieveSiteAPI(siteID: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
@@ -16,7 +16,7 @@ struct MockSettingActionHandler: MockActionHandler {
         }
     }
 
-    func retreiveSiteAPI(siteId: Int64, onCompletion: (SiteAPI?, Error?) -> Void) {
-        onCompletion(objectGraph.defaultSiteAPI, nil)
+    func retreiveSiteAPI(siteId: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void) {
+        onCompletion(.success(objectGraph.defaultSiteAPI))
     }
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -83,9 +83,7 @@ private extension SettingStore {
     /// This call does NOT persist returned data into the Storage layer.
     ///
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
-        siteAPIRemote.loadAPIInformation(for: siteID) { result in
-            onCompletion(result)
-        }
+        siteAPIRemote.loadAPIInformation(for: siteID, completion: onCompletion)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -82,9 +82,9 @@ private extension SettingStore {
     /// Retrieves the site API information associated with the provided Site ID (if any!).
     /// This call does NOT persist returned data into the Storage layer.
     ///
-    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (SiteAPI?, Error?) -> Void) {
-        siteAPIRemote.loadAPIInformation(for: siteID) { (siteAPI, error) in
-            onCompletion(siteAPI, error)
+    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
+        siteAPIRemote.loadAPIInformation(for: siteID) { result in
+            onCompletion(result)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -477,71 +477,81 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `SettingAction.retrieveSiteAPI` returns the expected API information.
     ///
-    func testRetrieveSiteAPIReturnsExpectedStatus() {
+    func test_retrieveSiteAPI_returns_expected_status() throws {
+        // Given
         let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectation = self.expectation(description: "Retrieve Site API info successfully")
-
         network.simulateResponse(requestUrlSuffix: "", filename: "site-api")
-        let action = SettingAction.retrieveSiteAPI(siteID: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(siteAPI)
-            XCTAssertEqual(siteAPI, self.sampleSiteAPIWithWoo())
-            expectation.fulfill()
+
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            let action = SettingAction.retrieveSiteAPI(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
 
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let siteAPI = try result.get()
+        XCTAssertEqual(siteAPI, sampleSiteAPIWithWoo())
     }
 
     /// Verifies that `SettingAction.retrieveSiteAPI` returns the expected API information.
     ///
-    func testRetrieveSiteAPIReturnsExpectedStatusForNonWooSite() {
+    func test_retrieveSiteAPI_returns_expected_status_for_non_woo_site() throws {
+        // Given
         let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectation = self.expectation(description: "Retrieve Site API info successfully for non-Woo site")
-
         network.simulateResponse(requestUrlSuffix: "", filename: "site-api-no-woo")
-        let action = SettingAction.retrieveSiteAPI(siteID: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(siteAPI)
-            XCTAssertEqual(siteAPI, self.sampleSiteAPINoWoo())
-            expectation.fulfill()
+
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            let action = SettingAction.retrieveSiteAPI(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
 
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let siteAPI = try result.get()
+        XCTAssertEqual(siteAPI, sampleSiteAPINoWoo())
     }
 
     /// Verifies that `SettingAction.retrieveSiteAPI` returns an error whenever there is an error response from the backend.
     ///
-    func testRetrieveSiteAPIReturnsErrorUponReponseError() {
-        let expectation = self.expectation(description: "Retrieve Site API info error response")
-        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
+    func test_retrieveSiteAPI_returns_error_upon_reponse_error() {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         network.simulateResponse(requestUrlSuffix: "", filename: "generic_error")
-        let action = SettingAction.retrieveSiteAPI(siteID: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(siteAPI)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            let action = SettingAction.retrieveSiteAPI(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
 
-        settingStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 
     /// Verifies that `SettingAction.retrieveSiteAPI` returns an error whenever there is no backend response.
     ///
-    func testRetrieveSiteAPIReturnsErrorUponEmptyResponse() {
-        let expectation = self.expectation(description: "Retrieve Site API info empty response")
-        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    func test_retrieveSiteAPI_returns_error_upon_empty_response() {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = SettingAction.retrieveSiteAPI(siteID: sampleSiteID) { (siteAPI, error) in
-            XCTAssertNil(siteAPI)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        let result: Result<SiteAPI, Error> = waitFor { promise in
+            let action = SettingAction.retrieveSiteAPI(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
         }
 
-        settingStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 }
 


### PR DESCRIPTION
## Description

This PR updates SettingsAction + related Store and Remote to use `Result`, so the state of response is more limited with less optional parameters.

## Test

1. Check CI status for unit tests.
2. Run app to trigger `RequirementsChecker` and verify there are no errors.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
