### PR TITLE
Remove unnecessary Alamofire imports

### DIFF
--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// Account: Remote Endpoints
 ///
@@ -7,7 +6,7 @@ public class AccountRemote: Remote {
 
     /// Loads the Account Details associated with the Credential's authToken.
     ///
-    public func loadAccount(completion: @escaping (Swift.Result<Account, Error>) -> Void) {
+    public func loadAccount(completion: @escaping (Result<Account, Error>) -> Void) {
         let path = "me"
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path)
         let mapper = AccountMapper()
@@ -20,7 +19,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - for: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func loadAccountSettings(for userID: Int64, completion: @escaping (Swift.Result<AccountSettings, Error>) -> Void) {
+    public func loadAccountSettings(for userID: Int64, completion: @escaping (Result<AccountSettings, Error>) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out,first_name,last_name"
@@ -35,7 +34,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - userID: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (Swift.Result<AccountSettings, Error>) -> Void) {
+    public func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (Result<AccountSettings, Error>) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out",
@@ -51,7 +50,7 @@ public class AccountRemote: Remote {
 
     /// Loads the Sites collection associated with the WordPress.com User.
     ///
-    public func loadSites(completion: @escaping (Swift.Result<[Site], Error>) -> Void) {
+    public func loadSites(completion: @escaping (Result<[Site], Error>) -> Void) {
         let path = "me/sites"
         let parameters = [
             "fields": "ID,name,description,URL,options",
@@ -66,7 +65,7 @@ public class AccountRemote: Remote {
 
     /// Loads the site plan for the default site associated with the WordPress.com user.
     ///
-    public func loadSitePlan(for siteID: Int64, completion: @escaping (Swift.Result<SitePlan, Error>) -> Void) {
+    public func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void) {
         let path = "sites/\(siteID)"
         let parameters = [
             "fields": "ID,plan"

--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// Enum containing the available moderation statuses

--- a/Networking/Networking/Remote/DevicesRemote.swift
+++ b/Networking/Networking/Remote/DevicesRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// Devices: Remote Endpoints (Push Notifications Registration / Unregistration!)

--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// OrderStats: Remote Endpoints found in wc-admin's v4 API
 ///

--- a/Networking/Networking/Remote/RefundsRemote.swift
+++ b/Networking/Networking/Remote/RefundsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// Refunds: Remote Endpoints

--- a/Networking/Networking/Remote/ShipmentsRemote.swift
+++ b/Networking/Networking/Remote/ShipmentsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// ShipmentsRemote: Remote Endpoints

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// SiteSettings: Remote Endpoints

--- a/Networking/Networking/Remote/SiteVisitStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteVisitStatsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// SiteVisitStats: Remote Endpoints
 ///

--- a/Networking/Networking/Remote/TaxClassRemote.swift
+++ b/Networking/Networking/Remote/TaxClassRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// Tax Class: Remote Endpoints
 ///

--- a/Networking/Networking/Remote/TopEarnersStatsRemote.swift
+++ b/Networking/Networking/Remote/TopEarnersStatsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// TopEarnersStats: Remote Endpoints


### PR DESCRIPTION
## Description

Remove Alamofire import on all specific remotes + unnecessary `Swift.Result` namespacing in `AccountRemote`.

## Test

Just check unit tests status.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
