### PR TITLE
Shipping Label: display the bottom sheet when the user taps the info area on WooCommerce Discount

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ target 'WooCommerce' do
 
   pod 'WordPressShared', '~> 1.15'
 
-  pod 'WordPressUI', '~> 1.7.2'
+  pod 'WordPressUI', '~> 1.12.1-beta.3'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
 
   aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
   - WordPressShared (1.15.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
-  - WordPressUI (1.7.2)
+  - WordPressUI (1.12.1-beta.3)
   - Wormholy (1.6.4)
   - WPMediaPicker (1.7.1)
   - wpxmlrpc (0.9.0)
@@ -108,7 +108,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.38.0)
   - WordPressKit (~> 4.32.0)
   - WordPressShared (~> 1.15)
-  - WordPressUI (~> 1.7.2)
+  - WordPressUI (~> 1.12.1-beta.3)
   - Wormholy (~> 1.6.4)
   - WPMediaPicker (~> 1.7.1)
   - XLPagerTabStrip (~> 9.0)
@@ -119,7 +119,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
-    - WordPressUI
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -146,6 +145,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressUI
     - Wormholy
     - WPMediaPicker
     - wpxmlrpc
@@ -187,7 +187,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 4ccd7f41bae37247883922ad92a14f18cc759bf3
   WordPressKit: 438af1e601ca74ff0d68efa17b4528cb7d8638a7
   WordPressShared: e1915cf3b4ac33f41c47610693b9ca30c0cdab45
-  WordPressUI: a50ea1786cb75330c8cfafe0c97a88db8d796699
+  WordPressUI: cf3b3ef744663811a8d8a9844f42386e1826f512
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
   WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
@@ -200,6 +200,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 7323ee6703bf1714a01eca73fc930e96657d5634
+PODFILE CHECKSUM: 6199f56aa674f5b62cf0f2c1ec271aa23ebc600c
 
 COCOAPODS: 1.10.1

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
@@ -24,19 +24,35 @@ final class ShippingLabelDiscountInfoViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        preferredContentSize = CGSize(width: .zero, height: stackView.frame.height + (BottomSheetViewController.Constants.additionalContentTopMargin * 2))
+    }
 }
 
 private extension ShippingLabelDiscountInfoViewController {
     func configureImages() {
-        icon.image = .infoImage
+        icon.image = .infoOutlineImage
         separator.backgroundColor = .systemColor(.separator)
     }
 
     func configureLabels() {
         titleLabel.applyHeadlineStyle()
         titleLabel.numberOfLines = 0
+        titleLabel.text = Localization.title
         descriptionLabel.applyBodyStyle()
         descriptionLabel.numberOfLines = 0
+        descriptionLabel.text = Localization.description
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "What is WooCommerce Services discount?",
+            comment: "Shipping Labels: info title about WooCommerce Services discount")
+        static let description = NSLocalizedString(
+            "When purchasing shipping labels with WooCommerce, you get access to discounted commercial prices.",
+            comment: "Shipping Labels: info description about WooCommerce Services discount")
     }
 }
 
