### PR TITLE
Fix magic link flow not opening 3rd party mail apps

### DIFF
--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -54,6 +54,12 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org-appextension-feature-password-management</string>
+		<string>googlegmail</string>
+		<string>airmail</string>
+		<string>ms-outlook</string>
+		<string>readdle-spark</string>
+		<string>ymail</string>
+		<string>fastmail</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
Fixes #3272.

This change adds several mail app schemes that are [supported by WordPressAuthenticator](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/1470051a4a8cee41fcb15ca4e5cfbd4c28455c2c/WordPressAuthenticator/Resources/SupportedEmailClients/EmailClients.plist) to `LSApplicationQueriesSchemes` in the `Info.plist`. 

**Note: This change is not tested yet!** I'm unable to test because my personal device is on 14.5 while my Xcode is 12.4 - I'm still downloading Xcode 12.5 🙃. And apparently, it's not possible to install additional Mail apps on the simulator. 

I'll give it another go once I have successfully downloaded Xcode 12.5. Meanwhile, any help testing this would be appreciated! 🙂 

Before | After
-- | --
**Description:** An alert is shown instead of options of supported mail apps. | **Description:** A sheet is presented, prompting the user to select one of the mail apps.
![3272_before](https://user-images.githubusercontent.com/1299411/122440215-8d896c80-cfc6-11eb-8a22-49f699a025f4.png) | ![IMG_E39C8E51B4AB-1](https://user-images.githubusercontent.com/1299411/122439156-9af22700-cfc5-11eb-9bd9-264cc6ec19e4.jpeg)

## To Test

1. Build & run the app on a device with a third-party mail app installed. Note that mail apps are not available in Simulator.
2. Ensure that the app is installed in a clean, logged out state. Then log in with WordPress.com account flow.
3. Select the magic link option.
4. Tap the Open Mail button, and verify that the sheet is shown (instead of an alert).

## Author Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
