### PR TITLE
Shipping Labels: Networking layer for Shipping Label Status endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
 		CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */; };
+		CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -936,6 +937,7 @@
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
 		CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapperTests.swift; sourceTree = "<group>"; };
+		CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusMapper.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1705,6 +1707,7 @@
 				456930AA264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift */,
 				CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */,
 				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
+				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2344,6 +2347,7 @@
 				45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */,
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
+				CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */,
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
 				31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -402,6 +402,8 @@
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
 		CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */; };
 		CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */; };
+		CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */; };
+		CC0786C9267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -938,6 +940,8 @@
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
 		CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapperTests.swift; sourceTree = "<group>"; };
 		CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusMapper.swift; sourceTree = "<group>"; };
+		CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-status-success.json"; sourceTree = "<group>"; };
+		CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusMapperTests.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1595,6 +1599,7 @@
 				CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */,
 				456930AC2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json */,
 				CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */,
+				CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */,
 				B56C1EB920EA7D2C00D749F9 /* sites.json */,
 				7426CA1221AF34A3004E9FFC /* site-api.json */,
 				74AB5B4E21AF3F0D00859C12 /* site-api-no-woo.json */,
@@ -1810,6 +1815,7 @@
 				CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */,
 				CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */,
 				CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */,
+				CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 			);
 			path = Mapper;
@@ -2035,6 +2041,7 @@
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
+				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
 				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
 				3105472C262E303400C5C02B /* wcpay-payment-intent-unknown-status.json in Resources */,
@@ -2468,6 +2475,7 @@
 				02698CF824C183A5005337C4 /* ProductVariationListMapperTests.swift in Sources */,
 				B524194921AC659500D6FC0A /* DevicesRemoteTests.swift in Sources */,
 				2685C0DA263B551300D9EE97 /* AddOnGroupMapperTests.swift in Sources */,
+				CC0786C9267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift in Sources */,
 				B505F6D320BEE3A500BB1B69 /* AccountMapperTests.swift in Sources */,
 				CC9A254A26442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift in Sources */,
 				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Mapper: Check Status of Shipping Labels
+///
+struct ShippingLabelStatusMapper: Mapper {
+    /// Site ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the shipping label endpoints.
+    ///
+    let siteID: Int64
+
+    /// Order ID associated to the shipping labels that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because OrderID is not returned in any of the shipping label endpoints.
+    ///
+    let orderID: Int64
+
+    /// (Attempts) to convert a dictionary into [ShippingLabel].
+    ///
+    func map(response: Data) throws -> [ShippingLabel] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.userInfo = [
+            .siteID: siteID,
+            .orderID: orderID
+        ]
+
+        return try decoder.decode(ShippingLabelStatusResponse.self, from: response).data.labels
+    }
+}
+
+/// ShippingLabelPurchaseResponse Disposable Entity
+///
+/// `Check Shipping Labels Status` endpoint returns the data wrapper in the `data` key.
+///
+private struct ShippingLabelStatusResponse: Decodable {
+    let data: ShippingLabelStatusEnvelope
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}
+
+/// ShippingLabelPurchaseEnvelope Disposable Entity
+///
+/// `Check Shipping Labels Status` endpoint returns the shipping label purchases in the `data.labels` key.
+///
+private struct ShippingLabelStatusEnvelope: Decodable {
+    let labels: [ShippingLabel]
+
+    private enum CodingKeys: String, CodingKey {
+        case labels
+    }
+}

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -36,6 +36,13 @@ public protocol ShippingLabelRemoteProtocol {
                                   canCreateCustomsForm: Bool,
                                   canCreatePackage: Bool,
                                   completion: @escaping (Result<ShippingLabelCreationEligibilityResponse, Error>) -> Void)
+    func purchaseShippingLabel(siteID: Int64,
+                               orderID: Int64,
+                               originAddress: ShippingLabelAddress,
+                               destinationAddress: ShippingLabelAddress,
+                               packages: [ShippingLabelPackageSelected],
+                               emailCustomerReceipt: Bool,
+                               completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -249,6 +249,26 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
             completion(.failure(error))
         }
     }