@@ -48,5 +64,4 @@ extension ShippingLabelDiscountInfoViewController: DrawerPresentable {
     var expandedHeight: DrawerHeight {
         return .intrinsicHeight
     }
-
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 import WordPressUI
 
+/// This view controller is embedded in a bottom sheet, and display the information about the Shipping Label Discount
+///
 final class ShippingLabelDiscountInfoViewController: UIViewController {
 
     @IBOutlet private weak var stackView: UIStackView!

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.swift
@@ -1,0 +1,52 @@
+import UIKit
+import WordPressUI
+
+final class ShippingLabelDiscountInfoViewController: UIViewController {
+
+    @IBOutlet private weak var stackView: UIStackView!
+    @IBOutlet private weak var icon: UIImageView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var separator: UIImageView!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureImages()
+        configureLabels()
+    }
+
+    /// Init
+    ///
+    init() {
+        super.init(nibName: Self.nibName, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension ShippingLabelDiscountInfoViewController {
+    func configureImages() {
+        icon.image = .infoImage
+        separator.backgroundColor = .systemColor(.separator)
+    }
+
+    func configureLabels() {
+        titleLabel.applyHeadlineStyle()
+        titleLabel.numberOfLines = 0
+        descriptionLabel.applyBodyStyle()
+        descriptionLabel.numberOfLines = 0
+    }
+}
+
+extension ShippingLabelDiscountInfoViewController: DrawerPresentable {
+    var collapsedHeight: DrawerHeight {
+        return .intrinsicHeight
+    }
+
+    var expandedHeight: DrawerHeight {
+        return .intrinsicHeight
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.xib
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ShippingLabelDiscountInfoViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="descriptionLabel" destination="a4n-Jx-7c4" id="p5D-WW-sp2"/>
+                <outlet property="icon" destination="qij-8M-eCA" id="274-zg-GmW"/>
+                <outlet property="separator" destination="9s3-KP-YXx" id="QgG-Mz-1nd"/>
+                <outlet property="stackView" destination="PhO-mb-RvI" id="da3-ot-bfw"/>
+                <outlet property="titleLabel" destination="8gr-jV-Ev1" id="5Mv-CW-vX2"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="147"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qij-8M-eCA">
+                    <rect key="frame" x="195" y="16" width="24" height="24"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="24" id="e0g-b2-gSA"/>
+                        <constraint firstAttribute="height" constant="24" id="qrJ-9P-2We"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8gr-jV-Ev1">
+                    <rect key="frame" x="16" y="56" width="382" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="21" id="0Kz-D9-B12"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9s3-KP-YXx">
+                    <rect key="frame" x="16" y="93" width="398" height="1"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="wVC-Jf-Doo"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a4n-Jx-7c4">
+                    <rect key="frame" x="16" y="110" width="382" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="21" id="RbH-z4-jv0"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PhO-mb-RvI">
+                    <rect key="frame" x="109" y="-53" width="110" height="200"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="9s3-KP-YXx" secondAttribute="trailing" id="B4o-DO-Gsh"/>
+                <constraint firstItem="8gr-jV-Ev1" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="DmO-IC-zyQ"/>
+                <constraint firstItem="qij-8M-eCA" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="16" id="KP8-g9-6ha"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="8gr-jV-Ev1" secondAttribute="trailing" constant="16" id="OsL-kL-RBT"/>
+                <constraint firstAttribute="bottom" secondItem="a4n-Jx-7c4" secondAttribute="bottom" constant="16" id="PNp-IH-GDo"/>
+                <constraint firstItem="9s3-KP-YXx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="PRp-9c-erQ"/>
+                <constraint firstItem="qij-8M-eCA" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="UPp-Tc-Enj"/>
+                <constraint firstItem="a4n-Jx-7c4" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="Z0i-xZ-SKS"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="a4n-Jx-7c4" secondAttribute="trailing" constant="16" id="aUk-a5-ajT"/>
+                <constraint firstItem="8gr-jV-Ev1" firstAttribute="top" secondItem="qij-8M-eCA" secondAttribute="bottom" constant="16" id="h3z-qT-aKA"/>
+                <constraint firstItem="9s3-KP-YXx" firstAttribute="top" secondItem="8gr-jV-Ev1" secondAttribute="bottom" constant="16" id="pkO-ee-0EA"/>
+                <constraint firstItem="a4n-Jx-7c4" firstAttribute="top" secondItem="9s3-KP-YXx" secondAttribute="bottom" constant="16" id="r8a-ew-Syq"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="63.768115942028992" y="193.52678571428569"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Bottom Sheets/ShippingLabelDiscountInfoViewController.xib
@@ -23,57 +23,72 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="147"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qij-8M-eCA">
-                    <rect key="frame" x="195" y="16" width="24" height="24"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="24" id="e0g-b2-gSA"/>
-                        <constraint firstAttribute="height" constant="24" id="qrJ-9P-2We"/>
-                    </constraints>
-                </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8gr-jV-Ev1">
-                    <rect key="frame" x="16" y="56" width="382" height="21"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="21" id="0Kz-D9-B12"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9s3-KP-YXx">
-                    <rect key="frame" x="16" y="93" width="398" height="1"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="wVC-Jf-Doo"/>
-                    </constraints>
-                </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a4n-Jx-7c4">
-                    <rect key="frame" x="16" y="110" width="382" height="21"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="21" id="RbH-z4-jv0"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PhO-mb-RvI">
-                    <rect key="frame" x="109" y="-53" width="110" height="200"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="PhO-mb-RvI">
+                    <rect key="frame" x="16" y="16" width="382" height="115"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ony-W6-btj">
+                            <rect key="frame" x="0.0" y="0.0" width="382" height="24"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qij-8M-eCA">
+                                    <rect key="frame" x="179" y="0.0" width="24" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="24" id="e0g-b2-gSA"/>
+                                        <constraint firstAttribute="height" constant="24" id="qrJ-9P-2We"/>
+                                    </constraints>
+                                </imageView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="qij-8M-eCA" firstAttribute="top" secondItem="Ony-W6-btj" secondAttribute="top" id="IyP-3s-nUD"/>
+                                <constraint firstItem="qij-8M-eCA" firstAttribute="centerX" secondItem="Ony-W6-btj" secondAttribute="centerX" id="ret-3G-YL4"/>
+                                <constraint firstAttribute="bottom" secondItem="qij-8M-eCA" secondAttribute="bottom" id="yLa-O7-xbK"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8gr-jV-Ev1">
+                            <rect key="frame" x="0.0" y="40" width="382" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="0Kz-D9-B12"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mqk-b8-hoT">
+                            <rect key="frame" x="0.0" y="77" width="382" height="1"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9s3-KP-YXx">
+                                    <rect key="frame" x="0.0" y="0.0" width="382" height="1"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="wVC-Jf-Doo"/>
+                                    </constraints>
+                                </imageView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="9s3-KP-YXx" secondAttribute="trailing" id="T4c-Mu-mLM"/>
+                                <constraint firstItem="9s3-KP-YXx" firstAttribute="leading" secondItem="mqk-b8-hoT" secondAttribute="leading" id="gm4-Ik-Qy2"/>
+                                <constraint firstItem="9s3-KP-YXx" firstAttribute="top" secondItem="mqk-b8-hoT" secondAttribute="top" id="ksW-Iz-E4D"/>
+                                <constraint firstAttribute="bottom" secondItem="9s3-KP-YXx" secondAttribute="bottom" id="tCH-kP-4YZ"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a4n-Jx-7c4">
+                            <rect key="frame" x="0.0" y="94" width="382" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="RbH-z4-jv0"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="9s3-KP-YXx" secondAttribute="trailing" id="B4o-DO-Gsh"/>
-                <constraint firstItem="8gr-jV-Ev1" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="DmO-IC-zyQ"/>
-                <constraint firstItem="qij-8M-eCA" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="16" id="KP8-g9-6ha"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="8gr-jV-Ev1" secondAttribute="trailing" constant="16" id="OsL-kL-RBT"/>
-                <constraint firstAttribute="bottom" secondItem="a4n-Jx-7c4" secondAttribute="bottom" constant="16" id="PNp-IH-GDo"/>
-                <constraint firstItem="9s3-KP-YXx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="PRp-9c-erQ"/>
-                <constraint firstItem="qij-8M-eCA" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="UPp-Tc-Enj"/>
-                <constraint firstItem="a4n-Jx-7c4" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="Z0i-xZ-SKS"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="a4n-Jx-7c4" secondAttribute="trailing" constant="16" id="aUk-a5-ajT"/>
-                <constraint firstItem="8gr-jV-Ev1" firstAttribute="top" secondItem="qij-8M-eCA" secondAttribute="bottom" constant="16" id="h3z-qT-aKA"/>
-                <constraint firstItem="9s3-KP-YXx" firstAttribute="top" secondItem="8gr-jV-Ev1" secondAttribute="bottom" constant="16" id="pkO-ee-0EA"/>
-                <constraint firstItem="a4n-Jx-7c4" firstAttribute="top" secondItem="9s3-KP-YXx" secondAttribute="bottom" constant="16" id="r8a-ew-Syq"/>
+                <constraint firstItem="PhO-mb-RvI" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="16" id="Hne-Vu-M2Z"/>
+                <constraint firstItem="PhO-mb-RvI" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="LaY-T6-gTC"/>
+                <constraint firstAttribute="trailing" secondItem="PhO-mb-RvI" secondAttribute="trailing" constant="16" id="R3p-N7-yNw"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="63.768115942028992" y="193.52678571428569"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -30,6 +30,10 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
         }
     }
 
+    /// Closure to be executed whenever the Discount View is tapped
+    ///
+    private var onDiscountTouchUp: (() -> Void)?
+
     /// Closure to be executed whenever the Switch is flipped
     ///
     private var onSwitchChange: ((Bool) -> Void)?
@@ -44,11 +48,14 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
         configureLabels()
         configureSwitch()
         configureButton()
+        discountView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(discountViewTapped)))
     }
 
     func configure(state: ShippingLabelFormStepTableViewCell.State,
+                   onDiscountTouchUp: (() -> Void)?,
                    onSwitchChange: ((Bool) -> Void)?,
                    onButtonTouchUp: (() -> Void)?) {
+        self.onDiscountTouchUp = onDiscountTouchUp
         self.onSwitchChange = onSwitchChange
         self.onButtonTouchUp = onButtonTouchUp
         configureCellBasedOnState(state)
@@ -76,6 +83,11 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
 
     func setOrderTotal(_ total: String) {
         orderTotalBody.text = total
+    }
+
+    @objc private func discountViewTapped() {
+        print("entra qui")
+        onDiscountTouchUp?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -86,7 +86,6 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
     }
 
     @objc private func discountViewTapped() {
-        print("entra qui")
         onDiscountTouchUp?()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 import SwiftUI
+import WordPressUI
 
 final class ShippingLabelFormViewController: UIViewController {
 
@@ -273,7 +274,11 @@ private extension ShippingLabelFormViewController {
     }
 
     func configureOrderSummary(cell: ShippingLabelSummaryTableViewCell, row: Row) {
-        cell.configure(state: row.cellState) { (switchIsOn) in
+        cell.configure(state: row.cellState) {
+            let discountInfoVC = ShippingLabelDiscountInfoViewController()
+            let bottomSheet = BottomSheetViewController(childViewController: discountInfoVC)
+            bottomSheet.show(from: self)
+        } onSwitchChange: { (switchIsOn) in
             // TODO: Handle order completion
         } onButtonTouchUp: {
             // TODO: Purchase Label action

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -277,7 +277,7 @@ private extension ShippingLabelFormViewController {
         cell.configure(state: row.cellState) {
             let discountInfoVC = ShippingLabelDiscountInfoViewController()
             let bottomSheet = BottomSheetViewController(childViewController: discountInfoVC)
-            bottomSheet.show(from: self)
+            bottomSheet.show(from: self, sourceView: cell)
         } onSwitchChange: { (switchIsOn) in
             // TODO: Handle order completion
         } onButtonTouchUp: {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -647,6 +647,8 @@
 		45F627B7253603AE00894B86 /* ProductDownloadSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45F627B3253603AE00894B86 /* ProductDownloadSettingsViewController.xib */; };
 		45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F627B4253603AE00894B86 /* ProductDownloadSettingsViewController.swift */; };
 		45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F627B5253603AE00894B86 /* ProductDownloadSettingsViewModel.swift */; };
+		45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F8C4392680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift */; };
+		45F8C43C2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45F8C43A2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.xib */; };
 		45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */; };
 		45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */; };
 		45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45FBDF36238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.xib */; };
@@ -1936,6 +1938,8 @@
 		45F627B3253603AE00894B86 /* ProductDownloadSettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductDownloadSettingsViewController.xib; sourceTree = "<group>"; };
 		45F627B4253603AE00894B86 /* ProductDownloadSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDownloadSettingsViewController.swift; sourceTree = "<group>"; };
 		45F627B5253603AE00894B86 /* ProductDownloadSettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDownloadSettingsViewModel.swift; sourceTree = "<group>"; };
+		45F8C4392680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelDiscountInfoViewController.swift; sourceTree = "<group>"; };
+		45F8C43A2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelDiscountInfoViewController.xib; sourceTree = "<group>"; };
 		45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF35238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -3850,6 +3854,7 @@
 				4569317A2653E7F9009ED69D /* Carriers and Rates */,
 				CC4A4E91265523DB00B75DCD /* Payment Methods */,
 				456396B325C8266D001F1A26 /* Cells */,
+				45F8C4382680BC0A00F1A6EC /* Bottom Sheets */,
 			);
 			path = "Create Shipping Label Form";
 			sourceTree = "<group>";
