### PR TITLE
Refactor ProductAction, ProductStore and ProductsRemote to use Result

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -25,10 +25,10 @@ public protocol ProductsRemoteProtocol {
                         pageNumber: Int,
                         pageSize: Int,
                         excludedProductIDs: [Int64],
-                        completion: @escaping ([Product]?, Error?) -> Void)
+                        completion: @escaping (Result<[Product], Error>) -> Void)
     func searchSku(for siteID: Int64,
                    sku: String,
-                   completion: @escaping (String?, Error?) -> Void)
+                   completion: @escaping (Result<String, Error>) -> Void)
     func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
 }
 
@@ -199,7 +199,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                pageNumber: Int,
                                pageSize: Int,
                                excludedProductIDs: [Int64] = [],
-                               completion: @escaping ([Product]?, Error?) -> Void) {
+                               completion: @escaping (Result<[Product], Error>) -> Void) {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
 
@@ -226,7 +226,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func searchSku(for siteID: Int64,
                                sku: String,
-                               completion: @escaping (String?, Error?) -> Void) {
+                               completion: @escaping (Result<String, Error>) -> Void) {
         let parameters = [
             ParameterKey.sku: sku,
             ParameterKey.fields: ParameterValues.skuFieldValues

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -372,41 +372,45 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that searchProducts properly parses the `products-load-all` sample response.
     ///
-    func testSearchProductsProperlyReturnsParsedProducts() {
+    func test_searchProducts_properly_returns_parsed_products() throws {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Wait for product search results")
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
 
-        remote.searchProducts(for: sampleSiteID,
-                              keyword: "photo",
-                              pageNumber: 0,
-                              pageSize: 100) { (products, error) in
-                                XCTAssertNil(error)
-                                XCTAssertNotNil(products)
-                                XCTAssertEqual(products?.count, 2)
-                                expectation.fulfill()
+        // When
+        let result: Result<[Product], Error> = waitFor { promise in
+            remote.searchProducts(for: self.sampleSiteID,
+                                  keyword: "photo",
+                                  pageNumber: 0,
+                                  pageSize: 100) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let products = try result.get()
+        XCTAssertEqual(products.count, 2)
     }
 
     /// Verifies that searchProducts properly relays Networking Layer errors.
     ///
-    func testSearchProductsProperlyRelaysNetwokingErrors() {
+    func test_searchProducts_properly_relays_netwoking_errors() {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Wait for product search results")
 
-        remote.searchProducts(for: sampleSiteID,
-                              keyword: String(),
-                              pageNumber: 0,
-                              pageSize: 100) { (products, error) in
-                                XCTAssertNil(products)
-                                XCTAssertNotNil(error)
-                                expectation.fulfill()
+        // When
+        let result: Result<[Product], Error> = waitFor { promise in
+            remote.searchProducts(for: self.sampleSiteID,
+                                  keyword: String(),
+                                  pageNumber: 0,
+                                  pageSize: 100) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 
 
@@ -414,39 +418,41 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that searchSku properly parses the product `sku` sample response.
     ///
-    func testSearchSkuProperlyReturnsParsedSku() {
+    func test_searchSku_properly_returns_parsed_sku() throws {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Search for a product sku")
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
-
         let expectedSku = "T-SHIRT-HAPPY-NINJA"
 
-        remote.searchSku(for: sampleSiteID, sku: expectedSku) { (sku, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(sku)
-            XCTAssertEqual(sku, expectedSku)
-            expectation.fulfill()
+        // When
+        let result: Result<String, Error> = waitFor { promise in
+            remote.searchSku(for: self.sampleSiteID, sku: expectedSku) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let sku = try result.get()
+        XCTAssertEqual(sku, expectedSku)
     }
 
     /// Verifies that searchSku properly relays Networking Layer errors.
     ///
-    func testSearchSkuProperlyRelaysNetwokingErrors() {
+    func test_searchSku_properly_relays_netwoking_errors() {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Wait for a product sku result")
-
         let skuToSearch = "T-SHIRT-HAPPY-NINJA"
 
-        remote.searchSku(for: sampleSiteID, sku: skuToSearch) { (sku, error) in
-            XCTAssertNil(sku)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        let result: Result<String, Error> = waitFor { promise in
+            remote.searchSku(for: self.sampleSiteID, sku: skuToSearch) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListMultiSelectorSearchUICommand.swift
@@ -75,12 +75,12 @@ final class ProductListMultiSelectorSearchUICommand: NSObject, SearchUICommand {
                                                   keyword: keyword,
                                                   pageNumber: pageNumber,
                                                   pageSize: pageSize,
-                                                  excludedProductIDs: excludedProductIDs) { error in
-                                                    if let error = error {
-                                                        DDLogError("☠️ Product Search Failure! \(error)")
-                                                    }
+                                                  excludedProductIDs: excludedProductIDs) { result in
+            if case let .failure(error) = result {
+                DDLogError("☠️ Product Search Failure! \(error)")
+            }
 
-                                                    onCompletion?(error == nil)
+            onCompletion?(result.isSuccess)
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -53,12 +53,12 @@ final class ProductSearchUICommand: SearchUICommand {
         let action = ProductAction.searchProducts(siteID: siteID,
                                                   keyword: keyword,
                                                   pageNumber: pageNumber,
-                                                  pageSize: pageSize) { error in
-                                                    if let error = error {
-                                                        DDLogError("☠️ Product Search Failure! \(error)")
-                                                    }
+                                                  pageSize: pageSize) { result in
+            if case let .failure(error) = result {
+                DDLogError("☠️ Product Search Failure! \(error)")
+            }
 
-                                                    onCompletion?(error == nil)
+            onCompletion?(result.isSuccess)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -8,7 +8,7 @@ public enum ProductAction: Action {
 
     /// Searches products that contain a given keyword.
     ///
-    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64] = [], onCompletion: (Error?) -> Void)
+    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64] = [], onCompletion: (Result<Void, Error>) -> Void)
 
     /// Synchronizes the Products matching the specified criteria.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -8,7 +8,12 @@ public enum ProductAction: Action {
 
     /// Searches products that contain a given keyword.
     ///
-    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64] = [], onCompletion: (Result<Void, Error>) -> Void)
+    case searchProducts(siteID: Int64,
+                        keyword: String,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        excludedProductIDs: [Int64] = [],
+                        onCompletion: (Result<Void, Error>) -> Void)
 
     /// Synchronizes the Products matching the specified criteria.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -103,7 +103,12 @@ private extension ProductStore {
 
     /// Searches all of the products that contain a given Keyword.
     ///
-    func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64], onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func searchProducts(siteID: Int64,
+                        keyword: String,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        excludedProductIDs: [Int64],
+                        onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.searchProducts(for: siteID,
                               keyword: keyword,
                               pageNumber: pageNumber,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -138,11 +138,11 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                         pageNumber: Int,
                         pageSize: Int,
                         excludedProductIDs: [Int64],
-                        completion: @escaping ([Product]?, Error?) -> Void) {
+                        completion: @escaping (Result<[Product], Error>) -> Void) {
         // no-op
     }
 
-    func searchSku(for siteID: Int64, sku: String, completion: @escaping (String?, Error?) -> Void) {
+    func searchSku(for siteID: Int64, sku: String, completion: @escaping (Result<String, Error>) -> Void) {
         // no-op
     }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -930,10 +930,9 @@ final class ProductStoreTests: XCTestCase {
 
     /// Verifies that `ProductAction.searchProducts` effectively persists the retrieved products.
     ///
-    func testSearchProductsEffectivelyPersistsRetrievedSearchProducts() {
-        let expectation = self.expectation(description: "Search Products")
+    func test_searchProducts_effectively_persists_retrieved_search_products() throws {
+        // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
@@ -941,117 +940,100 @@ final class ProductStoreTests: XCTestCase {
         let expectedProductID: Int64 = 67
         let expectedProductName = "Photo"
 
+        // When
         let keyword = "photo"
-        let action = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                  keyword: keyword,
-                                                  pageNumber: defaultPageNumber,
-                                                  pageSize: defaultPageSize,
-                                                  onCompletion: { [weak self] error in
-                                                    guard let self = self else {
-                                                        XCTFail()
-                                                        return
-                                                    }
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                      keyword: keyword,
+                                                      pageNumber: self.defaultPageNumber,
+                                                      pageSize: self.defaultPageSize,
+                                                      onCompletion: { result in
+                                                        promise(result)
+                                                      })
+            store.onAction(action)
+        }
 
-                                                    let expectedProduct = self.viewStorage
-                                                        .loadProduct(siteID: self.sampleSiteID,
-                                                                     productID: expectedProductID)?.toReadOnly()
-                                                    XCTAssertEqual(expectedProduct?.name, expectedProductName)
-
-                                                    XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 2)
-
-                                                    XCTAssertNil(error)
-
-                                                    expectation.fulfill()
-        })
-
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let expectedProduct = try XCTUnwrap(viewStorage.loadProduct(siteID: sampleSiteID, productID: expectedProductID)?.toReadOnly())
+        XCTAssertEqual(expectedProduct.name, expectedProductName)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 2)
     }
 
     /// Verifies that `ProductAction.searchProducts` effectively upserts the `ProductSearchResults` entity.
     ///
-    func testSearchProductsEffectivelyPersistsSearchResultsEntity() {
-        let expectation = self.expectation(description: "Search Products")
+    func test_searchProducts_effectively_persists_search_eesults_entity() throws {
+        // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
+        // When
         let keyword = "hiii"
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                      keyword: keyword,
+                                                      pageNumber: self.defaultPageNumber,
+                                                      pageSize: self.defaultPageSize,
+                                                      onCompletion: { result in
+                                                        promise(result)
+                                                      })
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let searchResults = try XCTUnwrap(viewStorage.loadProductSearchResults(keyword: keyword))
+        XCTAssertEqual(searchResults.keyword, keyword)
+        XCTAssertEqual(searchResults.products?.count, viewStorage.countObjects(ofType: Storage.Product.self))
+
         let anotherKeyword = "hello"
-        let action = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                  keyword: keyword,
-                                                  pageNumber: defaultPageNumber,
-                                                  pageSize: defaultPageSize,
-                                                  onCompletion: { [weak self] error in
-                                                    guard let self = self else {
-                                                        XCTFail()
-                                                        return
-                                                    }
-
-                                                    XCTAssertNil(error)
-
-                                                    let searchResults = self.viewStorage.loadProductSearchResults(keyword: keyword)
-                                                    XCTAssertEqual(searchResults?.keyword, keyword)
-                                                    XCTAssertEqual(searchResults?.products?.count, self.viewStorage.countObjects(ofType: Storage.Product.self))
-
-                                                    let searchResultsWithAnotherKeyword = self.viewStorage.loadProductSearchResults(keyword: anotherKeyword)
-                                                    XCTAssertNil(searchResultsWithAnotherKeyword)
-
-                                                    expectation.fulfill()
-        })
-
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        let searchResultsWithAnotherKeyword = viewStorage.loadProductSearchResults(keyword: anotherKeyword)
+        XCTAssertNil(searchResultsWithAnotherKeyword)
     }
 
     /// Verifies that `ProductAction.searchProducts` does not result in duplicated entries in the ProductSearchResults entity.
     ///
-    func testSearchProductsDoesNotProduceDuplicatedReferences() {
-        let expectation = self.expectation(description: "Search Products")
+    func test_searchProducts_does_not_produce_duplicated_references() {
+        // Given
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
+        // When
         let keyword = "hiii"
-        let nestedAction = ProductAction
-            .searchProducts(siteID: sampleSiteID,
-                            keyword: keyword,
-                            pageNumber: defaultPageNumber,
-                            pageSize: defaultPageSize,
-                            onCompletion: { [weak self] error in
-                                guard let self = self else {
-                                    XCTFail()
-                                    return
-                                }
-                                let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
-                                XCTAssertEqual(products.count, 10)
-                                for product in products {
-                                    XCTAssertEqual(product.searchResults?.count, 1)
-                                    XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
-                                }
+        let result: Result<Void, Error> = waitFor { promise in
+            let nestedAction = ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                            keyword: keyword,
+                                                            pageNumber: self.defaultPageNumber,
+                                                            pageSize: self.defaultPageSize,
+                                                            onCompletion: { result in
+                                                                promise(result)
+                                                            })
+            let firstAction = ProductAction.searchProducts(siteID: self.sampleSiteID,
+                                                           keyword: keyword,
+                                                           pageNumber: self.defaultPageNumber,
+                                                           pageSize: self.defaultPageSize,
+                                                           onCompletion: { result in
+                                                            store.onAction(nestedAction)
+                                                           })
+            store.onAction(firstAction)
+        }
 
-                                let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
-                                XCTAssertEqual(searchResults.count, 1)
-                                XCTAssertEqual(searchResults.first?.products?.count, 10)
-                                XCTAssertEqual(searchResults.first?.keyword, keyword)
+        // Then
+        XCTAssertTrue(result.isSuccess)
 
-                                XCTAssertNil(error)
+        let products = viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
+        XCTAssertEqual(products.count, 10)
+        for product in products {
+            XCTAssertEqual(product.searchResults?.count, 1)
+            XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
+        }
 
-                                expectation.fulfill()
-            })
-
-        let firstAction = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                       keyword: keyword,
-                                                       pageNumber: defaultPageNumber,
-                                                       pageSize: defaultPageSize,
-                                                       onCompletion: { error in
-                                                        store.onAction(nestedAction)
-        })
-
-        store.onAction(firstAction)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        let searchResults = viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
+        XCTAssertEqual(searchResults.count, 1)
+        XCTAssertEqual(searchResults.first?.products?.count, 10)
+        XCTAssertEqual(searchResults.first?.keyword, keyword)
     }
 
     // MARK: - ProductAction.updateProduct


### PR DESCRIPTION
## Description

This PR updates ProductAction + related Store and Remote to use Result, so the state of response is more limited with less optional parameters.

## Test

1. Check CI status for unit tests.
2. Run app and try products search, verify it works well.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
