### PR TITLE
[Mobile Payments] UI Improvements to card reader instructions, part 2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -192,29 +192,34 @@ private extension CardReaderSettingsUnknownViewController {
 
     private func configureHeader(cell: HeadlineTableViewCell) {
         cell.headlineLabel?.text = Localization.connectYourCardReaderTitle
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 
     private func configureImage(cell: ImageTableViewCell) {
         cell.detailImageView?.image = UIImage(named: "card-reader-connect")
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 
     private func configureHelpHintChargeReader(cell: NumberedListItemTableViewCell) {
         cell.numberLabel?.text = Localization.hintOneTitle
         cell.itemTextLabel?.text = Localization.hintOne
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 
     private func configureHelpHintTurnOnReader(cell: NumberedListItemTableViewCell) {
         cell.numberLabel?.text = Localization.hintTwoTitle
         cell.itemTextLabel?.text = Localization.hintTwo
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 
     private func configureHelpHintEnableBluetooth(cell: NumberedListItemTableViewCell) {
         cell.numberLabel?.text = Localization.hintThreeTitle
         cell.itemTextLabel?.text = Localization.hintThree
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
    }
 
@@ -223,6 +228,7 @@ private extension CardReaderSettingsUnknownViewController {
         cell.configure(title: buttonTitle) { [weak self] in
             self?.viewModel?.startReaderDiscovery()
         }
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 
@@ -230,6 +236,7 @@ private extension CardReaderSettingsUnknownViewController {
         cell.learnMoreTextView.attributedText = Localization.learnMore
         cell.learnMoreTextView.tintColor = .textLink
         cell.learnMoreTextView.delegate = self
+        cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -236,6 +236,10 @@ private extension CardReaderSettingsUnknownViewController {
         cell.learnMoreTextView.attributedText = Localization.learnMore
         cell.learnMoreTextView.tintColor = .textLink
         cell.learnMoreTextView.delegate = self
+        cell.learnMoreTextView.linkTextAttributes = [
+            .foregroundColor: UIColor.textLink,
+            .underlineColor: UIColor.clear
+        ]
         cell.backgroundColor = .systemBackground
         cell.selectionStyle = .none
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.swift
@@ -2,5 +2,11 @@ import UIKit
 
 /// A table view cell with linkable text prompting users to learn more
 class LearnMoreTableViewCell: UITableViewCell {
+    @IBOutlet private weak var learnMoreButton: UIButton!
     @IBOutlet weak var learnMoreTextView: UITextView!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        learnMoreButton.setImage(.infoOutlineImage, for: .normal)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
@@ -29,7 +29,7 @@
                         <rect key="frame" x="60" y="10" width="334" height="54"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
                 </subviews>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
@@ -23,7 +23,6 @@
                             <constraint firstAttribute="height" constant="20" id="Osj-o1-fKz"/>
                         </constraints>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <state key="normal" image="info-outline"/>
                     </button>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pn2-lW-lwh">
                         <rect key="frame" x="60" y="10" width="334" height="54"/>
@@ -50,7 +49,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="info-outline" width="24" height="24"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LearnMoreTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,13 +16,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zTM-KS-b6r">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zTM-KS-b6r">
                         <rect key="frame" x="20" y="27" width="20" height="20"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="20" id="JSv-z4-9Zr"/>
                             <constraint firstAttribute="height" constant="20" id="Osj-o1-fKz"/>
                         </constraints>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <state key="normal" image="info-outline"/>
                     </button>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pn2-lW-lwh">
                         <rect key="frame" x="60" y="10" width="334" height="54"/>
@@ -43,12 +43,14 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
+                <outlet property="learnMoreButton" destination="zTM-KS-b6r" id="kxk-pX-Y8T"/>
                 <outlet property="learnMoreTextView" destination="pn2-lW-lwh" id="A5r-mE-9rz"/>
             </connections>
             <point key="canvasLocation" x="37.681159420289859" y="103.79464285714285"/>
         </tableViewCell>
     </objects>
     <resources>
+        <image name="info-outline" width="24" height="24"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>


### PR DESCRIPTION
Part of #4361
Fixes #4374 4374

This continues the work in #4411, and addresses the following feedback:

- Use the `info-outline` gridicon for the _learn more_ icon. Apparently, storyboards can't use images coming from Gridicons, so I left that empty and set it in code, but please let me know if there's a better way.
- Use footnote style for the _learn more_ text. I'm not sure I appreciate the difference, but the style is set.
- Use correct background colors for the whole screen, as pointed out in https://github.com/woocommerce/woocommerce-ios/pull/4411#pullrequestreview-684026224. This felt hacky because I had to apply the background to each cell individually, but we're using a table view to build a view that doesn't look like a table, so I guess it's OK.
- Remove the underline from the link in _learn more_

There are still a few items in #4361 that haven't been addressed yet, as I'm having a harder time re-learning auto layout after all this time 😅. I'm not sure if the fact that we're using a table view is problematic here, or I just haven't figured those out yet.

## To test

I've tested this on Light/Dark mode, and connecting from Settings/connecting from tapping Collect Payment within an order. Depending on how you get to this screen, it is presented in a navigation controller (from settings) or in a modal (from orders). The `systemBackground` applied basically makes the views transparent, so the modal will have the default background color, while the one with the navigation controller will have a black background.

### From settings (Light)

Before|After
-|-
![before-nav-light](https://user-images.githubusercontent.com/8739/122088123-c1696400-ce05-11eb-8951-1a55936fa505.png)|![after-nav-light](https://user-images.githubusercontent.com/8739/122088132-c3cbbe00-ce05-11eb-8354-1c8db62af151.png)


### From settings (Dark)

Before|After
-|-
![before-nav-dark](https://user-images.githubusercontent.com/8739/122088145-c6c6ae80-ce05-11eb-83c0-31ba4545bd7e.png)|![after-nav-dark](https://user-images.githubusercontent.com/8739/122088152-c8907200-ce05-11eb-977e-113734876e3e.png)

### From orders (Light)

Before|After
-|-
![before-modal-light](https://user-images.githubusercontent.com/8739/122088171-ccbc8f80-ce05-11eb-8aa5-93ea255ca18c.png)|![after-modal-light](https://user-images.githubusercontent.com/8739/122088209-d2b27080-ce05-11eb-9334-7302fda84ca7.png)

### From orders (Dark)

Before|After
-|-
![before-modal-dark](https://user-images.githubusercontent.com/8739/122088233-d645f780-ce05-11eb-9172-6b073a404a24.png)|![after-modal-dark](https://user-images.githubusercontent.com/8739/122088242-d80fbb00-ce05-11eb-95ac-180b79917c2e.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
