### PR TITLE
Refactor AccountAction, AccountStore and AccountRemote to use Result

### DIFF
--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -7,7 +7,7 @@ public class AccountRemote: Remote {
 
     /// Loads the Account Details associated with the Credential's authToken.
     ///
-    public func loadAccount(completion: @escaping (Account?, Error?) -> Void) {
+    public func loadAccount(completion: @escaping (Swift.Result<Account, Error>) -> Void) {
         let path = "me"
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
         let mapper = AccountMapper()
@@ -20,7 +20,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - for: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func loadAccountSettings(for userID: Int64, completion: @escaping (AccountSettings?, Error?) -> Void) {
+    public func loadAccountSettings(for userID: Int64, completion: @escaping (Swift.Result<AccountSettings, Error>) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out,first_name,last_name"
@@ -35,7 +35,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - userID: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (AccountSettings?, Error?) -> Void) {
+    public func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (Swift.Result<AccountSettings, Error>) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out",
@@ -51,7 +51,7 @@ public class AccountRemote: Remote {
 
     /// Loads the Sites collection associated with the WordPress.com User.
     ///
-    public func loadSites(completion: @escaping ([Site]?, Error?) -> Void) {
+    public func loadSites(completion: @escaping (Swift.Result<[Site], Error>) -> Void) {
         let path = "me/sites"
         let parameters = [
             "fields": "ID,name,description,URL,options",
@@ -66,7 +66,7 @@ public class AccountRemote: Remote {
 
     /// Loads the site plan for the default site associated with the WordPress.com user.
     ///
-    public func loadSitePlan(for siteID: Int64, completion: @escaping (SitePlan?, Error?) -> Void) {
+    public func loadSitePlan(for siteID: Int64, completion: @escaping (Swift.Result<SitePlan, Error>) -> Void) {
         let path = "sites/\(siteID)"
         let parameters = [
             "fields": "ID,plan"

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -19,36 +19,37 @@ class AccountRemoteTests: XCTestCase {
 
     /// Verifies that loadAccountDetails properly parses the `me` sample response.
     ///
-    func testLoadAccountDetailsProperlyReturnsParsedAccount() {
+    func test_loadAccount_properly_returns_parsed_account() {
+        // Given
         let remote = AccountRemote(network: network)
-        let expectation = self.expectation(description: "Load Account Details")
-
         network.simulateResponse(requestUrlSuffix: "me", filename: "me")
 
-        remote.loadAccount { (account, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(account)
-
-            expectation.fulfill()
+        // When
+        let result: Result<Account, Error> = waitFor { promise in
+            remote.loadAccount { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
     }
 
-    func testUpdateAccountDetailsProperlyReturnsParsedAccount() {
+    func test_updateAccountSettings_properly_returns_parsed_account() {
+        // Given
         let remoteID: Int64 = 1
         let optOut = false
         let remote = AccountRemote(network: network)
-        let expectation = self.expectation(description: "Update Account Details")
-
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
-        remote.updateAccountSettings(for: remoteID, tracksOptOut: optOut) { (accountSettings, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(accountSettings)
 
-            expectation.fulfill()
+        // When
+        let result: Result<AccountSettings, Error> = waitFor { promise in
+            remote.updateAccountSettings(for: remoteID, tracksOptOut: optOut) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
     }
 }

--- a/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
@@ -19,23 +19,24 @@ class AccountSettingsRemoteTests: XCTestCase {
 
     /// Verifies that loadAccountDetails properly parses the `me` sample response.
     ///
-    func testLoadAccountDetailsProperlyReturnsParsedAccount() {
+    func test_loadAccountSettings_properly_returns_parsed_account() throws {
+        // Given
         let remote = AccountRemote(network: network)
-        let expectation = self.expectation(description: "Load Account Settings Details")
-
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
 
-        remote.loadAccountSettings(for: 1) { (accountSettings, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(accountSettings)
-            XCTAssertEqual(1, accountSettings!.userID)
-            XCTAssertTrue(accountSettings!.tracksOptOut)
-            XCTAssertEqual(accountSettings!.firstName, "Dem 123")
-            XCTAssertEqual(accountSettings!.lastName, "Nines")
-
-            expectation.fulfill()
+        // When
+        let result: Result<AccountSettings, Error> = waitFor { promise in
+            remote.loadAccountSettings(for: 1) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let accountSettings = try result.get()
+        XCTAssertTrue(accountSettings.tracksOptOut)
+        XCTAssertEqual(accountSettings.userID, 1)
+        XCTAssertEqual(accountSettings.firstName, "Dem 123")
+        XCTAssertEqual(accountSettings.lastName, "Nines")
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -346,13 +346,14 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         appleUserID = nil
 
         ServiceLocator.stores.authenticate(credentials: .init(authToken: wpcom.authToken))
-        let action = AccountAction.synchronizeAccount { (account, error) in
-            if let account = account {
+        let action = AccountAction.synchronizeAccount { result in
+            switch result {
+            case .success(let account):
                 let credentials = Credentials(username: account.username, authToken: wpcom.authToken, siteAddress: wpcom.siteURL)
                 ServiceLocator.stores
                     .authenticate(credentials: credentials)
                     .synchronizeEntities(onCompletion: onCompletion)
-            } else {
+            case .failure:
                 ServiceLocator.stores.synchronizeEntities(onCompletion: onCompletion)
             }
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -218,14 +218,18 @@ private extension DefaultStoresManager {
 
     /// Synchronizes the WordPress.com Account, associated with the current credentials.
     ///
-    func synchronizeAccount(onCompletion: @escaping (Error?) -> Void) {
-        let action = AccountAction.synchronizeAccount { [weak self] (account, error) in
-            if let `self` = self, let account = account, self.isAuthenticated {
-                self.sessionManager.defaultAccount = account
-                ServiceLocator.analytics.refreshUserData()
+    func synchronizeAccount(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let action = AccountAction.synchronizeAccount { [weak self] result in
+            switch result {
+            case .success(let account):
+                if let self = self, self.isAuthenticated {
+                    self.sessionManager.defaultAccount = account
+                    ServiceLocator.analytics.refreshUserData()
+                }
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
-
-            onCompletion(error)
         }
 
         dispatch(action)
@@ -233,21 +237,23 @@ private extension DefaultStoresManager {
 
     /// Synchronizes the WordPress.com Account Settings, associated with the current credentials.
     ///
-    func synchronizeAccountSettings(onCompletion: @escaping (Error?) -> Void) {
-        guard let userID = self.sessionManager.defaultAccount?.userID else {
-            onCompletion(StoresManagerError.missingDefaultSite)
+    func synchronizeAccountSettings(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        guard let userID = sessionManager.defaultAccount?.userID else {
+            onCompletion(.failure(StoresManagerError.missingDefaultSite))
             return
         }
 
-        let action = AccountAction.synchronizeAccountSettings(userID: userID) { [weak self] (accountSettings, error) in
-            if let self = self,
-                let accountSettings = accountSettings,
-                self.isAuthenticated {
-                // Save the user's preference
-                ServiceLocator.analytics.setUserHasOptedOut(accountSettings.tracksOptOut)
+        let action = AccountAction.synchronizeAccountSettings(userID: userID) { [weak self] result in
+            switch result {
+            case .success(let accountSettings):
+                if let self = self, self.isAuthenticated {
+                    // Save the user's preference
+                    ServiceLocator.analytics.setUserHasOptedOut(accountSettings.tracksOptOut)
+                }
+                onCompletion(.success(()))
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
-
-            onCompletion(error)
         }
 
         dispatch(action)
@@ -269,16 +275,16 @@ private extension DefaultStoresManager {
 
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.
     ///
-    func synchronizeSites(onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeSites(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let action = AccountAction.synchronizeSites(onCompletion: onCompletion)
         dispatch(action)
     }
 
     /// Synchronizes the WordPress.com Site Plan.
     ///
-    func synchronizeSitePlan(onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeSitePlan(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         guard let siteID = sessionManager.defaultSite?.siteID else {
-            onCompletion(StoresManagerError.missingDefaultSite)
+            onCompletion(.failure(StoresManagerError.missingDefaultSite))
             return
         }
 

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -8,9 +8,9 @@ import Networking
 public enum AccountAction: Action {
     case loadAccount(userID: Int64, onCompletion: (Account?) -> Void)
     case loadSite(siteID: Int64, onCompletion: (Site?) -> Void)
-    case synchronizeAccount(onCompletion: (Account?, Error?) -> Void)
-    case synchronizeAccountSettings(userID: Int64, onCompletion: (AccountSettings?, Error?) -> Void)
-    case synchronizeSites(onCompletion: (Error?) -> Void)
-    case synchronizeSitePlan(siteID: Int64, onCompletion: (Error?) -> Void)
-    case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Error?) -> Void)
+    case synchronizeAccount(onCompletion: (Result<Account, Error>) -> Void)
+    case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
+    case synchronizeSites(onCompletion: (Result<Void, Error>) -> Void)
+    case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+    case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
 }


### PR DESCRIPTION
## Description

This PR updates AccountAction + related Store and Remote to use Result, so the state of response is more limited with less optional parameters.

## Test

1. Check CI status for unit tests.
2. Run app and do a cycle of logout-login, verify that account actions work well.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
