### PR TITLE
Allow ProductAddOnViewModel to be created from a ProductAddOn

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOn.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOn.swift
@@ -30,9 +30,10 @@ struct ProductAddOn: View {
                     .renderedIf(viewModel.showPrice)
             }
             .padding([.leading, .trailing])
+            .renderedIf(viewModel.showPrice || viewModel.showDescription)
 
             Spacer()
-                .frame(height: 2)
+                .frame(height: 1)
 
             // Add-on options
             ForEach(viewModel.options) { option in
@@ -62,7 +63,15 @@ struct ProductAddOn: View {
 struct ProductAddOn_Previews: PreviewProvider {
 
     static let toppingViewModel = ProductAddOnViewModel(name: "Pizza Topping",
-                                                 description: "Select your favorite topping",
+                                                 description: "Select your topping",
+                                                 price: "",
+                                                 options: [
+                                                    .init(name: "Peperoni", price: "$2.99", offSetDivider: true),
+                                                    .init(name: "Salami", price: "$1.99", offSetDivider: true),
+                                                    .init(name: "Ham", price: "$1.99", offSetDivider: false),
+                                                 ])
+    static let toppingViewModel2 = ProductAddOnViewModel(name: "Pizza Topping",
+                                                 description: "",
                                                  price: "",
                                                  options: [
                                                     .init(name: "Peperoni", price: "$2.99", offSetDivider: true),
@@ -85,6 +94,10 @@ struct ProductAddOn_Previews: PreviewProvider {
                 .previewLayout(.fixed(width: 420, height: 100))
 
             ProductAddOn(viewModel: toppingViewModel)
+                .environment(\.colorScheme, .light)
+                .previewLayout(.fixed(width: 420, height: 220))
+
+            ProductAddOn(viewModel: toppingViewModel2)
                 .environment(\.colorScheme, .light)
                 .previewLayout(.fixed(width: 420, height: 220))
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -3,11 +3,11 @@ import Yosemite
 
 /// ViewModel for `ProductAddOn`
 ///
-struct ProductAddOnViewModel: Identifiable {
+struct ProductAddOnViewModel: Identifiable, Equatable {
 
     /// Represents an Add-on option
     ///
-    struct Option: Identifiable {
+    struct Option: Identifiable, Equatable {
 
         /// Option name
         ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -80,12 +80,15 @@ extension ProductAddOnViewModel {
 
     /// Initializes properties using a `Yosemite.ProductAddOn` as  source.
     ///
-    init(addOn: Yosemite.ProductAddOn) {
+    init(addOn: Yosemite.ProductAddOn,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         name = addOn.name
         description = addOn.description
-        price = addOn.price
+        price = currencyFormatter.formatAmount(addOn.price) ?? ""
         options = addOn.options.enumerated().map { index, option in
-            Option(name: option.label ?? "", price: option.price ?? "", offSetDivider: index < (addOn.options.count - 1))
+            Option(name: option.label ?? "",
+                   price: currencyFormatter.formatAmount(option.price ?? "") ?? "",
+                   offSetDivider: index < (addOn.options.count - 1))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -85,10 +85,15 @@ extension ProductAddOnViewModel {
         name = addOn.name
         description = addOn.description
         price = currencyFormatter.formatAmount(addOn.price) ?? ""
-        options = addOn.options.enumerated().map { index, option in
-            Option(name: option.label ?? "",
-                   price: currencyFormatter.formatAmount(option.price ?? "") ?? "",
-                   offSetDivider: index < (addOn.options.count - 1))
+
+        // Convert options and filter empty ones.
+        options = addOn.options.enumerated().compactMap { index, option in
+            guard !option.label.isNilOrEmpty || !option.price.isNilOrEmpty else {
+                return nil
+            }
+            return Option(name: option.label ?? "",
+                          price: currencyFormatter.formatAmount(option.price ?? "") ?? "",
+                          offSetDivider: index < (addOn.options.count - 1))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// ViewModel for `ProductAddOn`
 ///
-struct ProductAddOnViewModel {
+struct ProductAddOnViewModel: Identifiable {
 
     /// Represents an Add-on option
     ///
@@ -49,6 +49,12 @@ struct ProductAddOnViewModel {
     /// Add-on options.
     ///
     let options: [Option]
+
+    /// Identifiable conformance.
+    ///
+    var id: String {
+        name
+    }
 
     /// Determines the main description visibility
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// ViewModel for `ProductAddOn`
 ///
@@ -65,5 +66,18 @@ struct ProductAddOnViewModel {
     ///
     var showBottomDivider: Bool {
         options.isEmpty
+    }
+}
+
+// MARK: Initializers
+extension ProductAddOnViewModel {
+
+    /// Initializes properties using a `Yosemite.ProductAddOn` as  source.
+    ///
+    init(addOn: Yosemite.ProductAddOn) {
+        name = addOn.name
+        description = addOn.description
+        price = addOn.price
+        options = addOn.options.map { Option(name: $0.label ?? "", price: $0.price ?? "") }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -84,6 +84,8 @@ extension ProductAddOnViewModel {
         name = addOn.name
         description = addOn.description
         price = addOn.price
-        options = addOn.options.map { Option(name: $0.label ?? "", price: $0.price ?? "") }
+        options = addOn.options.enumerated().map { index, option in
+            Option(name: option.label ?? "", price: option.price ?? "", offSetDivider: index < (addOn.options.count - 1))
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -27,7 +27,17 @@ struct ProductAddOnsList: View {
     let viewModel: ProductAddOnsListViewModel
 
     var body: some View {
-        AddOnListNotice(updateText: viewModel.infoNotice)
+        ZStack {
+            // Solid color as a background view to cover all non-safe area
+            Color(.listBackground).edgesIgnoringSafeArea(.all)
+
+            List {
+                ForEach(viewModel.addOns) { addOn in
+                    ProductAddOn(viewModel: addOn)
+                }
+                AddOnListNotice(updateText: viewModel.infoNotice)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -7,7 +7,7 @@ import SwiftUI
 ///
 final class ProductAddOnsListViewController: UIHostingController<ProductAddOnsList> {
     init(viewModel: ProductAddOnsListViewModel) {
-        super.init(rootView: ProductAddOnsList())
+        super.init(rootView: ProductAddOnsList(viewModel: viewModel))
         title = viewModel.title
     }
 
@@ -21,15 +21,39 @@ final class ProductAddOnsListViewController: UIHostingController<ProductAddOnsLi
 /// Renders a list of product add-ons
 ///
 struct ProductAddOnsList: View {
+
+    /// View model that directs the view content.
+    ///
+    let viewModel: ProductAddOnsListViewModel
+
     var body: some View {
-        Text("WIP")
+        AddOnListNotice(updateText: viewModel.infoNotice)
     }
 }
+
+/// Renders a info notice with an icon
+///
+private struct AddOnListNotice: View {
+
+    /// Content to be rendered next to the info icon.
+    ///
+    let updateText: String
+
+    var body: some View {
+        HStack {
+            Image(uiImage: .infoOutlineImage)
+            Text(updateText)
+        }
+        .footnoteStyle()
+        .padding([.leading, .trailing]).padding(.top, 4)
+    }
+}
+
 
 // MARK: Previews
 struct ProductAddOnsList_Previews: PreviewProvider {
     static var previews: some View {
-        ProductAddOnsList()
+        ProductAddOnsList(viewModel: ProductAddOnsListViewModel())
             .environment(\.colorScheme, .light)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -27,17 +27,17 @@ struct ProductAddOnsList: View {
     let viewModel: ProductAddOnsListViewModel
 
     var body: some View {
-        ZStack {
-            // Solid color as a background view to cover all non-safe area
-            Color(.listBackground).edgesIgnoringSafeArea(.all)
-
-            List {
+        ScrollView {
+            LazyVStack {
                 ForEach(viewModel.addOns) { addOn in
                     ProductAddOn(viewModel: addOn)
                 }
                 AddOnListNotice(updateText: viewModel.infoNotice)
             }
         }
+        .background(
+            Color(.listBackground).edgesIgnoringSafeArea(.all)
+        )
     }
 }
 
@@ -65,11 +65,12 @@ struct ProductAddOnsList_Previews: PreviewProvider {
 
     static let viewModel = ProductAddOnsListViewModel(addOns: [
         .init(name: "Toppings", description: "Select your toppings", price: "", options: [
-            .init(name: "Peperoni", price: "$2.99"),
-            .init(name: "Salami", price: "$1.99"),
-            .init(name: "Ham", price: "$1.99")
+            .init(name: "Pepperoni", price: "$2.99", offSetDivider: true),
+            .init(name: "Salami", price: "$1.99", offSetDivider: true),
+            .init(name: "Ham", price: "$1.99", offSetDivider: false),
         ]),
         .init(name: "Delivery", description: "Do you want it delivered to your address?", price: "$10.00", options: []),
+        .init(name: "Engraving", description: "", price: "$10.00", options: []),
     ])
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -52,8 +52,18 @@ private struct AddOnListNotice: View {
 
 // MARK: Previews
 struct ProductAddOnsList_Previews: PreviewProvider {
+
+    static let viewModel = ProductAddOnsListViewModel(addOns: [
+        .init(name: "Toppings", description: "Select your toppings", price: "", options: [
+            .init(name: "Peperoni", price: "$2.99"),
+            .init(name: "Salami", price: "$1.99"),
+            .init(name: "Ham", price: "$1.99")
+        ]),
+        .init(name: "Delivery", description: "Do you want it delivered to your address?", price: "$10.00", options: []),
+    ])
+
     static var previews: some View {
-        ProductAddOnsList(viewModel: ProductAddOnsListViewModel())
+        ProductAddOnsList(viewModel: viewModel)
             .environment(\.colorScheme, .light)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
@@ -7,11 +7,17 @@ final class ProductAddOnsListViewModel {
     /// View title
     ///
     let title = Localization.title
+
+    /// View info notice
+    ///
+    let infoNotice = Localization.infoNotice
 }
 
 // MARK: Constants
 extension ProductAddOnsListViewModel {
     enum Localization {
         static let title = NSLocalizedString("Product Add-ons", comment: "Title for the product add-ons screen")
+        static let infoNotice = NSLocalizedString("You can edit product add-ons in the web dashboard",
+                                                  comment: "Info notice at the bottom of the product add-ons screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
@@ -25,7 +25,7 @@ final class ProductAddOnsListViewModel {
 // MARK: Initializers
 extension ProductAddOnsListViewModel {
     convenience init(addOns: [Yosemite.ProductAddOn]) {
-        let viewModels = addOns.map(ProductAddOnViewModel.init(addOn:))
+        let viewModels = addOns.map { ProductAddOnViewModel(addOn: $0) }
         self.init(addOns: viewModels)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// ViewModel for `ProductAddOnsList`
 ///
@@ -11,13 +12,29 @@ final class ProductAddOnsListViewModel {
     /// View info notice
     ///
     let infoNotice = Localization.infoNotice
+
+    /// Add-ons to render
+    ///
+    let addOns: [ProductAddOnViewModel]
+
+    init(addOns: [ProductAddOnViewModel]) {
+        self.addOns = addOns
+    }
+}
+
+// MARK: Initializers
+extension ProductAddOnsListViewModel {
+    convenience init(addOns: [Yosemite.ProductAddOn]) {
+        let viewModels = addOns.map(ProductAddOnViewModel.init(addOn:))
+        self.init(addOns: viewModels)
+    }
 }
 
 // MARK: Constants
 extension ProductAddOnsListViewModel {
     enum Localization {
         static let title = NSLocalizedString("Product Add-ons", comment: "Title for the product add-ons screen")
-        static let infoNotice = NSLocalizedString("You can edit product add-ons in the web dashboard",
+        static let infoNotice = NSLocalizedString("You can edit product add-ons in the web dashboard.",
                                                   comment: "Info notice at the bottom of the product add-ons screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1395,7 +1395,10 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func navigateToAddOns() {
-        let viewModel = ProductAddOnsListViewModel()
+        guard let product = product as? EditableProductModel else {
+            return
+        }
+        let viewModel = ProductAddOnsListViewModel(addOns: product.product.addOns)
         let viewController = ProductAddOnsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
@@ -64,4 +64,21 @@ class ProductAddOnViewModelTests: XCTestCase {
         ])
         assertEqual(viewModel, expected)
     }
+
+    func test_empty_options_are_excluded() {
+        // Given
+        let productAddOn = Yosemite.ProductAddOn.fake().copy(name: "Name", description: "Description", price: "20.0", options: [
+            ProductAddOnOption.fake().copy(label: "", price: ""),
+            ProductAddOnOption.fake().copy(label: "Option 1", price: "11.0"),
+        ])
+
+        // When
+        let viewModel = ProductAddOnViewModel(addOn: productAddOn)
+
+        // Then
+        let expected = ProductAddOnViewModel(name: "Name", description: "Description", price: "$20.00", options: [
+            .init(name: "Option 1", price: "$11.00", offSetDivider: false),
+        ])
+        assertEqual(viewModel, expected)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import TestKit
 
 @testable import WooCommerce
+@testable import Yosemite
 
 class ProductAddOnViewModelTests: XCTestCase {
 
@@ -44,5 +45,23 @@ class ProductAddOnViewModelTests: XCTestCase {
 
         // Then & When
         XCTAssertTrue(viewModel.showBottomDivider)
+    }
+
+    func test_fields_are_properly_populated_from_entity() {
+        // Given
+        let productAddOn = Yosemite.ProductAddOn.fake().copy(name: "Name", description: "Description", price: "20.0", options: [
+            ProductAddOnOption.fake().copy(label: "option 1", price: "11.0"),
+            ProductAddOnOption.fake().copy(label: "option 2", price: "9.0"),
+        ])
+
+        // When
+        let viewModel = ProductAddOnViewModel(addOn: productAddOn)
+
+        // Then
+        let expected = ProductAddOnViewModel(name: productAddOn.name, description: productAddOn.description, price: productAddOn.price, options: [
+            .init(name: productAddOn.options[0].label ?? "", price: productAddOn.options[0].price ?? "", offSetDivider: true),
+            .init(name: productAddOn.options[1].label ?? "", price: productAddOn.options[1].price ?? "", offSetDivider: false),
+        ])
+        assertEqual(viewModel, expected)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
@@ -50,17 +50,17 @@ class ProductAddOnViewModelTests: XCTestCase {
     func test_fields_are_properly_populated_from_entity() {
         // Given
         let productAddOn = Yosemite.ProductAddOn.fake().copy(name: "Name", description: "Description", price: "20.0", options: [
-            ProductAddOnOption.fake().copy(label: "option 1", price: "11.0"),
-            ProductAddOnOption.fake().copy(label: "option 2", price: "9.0"),
+            ProductAddOnOption.fake().copy(label: "Option 1", price: "11.0"),
+            ProductAddOnOption.fake().copy(label: "Option 2", price: "9.0"),
         ])
 
         // When
         let viewModel = ProductAddOnViewModel(addOn: productAddOn)
 
         // Then
-        let expected = ProductAddOnViewModel(name: productAddOn.name, description: productAddOn.description, price: productAddOn.price, options: [
-            .init(name: productAddOn.options[0].label ?? "", price: productAddOn.options[0].price ?? "", offSetDivider: true),
-            .init(name: productAddOn.options[1].label ?? "", price: productAddOn.options[1].price ?? "", offSetDivider: false),
+        let expected = ProductAddOnViewModel(name: "Name", description: "Description", price: "$20.00", options: [
+            .init(name: "Option 1", price: "$11.00", offSetDivider: true),
+            .init(name: "Option 2", price: "$9.00", offSetDivider: false),
         ])
         assertEqual(viewModel, expected)
     }


### PR DESCRIPTION
closes #4269

# Why

This PR integrates #4435 and #4267 to be able to show a list of all the add-ons a product supports.

# How

- Updated `ProductAddOnViewModel` to be able to create instances of it using a `ProductAddOn`.

- Updated `ProductAddOnsListViewController` to create the list view that will render the add-ons.

- Updated `ProductAddOnsListViewModel` to create proper `ProductAddOnViewModel` instances.

# Demo
https://user-images.githubusercontent.com/562080/122615895-f7e5ef80-d04e-11eb-859c-1b9f59b9a009.mov

# Testing
**Prerequisites:** 
- Have your site with the add-ons plugin installed and with at least one product with add-ons.
- Enable the "Add-Ons" feature from the beta features screen in settings.

**Steps:**
- Launch the app and navigate to the product with add-ons
- Tap on the "Product Add-Ons" button.
- See a screen when all the product add-ons are listed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
