### PR TITLE
Add-ons: Adds empty ProductAddOnsListViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -1,0 +1,2 @@
+
+import Foundation

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -1,2 +1,34 @@
+import UIKit
+import SwiftUI
 
-import Foundation
+// MARK: Hosting Controller
+
+/// Hosting controller that wraps an `ProductAddOnsList` view.
+///
+final class ProductAddOnsListViewController: UIHostingController<ProductAddOnsList> {
+    init() {
+        super.init(rootView: ProductAddOnsList())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Views
+
+/// Renders a list of product add-ons
+///
+struct ProductAddOnsList: View {
+    var body: some View {
+        Text("WIP")
+    }
+}
+
+// MARK: Previews
+struct ProductAddOnsList_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductAddOnsList()
+            .environment(\.colorScheme, .light)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -6,8 +6,9 @@ import SwiftUI
 /// Hosting controller that wraps an `ProductAddOnsList` view.
 ///
 final class ProductAddOnsListViewController: UIHostingController<ProductAddOnsList> {
-    init() {
+    init(viewModel: ProductAddOnsListViewModel) {
         super.init(rootView: ProductAddOnsList())
+        title = viewModel.title
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// ViewModel for `ProductAddOnsList`
+///
+final class ProductAddOnsListViewModel {
+
+    /// View title
+    ///
+    let title = Localization.title
+}
+
+// MARK: Constants
+extension ProductAddOnsListViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("Product Add-ons", comment: "Title for the product add-ons screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -314,7 +314,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isEditable else {
                     return
                 }
-                // TODO: Navigate to product add-ons
+                navigateToAddOns()
             case .categories(_, let isEditable):
                 guard isEditable else {
                     return
@@ -1388,6 +1388,16 @@ private extension ProductFormViewController {
     func onAttributeUpdated(attributesViewController: UIViewController, updatedProduct: Product) {
         viewModel.updateProductVariations(from: updatedProduct)
         navigationController?.popToViewController(attributesViewController, animated: true)
+    }
+}
+
+// MARK: Action - View Add-ons
+//
+private extension ProductFormViewController {
+    func navigateToAddOns() {
+        let viewModel = ProductAddOnsListViewModel()
+        let viewController = ProductAddOnsListViewController(viewModel: viewModel)
+        show(viewController, sender: self)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
 		26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */; };
+		26F94E21267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E20267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift */; };
 		26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056725F6CB6000A40B26 /* Fakes.framework */; };
 		26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
@@ -1732,6 +1733,7 @@
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
 		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
+		26F94E20267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewModel.swift; sourceTree = "<group>"; };
 		26FB056725F6CB6000A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
@@ -3655,6 +3657,7 @@
 			isa = PBXGroup;
 			children = (
 				26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */,
+				26F94E20267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift */,
 			);
 			path = Addons;
 			sourceTree = "<group>";
@@ -6933,6 +6936,7 @@
 				262A09812628A8F40033AD20 /* WooStyleModifiers.swift in Sources */,
 				02F4F50F237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.swift in Sources */,
 				021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorCommand.swift in Sources */,
+				26F94E21267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift in Sources */,
 				5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */,
 				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
+		26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */; };
 		26FB056825F6CB6000A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056725F6CB6000A40B26 /* Fakes.framework */; };
 		26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
@@ -1730,6 +1731,7 @@
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
+		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
 		26FB056725F6CB6000A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
@@ -2696,6 +2698,7 @@
 		021627232379637E000208D2 /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				26F94E1A267A3B3C00DB6CCF /* Addons */,
 				452FE64825657E5F00EB54A0 /* Linked Products */,
 				022F7A0024A05F3700012601 /* Linked Products List Selector */,
 				77E53EB5250E6972003D385F /* Downloadable Files */,
@@ -3646,6 +3649,14 @@
 				26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		26F94E1A267A3B3C00DB6CCF /* Addons */ = {
+			isa = PBXGroup;
+			children = (
+				26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */,
+			);
+			path = Addons;
 			sourceTree = "<group>";
 		};
 		26FE09E224DCFE4000B9BDF5 /* inAppFeedback */ = {
@@ -6642,6 +6653,7 @@
 				E1ED16E4266E10A10037B8DB /* ApplicationLogViewModel.swift in Sources */,
 				02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */,
 				02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */,
+				26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */,
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.swift in Sources */,
 				D8C2A28823190B2300F503E9 /* StorageProductReview+Woo.swift in Sources */,


### PR DESCRIPTION
Close #4267 

# Why

Resuming the Add-ons work, this PR creates a view controller(currently empty) that will hold all the add-ons a product can have.

# How

- Creates an empty `SwiftUI` view, `ViewModel` and hosting `ViewController`.

- Navigate to `ProductAddOnsListViewController` when tapping the "Product Add-ons" button.

**Note:** This is behind a local feature flag and behind an experimental feature switch.

# Demo

https://user-images.githubusercontent.com/562080/122244628-a4c33f80-ce8a-11eb-8ca4-71e0f00fa154.mov

# Testing

**Prerequisites:** 
- Have your site with the add-ons plugin installed and with at least one product with add-ons.
- Enable the "Add-Ons" feature from the beta features screen in settings.

**Steps** 
- Launch the app and navigate to a product with add-ons
- Tap on the "Product Add-ons" button
- See that the app navigates to an empty "Product Add-ons" screen

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
