### PR TITLE
Shipping Labels: Networking layer for Shipping Label Purchase endpoint

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1101,8 +1101,6 @@ extension ShippingLabelPurchase {
             serviceName: .fake(),
             refundableAmount: .fake(),
             status: .fake(),
-            originAddress: .fake(),
-            destinationAddress: .fake(),
             productIDs: .fake(),
             productNames: .fake()
         )

--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1086,6 +1086,28 @@ extension ShippingLabelPrintData {
         )
     }
 }
+extension ShippingLabelPurchase {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelPurchase {
+        .init(
+            siteID: .fake(),
+            orderID: .fake(),
+            shippingLabelID: .fake(),
+            carrierID: .fake(),
+            dateCreated: .fake(),
+            packageName: .fake(),
+            trackingNumber: .fake(),
+            serviceName: .fake(),
+            refundableAmount: .fake(),
+            status: .fake(),
+            originAddress: .fake(),
+            destinationAddress: .fake(),
+            productIDs: .fake(),
+            productNames: .fake()
+        )
+    }
+}
 extension ShippingLabelRefund {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
+		CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -934,6 +935,7 @@
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
+		CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapperTests.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1804,6 +1806,7 @@
 				451A9835260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift */,
 				CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */,
 				CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */,
+				CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 			);
 			path = Mapper;
@@ -2512,6 +2515,7 @@
 				74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */,
 				0212683524C046CB00F8A892 /* MockNetwork+Path.swift in Sources */,
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,
+				CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
+		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -932,6 +933,7 @@
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
+		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1588,6 +1590,7 @@
 				CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */,
 				CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */,
 				456930AC2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json */,
+				CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */,
 				B56C1EB920EA7D2C00D749F9 /* sites.json */,
 				7426CA1221AF34A3004E9FFC /* site-api.json */,
 				74AB5B4E21AF3F0D00859C12 /* site-api-no-woo.json */,
@@ -2095,6 +2098,7 @@
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,
 				CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */,
 				02698CFA24C188E9005337C4 /* product-variations-load-all-alternative-types.json in Resources */,
+				CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
 				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */; };
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
+		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -928,6 +929,7 @@
 		B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsRemote.swift; sourceTree = "<group>"; };
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
+		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1079,6 +1081,7 @@
 				45A4B86125D3086600776FB4 /* ShippingLabelAddressValidationError.swift */,
 				CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */,
 				CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */,
+				CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */,
 				02C2549F25636F6900A04423 /* ShippingLabelRefund.swift */,
 				02C254A3256371B200A04423 /* ShippingLabelSettings.swift */,
 				451A97C72609FDE50059D135 /* Packages */,
@@ -2265,6 +2268,7 @@
 				D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
+				CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */,
 				45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift in Sources */,
 				CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */,
 				45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
+		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -930,6 +931,7 @@
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
+		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1697,6 +1699,7 @@
 				CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */,
 				456930AA264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift */,
 				CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */,
+				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2250,6 +2253,7 @@
 				24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */,
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
+				CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */,
 				456930AB264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift in Sources */,
 				CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelPurchaseMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelPurchaseMapper.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Mapper: List of Shipping Label Purchases
