### PR TITLE
Handled big font sizes in Shipping Label Creation Form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.swift
@@ -79,6 +79,7 @@ private extension ShippingLabelFormStepTableViewCell {
 
     func configureLabels() {
         titleLabel.applyBodyStyle()
+        titleLabel.numberOfLines = 0
         bodyLabel.applySubheadlineStyle()
         bodyLabel.numberOfLines = 0
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.xib
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -34,7 +33,7 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gj6-sV-Ol2">
                                         <rect key="frame" x="40" y="0.0" width="306" height="24"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="rea-0N-A8t"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="rea-0N-A8t"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -90,16 +90,22 @@ private extension ShippingLabelSummaryTableViewCell {
     func configureLabels() {
         subtotalTitle.applyBodyStyle()
         subtotalTitle.text = Localization.subtotal
+        subtotalTitle.numberOfLines = 0
         subtotalBody.applyBodyStyle()
+        subtotalBody.numberOfLines = 0
         discountTitle.applyBodyStyle()
         discountTitle.text = Localization.discount
+        discountTitle.numberOfLines = 0
         discountBody.applyBodyStyle()
+        discountBody.numberOfLines = 0
         orderTotalTitle.applyHeadlineStyle()
         orderTotalTitle.text = Localization.orderTotal
+        orderTotalTitle.numberOfLines = 0
         orderTotalBody.applyHeadlineStyle()
+        orderTotalBody.numberOfLines = 0
         orderCompleteTitle.applySubheadlineStyle()
-        orderCompleteTitle.numberOfLines = 0
         orderCompleteTitle.text = Localization.orderComplete
+        orderCompleteTitle.numberOfLines = 0
     }
 
     func configureSwitch() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.xib
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -20,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6I4-gt-sh2">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="6I4-gt-sh2">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>


### PR DESCRIPTION
Fixes #4343 

## Description
Now the fonts inside the Shipping Label Creation Form are handled correctly, and we are able to display Larger Accessibility Sizes.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Make sure the form is displayed correctly with Larger Accessibility Sizes (you can change it from iOS preferences).

## Screenshots
| Example 1            |  Example 2 |  Example 3 |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-22 at 11 57 08](https://user-images.githubusercontent.com/495617/122905767-ca03f200-d351-11eb-84ec-1a9ba35426b9.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-22 at 11 50 22](https://user-images.githubusercontent.com/495617/122905780-ce300f80-d351-11eb-86d3-979586accbb3.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-22 at 11 57 10](https://user-images.githubusercontent.com/495617/122905788-cff9d300-d351-11eb-9f97-c9891ccacbce.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
