### PR TITLE
Fix Stats tabs not ordered correctly in RTL layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 7.0
 -----
 - [*] If the Orders, Products, or Reviews lists can't load, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4400, https://github.com/woocommerce/woocommerce-ios/pull/4407]
+- [*] Fix: Stats tabs are now displayed and ordered correctly in RTL languages. [https://github.com/woocommerce/woocommerce-ios/pull/4444]
 
 6.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -57,18 +57,6 @@ final class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripView
         ensureGhostContentIsAnimated()
     }
 
-    // MARK: - RTL support
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        /// ButtonBarView is a collection view, and it should flip to support
-        /// RTL languages automatically. And yet it doesn't.
-        /// So, for RTL languages, we flip it. This also flips the cells
-        if traitCollection.layoutDirection == .rightToLeft {
-            buttonBarView.transform = CGAffineTransform(scaleX: -1, y: 1)
-        }
-    }
-
     // MARK: - PagerTabStripDataSource
 
     override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
@@ -260,6 +248,13 @@ private extension StoreStatsAndTopPerformersViewController {
 
         // Disables any content inset adjustment since `XLPagerTabStrip` doesn't seem to support safe area insets.
         containerView.contentInsetAdjustmentBehavior = .never
+
+        /// ButtonBarView is a collection view, and it should flip to support
+        /// RTL languages automatically. And yet it doesn't.
+        /// So, for RTL languages, we flip it. This also flips the cells
+        if traitCollection.layoutDirection == .rightToLeft {
+            buttonBarView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
     }
 
     func configurePeriodViewControllers() {


### PR DESCRIPTION
Fixes #3934.

This bug originates from one of the third-party dependencies, XLPagerTabStrip. When the total length of the tabs surpasses the screen width – such that the tab strip is horizontally scrollable – the built-in RTL adjustments from `UICollectionView` does not work somehow. 

Previously, we implemented a workaround by "flipping" the tabs container, and then flipping each individual tab again to make sure the text is not reversed. However, the first flip happens in `traitCollectionDidChange` method, which is not guaranteed to be called when the app is opened.

## Changes
Moved the transformation logic from `traitCollectionDidChange` to `configureView`, which gets called once during `viewDidLoad`. This ensures that the first flip for the tabs container always occurs.

Before | After
-- | --
![3934_before](https://user-images.githubusercontent.com/1299411/122376088-07e9ca80-cf8e-11eb-8ef2-c331c820e340.png) | ![3934_after](https://user-images.githubusercontent.com/1299411/122376118-10da9c00-cf8e-11eb-9433-1f59efe011cb.png)


## To Test

1. Change device language to any RTL languages. 💡 **Pro Tip:** when testing from simulators, you can force the app to be displayed in RTL layout with _any language_ by adding `-NSForceRightToLeftWritingDirection YES` as launch argument.
2. Launch WooCommerce app, and log in to an account. 
3. On the Stats page, verify that the first highlighted tab should be the right-most tab, with the title "Today".

## Author Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
