### PR TITLE
Address new warnings from Xcode 12.5

### DIFF
--- a/Storage/Storage/Protocols/Object.swift
+++ b/Storage/Storage/Protocols/Object.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Defines the basic properties of any persisted entity.
 ///
-public protocol Object: class {
+public protocol Object: AnyObject {
 
     /// ObjectID Instance Type.
     ///

--- a/Storage/Storage/Protocols/StorageType.swift
+++ b/Storage/Storage/Protocols/StorageType.swift
@@ -5,7 +5,7 @@ import CoreData.NSFetchRequest
 
 /// Defines all of the methods made available by the Storage.
 ///
-public protocol StorageType: class {
+public protocol StorageType: AnyObject {
 
     var parentStorage: StorageType? {get}
 

--- a/TestKit/Sources/TestKit/XCTestCase+Wait.swift
+++ b/TestKit/Sources/TestKit/XCTestCase+Wait.swift
@@ -72,7 +72,7 @@ extension XCTestCase {
     public func waitFor<ValueType>(file: StaticString = #file,
                                    line: UInt = #line,
                                    timeout: TimeInterval = 5.0,
-                                   await: @escaping (_ promise: (@escaping (ValueType) -> Void)) throws -> Void) rethrows -> ValueType {
+                                   awaiting: @escaping (_ promise: (@escaping (ValueType) -> Void)) throws -> Void) rethrows -> ValueType {
         let exp = expectation(description: "Expect promise to be called.")
 
         var receivedValue: ValueType? = nil
@@ -81,7 +81,7 @@ extension XCTestCase {
             exp.fulfill()
         }
 
-        try await(promise)
+        try awaiting(promise)
 
         let result = XCTWaiter.wait(for: [exp], timeout: timeout)
         switch result {

--- a/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
+++ b/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
@@ -4,7 +4,7 @@ import UIKit
 
 /// ApplicationAdapter: Wraps UIApplication's API. Meant for Unit Testing Purposes.
 ///
-protocol ApplicationAdapter: class {
+protocol ApplicationAdapter: AnyObject {
 
     /// App's Badge Count
     ///

--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -1,7 +1,7 @@
 import Yosemite
 
 /// Delegate of `PaginationTracker` that implements syncing per page number and size.
-protocol PaginationTrackerDelegate: class {
+protocol PaginationTrackerDelegate: AnyObject {
     typealias SyncCompletion = (Result<Bool, Error>) -> Void
 
     /// Syncs a page by the number and size, and returns an error or whether there might be the next page on completion.

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 /// SyncingCoordinatorDelegate: Delegate that's expected to provide Sync'ing Services per Page.
 ///
-protocol SyncingCoordinatorDelegate: class {
+protocol SyncingCoordinatorDelegate: AnyObject {
 
     /// The receiver is expected to synchronize the pageNumber. On completion, it should indicate if the sync was
     /// successful or not.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -21,7 +21,7 @@ protocol DashboardUI: UIViewController {
 }
 
 /// Relays the scroll events to a delegate for navigation bar large title workaround.
-protocol DashboardUIScrollDelegate: class {
+protocol DashboardUIScrollDelegate: AnyObject {
     /// Called when a dashboard tab `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
     func dashboardUIScrollViewDidScroll(_ scrollView: UIScrollView)
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -164,7 +164,7 @@ private extension IssueRefundCoordinatingController {
 
 /// Conform to this protocol to allow custom behaviour on when to allow an interactive dismiss gesture.
 ///
-protocol IssueRefundInteractiveDismissDelegate: class {
+protocol IssueRefundInteractiveDismissDelegate: AnyObject {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -11,7 +11,7 @@ import XLPagerTabStrip
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 
-protocol OrderListViewControllerDelegate: class {
+protocol OrderListViewControllerDelegate: AnyObject {
     /// Called when `OrderListViewController` (or `OrdersViewController`) is about to fetch Orders from the API.
     ///
     func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -6,7 +6,7 @@ import enum Yosemite.OrderStatusEnum
 import struct Yosemite.Note
 
 /// Relays the scroll events to a delegate for navigation bar large title workaround.
-protocol OrdersTabbedViewControllerScrollDelegate: class {
+protocol OrdersTabbedViewControllerScrollDelegate: AnyObject {
     /// Called when an order list `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView)
 }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol TextViewViewControllerDelegate: class {
+protocol TextViewViewControllerDelegate: AnyObject {
 
     // Text validation.
     func validate(text: String) -> Bool

--- a/Yosemite/Yosemite/Base/Dispatcher.swift
+++ b/Yosemite/Yosemite/Base/Dispatcher.swift
@@ -8,7 +8,7 @@ public protocol Action { }
 
 // MARK: - Action: Represents a Flux Action Processor. Processors should get registered into the Dispatcher instance, for action processing.
 //
-public protocol ActionsProcessor: class {
+public protocol ActionsProcessor: AnyObject {
 
     /// Called whenever a given Action is dispatched.
     ///


### PR DESCRIPTION
Migrating to Xcode 12.5 (#4459) introduced two new warnings:

> Using '`class`' keyword for protocol inheritance is deprecated; use '`AnyObject`' instead

and 

> Future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it

This PR addresses them.

@jaclync, @shiki, @Ecarrion: GitHub suggested you as reviewers 😅 cc @jkmassel as release manager.

_I based this on `xcode-12.5` for ease of review. As an aside, these changes should still work if rebased onto `develop` without the ones from that branch._

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. _N.A._