### PR TITLE
Add-ons: Adds products add-on analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -313,7 +313,7 @@ extension WooAnalyticsEvent {
 
     // Namespace
     enum ProductDetailAddOns {
-        static func productAddOnsButtonTappedViewed(productID: Int64) -> WooAnalyticsEvent {
+        static func productAddOnsButtonTapped(productID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailViewProductAddOnsTapped, properties: [Keys.productID: "\(productID)"])
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -301,3 +301,20 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Product Detail Add-ons
+//
+extension WooAnalyticsEvent {
+    /// Common event keys
+    ///
+    private enum Keys {
+        static let productID = "product_id"
+    }
+
+    // Namespace
+    enum ProductDetailAddOns {
+        static func productAddOnsButtonTappedViewed(productID: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailViewProductAddOnsTapped, properties: [Keys.productID: "\(productID)"])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -327,6 +327,7 @@ public enum WooAnalyticsStat: String {
     case productDetailViewDownloadableFilesTapped = "product_detail_view_downloadable_files_tapped"
     case productDetailViewLinkedProductsTapped = "product_detail_view_linked_products_tapped"
     case productDetailProductDeleted = "product_detail_product_deleted"
+    case productDetailViewProductAddOnsTapped = "product_detail_view_product_addons_tapped"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -314,6 +314,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isEditable else {
                     return
                 }
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent.ProductDetailAddOns.productAddOnsButtonTapped(productID: product.productID))
                 navigateToAddOns()
             case .categories(_, let isEditable):
                 guard isEditable else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -527,7 +527,7 @@ private extension ProductFormViewModel {
             guard let self = self, case .success(let addOnsEnabled) = result else {
                 return
             }
-            self.isAddOnsFeatureEnabled = addOnsEnabled && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.addOnsI1)
+            self.isAddOnsFeatureEnabled = addOnsEnabled
         }
         stores.dispatch(action)
     }


### PR DESCRIPTION
closes #4270

# Why 

This PR adds some basic tracking to measure how many merchants are interested in add-on information.
As well as removing the local feature flag, as the workaround is ready to be accessed by the users only by the beta feature switch

# Testing

**Prerequisites:** 
- Have your site with the add-ons plugin installed and with at product with add-ons.
- Enable the "Add-Ons" feature from the beta features screen in settings.

**Steps:**
- Launch the app and navigate to the product
- Tap on the "Product Add-Ons" button.
- See in the console that the event is being tracked.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
