### PR TITLE
Display Order Items and Shipping Labels Packages as separate sections in the Order Detail Screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 7.0
 -----
 - [*] If the Orders, Products, or Reviews lists can't load, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4400, https://github.com/woocommerce/woocommerce-ios/pull/4407]
+- [*] Fix: Orders for a variable product with different configurations of a single variation will now show each order item separately. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
+- [**] Order Detail: now we display Order Items and Shipping Label Packages as separate sections. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
 
 6.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,10 @@
 
 7.0
 -----
-- [*] If the Orders, Products, or Reviews lists can't load, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4400, https://github.com/woocommerce/woocommerce-ios/pull/4407]
-- [*] Fix: Orders for a variable product with different configurations of a single variation will now show each order item separately. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
 - [**] Order Detail: now we display Order Items and Shipping Label Packages as separate sections. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
+- [*] Fix: Orders for a variable product with different configurations of a single variation will now show each order item separately. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
+- [*] If the Orders, Products, or Reviews lists can't load, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4400, https://github.com/woocommerce/woocommerce-ios/pull/4407]
+
 
 6.9
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -169,7 +169,6 @@ public enum WooAnalyticsStat: String {
     case orderDetailCustomerPhoneOptionTapped   = "order_detail_customer_info_phone_menu_phone_tapped"
     case orderDetailCustomerSMSOptionTapped     = "order_detail_customer_info_phone_menu_sms_tapped"
     case orderDetailOrderStatusEditButtonTapped = "order_detail_order_status_edit_button_tapped"
-    case orderDetailProductDetailTapped         = "order_detail_product_detail_button_tapped"
     case orderDetailRefundDetailTapped          = "order_detail_refund_detail_tapped"
     case orderDetailAddOnsViewed                = "order_detail_addons_viewed"
     case refundedProductsDetailTapped           = "order_detail_refunded_products_detail_tapped"

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -129,36 +129,4 @@ final class AggregateDataHelper {
 
         return sorted
     }
-
-    /// Combines aggregate order items with order items from non-refunded shipping labels.
-    ///
-    /// - Parameters:
-    ///   - orderItems: an array of aggregate order items, like after combining with refunded products by calling `combineOrderItems`.
-    ///   - orderItemsInNonRefundedShippingLabels: an array of aggregate order items from shipping labels that could have duplicate products/variations.
-    /// - Returns: an array of aggregate order items based on the given `orderItems` whose elements are removed if fully covered in shipping labels, and the
-    ///            quantity is subtracted by the total quantity from the given order items in shipping labels.
-    static func combineAggregatedOrderItems(_ orderItems: [AggregateOrderItem],
-                                            with orderItemsInNonRefundedShippingLabels: [AggregateOrderItem]) -> [AggregateOrderItem] {
-        // Generates a dictionary that maps a unique order item (keyed by `productID` and `variationID`) to the sum of quantity from order items in shipping
-        // labels.
-        let orderItemsByProductAndVariationID = Dictionary(grouping: orderItemsInNonRefundedShippingLabels) { $0.hashValue }
-        let orderItemCountsByProductAndVariationID = orderItemsByProductAndVariationID.mapValues {
-            $0.reduce(into: 0) { result, orderItem in
-                result += orderItem.quantity
-            }
-        }
-        return orderItems.compactMap { orderItem in
-            // If the order item is not in any shipping labels, the original order item is returned.
-            guard let orderItemCountInNonRefundedShippingLabels = orderItemCountsByProductAndVariationID[orderItem.hashValue] else {
-                return orderItem
-            }
-            // If the order item quantity is <= the sum in the shipping labels, the order item is skipped since it's shown in the shipping label sections.
-            guard orderItemCountInNonRefundedShippingLabels < orderItem.quantity else {
-                return nil
-            }
-            // If the order item quantity is larger than the sum in the shipping labels, the order item's quantity is deducted by the sum in the shipping
-            // labels.
-            return orderItem.copy(quantity: orderItem.quantity - orderItemCountInNonRefundedShippingLabels)
-        }
-    }
 }

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -125,7 +125,7 @@ final class AggregateDataHelper {
 
         let filtered = unsortedResult.filter { $0.quantity > 0 }
 
-        let sorted = filtered.sorted(by: { ($0.productID, $0.variationID) < ($1.productID, $1.variationID) })
+        let sorted = filtered.sorted(by: { $0.hashValue > $1.hashValue })
 
         return sorted
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -65,6 +65,7 @@ extension AggregateOrderItem: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(productID)
         hasher.combine(variationID)
+        hasher.combine(attributes)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -215,6 +215,13 @@ final class OrderDetailsDataSource: NSObject {
         }
         return shippingLabelOrderItemsAggregator.orderItem(of: shippingLabel, at: indexPath.row)
     }
