### PR TITLE
Shipping Labels: Yosemite layer for shipping label purchases

### DIFF
--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -235,7 +235,18 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Purchases the shipping label.
+    /// Initiates a shipping label purchase.
+    ///
+    /// This request returns the label purchase data, including a `PURCHASE_IN_PROGRESS` status.
+    /// After initiating the purchase, we must poll the backend for the updated label status (successful purchase or error).
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site.
+    ///   - orderID: Remote ID of the order that owns the shipping labels.
+    ///   - originAddress: the origin address entity.
+    ///   - destinationAddress: the destination address entity.
+    ///   - packages: The package previously selected with all their data.
+    ///   - emailCustomerReceipt: Whether to email an order receipt to the customer.
+    ///   - completion: Closure to be executed upon completion.
     public func purchaseShippingLabel(siteID: Int64,
                                       orderID: Int64,
                                       originAddress: ShippingLabelAddress,

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -66,4 +66,14 @@ public enum ShippingLabelAction: Action {
     case updateShippingLabelAccountSettings(siteID: Int64,
                                             settings: ShippingLabelAccountSettings,
                                             completion: (Result<Bool, Error>) -> Void)
+
+    /// Purchases a shipping label
+    ///
+    case purchaseShippingLabel(siteID: Int64,
+                               orderID: Int64,
+                               originAddress: ShippingLabelAddress,
+                               destinationAddress: ShippingLabelAddress,
+                               packages: [ShippingLabelPackageSelected],
+                               emailCustomerReceipt: Bool,
+                               completion: (Result<[ShippingLabel], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -69,6 +69,14 @@ public final class ShippingLabelStore: Store {
             synchronizeShippingLabelAccountSettings(siteID: siteID, completion: completion)
         case .updateShippingLabelAccountSettings(let siteID, let settings, let completion):
             updateShippingLabelAccountSettings(siteID: siteID, settings: settings, completion: completion)
+        case .purchaseShippingLabel(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let emailCustomerReceipt, let completion):
+            purchaseShippingLabel(siteID: siteID,
+                                  orderID: orderID,
+                                  originAddress: originAddress,
+                                  destinationAddress: destinationAddress,
+                                  packages: packages,
+                                  emailCustomerReceipt: emailCustomerReceipt,
+                                  completion: completion)
         }
     }
 }
@@ -210,6 +218,49 @@ private extension ShippingLabelStore {
             case .failure(let error):
                 completion(.failure(error))
             }
+        }
+    }
+
+    func purchaseShippingLabel(siteID: Int64,
+                               orderID: Int64,
+                               originAddress: ShippingLabelAddress,
+                               destinationAddress: ShippingLabelAddress,
+                               packages: [ShippingLabelPackageSelected],
+                               emailCustomerReceipt: Bool,
+                               completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+        var labelPurchaseIDs: [Int64] = []
+
+        // Make the initial purchase request.
+        remote.purchaseShippingLabel(siteID: siteID,
+                                     orderID: orderID,
+                                     originAddress: originAddress,
+                                     destinationAddress: destinationAddress,
+                                     packages: packages,
+                                     emailCustomerReceipt: emailCustomerReceipt) { result in
+            switch result {
+            case .success(let labelPurchases):
+                // Save the IDs of label purchases in the response so we can poll the backend for their status.
+                for label in labelPurchases {
+                    labelPurchaseIDs.append(label.shippingLabelID)
+                }
+            case .failure(let error):
+                DDLogError("⛔️ Error purchasing shipping label for order \(orderID): \(error)")
+                completion(.failure(error))
+            }
+        }
+
+        // Wait for 2 seconds (give the backend time to process the purchase)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self = self else { return }
+
+            // Poll the status of the label purchases from the response above
+            // with a delay of 1 second each time, with a maximum of 3 retries
+            self.pollLabelStatus(withDelayInSeconds: 1.0,
+                                 maxRetries: 3,
+                                 siteID: siteID,
+                                 orderID: orderID,
+                                 labelIDs: labelPurchaseIDs,
+                                 completion: completion)
         }
     }
 }
@@ -354,5 +405,55 @@ private extension ShippingLabelStore {
             newStoragePaymentMethod.update(with: paymentMethod)
             storageAccountSettings.addToPaymentMethods(newStoragePaymentMethod)
         }
+    }
+
+    func pollLabelStatus(withDelayInSeconds delay: Double,
+                         maxRetries: Int64,
+                         siteID: Int64,
+                         orderID: Int64,
+                         labelIDs: [Int64],
+                         completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+        remote.checkLabelStatus(siteID: siteID, orderID: orderID, labelIDs: labelIDs) { result in
+            switch result {
+            case .success(let labels):
+                // If all labels have PURCHASED status, stop polling
+                if labels.allSatisfy({ $0.status == .purchased }) {
+                    completion(.success(labels))
+                }
+
+                // If any label has PURCHASE_ERROR status, return error and stop polling
+                else if labels.contains(where: { $0.status == .purchaseError }) {
+                    DDLogError("⛔️ Error purchasing shipping label for order \(orderID)")
+                    completion(.failure(LabelPurchaseError.purchaseErrorStatus))
+                }
+
+                // If no errors but status is not PURCHASED for all labels, poll again after delay
+                else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                        self?.pollLabelStatus(withDelayInSeconds: delay, maxRetries: maxRetries - 1, siteID: siteID, orderID: orderID, labelIDs: labelIDs, completion: completion)
+                    }
+                }
+
+            case .failure(let error):
+                // If there are retries left, poll again after delay
+                if maxRetries > 0 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                        self?.pollLabelStatus(withDelayInSeconds: delay, maxRetries: maxRetries - 1, siteID: siteID, orderID: orderID, labelIDs: labelIDs, completion: completion)
+                    }
+                }
+
+                // If there are no retries left, stop polling
+                else {
+                    DDLogError("⛔️ Error checking shipping label status for order \(orderID): \(error)")
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    /// Represents errors that can be returned when checking shipping label purchase status
+    enum LabelPurchaseError: Error {
+        /// API returns a `PURCHASE_ERROR` status for a label
+        case purchaseErrorStatus
     }
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -466,12 +466,12 @@ private extension ShippingLabelStore {
             }
         }
     }