@@ -4084,6 +4089,15 @@
 				45F627B5253603AE00894B86 /* ProductDownloadSettingsViewModel.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		45F8C4382680BC0A00F1A6EC /* Bottom Sheets */ = {
+			isa = PBXGroup;
+			children = (
+				45F8C4392680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift */,
+				45F8C43A2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.xib */,
+			);
+			path = "Bottom Sheets";
 			sourceTree = "<group>";
 		};
 		45FBDF29238BF87800127F77 /* Collection View Cells */ = {
@@ -6257,6 +6271,7 @@
 				77E53EB9250E6A4E003D385F /* ProductDownloadListViewController.xib in Resources */,
 				D881A31C256B5CC500FE5605 /* ULErrorViewController.xib in Resources */,
 				D81D9229222E7F0800FFA585 /* OrderStatusListViewController.xib in Resources */,
+				45F8C43C2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.xib in Resources */,
 				748D34DE214828DD00E21A2F /* TopPerformerDataViewController.xib in Resources */,
 				456396A825C81C9A001F1A26 /* ShippingLabelFormViewController.xib in Resources */,
 				CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */,
@@ -6546,6 +6561,7 @@
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
+				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,


### PR DESCRIPTION
Fixes #4088 

## Description
Implemented the bottom sheet that displays the information about the WooCommerce Discount that will be shown when a Shipping Label purchase is eligible for a discount price.
Updated also `WordPressUI` to release 1.12.1-beta.3.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields, and try to select the more expensive option under "Shipping Carriers and Rates" (in theory, this makes your shipping label eligible for our WooCommerce discount).
6. You should be able to see the "Shipping Label Order Summary" section at the end of the Shipping Label Form, and the "WooCommerce Discount" row should be visible.
7. Tap the "WooCommerce Discount" row.
8. You should see the bottom sheet displaying the information about the discount.

## Screenshots
| Light mode            |  Dark mode |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-21 at 20 14 35](https://user-images.githubusercontent.com/495617/122889552-2f041b80-d343-11eb-8189-25d7597b44d8.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-21 at 20 14 53](https://user-images.githubusercontent.com/495617/122889566-31667580-d343-11eb-88d3-7067722f482b.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