+///
+struct ShippingLabelPurchaseMapper: Mapper {
+    /// Site ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the shipping label endpoints.
+    ///
+    let siteID: Int64
+
+    /// Order ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because OrderID is not returned in any of the shipping label endpoints.
+    ///
+    let orderID: Int64
+
+    /// (Attempts) to convert a dictionary into [ShippingLabelPurchase].
+    ///
+    func map(response: Data) throws -> [ShippingLabelPurchase] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.userInfo = [
+            .siteID: siteID,
+            .orderID: orderID
+        ]
+
+        return try decoder.decode(ShippingLabelPurchaseResponse.self, from: response).data.labels
+    }
+}
+
+/// ShippingLabelPurchaseResponse Disposable Entity
+///
+/// `Purchase Shipping Labels` endpoint returns the data wrapper in the `data` key.
+///
+private struct ShippingLabelPurchaseResponse: Decodable {
+    let data: ShippingLabelPurchaseEnvelope
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}
+
+/// ShippingLabelPurchaseEnvelope Disposable Entity
+///
+/// `Purchase Shipping Labels` endpoint returns the shipping label purchases in the `data.labels` key.
+///
+private struct ShippingLabelPurchaseEnvelope: Decodable {
+    let labels: [ShippingLabelPurchase]
+
+    private enum CodingKeys: String, CodingKey {
+        case labels
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -730,6 +730,51 @@ extension ShippingLabelPaymentMethod {
     }
 }
 
+extension ShippingLabelPurchase {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        orderID: CopiableProp<Int64> = .copy,
+        shippingLabelID: CopiableProp<Int64> = .copy,
+        carrierID: NullableCopiableProp<String> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        packageName: CopiableProp<String> = .copy,
+        trackingNumber: NullableCopiableProp<String> = .copy,
+        serviceName: CopiableProp<String> = .copy,
+        refundableAmount: CopiableProp<Double> = .copy,
+        status: CopiableProp<ShippingLabelStatus> = .copy,
+        productIDs: CopiableProp<[Int64]> = .copy,
+        productNames: CopiableProp<[String]> = .copy
+    ) -> ShippingLabelPurchase {
+        let siteID = siteID ?? self.siteID
+        let orderID = orderID ?? self.orderID
+        let shippingLabelID = shippingLabelID ?? self.shippingLabelID
+        let carrierID = carrierID ?? self.carrierID
+        let dateCreated = dateCreated ?? self.dateCreated
+        let packageName = packageName ?? self.packageName
+        let trackingNumber = trackingNumber ?? self.trackingNumber
+        let serviceName = serviceName ?? self.serviceName
+        let refundableAmount = refundableAmount ?? self.refundableAmount
+        let status = status ?? self.status
+        let productIDs = productIDs ?? self.productIDs
+        let productNames = productNames ?? self.productNames
+
+        return ShippingLabelPurchase(
+            siteID: siteID,
+            orderID: orderID,
+            shippingLabelID: shippingLabelID,
+            carrierID: carrierID,
+            dateCreated: dateCreated,
+            packageName: packageName,
+            trackingNumber: trackingNumber,
+            serviceName: serviceName,
+            refundableAmount: refundableAmount,
+            status: status,
+            productIDs: productIDs,
+            productNames: productNames
+        )
+    }
+}
+
 extension SitePlugin {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatus.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatus.swift
@@ -4,6 +4,8 @@ import Codegen
 /// The status of shipping label.
 public enum ShippingLabelStatus: GeneratedFakeable {
     case purchased
+    case purchaseError
+    case purchaseInProgress
 }
 
 /// RawRepresentable Conformance
@@ -14,6 +16,10 @@ extension ShippingLabelStatus: RawRepresentable {
         switch rawValue {
         case Keys.purchased:
             self = .purchased
+        case Keys.purchaseInProgress:
+            self = .purchaseInProgress
+        case Keys.purchaseError:
+            self = .purchaseError
         default:
             assertionFailure("Unexpected value for `ShippingLabelStatus`: \(rawValue)")
             self = .purchased
@@ -26,6 +32,10 @@ extension ShippingLabelStatus: RawRepresentable {
         switch self {
         case .purchased:
             return Keys.purchased
+        case .purchaseInProgress:
+            return Keys.purchaseInProgress
+        case .purchaseError:
+            return Keys.purchaseError
         }
     }
 }
@@ -33,4 +43,6 @@ extension ShippingLabelStatus: RawRepresentable {
 /// Contains the supported ShippingLabelStatus values.
 private enum Keys {
     static let purchased = "PURCHASED"
+    static let purchaseError = "PURCHASE_ERROR"
+    static let purchaseInProgress = "PURCHASE_IN_PROGRESS"
 }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Codegen
+
+/// Represents a Shipping Label purchase.
+///
+public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFakeable {
+    /// The remote ID of the site that owns this shipping label.
+    public let siteID: Int64
+
+    /// The remote ID of the order that owns the shipping label.
+    public let orderID: Int64
+
+    /// The remote ID of the shipping label.
+    public let shippingLabelID: Int64
+
+    /// The remote ID of the shipping carrier.
+    public let carrierID: String
+
+    /// The date the shipping label was created.
+    public let dateCreated: Date
+
+    /// The name of the package for the shipping label.
+    public let packageName: String
+
+    /// The tracking number of the shipping label.
+    public let trackingNumber: String
+
+    /// The name of service for the shipping label (e.g. "USPS - Media Mail").
+    public let serviceName: String
+
+    /// The amount that is refundable.
+    public let refundableAmount: Double
+
+    /// The status of the shipping label (e.g. `PURCHASE_IN_PROGRESS`).
+    public let status: ShippingLabelStatus
+
+    /// A list of product IDs included in the shipping label.
+    /// This could be empty for older plugin versions.
+    public let productIDs: [Int64]
+
+    /// A list of product names included in the shipping label.
+    /// This is only used to look up a product in case `productIDs` is not available.
+    public let productNames: [String]
+
+    public init(siteID: Int64,
+                orderID: Int64,
+                shippingLabelID: Int64,
+                carrierID: String,
+                dateCreated: Date,
+                packageName: String,
+                trackingNumber: String,
+                serviceName: String,
+                refundableAmount: Double,
+                status: ShippingLabelStatus,
+                originAddress: ShippingLabelAddress,
+                destinationAddress: ShippingLabelAddress,
+                productIDs: [Int64],
+                productNames: [String]) {
+        self.siteID = siteID
+        self.orderID = orderID
+        self.shippingLabelID = shippingLabelID
+        self.carrierID = carrierID
+        self.dateCreated = dateCreated
+        self.packageName = packageName
+        self.trackingNumber = trackingNumber
+        self.serviceName = serviceName
+        self.refundableAmount = refundableAmount
+        self.status = status
+        self.productIDs = productIDs
+        self.productNames = productNames
+    }
+}
+
+// MARK: Decodable
+//
+extension ShippingLabelPurchase: Decodable {
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ShippingLabelDecodingError.missingSiteID
+        }
+
+        guard let orderID = decoder.userInfo[.orderID] as? Int64 else {
+            throw ShippingLabelDecodingError.missingOrderID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let shippingLabelID = try container.decode(Int64.self, forKey: .shippingLabelID)
+        let carrierID = try container.decode(String.self, forKey: .carrierID)
+        let dateCreated = try container.decode(Date.self, forKey: .dateCreated)
+        let packageName = try container.decode(String.self, forKey: .packageName)
+        let trackingNumber = try container.decode(String.self, forKey: .trackingNumber)
+        let serviceName = try container.decode(String.self, forKey: .serviceName)
+        let refundableAmount = try container.decode(Double.self, forKey: .refundableAmount)
+
+        let statusRawValue = try container.decode(String.self, forKey: .status)
+        let status = ShippingLabelStatus(rawValue: statusRawValue)
+
+        let productIDs = try container.decodeIfPresent([Int64].self, forKey: .productIDs) ?? []
+        let productNames = try container.decode([String].self, forKey: .productNames)
+
+        self.init(siteID: siteID,
+                  orderID: orderID,
+                  shippingLabelID: shippingLabelID,
+                  carrierID: carrierID,
+                  dateCreated: dateCreated,
+                  packageName: packageName,
+                  trackingNumber: trackingNumber,
+                  serviceName: serviceName,
+                  refundableAmount: refundableAmount,
+                  status: status,
+                  originAddress: .init(),
+                  destinationAddress: .init(),
+                  productIDs: productIDs,
+                  productNames: productNames)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case siteID
+        case orderID
+        case shippingLabelID = "label_id"
+        case carrierID = "carrier_id"
+        case dateCreated = "created"
+        case packageName = "package_name"
+        case trackingNumber = "tracking"
+        case serviceName = "service_name"
+        case refundableAmount = "refundable_amount"
+        case status
+        case productIDs = "product_ids"
+        case productNames = "product_names"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum ShippingLabelPurchaseDecodingError: Error {
+    case missingSiteID
+    case missingOrderID
+}

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -54,8 +54,6 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
                 serviceName: String,
                 refundableAmount: Double,
                 status: ShippingLabelStatus,
-                originAddress: ShippingLabelAddress,
-                destinationAddress: ShippingLabelAddress,
                 productIDs: [Int64],
                 productNames: [String]) {
         self.siteID = siteID
@@ -111,8 +109,6 @@ extension ShippingLabelPurchase: Decodable {
                   serviceName: serviceName,
                   refundableAmount: refundableAmount,
                   status: status,
-                  originAddress: .init(),
-                  destinationAddress: .init(),
                   productIDs: productIDs,
                   productNames: productNames)
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -86,10 +86,10 @@ extension ShippingLabelPurchase: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let shippingLabelID = try container.decode(Int64.self, forKey: .shippingLabelID)
-        let carrierID = try container.decode(String.self, forKey: .carrierID)
+        let carrierID = try container.decodeIfPresent(String.self, forKey: .carrierID)
         let dateCreated = try container.decode(Date.self, forKey: .dateCreated)
         let packageName = try container.decode(String.self, forKey: .packageName)
-        let trackingNumber = try container.decode(String.self, forKey: .trackingNumber)
+        let trackingNumber = try container.decodeIfPresent(String.self, forKey: .trackingNumber)
         let serviceName = try container.decode(String.self, forKey: .serviceName)
         let refundableAmount = try container.decode(Double.self, forKey: .refundableAmount)
 

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelPurchase.swift
@@ -3,6 +3,8 @@ import Codegen
 
 /// Represents a Shipping Label purchase.
 ///
+/// Shipping label purchases contain a subset of the label data included in a purchased `ShippingLabel`.
+///
 public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFakeable {
     /// The remote ID of the site that owns this shipping label.
     public let siteID: Int64
@@ -14,7 +16,7 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
     public let shippingLabelID: Int64
 
     /// The remote ID of the shipping carrier.
-    public let carrierID: String
+    public let carrierID: String?
 
     /// The date the shipping label was created.
     public let dateCreated: Date
@@ -23,7 +25,7 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
     public let packageName: String
 
     /// The tracking number of the shipping label.
-    public let trackingNumber: String
+    public let trackingNumber: String?
 
     /// The name of service for the shipping label (e.g. "USPS - Media Mail").
     public let serviceName: String
@@ -45,10 +47,10 @@ public struct ShippingLabelPurchase: Equatable, GeneratedCopiable, GeneratedFake
     public init(siteID: Int64,
                 orderID: Int64,
                 shippingLabelID: Int64,
-                carrierID: String,
+                carrierID: String?,
                 dateCreated: Date,
                 packageName: String,
-                trackingNumber: String,
+                trackingNumber: String?,
                 serviceName: String,
                 refundableAmount: Double,
                 status: ShippingLabelStatus,

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -223,6 +223,32 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
         let mapper = ShippingLabelCreationEligibilityMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Purchases the shipping label.
+    public func purchaseShippingLabel(siteID: Int64,
+                                      orderID: Int64,
+                                      originAddress: ShippingLabelAddress,
+                                      destinationAddress: ShippingLabelAddress,
+                                      packages: [ShippingLabelPackageSelected],
+                                      emailCustomerReceipt: Bool,
+                                      completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
+        do {
+            let parameters: [String: Any] = [
+                ParameterKey.async: true,
+                ParameterKey.originAddress: try originAddress.toDictionary(),
+                ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
+                ParameterKey.packages: try packages.map { try $0.toDictionary() },
+                ParameterKey.emailReceipt: emailCustomerReceipt
+            ]
+            let path = "\(Path.shippingLabels)/\(orderID)"
+            let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let mapper = ShippingLabelPurchaseMapper(siteID: siteID, orderID: orderID)
+            enqueue(request, mapper: mapper, completion: completion)
+        }
+        catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constant
@@ -248,5 +274,7 @@ private extension ShippingLabelRemote {
         static let packages = "packages"
         static let selectedPaymentMethodID = "selected_payment_method_id"
         static let emailReceipts = "email_receipts"
+        static let emailReceipt = "email_receipt"
+        static let async = "async"
     }
 }

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPurchaseMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPurchaseMapperTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ShippingLabelPurchaseMapper`
+///
+class ShippingLabelPurchaseMapperTests: XCTestCase {
+
+    /// Sample Site ID
+    private let sampleSiteID: Int64 = 1234
+
+    /// Sample Order ID
+    private let sampleOrderID: Int64 = 1234
+
+    /// Verifies that the Shipping Label Purchase is parsed correctly.
+    ///
+    func test_ShippingLabelPurchase_is_properly_parsed() {
+        guard let shippingLabelList = mapLoadShippingLabelPurchase(),
+              let shippingLabel = shippingLabelList.first else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(shippingLabel.siteID, sampleSiteID)
+        XCTAssertEqual(shippingLabel.orderID, sampleOrderID)
+        XCTAssertEqual(shippingLabel.shippingLabelID, 733)
+        XCTAssertNil(shippingLabel.carrierID)
+        XCTAssertEqual(shippingLabel.dateCreated, Date(timeIntervalSince1970: 1584549793.938))
+        XCTAssertEqual(shippingLabel.packageName, "Test")
+        XCTAssertNil(shippingLabel.trackingNumber)
+        XCTAssertEqual(shippingLabel.serviceName, "USPS - First Class Mail")
+        XCTAssertEqual(shippingLabel.refundableAmount, 0)
+        XCTAssertEqual(shippingLabel.status, ShippingLabelStatus.purchaseInProgress)
+        XCTAssertEqual(shippingLabel.productIDs, [])
+        XCTAssertEqual(shippingLabel.productNames, ["Beanie"])
+    }
+}
+
+/// Private Helpers
+///
+private extension ShippingLabelPurchaseMapperTests {
+
+    /// Returns the ShippingLabelPurchaseMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapShippingLabelPurchase(from filename: String) -> [ShippingLabelPurchase]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! ShippingLabelPurchaseMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
+    }
+
+    /// Returns the ShippingLabelPurchaseMapper output upon receiving `shipping-label-purchase-success`
+    ///
+    func mapLoadShippingLabelPurchase() -> [ShippingLabelPurchase]? {
+        return mapShippingLabelPurchase(from: "shipping-label-purchase-success")
+    }
+}

--- a/Networking/NetworkingTests/Responses/shipping-label-purchase-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-purchase-success.json
@@ -1,0 +1,16 @@
+{
+    "data": {
+        "labels": [{
+            "label_id": 733,
+            "tracking": null,
+            "refundable_amount": 0,
+            "created": 1584549793938,
+            "carrier_id": null,
+            "service_name": "USPS - First Class Mail",
+            "status": "PURCHASE_IN_PROGRESS",
+            "package_name": "Test",
+            "product_names": ["Beanie"]
+        }],
+        "success": true
+    }
+}


### PR DESCRIPTION
Part of: #4089

## Description

This PR adds support in the Networking layer for the Shipping Label Purchase endpoint (`POST /wc/v1/connect/label/{orderID}`). This endpoint is used to purchase a new shipping label, and it returns data about the pending shipping label purchase (a subset of the data returned for a fully purchased shipping label).

## Changes

* Adds `ShippingLabelRemote.purchaseShippingLabel` to make the API request to purchase a shipping label.
* Adds the mapper `ShippingLabelPurchaseMapper` to handle the API response (a list of shipping label purchases).
* Adds a new model `ShippingLabelPurchase` to represent the data returned about the purchase.
* Updates the enum `ShippingLabelStatus` to include additional statuses (`PURCHASE_IN_PROGRESS` and `PURCHASE_ERROR`).
* Adds mocks and unit tests for the remote endpoint (`ShippingLabelRemoteTests`) and mapper (`ShippingLabelPurchaseMapperTests`).
* Adds `fake()` and `copy()` methods for `ShippingLabelPurchase`.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