+
+    func shippingLabelOrderItems(at indexPath: IndexPath) -> [AggregateOrderItem] {
+        guard let shippingLabel = shippingLabel(at: indexPath) else {
+            return []
+        }
+        return shippingLabelOrderItemsAggregator.orderItems(of: shippingLabel)
+    }
 }
 
 
@@ -310,8 +317,8 @@ private extension OrderDetailsDataSource {
             configureRefund(cell: cell, at: indexPath)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .netAmount:
             configureNetAmount(cell: cell)
-        case let cell as ProductDetailsTableViewCell where row == .shippingLabelProduct:
-            configureShippingLabelProduct(cell: cell, at: indexPath)
+        case let cell as WooBasicTableViewCell where row == .shippingLabelProducts:
+            configureShippingLabelProducts(cell: cell, at: indexPath)
         case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
             configureAggregateOrderItem(cell: cell, at: indexPath)
         case let cell as ButtonTableViewCell where row == .collectCardPaymentButton:
@@ -487,8 +494,7 @@ private extension OrderDetailsDataSource {
 
     private func configureCollectPaymentButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
         cell.configure(style: .primary,
-                       title: Titles.collectPayment,
-                       bottomSpacing: ButtonTableViewCell.Constants.defaultBottomSpacing) {
+                       title: Titles.collectPayment) {
             self.onCellAction?(.collectPayment, indexPath)
         }
         cell.hideSeparator()
@@ -558,23 +564,33 @@ private extension OrderDetailsDataSource {
                                 "VoiceOver accessibility hint for the row that shows instructions on how to print a shipping label on the mobile device")
     }
 
-    private func configureShippingLabelProduct(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
-        cell.selectionStyle = .default
-
-        guard let shippingLabel = shippingLabel(at: indexPath),
-              let orderItem = shippingLabelOrderItemsAggregator.orderItem(of: shippingLabel, at: indexPath.row) else {
+    private func configureShippingLabelProducts(cell: WooBasicTableViewCell, at indexPath: IndexPath) {
+        guard let shippingLabel = shippingLabel(at: indexPath) else {
             assertionFailure("Cannot access shipping label and/or order item at \(indexPath)")
             return
         }
 
-        let addOns = filterAddOns(of: orderItem)
-        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: orderItem,
-                                                        currency: order.currency,
-                                                        hasAddOns: addOns.isNotEmpty)
-        cell.configure(item: itemViewModel, imageService: imageService)
-        cell.onViewAddOnsTouchUp = { [weak self] in
-            self?.onCellAction?(.viewAddOns(addOns: addOns), nil)
-        }
+        let orderItems = shippingLabelOrderItemsAggregator.orderItems(of: shippingLabel)
+        let singular = NSLocalizedString("%d item",
+                                         comment: "For example: `1 item` in Shipping Label package row")
+        let plural = NSLocalizedString("%d items",
+                                       comment: "For example: `5 items` in Shipping Label package row")
+        let itemsText = String.pluralize(orderItems.count, singular: singular, plural: plural)
+
+        cell.bodyLabel?.text = itemsText
+        cell.applySecondaryTextStyle()
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.hideSeparator()
+
+        cell.accessibilityTraits = .button
+        cell.accessibilityLabel = NSLocalizedString(
+            "View items in this shipping label package.",
+            comment: "Accessibility label for the items inside a Shipping Label package"
+        )
+
+        cell.accessibilityHint = NSLocalizedString("Show the items included inside this shipping label package.",
+        comment: "VoiceOver accessibility hint, informing the user that the button can be used to view the items inside the shipping label package")
     }
 
     private func configureShippingLabelTrackingNumber(cell: ImageAndTitleAndTextTableViewCell, at indexPath: IndexPath) {
@@ -623,6 +639,7 @@ private extension OrderDetailsDataSource {
     private func configureReprintShippingLabelButton(cell: ButtonTableViewCell, at indexPath: IndexPath) {
         cell.configure(style: .secondary,
                        title: Titles.reprintShippingLabel,
+                       topSpacing: 0,
                        bottomSpacing: 8) { [weak self] in
             guard let self = self else { return }
             guard let shippingLabel = self.shippingLabel(at: indexPath) else {
@@ -685,7 +702,7 @@ private extension OrderDetailsDataSource {
     private func configureMarkCompleteButton(cell: ButtonTableViewCell,
                                              buttonStyle: ButtonTableViewCell.Style,
                                              showsBottomSpacing: Bool) {
-        let bottomSpacing: CGFloat = showsBottomSpacing ? ButtonTableViewCell.Constants.defaultBottomSpacing : 0
+        let bottomSpacing: CGFloat = showsBottomSpacing ? ButtonTableViewCell.Constants.defaultSpacing : 0
         cell.configure(style: buttonStyle, title: Titles.markComplete, bottomSpacing: bottomSpacing) { [weak self] in
             self?.onCellAction?(.markComplete, nil)
         }
@@ -899,9 +916,7 @@ extension OrderDetailsDataSource {
                     rows = [.shippingLabelRefunded, .shippingLabelDetail]
                     headerStyle = .primary
                 } else {
-                    let orderItemsCount = shippingLabelOrderItemsAggregator.orderItems(of: shippingLabel).count
-                    rows = Array(repeating: .shippingLabelProduct, count: orderItemsCount)
-                        + [.shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]
+                    rows = [.shippingLabelProducts, .shippingLabelReprintButton, .shippingLabelPrintingInfo, .shippingLabelTrackingNumber, .shippingLabelDetail]
                     let headerActionConfig = PrimarySectionHeaderView.ActionConfiguration(image: .moreImage) { [weak self] sourceView in
                         self?.onShippingLabelMoreMenuTapped?(shippingLabel, sourceView)
                     }
@@ -1314,7 +1329,7 @@ extension OrderDetailsDataSource {
         case shippingLabelCreationInfo(showsSeparator: Bool)
         case shippingLabelDetail
         case shippingLabelPrintingInfo
-        case shippingLabelProduct
+        case shippingLabelProducts
         case shippingLabelRefunded
         case shippingLabelReprintButton
         case shippingLabelTrackingNumber
@@ -1367,8 +1382,8 @@ extension OrderDetailsDataSource {
                 return WooBasicTableViewCell.reuseIdentifier
             case .shippingLabelPrintingInfo:
                 return ImageAndTitleAndTextTableViewCell.reuseIdentifier
-            case .shippingLabelProduct:
-                return ProductDetailsTableViewCell.reuseIdentifier
+            case .shippingLabelProducts:
+                return WooBasicTableViewCell.reuseIdentifier
             case .shippingLabelTrackingNumber, .shippingLabelRefunded:
                 return ImageAndTitleAndTextTableViewCell.reuseIdentifier
             case .shippingLabelReprintButton:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -575,7 +575,7 @@ private extension OrderDetailsDataSource {
                                          comment: "For example: `1 item` in Shipping Label package row")
         let plural = NSLocalizedString("%1$d items",
                                        comment: "For example: `5 items` in Shipping Label package row")
-        let itemsText = String.pluralize(orderItems.count, singular: singular, plural: plural)
+        let itemsText = String.pluralize(orderItems.map { $0.quantity.intValue }.reduce(0, +), singular: singular, plural: plural)
 
         cell.bodyLabel?.text = itemsText
         cell.applySecondaryTextStyle()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -571,9 +571,9 @@ private extension OrderDetailsDataSource {
         }
 
         let orderItems = shippingLabelOrderItemsAggregator.orderItems(of: shippingLabel)
-        let singular = NSLocalizedString("%d item",
+        let singular = NSLocalizedString("%1$d item",
                                          comment: "For example: `1 item` in Shipping Label package row")
-        let plural = NSLocalizedString("%d items",
+        let plural = NSLocalizedString("%1$d items",
                                        comment: "For example: `5 items` in Shipping Label package row")
         let itemsText = String.pluralize(orderItems.count, singular: singular, plural: plural)
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -258,15 +258,17 @@ extension OrderDetailsViewModel {
             let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
             let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)
             viewController.present(navigationController, animated: true, completion: nil)
-        case .shippingLabelProduct:
-            guard let item = dataSource.shippingLabelOrderItem(at: indexPath), item.productOrVariationID > 0 else {
+        case .shippingLabelProducts:
+            let shippingLabelItems = dataSource.shippingLabelOrderItems(at: indexPath)
+
+            let identifier = AggregatedProductListViewController.classNameWithoutNamespaces
+            guard let productListVC = UIStoryboard.orders.instantiateViewController(identifier: identifier) as? AggregatedProductListViewController else {
+                DDLogError("Error: attempted to instantiate AggregatedProductListViewController. Instantiation failed.")
                 return
             }
-            let loaderViewController = ProductLoaderViewController(model: .init(aggregateOrderItem: item),
-                                                                   siteID: order.siteID,
-                                                                   forceReadOnly: true)
-            let navController = WooNavigationController(rootViewController: loaderViewController)
-            viewController.present(navController, animated: true, completion: nil)
+            productListVC.viewModel = self
+            productListVC.items = shippingLabelItems
+            viewController.navigationController?.show(productListVC, sender: nil)
         case .billingDetail:
             ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
             let billingInformationViewController = BillingInformationViewController(order: order)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -260,15 +260,8 @@ extension OrderDetailsViewModel {
             viewController.present(navigationController, animated: true, completion: nil)
         case .shippingLabelProducts:
             let shippingLabelItems = dataSource.shippingLabelOrderItems(at: indexPath)
-
-            let identifier = AggregatedProductListViewController.classNameWithoutNamespaces
-            guard let productListVC = UIStoryboard.orders.instantiateViewController(identifier: identifier) as? AggregatedProductListViewController else {
-                DDLogError("Error: attempted to instantiate AggregatedProductListViewController. Instantiation failed.")
-                return
-            }
-            productListVC.viewModel = self
-            productListVC.items = shippingLabelItems
-            viewController.navigationController?.show(productListVC, sender: nil)
+            let productListVC = AggregatedProductListViewController(viewModel: self, items: shippingLabelItems)
+            viewController.show(productListVC, sender: nil)
         case .billingDetail:
             ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
             let billingInformationViewController = BillingInformationViewController(order: order)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -271,15 +271,6 @@ extension OrderDetailsViewModel {
             ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
             let billingInformationViewController = BillingInformationViewController(order: order)
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
-        case .details:
-            ServiceLocator.analytics.track(.orderDetailProductDetailTapped)
-            let identifier = ProductListViewController.classNameWithoutNamespaces
-            guard let productListVC = UIStoryboard.orders.instantiateViewController(identifier: identifier) as? ProductListViewController else {
-                DDLogError("Error: attempted to instantiate ProductListViewController. Instantiation failed.")
-                return
-            }
-            productListVC.viewModel = self
-            viewController.navigationController?.pushViewController(productListVC, animated: true)
         case .seeReceipt:
             ServiceLocator.analytics.track(.receiptViewTapped)
             guard let receipt = receipt else {

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -40,11 +40,6 @@ struct AggregatedShippingLabelOrderItems {
     func orderItem(of shippingLabel: ShippingLabel, at index: Int) -> AggregateOrderItem? {
         orderItems(of: shippingLabel)[safe: index]
     }
-
-    /// Returns an array of order items from all of the given non-refunded shipping labels.
-    func orderItemsOfNonRefundedShippingLabels(_ shippingLabels: [ShippingLabel]) -> [AggregateOrderItem] {
-        shippingLabels.nonRefunded.flatMap { orderItems(of: $0) }
-    }
 }
 
 private extension AggregatedShippingLabelOrderItems {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.swift
@@ -9,17 +9,16 @@ import Yosemite
 final class AggregatedProductListViewController: UIViewController {
     @IBOutlet private var tableView: UITableView!
 
-    private var viewModel: OrderDetailsViewModel
-    private var products: [Product]? = []
-    private var items: [AggregateOrderItem]
-
-    private let imageService: ImageService = ServiceLocator.imageService
+    private let viewModel: OrderDetailsViewModel
+    private let items: [AggregateOrderItem]
+    private let imageService: ImageService
 
     /// Init
     ///
-    init(viewModel: OrderDetailsViewModel, items: [AggregateOrderItem]) {
+    init(viewModel: OrderDetailsViewModel, items: [AggregateOrderItem], imageService: ImageService = ServiceLocator.imageService) {
         self.viewModel = viewModel
         self.items = items
+        self.imageService = imageService
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -29,8 +28,6 @@ final class AggregatedProductListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        self.products = viewModel.products
 
         configureMainView()
         configureTableView()
@@ -45,7 +42,7 @@ private extension AggregatedProductListViewController {
     /// Setup: Main View
     ///
     func configureMainView() {
-        title = String.pluralize(items.count, singular: Localization.titleSingular, plural: Localization.titlePlural)
+        title = String.pluralize(items.map { $0.quantity.intValue }.reduce(0, +), singular: Localization.titleSingular, plural: Localization.titlePlural)
         view.backgroundColor = .listBackground
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.swift
@@ -1,0 +1,148 @@
+import UIKit
+import Yosemite
+
+
+/// A simple Product List presented from the Order Details screen -> Shipping Labels Packages.
+///
+/// The list shows the product name and the quantity.
+///
+final class AggregatedProductListViewController: UIViewController {
+    @IBOutlet private var tableView: UITableView!
+
+    var viewModel: OrderDetailsViewModel!
+    private var products: [Product]? = []
+    var items: [AggregateOrderItem] = []
+
+    private let imageService: ImageService = ServiceLocator.imageService
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.products = viewModel.products
+
+        configureMainView()
+        configureTableView()
+    }
+}
+
+
+// MARK: - Configuration
+//
+private extension AggregatedProductListViewController {
+
+    /// Setup: Main View
+    ///
+    func configureMainView() {
+        title = String.pluralize(items.count, singular: Localization.titleSingular, plural: Localization.titlePlural)
+        view.backgroundColor = .listBackground
+    }
+
+    /// Setup: TableView
+    ///
+    func configureTableView() {
+        tableView.backgroundColor = .listBackground
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.registerNib(for: PickListTableViewCell.self)
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension AggregatedProductListViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let item = itemAtIndexPath(indexPath)
+        let product = lookUpProduct(by: item.productOrVariationID)
+        let addOns = itemAddOnsAttributes(item: item)
+        let itemViewModel = ProductDetailsCellViewModel(aggregateItem: item,
+                                                        currency: viewModel.order.currency,
+                                                        product: product,
+                                                        hasAddOns: addOns.isNotEmpty)
+        let cell = tableView.dequeueReusableCell(PickListTableViewCell.self, for: indexPath)
+        cell.selectionStyle = .default
+        cell.configure(item: itemViewModel, imageService: imageService)
+        cell.onViewAddOnsTouchUp = { [weak self] in
+            self?.itemAddOnsButtonTapped(addOns: addOns)
+        }
+
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension AggregatedProductListViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let orderItem = itemAtIndexPath(indexPath)
+        productWasPressed(orderItem: orderItem)
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension AggregatedProductListViewController {
+
+    func itemAtIndexPath(_ indexPath: IndexPath) -> AggregateOrderItem {
+        return items[indexPath.row]
+    }
+
+    func lookUpProduct(by productID: Int64) -> Product? {
+        return products?.filter({ $0.productID == productID }).first
+    }
+
+    /// Returns the item attributes that can be identified as add-ons attributes.
+    /// If the "view add-ons" feature is disabled an empty array will be returned.
+    ///
+    func itemAddOnsAttributes(item: AggregateOrderItem) -> [OrderItemAttribute] {
+        guard let product = lookUpProduct(by: item.productID), viewModel.dataSource.showAddOns else {
+            return []
+        }
+
+        let globalAddOns = viewModel.dataSource.addOnGroups
+        return AddOnCrossreferenceUseCase(orderItemAttributes: item.attributes, product: product, addOnGroups: globalAddOns).addOnsAttributes()
+    }
+
+    /// Displays the product details screen for the provided AggregateOrderItem
+    ///
+    func productWasPressed(orderItem: AggregateOrderItem) {
+        let loaderViewController = ProductLoaderViewController(model: .init(aggregateOrderItem: orderItem),
+                                                               siteID: viewModel.order.siteID,
+                                                               forceReadOnly: true)
+        let navController = WooNavigationController(rootViewController: loaderViewController)
+        present(navController, animated: true, completion: nil)
+    }
+
+    private func itemAddOnsButtonTapped(addOns: [OrderItemAttribute]) {
+        let addOnsViewModel = OrderAddOnListI1ViewModel(attributes: addOns)
+        let addOnsController = OrderAddOnsListViewController(viewModel: addOnsViewModel)
+        let navigationController = WooNavigationController(rootViewController: addOnsController)
+        present(navigationController, animated: true, completion: nil)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension AggregatedProductListViewController {
+    struct Localization {
+        static let titleSingular = NSLocalizedString("%d item", comment: "For example: `1 item` in Aggregated Product List")
+        static let titlePlural = NSLocalizedString("%d items",
+                                       comment: "For example: `5 items` in Aggregated Product List")
+    }
+
+    struct Constants {
+        static let rowHeight = CGFloat(80)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/AggregatedProductListViewController.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AggregatedProductListViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="tyX-n4-teD" id="DuV-tR-bkN"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="tyX-n4-teD">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="ldm-QL-UeO"/>
+                        <outlet property="delegate" destination="-1" id="J1u-xE-hmV"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="tyX-n4-teD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="51J-46-vCD"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="tyX-n4-teD" secondAttribute="bottom" id="ALy-qf-JeZ"/>
+                <constraint firstItem="tyX-n4-teD" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="SXC-dQ-PE4"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="tyX-n4-teD" secondAttribute="trailing" id="p7j-vw-eUW"/>
+            </constraints>
+            <point key="canvasLocation" x="64" y="64"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -81,45 +81,8 @@
             </objects>
             <point key="canvasLocation" x="3780" y="543"/>
         </scene>
-        <!--Aggregated Product List View Controller-->
-        <scene sceneID="eSi-uk-4bD">
-            <objects>
-                <viewController storyboardIdentifier="AggregatedProductListViewController" id="B3T-oW-Fi5" customClass="AggregatedProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ytU-Ra-2hR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="vwa-0g-u3c">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
-                                <connections>
-                                    <outlet property="dataSource" destination="B3T-oW-Fi5" id="mHz-c5-M6o"/>
-                                    <outlet property="delegate" destination="B3T-oW-Fi5" id="rK6-Hq-P5J"/>
-                                </connections>
-                            </tableView>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="ywQ-NR-248"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="ywQ-NR-248" firstAttribute="bottom" secondItem="vwa-0g-u3c" secondAttribute="bottom" id="5bx-bg-wAx"/>
-                            <constraint firstItem="ywQ-NR-248" firstAttribute="trailing" secondItem="vwa-0g-u3c" secondAttribute="trailing" id="j3J-BH-ck2"/>
-                            <constraint firstItem="vwa-0g-u3c" firstAttribute="leading" secondItem="ywQ-NR-248" secondAttribute="leading" id="lMb-Tf-cAQ"/>
-                            <constraint firstItem="vwa-0g-u3c" firstAttribute="top" secondItem="ywQ-NR-248" secondAttribute="top" id="yVb-6c-Cds"/>
-                        </constraints>
-                    </view>
-                    <connections>
-                        <outlet property="tableView" destination="vwa-0g-u3c" id="hli-eR-Rku"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="d1d-rz-O67" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4465" y="543"/>
-        </scene>
     </scenes>
     <resources>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -81,8 +81,45 @@
             </objects>
             <point key="canvasLocation" x="3780" y="543"/>
         </scene>
+        <!--Aggregated Product List View Controller-->
+        <scene sceneID="eSi-uk-4bD">
+            <objects>
+                <viewController storyboardIdentifier="AggregatedProductListViewController" id="B3T-oW-Fi5" customClass="AggregatedProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ytU-Ra-2hR">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="vwa-0g-u3c">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="B3T-oW-Fi5" id="mHz-c5-M6o"/>
+                                    <outlet property="delegate" destination="B3T-oW-Fi5" id="rK6-Hq-P5J"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ywQ-NR-248"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="ywQ-NR-248" firstAttribute="bottom" secondItem="vwa-0g-u3c" secondAttribute="bottom" id="5bx-bg-wAx"/>
+                            <constraint firstItem="ywQ-NR-248" firstAttribute="trailing" secondItem="vwa-0g-u3c" secondAttribute="trailing" id="j3J-BH-ck2"/>
+                            <constraint firstItem="vwa-0g-u3c" firstAttribute="leading" secondItem="ywQ-NR-248" secondAttribute="leading" id="lMb-Tf-cAQ"/>
+                            <constraint firstItem="vwa-0g-u3c" firstAttribute="top" secondItem="ywQ-NR-248" secondAttribute="top" id="yVb-6c-Cds"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="vwa-0g-u3c" id="hli-eR-Rku"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="d1d-rz-O67" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4465" y="543"/>
+        </scene>
     </scenes>
     <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -4,6 +4,7 @@ import UIKit
 ///
 final class ButtonTableViewCell: UITableViewCell {
     @IBOutlet private var button: UIButton!
+    @IBOutlet private weak var topConstraint: NSLayoutConstraint!
     @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
 
     /// The style of this view, particularly the button.
@@ -32,11 +33,16 @@ final class ButtonTableViewCell: UITableViewCell {
     ///   - title: Button title.
     ///   - bottomSpacing: If non-nil, the value is set to the spacing between the button bottom edge and cell bottom edge.
     ///   - onButtonTouchUp: Called when the button is tapped.
-    func configure(style: Style = .default, title: String?, bottomSpacing: CGFloat = Constants.defaultBottomSpacing, onButtonTouchUp: (() -> Void)? = nil) {
+    func configure(style: Style = .default,
+                   title: String?,
+                   topSpacing: CGFloat = Constants.defaultSpacing,
+                   bottomSpacing: CGFloat = Constants.defaultSpacing,
+                   onButtonTouchUp: (() -> Void)? = nil) {
         apply(style: style)
         button.setTitle(title, for: .normal)
         self.onButtonTouchUp = onButtonTouchUp
 
+        topConstraint.constant = topSpacing
         bottomConstraint.constant = bottomSpacing
     }
 }
@@ -64,6 +70,6 @@ private extension ButtonTableViewCell {
 
 extension ButtonTableViewCell {
     enum Constants {
-        static let defaultBottomSpacing = CGFloat(20)
+        static let defaultSpacing = CGFloat(20)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,6 +35,7 @@
             <connections>
                 <outlet property="bottomConstraint" destination="pd5-X4-yaY" id="ly8-CL-KSD"/>
                 <outlet property="button" destination="Rng-8C-l5l" id="GrA-wO-Ocb"/>
+                <outlet property="topConstraint" destination="Xrm-jK-VNb" id="hFK-BO-KB4"/>
             </connections>
             <point key="canvasLocation" x="39.200000000000003" y="75.112443778110944"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -82,4 +82,9 @@ extension WooBasicTableViewCell {
         bodyLabel.applyActionableStyle()
         bodyLabelTopMarginConstraint.constant = 8
     }
+
+    func applySecondaryTextStyle() {
+        bodyLabel.applySecondaryBodyStyle()
+        bodyLabelTopMarginConstraint.constant = 8
+    }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		456396B725C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456396B525C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib */; };
 		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
 		456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */; };
+		4565C72B267B581000259A82 /* AggregatedProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */; };
 		4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */; };
 		456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */; };
 		45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */; };
@@ -1828,6 +1829,7 @@
 		456396B525C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelFormStepTableViewCell.xib; sourceTree = "<group>"; };
 		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HelpersTests.swift"; sourceTree = "<group>"; };
+		4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedProductListViewController.swift; sourceTree = "<group>"; };
 		4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriers.swift; sourceTree = "<group>"; };
 		456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRow.swift; sourceTree = "<group>"; };
 		45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersViewModel.swift; sourceTree = "<group>"; };
@@ -5448,6 +5450,7 @@
 				CE37C04222984E81008DCB39 /* PickListTableViewCell.swift */,
 				CE37C04322984E81008DCB39 /* PickListTableViewCell.xib */,
 				CE21B3DC20FF9BC200A259D5 /* ProductListViewController.swift */,
+				4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */,
 			);
 			path = "Product Details";
 			sourceTree = "<group>";
@@ -6676,6 +6679,7 @@
 				D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */,
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,
+				4565C72B267B581000259A82 /* AggregatedProductListViewController.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -546,7 +546,6 @@
 		456396B725C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456396B525C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib */; };
 		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
 		456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */; };
-		4565C72B267B581000259A82 /* AggregatedProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */; };
 		4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */; };
 		456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */; };
 		45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */; };
@@ -561,6 +560,8 @@
 		457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */; };
 		4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */; };
 		4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */; };
+		457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */; };
+		457509E5267B9E91005FA2EA /* AggregatedProductListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457509E3267B9E91005FA2EA /* AggregatedProductListViewController.xib */; };
 		4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */; };
 		4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */; };
 		4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */; };
@@ -1829,7 +1830,6 @@
 		456396B525C82691001F1A26 /* ShippingLabelFormStepTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelFormStepTableViewCell.xib; sourceTree = "<group>"; };
 		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HelpersTests.swift"; sourceTree = "<group>"; };
-		4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedProductListViewController.swift; sourceTree = "<group>"; };
 		4569317E2653E82B009ED69D /* ShippingLabelCarriers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriers.swift; sourceTree = "<group>"; };
 		456931832653E9F1009ED69D /* ShippingLabelCarrierRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRow.swift; sourceTree = "<group>"; };
 		45693188265403A1009ED69D /* ShippingLabelCarriersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersViewModel.swift; sourceTree = "<group>"; };
@@ -1844,6 +1844,8 @@
 		457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSlugViewController.xib; sourceTree = "<group>"; };
 		4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTypeBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedProductListViewController.swift; sourceTree = "<group>"; };
+		457509E3267B9E91005FA2EA /* AggregatedProductListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AggregatedProductListViewController.xib; sourceTree = "<group>"; };
 		4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewController.swift; sourceTree = "<group>"; };
 		4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSettingsViewController.xib; sourceTree = "<group>"; };
 		4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -5450,7 +5452,8 @@
 				CE37C04222984E81008DCB39 /* PickListTableViewCell.swift */,
 				CE37C04322984E81008DCB39 /* PickListTableViewCell.xib */,
 				CE21B3DC20FF9BC200A259D5 /* ProductListViewController.swift */,
-				4565C72A267B581000259A82 /* AggregatedProductListViewController.swift */,
+				457509E2267B9E91005FA2EA /* AggregatedProductListViewController.swift */,
+				457509E3267B9E91005FA2EA /* AggregatedProductListViewController.xib */,
 			);
 			path = "Product Details";
 			sourceTree = "<group>";
@@ -6290,6 +6293,7 @@
 				74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */,
 				025C006A2550DE4700FAC222 /* ProductSKUInputScannerViewController.xib in Resources */,
 				D83F5931225B269C00626E75 /* DatePickerTableViewCell.xib in Resources */,
+				457509E5267B9E91005FA2EA /* AggregatedProductListViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6669,6 +6673,7 @@
 				02307924258731B2008EADEE /* ReprintShippingLabelViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
+				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
 				D8815B0D263861A400EDAD62 /* CardPresentModalSuccess.swift in Sources */,
 				0235595524496B6D004BE2B8 /* BottomSheetListSelectorCommand.swift in Sources */,
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
@@ -6679,7 +6684,6 @@
 				D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */,
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,
-				4565C72B267B581000259A82 /* AggregatedProductListViewController.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AggregateDataHelperTests.swift
@@ -91,42 +91,6 @@ final class AggregateDataHelperTests: XCTestCase {
         XCTAssertEqual(aggregatedOrderItems.count, 1)
         XCTAssertEqual(aggregatedOrderItems[0].attributes, orderItemAttributes)
     }
-
-    func test_combining_AggregateOrderItem_with_shipping_labels() {
-        // Given
-        // Order items (e.g. after combining with refunded products using `AggregateDataHelper.combineOrderItems`).
-        let orderItemNotInShippingLabels = MockAggregateOrderItem.emptyItem()
-            .copy(productID: 1, variationID: 32, quantity: 2)
-        let orderItemPartiallyInShippingLabels = MockAggregateOrderItem.emptyItem()
-            .copy(productID: 1, variationID: 26, quantity: 2.5)
-        let orderItemInShippingLabels = MockAggregateOrderItem.emptyItem()
-            .copy(productID: 1, variationID: 0, quantity: 3.5)
-        let orderItems = [orderItemInShippingLabels, orderItemPartiallyInShippingLabels, orderItemNotInShippingLabels]
-
-        // Order items from non-refunded shipping labels.
-        let orderItemsInNonRefundedShippingLabels: [AggregateOrderItem] = [
-            MockAggregateOrderItem.emptyItem()
-                .copy(productID: orderItemInShippingLabels.productID,
-                      variationID: orderItemInShippingLabels.variationID,
-                      quantity: 2.5),
-            MockAggregateOrderItem.emptyItem()
-                .copy(productID: orderItemPartiallyInShippingLabels.productID,
-                      variationID: orderItemPartiallyInShippingLabels.variationID,
-                      quantity: 1),
-            MockAggregateOrderItem.emptyItem()
-                .copy(productID: orderItemInShippingLabels.productID,
-                      variationID: orderItemInShippingLabels.variationID,
-                      quantity: 1)
-        ]
-
-        // When
-        let combinedOrderItems = AggregateDataHelper
-            .combineAggregatedOrderItems(orderItems, with: orderItemsInNonRefundedShippingLabels)
-
-        // Then
-        let orderItemPartiallyInShippingLabelsWithUpdatedQuantity = orderItemPartiallyInShippingLabels.copy(quantity: 1.5)
-        XCTAssertEqual(combinedOrderItems, [orderItemPartiallyInShippingLabelsWithUpdatedQuantity, orderItemNotInShippingLabels])
-    }
 }
 
 


### PR DESCRIPTION
Fixes #4436  
Fixes #4412

## Description
In this PR, I tried to fix two different issues that we encountered in the Order Detail screen.
The first issue was about displaying the Products section and the Shipping Label Packages sections at the same time, because previously, if there was an existing package, replaced the products. This change will allow us to solve this issue in the future https://github.com/woocommerce/woocommerce-ios/issues/4126 and this one #4412, which I solved following the code implemented previously by @koke here #4416.
This implementation, changed a little bit the Shipping Label Package section because now the items are not showed inside the section, but by tapping on them you will see a new screen showing the package items.
I also removed the cell "Details" under Products, because it was superfluous.

## Testing
#### Case 1
1. Open an order detail with partially refunded items.
2. Make sure that everything appears like before.

#### Case 2
1. Open an order, that is eligible for Shipping Label Creation.
2. Make sure to see the shipping label creation button under the Order Items.

#### Case 3
1. Open an order, with existing Shipping Label Packages.
2. Make sure you are able to see the order items in the order detail screen, without any button below (for example, you shouldn't see the shipping label creation button).
3. Make sure that you are able to see the shipping label packages under the order items section.

#### Case 4
1. Create a variable product.
2. Add “Color” as an attribute with “Blue|Green|Yellow” as the values.
3. Create a single variation of that variable product. Choose “Any” as the attribute option.
4. Create a single order for the product.
5. Add 1 Blue
6. Add 2 Green
7. Add 5 Yellow
8. Check out and submit the order.
9. In the app, view the order. It should show three different items, one for each color purchased.


## Screenshots
| New Shipping Label Package section in Order Detail             |  Shipping Label Package Items detail screen |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-17 at 13 33 42](https://user-images.githubusercontent.com/495617/122403011-49727980-cf7e-11eb-916f-cec89c283155.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-17 at 13 33 49](https://user-images.githubusercontent.com/495617/122403024-4bd4d380-cf7e-11eb-8f92-cfc3f553a921.png)

Variable Products Before | Variable Products Before After
-|-
![Screen Shot 2021-06-15 at 09 44 15](https://user-images.githubusercontent.com/8739/122014512-83495180-cdbf-11eb-9d9a-631d9a417643.png)|![Screen Shot 2021-06-15 at 09 44 59](https://user-images.githubusercontent.com/8739/122014520-85131500-cdbf-11eb-98fe-292980a40158.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
