### PR TITLE
Update AppStoreStrings to mention English comma keywords requirement

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -46,7 +46,7 @@ msgid ""
 msgstr ""
 
 #. translators: Keywords used in the App Store search engine to find the app.
-#. Delimit with a comma between each keyword. Limit to 100 characters including spaces and commas.
+#. Delimit with an English comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
 msgid "Woocommerce, woocommerce app, woocommerce mobile, woo app, woocommerce order alert, wordpress, eComm"
 msgstr ""


### PR DESCRIPTION
App Store Connect requires keywords to be separated by "English comma, Chinese comma, or a mix of both". For consistency and simplicity, I specify only English comma here.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (N.A.)