### PR TITLE
Hot fix: loading banner always visible in the Order Detail screen just in the release build

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -95,6 +95,11 @@ final class OrderDetailsViewController: UIViewController {
         super.viewWillAppear(animated)
         syncEverything { [weak self] in
             self?.topLoaderView.isHidden = true
+
+            /// We add the refresh control to the tableview just after the `topLoaderView` disappear for the first time.
+            if self?.tableView.refreshControl == nil {
+                self?.tableView.refreshControl = self?.refreshControl
+            }
         }
     }
 
@@ -132,7 +137,6 @@ private extension OrderDetailsViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.refreshControl = refreshControl
 
         tableView.dataSource = viewModel.dataSource
     }
@@ -409,6 +413,7 @@ private extension OrderDetailsViewController {
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentPayments) else {
+            onCompletion?(nil)
             return
         }
 


### PR DESCRIPTION
As reported by Garance here p5T066-2p9#comment-8784 in our release 6.9 we have a bug, where the new banner introduced for showing a loading banner at the top of the Order Detail screen remain always visible, plus it's possible to do a pull to refresh action while the banner is visible.

## Demo of the bug
https://user-images.githubusercontent.com/495617/122586768-5d40dd00-d05d-11eb-91e5-d1e74d60ca90.MP4

## The bug
It turns out that the bug about the banner not disappearing only occurred on the testflight build, and not in debug mode.
Long short story: the `syncSavedReceipts` method did not return anything in case of an error (an error that occurred only in the release build due to the feature flag not enabled), and this meant that the `syncEverything` method never returned all the responses of the callbacks.

## Testing
Since it occurs just in the release build, you can simulate it by substituting the code of `static var current: BuildConfiguration` under the file `BuildConfiguration.swift` with 
```
    static var current: BuildConfiguration {
        return .appStore
    }
```

1. Open an order detail.
2. Make sure the loading banner on top is visible.
3. Make sure you can't do a pull to refresh while the banner remains visible.
4. Make sure the banner after a bit disappears, and now you are able to do a pull to refresh action.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