+}
 
-    /// Represents errors that can be returned when checking shipping label purchase status
-    enum LabelPurchaseError: Error {
-        /// API returns a `PURCHASE_ERROR` status for a label
-        case purchaseErrorStatus
-        /// Label purchase not complete after polling the backend
-        case purchaseIncomplete
-    }
+/// Represents errors that can be returned when checking shipping label purchase status
+public enum LabelPurchaseError: Error {
+    /// API returns a `PURCHASE_ERROR` status for a label
+    case purchaseErrorStatus
+    /// Label purchase not complete after polling the backend
+    case purchaseIncomplete
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -243,24 +243,24 @@ private extension ShippingLabelStore {
                 for label in labelPurchases {
                     labelPurchaseIDs.append(label.shippingLabelID)
                 }
+
+                // Wait for 2 seconds (give the backend time to process the purchase)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                    guard let self = self else { return }
+
+                    // Poll the status of the label purchases from the response above
+                    // with a delay of 1 second each time, with a maximum of 3 retries
+                    self.pollLabelStatus(withDelayInSeconds: 1.0,
+                                         maxRetries: 3,
+                                         siteID: siteID,
+                                         orderID: orderID,
+                                         labelIDs: labelPurchaseIDs,
+                                         completion: completion)
+                }
             case .failure(let error):
                 DDLogError("⛔️ Error purchasing shipping label for order \(orderID): \(error)")
                 completion(.failure(error))
             }
-        }
-
-        // Wait for 2 seconds (give the backend time to process the purchase)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            guard let self = self else { return }
-
-            // Poll the status of the label purchases from the response above
-            // with a delay of 1 second each time, with a maximum of 3 retries
-            self.pollLabelStatus(withDelayInSeconds: 1.0,
-                                 maxRetries: 3,
-                                 siteID: siteID,
-                                 orderID: orderID,
-                                 labelIDs: labelPurchaseIDs,
-                                 completion: completion)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -430,7 +430,12 @@ private extension ShippingLabelStore {
                 // If no errors but status is not PURCHASED for all labels, poll again after delay
                 else if maxRetries > 0 {
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                        self?.pollLabelStatus(withDelayInSeconds: delay, maxRetries: maxRetries - 1, siteID: siteID, orderID: orderID, labelIDs: labelIDs, completion: completion)
+                        self?.pollLabelStatus(withDelayInSeconds: delay,
+                                              maxRetries: maxRetries - 1,
+                                              siteID: siteID,
+                                              orderID: orderID,
+                                              labelIDs: labelIDs,
+                                              completion: completion)
                     }
                 }
 
@@ -444,7 +449,12 @@ private extension ShippingLabelStore {
                 // If there are retries left, poll again after delay
                 if maxRetries > 0 {
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                        self?.pollLabelStatus(withDelayInSeconds: delay, maxRetries: maxRetries - 1, siteID: siteID, orderID: orderID, labelIDs: labelIDs, completion: completion)
+                        self?.pollLabelStatus(withDelayInSeconds: delay,
+                                              maxRetries: maxRetries - 1,
+                                              siteID: siteID,
+                                              orderID: orderID,
+                                              labelIDs: labelIDs,
+                                              completion: completion)
                     }
                 }
 


### PR DESCRIPTION
Part of: #4089

## Description

This PR implements the Yosemite layer for purchasing shipping labels. It combines two remote endpoints to initiate the purchase and then poll for the label status until the purchase is complete, returning the purchased label(s) or an error.

This flow chart outlines the purchase flow:

<img src="https://user-images.githubusercontent.com/8658164/122834548-ad7ea000-d2e6-11eb-81c0-ad901afbff0e.png" width="400px">

(internal ref: p91TBi-4K3-p2)

## Changes

* Adds the action `purchaseShippingLabel` to `ShippingLabelAction` and `ShippingLabelStore`. This encapsulates the entire flow outline above.
* Adds a private method `pollLabelStatus` to poll the label status according to the flow chart above. This is called in `purchaseShippingLabel`.
* Adds an Error enum `LabelPurchaseError`, to identify the types of errors that could result from a successful response from `ShippingLabelRemote.checkLabelStatus`.
* Adds unit tests for `purchaseShippingLabel`.

It would be nice to abstract the polling behavior into a reusable class, for other places where we might want to poll the API like this. I thought I'd get feedback on this approach first, though — is this a reasonable way to do the polling (using `DispatchQueue`) or is there another way to do this that might be better?

## Testing

Confirm tests pass in CI (Yosemite action is not yet used in app).
Confirm the code matches the flow chart above and the tests are checking the right things.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.