+
+    /// Checks the shipping label status
+    ///
+    /// Used after purchasing a shipping label, to check for errors or confirm a successful purchase.
+    /// This is used instead of `loadShippingLabels` to ensure up-to-date (non-cached) results.
+    /// - Parameters:
+    ///     - siteID: Remote ID of the site.
+    ///     - orderID: Remote ID of the order that owns the shipping labels.
+    ///     - labelIDs: Remote ID(s) of the label(s) to check the status of.
+    ///     - completion: Closure to be executed upon completion.
+    public func checkLabelStatus(siteID: Int64,
+                                    orderID: Int64,
+                                    labelIDs: [Int64],
+                                    completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+        let labelIDs = labelIDs.map(String.init).joined(separator: ",")
+        let path = "\(Path.shippingLabels)/\(orderID)/\(labelIDs)"
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path)
+        let mapper = ShippingLabelStatusMapper(siteID: siteID, orderID: orderID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: Constant

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -43,6 +43,10 @@ public protocol ShippingLabelRemoteProtocol {
                                packages: [ShippingLabelPackageSelected],
                                emailCustomerReceipt: Bool,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void)
+    func checkLabelStatus(siteID: Int64,
+                             orderID: Int64,
+                             labelIDs: [Int64],
+                             completion: @escaping (Result<[ShippingLabel], Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.

--- a/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ShippingLabelStatusMapper`
+///
+class ShippingLabelStatusMapperTests: XCTestCase {
+
+    /// Sample Site ID
+    private let sampleSiteID: Int64 = 1234
+
+    /// Sample Order ID
+    private let sampleOrderID: Int64 = 1234
+
+    /// Verifies that the Shipping Label Purchase is parsed correctly.
+    ///
+    func test_ShippingLabelPurchase_is_properly_parsed() {
+        guard let shippingLabelList = mapLoadShippingLabelStatus(),
+              let shippingLabel = shippingLabelList.first else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(shippingLabel.siteID, sampleSiteID)
+        XCTAssertEqual(shippingLabel.orderID, sampleOrderID)
+        XCTAssertEqual(shippingLabel.shippingLabelID, 1825)
+        XCTAssertEqual(shippingLabel.carrierID, "usps")
+        XCTAssertEqual(shippingLabel.dateCreated, Date(timeIntervalSince1970: 1623764362.682))
+        XCTAssertEqual(shippingLabel.packageName, "Small Flat Rate Box")
+        XCTAssertEqual(shippingLabel.rate, 7.9)
+        XCTAssertEqual(shippingLabel.currency, "USD")
+        XCTAssertEqual(shippingLabel.trackingNumber, "9405500205309072644962")
+        XCTAssertEqual(shippingLabel.serviceName, "USPS - Priority Mail")
+        XCTAssertEqual(shippingLabel.refundableAmount, 7.9)
+        XCTAssertEqual(shippingLabel.status, ShippingLabelStatus.purchased)
+        XCTAssertNil(shippingLabel.refund)
+        XCTAssertEqual(shippingLabel.originAddress, ShippingLabelAddress.fake())
+        XCTAssertEqual(shippingLabel.destinationAddress, ShippingLabelAddress.fake())
+        XCTAssertEqual(shippingLabel.productIDs, [89])
+        XCTAssertEqual(shippingLabel.productNames, ["WordPress Pennant"])
+    }
+}
+
+/// Private Helpers
+///
+private extension ShippingLabelStatusMapperTests {
+
+    /// Returns the ShippingLabelStatusMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapShippingLabelStatus(from filename: String) -> [ShippingLabel]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! ShippingLabelStatusMapper(siteID: sampleSiteID, orderID: sampleOrderID).map(response: response)
+    }
+
+    /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-status-success`
+    ///
+    func mapLoadShippingLabelStatus() -> [ShippingLabel]? {
+        return mapShippingLabelStatus(from: "shipping-label-status-success")
+    }
+}

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -409,6 +409,47 @@ final class ShippingLabelRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    func test_checkLabelStatus_parses_success_response() throws {
+        // Given
+        let sampleLabelID: Int64 = 4321
+        let expectedLabelStatus = ShippingLabel.fake().status
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/\(sampleOrderID)/\(sampleLabelID)", filename: "shipping-label-status-success")
+
+        // When
+        let result: Result<[ShippingLabel], Error> = waitFor { promise in
+            remote.checkLabelStatus(siteID: self.sampleSiteID,
+                                    orderID: self.sampleOrderID,
+                                    labelIDs: [sampleLabelID]) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        let shippingLabel = successResponse.first
+        XCTAssertEqual(shippingLabel?.status, expectedLabelStatus)
+    }
+
+    func test_checkLabelStatus_returns_error_on_failure() throws {
+        // Given
+        let sampleLabelID: Int64 = 4321
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/\(sampleOrderID)/\(sampleLabelID)", filename: "generic_error")
+
+        // When
+        let result: Result<[ShippingLabel], Error> = waitFor { promise in
+            remote.checkLabelStatus(siteID: self.sampleSiteID,
+                                    orderID: self.sampleOrderID,
+                                    labelIDs: [sampleLabelID]) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension ShippingLabelRemoteTests {

--- a/Networking/NetworkingTests/Responses/shipping-label-status-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-status-success.json
@@ -1,0 +1,25 @@
+{
+    "data": {
+        "success":true,
+        "labels":[{
+            "label_id": 1825,
+            "tracking": "9405500205309072644962",
+            "refundable_amount": 7.9,
+            "created": 1623764362682,
+            "carrier_id": "usps",
+            "service_name": "USPS - Priority Mail",
+            "status": "PURCHASED",
+            "commercial_invoice_url": null,
+            "package_name": "Small Flat Rate Box",
+            "is_letter": false,
+            "product_names": ["WordPress Pennant"],
+            "product_ids": [89],
+            "receipt_item_id": 24601924,
+            "created_date": 1623764367000,
+            "expiry_date": 1639316366000,
+            "main_receipt_id": 19991879,
+            "rate": 7.9,
+            "currency": "USD"
+        }]
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -59,6 +59,10 @@ final class MockShippingLabelRemote {
         let siteID: Int64
     }
 
+    private struct CheckLabelStatusResultKey: Hashable {
+        let siteID: Int64
+    }
+
     /// The results to return based on the given arguments in `loadShippingLabels`
     private var loadAllResults = [LoadAllResultKey: Result<OrderShippingLabelListResponse, Error>]()
 
@@ -91,6 +95,9 @@ final class MockShippingLabelRemote {
 
     /// The results to return based on the given arguments in `purchaseShippingLabel`
     private var purchaseShippingLabelResults = [PurchaseShippingLabelResultKey: Result<[ShippingLabelPurchase], Error>]()
+
+    /// The results to return based on the given arguments in `checkLabelStatus`
+    private var checkLabelStatusResults = [CheckLabelStatusResultKey: Result<[ShippingLabel], Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -185,6 +192,15 @@ final class MockShippingLabelRemote {
                                    thenReturn result: Result<[ShippingLabelPurchase], Error>) {
         let key = PurchaseShippingLabelResultKey(siteID: siteID)
         purchaseShippingLabelResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `checkLabelStatus` is called.
+    func whenCheckLabelStatus(siteID: Int64,
+                              orderID: Int64,
+                              labelIDs: [Int64],
+                              thenReturn result: Result<[ShippingLabel], Error>) {
+        let key = CheckLabelStatusResultKey(siteID: siteID)
+        checkLabelStatusResults[key] = result
     }
 }
 
@@ -352,6 +368,22 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
             let key = PurchaseShippingLabelResultKey(siteID: siteID)
             if let result = self.purchaseShippingLabelResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func checkLabelStatus(siteID: Int64,
+                          orderID: Int64,
+                          labelIDs: [Int64],
+                          completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let key = CheckLabelStatusResultKey(siteID: siteID)
+            if let result = self.checkLabelStatusResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
Part of: #4089

## Description

This PR adds support in the Networking layer for the Shipping Label Status endpoint (`GET /wc/v1/connect/label/{order_id}/{label_id1},{label_id2}...`). This endpoint returns the requested shipping label(s).

This endpoint is used to get the status of a newly purchased shipping label, to check for errors or confirm a successful purchase. It's used instead of `loadShippingLabels` to ensure up-to-date (non-cached) results, since `loadShippingLabels` returns cached data.

## Changes

* Adds `ShippingLabelRemote.checkLabelStatus` to make the API request to check the status of one or more shipping labels.
* Adds the mapper `ShippingLabelStatusMapper` to handle the API response (a list of shipping labels according to the label IDs in the request).
* Adds mocks and unit tests for the remote endpoint (`ShippingLabelRemoteTests`) and mapper (`ShippingLabelStatusMapperTests`).
* Adds `checkLabelStatus` and `purchaseShippingLabel` to the `ShippingLabelRemoteProtocol`, and adds their respective mocks to `MockShippingLabelRemote` in the Yosemite layer. (I skipped this for `purchaseShippingLabel` in #4423, so I've added both here.)

## Testing

Confirm tests pass in CI (endpoint is not yet used in app).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
