### PR TITLE
Refactor Stats action (store and networking) to use Result

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -18,7 +18,7 @@ public final class OrderStatsRemoteV4: Remote {
                                earliestDateToInclude: Date,
                                latestDateToInclude: Date,
                                quantity: Int,
-                               completion: @escaping (OrderStatsV4?, Error?) -> Void) {
+                               completion: @escaping (Result<OrderStatsV4, Error>) -> Void) {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
 
         // Workaround for #1183: random number between 31-100 for `num_page` param.

--- a/Networking/Networking/Remote/SiteVisitStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteVisitStatsRemote.swift
@@ -18,7 +18,7 @@ public class SiteVisitStatsRemote: Remote {
                                      unit: StatGranularity,
                                      latestDateToInclude: Date,
                                      quantity: Int,
-                                     completion: @escaping (SiteVisitStats?, Error?) -> Void) {
+                                     completion: @escaping (Result<SiteVisitStats, Error>) -> Void) {
         let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.siteVisitStatsPath)/"
         let dateFormatter = DateFormatter.Stats.statsDayFormatter
         if let siteTimezone = siteTimezone {

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -22,65 +22,71 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
     /// Verifies that loadOrderStats properly parses the `OrderStatsV4` sample response
     /// when requesting the hourly stats
     ///
-    func testLoadOrderStatsProperlyReturnsParsedStatsForHourlyStats() {
+    func test_loadOrderStats_properly_returns_parsed_stats_for_hourly_stats() throws {
+        // Given
         let remote = OrderStatsRemoteV4(network: network)
-        let expectation = self.expectation(description: "Load order stats")
-
         network.simulateResponse(requestUrlSuffix: "reports/revenue/stats", filename: "order-stats-v4-hour")
 
-        remote.loadOrderStats(for: sampleSiteID,
-                              unit: .hourly,
-                              earliestDateToInclude: Date(),
-                              latestDateToInclude: Date(),
-                              quantity: 24) { (orderStatsV4, error) in
-                                XCTAssertNil(error)
-                                XCTAssertNotNil(orderStatsV4)
-                                XCTAssertEqual(orderStatsV4?.intervals.count, 24)
-                                expectation.fulfill()
+        // When
+        let result: Result<OrderStatsV4, Error> = waitFor { promise in
+            remote.loadOrderStats(for: self.sampleSiteID,
+                                  unit: .hourly,
+                                  earliestDateToInclude: Date(),
+                                  latestDateToInclude: Date(),
+                                  quantity: 24) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let orderStatsV4 = try result.get()
+        XCTAssertEqual(orderStatsV4.intervals.count, 24)
     }
 
     /// Verifies that loadOrderStats properly parses the `OrderStatsV4` sample response
     /// when requesting the weekly stats
     ///
-    func testLoadOrderStatsProperlyReturnsParsedStatsForWeeklyStats() {
+    func test_loadOrderStats_properly_returns_parsed_stats_for_weekly_stats() throws {
+        // Given
         let remote = OrderStatsRemoteV4(network: network)
-        let expectation = self.expectation(description: "Load order stats")
-
         network.simulateResponse(requestUrlSuffix: "reports/revenue/stats", filename: "order-stats-v4-defaults")
 
-        remote.loadOrderStats(for: sampleSiteID,
-                              unit: .weekly,
-                              earliestDateToInclude: Date(),
-                              latestDateToInclude: Date(),
-                              quantity: 2) { (orderStatsV4, error) in
-                                XCTAssertNil(error)
-                                XCTAssertNotNil(orderStatsV4)
-                                XCTAssertEqual(orderStatsV4?.intervals.count, 2)
-                                expectation.fulfill()
+        // When
+        let result: Result<OrderStatsV4, Error> = waitFor { promise in
+            remote.loadOrderStats(for: self.sampleSiteID,
+                                  unit: .weekly,
+                                  earliestDateToInclude: Date(),
+                                  latestDateToInclude: Date(),
+                                  quantity: 2) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let orderStatsV4 = try result.get()
+        XCTAssertEqual(orderStatsV4.intervals.count, 2)
     }
 
     /// Verifies that loadOrderStats properly relays Networking Layer errors.
     ///
-    func testLoadOrderStatsProperlyRelaysNetwokingErrors() {
+    func test_loadOrderStats_properly_relays_netwoking_errors() {
+        // Given
         let remote = OrderStatsRemoteV4(network: network)
-        let expectation = self.expectation(description: "Load order stats contains errors")
 
-        remote.loadOrderStats(for: sampleSiteID,
-                              unit: .daily,
-                              earliestDateToInclude: Date(),
-                              latestDateToInclude: Date(),
-                              quantity: 31) { (orderStats, error) in
-            XCTAssertNil(orderStats)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        let result: Result<OrderStatsV4, Error> = waitFor { promise in
+            remote.loadOrderStats(for: self.sampleSiteID,
+                                  unit: .daily,
+                                  earliestDateToInclude: Date(),
+                                  latestDateToInclude: Date(),
+                                  quantity: 31) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -136,11 +136,12 @@ private extension StoreStatsAndTopPerformersViewController {
                            siteTimezone: timezoneForSync,
                            timeRange: vc.timeRange,
                            latestDateToInclude: latestDateToInclude) { [weak self] result in
-                if case let .failure(error) = result {
+                switch result {
+                case .success:
+                    self?.trackStatsLoaded(for: vc.granularity)
+                case .failure(let error):
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     syncError = error
-                } else {
-                    self?.trackStatsLoaded(for: vc.granularity)
                 }
                 group.leave()
             }
@@ -367,13 +368,14 @@ private extension StoreStatsAndTopPerformersViewController {
                                                           earliestDateToInclude: earliestDateToInclude,
                                                           latestDateToInclude: latestDateToInclude,
                                                           onCompletion: { result in
-                                                            if case let .failure(error) = result {
-                                                                DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
-                                                            } else {
+                                                            switch result {
+                                                            case .success:
                                                                 ServiceLocator.analytics.track(.dashboardTopPerformersLoaded,
                                                                                                withProperties: [
                                                                                                 "granularity": timeRange.topEarnerStatsGranularity.rawValue
                                                                                                ])
+                                                            case .failure(let error):
+                                                                DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
                                                             }
                                                             onCompletion?(result)
         })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -135,8 +135,8 @@ private extension StoreStatsAndTopPerformersViewController {
             self.syncStats(for: siteID,
                            siteTimezone: timezoneForSync,
                            timeRange: vc.timeRange,
-                           latestDateToInclude: latestDateToInclude) { [weak self] error in
-                if let error = error {
+                           latestDateToInclude: latestDateToInclude) { [weak self] result in
+                if case let .failure(error) = result {
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     syncError = error
                 } else {
@@ -149,8 +149,8 @@ private extension StoreStatsAndTopPerformersViewController {
             self.syncSiteVisitStats(for: siteID,
                                     siteTimezone: timezoneForSync,
                                     timeRange: vc.timeRange,
-                                    latestDateToInclude: latestDateToInclude) { error in
-                if let error = error {
+                                    latestDateToInclude: latestDateToInclude) { result in
+                if case let .failure(error) = result {
                     DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
                     syncError = error
                 }
@@ -161,8 +161,8 @@ private extension StoreStatsAndTopPerformersViewController {
             self.syncTopEarnersStats(for: siteID,
                                      siteTimezone: timezoneForSync,
                                      timeRange: vc.timeRange,
-                                     latestDateToInclude: latestDateToInclude) { error in
-                if let error = error {
+                                     latestDateToInclude: latestDateToInclude) { result in
+                if case let .failure(error) = result {
                     DDLogError("⛔️ Error synchronizing top earners stats: \(error)")
                     syncError = error
                 }
@@ -320,18 +320,18 @@ private extension StoreStatsAndTopPerformersViewController {
                    siteTimezone: TimeZone,
                    timeRange: StatsTimeRangeV4,
                    latestDateToInclude: Date,
-                   onCompletion: ((Error?) -> Void)? = nil) {
+                   onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveStats(siteID: siteID,
                                                  timeRange: timeRange,
                                                  earliestDateToInclude: earliestDateToInclude,
                                                  latestDateToInclude: latestDateToInclude,
                                                  quantity: timeRange.maxNumberOfIntervals,
-                                                 onCompletion: { error in
-                                                    if let error = error {
+                                                 onCompletion: { result in
+                                                    if case let .failure(error) = result {
                                                         DDLogError("⛔️ Dashboard (Order Stats) — Error synchronizing order stats v4: \(error)")
                                                     }
-                                                    onCompletion?(error)
+                                                    onCompletion?(result)
         })
 
         ServiceLocator.stores.dispatch(action)
@@ -341,16 +341,17 @@ private extension StoreStatsAndTopPerformersViewController {
                             siteTimezone: TimeZone,
                             timeRange: StatsTimeRangeV4,
                             latestDateToInclude: Date,
-                            onCompletion: ((Error?) -> Void)? = nil) {
+                            onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let action = StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
                                                           siteTimezone: siteTimezone,
                                                           timeRange: timeRange,
-                                                          latestDateToInclude: latestDateToInclude) { error in
-                                                            if let error = error {
+                                                          latestDateToInclude: latestDateToInclude,
+                                                          onCompletion: { result in
+                                                            if case let .failure(error) = result {
                                                                 DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
                                                             }
-                                                            onCompletion?(error)
-        }
+                                                            onCompletion?(result)
+        })
 
         ServiceLocator.stores.dispatch(action)
     }
@@ -359,22 +360,23 @@ private extension StoreStatsAndTopPerformersViewController {
                              siteTimezone: TimeZone,
                              timeRange: StatsTimeRangeV4,
                              latestDateToInclude: Date,
-                             onCompletion: ((Error?) -> Void)? = nil) {
+                             onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
                                                           timeRange: timeRange,
                                                           earliestDateToInclude: earliestDateToInclude,
-                                                          latestDateToInclude: latestDateToInclude) { error in
-                                                            if let error = error {
+                                                          latestDateToInclude: latestDateToInclude,
+                                                          onCompletion: { result in
+                                                            if case let .failure(error) = result {
                                                                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
                                                             } else {
                                                                 ServiceLocator.analytics.track(.dashboardTopPerformersLoaded,
-                                                                                          withProperties: [
-                                                                                            "granularity": timeRange.topEarnerStatsGranularity.rawValue
-                                                                    ])
+                                                                                               withProperties: [
+                                                                                                "granularity": timeRange.topEarnerStatsGranularity.rawValue
+                                                                                               ])
                                                             }
-                                                            onCompletion?(error)
-        }
+                                                            onCompletion?(result)
+        })
 
         ServiceLocator.stores.dispatch(action)
     }

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -16,7 +16,7 @@ public enum StatsActionV4: Action {
         earliestDateToInclude: Date,
         latestDateToInclude: Date,
         quantity: Int,
-        onCompletion: (Error?) -> Void)
+        onCompletion: (Result<Void, Error>) -> Void)
 
     /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
     ///
@@ -24,7 +24,7 @@ public enum StatsActionV4: Action {
         siteTimezone: TimeZone,
         timeRange: StatsTimeRangeV4,
         latestDateToInclude: Date,
-        onCompletion: (Error?) -> Void)
+        onCompletion: (Result<Void, Error>) -> Void)
 
     /// Synchronizes `TopEarnerStats` for the provided siteID, time range, and date.
     ///
@@ -32,5 +32,5 @@ public enum StatsActionV4: Action {
         timeRange: StatsTimeRangeV4,
         earliestDateToInclude: Date,
         latestDateToInclude: Date,
-        onCompletion: (Error?) -> Void)
+        onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -20,7 +20,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
         }
     }
 
-    func retrieveStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Error?) -> ()) {
+    func retrieveStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Result<Void, Error>) -> ()) {
         let store = StatsStoreV4(dispatcher: Dispatcher(), storageManager: storageManager, network: NullNetwork())
 
         switch timeRange {
@@ -32,11 +32,11 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 success(onCompletion)
             case .thisYear:
                 store.upsertStoredOrderStats(readOnlyStats: objectGraph.thisYearOrderStats, timeRange: timeRange)
-                onCompletion(nil)
+                onCompletion(.success(()))
         }
     }
 
-    func retrieveSiteVisitStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Error?) -> ()) {
+    func retrieveSiteVisitStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Result<Void, Error>) -> ()) {
         let store = StatsStoreV4(dispatcher: Dispatcher(), storageManager: storageManager, network: NullNetwork())
 
         switch timeRange {
@@ -48,11 +48,11 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 success(onCompletion)
             case .thisYear:
                 store.upsertStoredSiteVisitStats(readOnlyStats: objectGraph.thisYearVisitStats, timeRange: timeRange)
-                onCompletion(nil)
+                onCompletion(.success(()))
         }
     }
 
-    func retrieveTopEarnerStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Error?) -> ()) {
+    func retrieveTopEarnerStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Result<Void, Error>) -> ()) {
         let store = StatsStoreV4(dispatcher: Dispatcher(), storageManager: storageManager, network: NullNetwork())
 
         switch timeRange {
@@ -64,7 +64,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 success(onCompletion)
             case .thisYear:
                 store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisYearTopProducts)
-                onCompletion(nil)
+                onCompletion(.success(()))
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/AvailabilityStore.swift
+++ b/Yosemite/Yosemite/Stores/AvailabilityStore.swift
@@ -43,12 +43,12 @@ private extension AvailabilityStore {
                               unit: .yearly,
                               earliestDateToInclude: Date(),
                               latestDateToInclude: Date(),
-                              quantity: 1) { (_, error) in
-                                if let error = error as? DotcomError, error == .noRestRoute {
-                                    onCompletion(false)
-                                } else {
-                                    onCompletion(true)
-                                }
+                              quantity: 1) { result in
+            if case let .failure(error) = result, error as? DotcomError == .noRestRoute {
+                onCompletion(false)
+            } else {
+                onCompletion(true)
+            }
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/AvailabilityStore.swift
+++ b/Yosemite/Yosemite/Stores/AvailabilityStore.swift
@@ -44,9 +44,10 @@ private extension AvailabilityStore {
                               earliestDateToInclude: Date(),
                               latestDateToInclude: Date(),
                               quantity: 1) { result in
-            if case let .failure(error) = result, error as? DotcomError == .noRestRoute {
+            switch result {
+            case .failure(let error) where error as? DotcomError == .noRestRoute:
                 onCompletion(false)
-            } else {
+            default:
                 onCompletion(true)
             }
         }

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -79,12 +79,12 @@ The sequence for the UI layer to trigger a request to fetch data would be:
 The full listing:
 
 ```swift
-func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
+func syncTopPerformers(onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
     let action = StatsAction.retrieveTopEarnerStats(siteID: siteID,
                                                     granularity: granularity,
-                                                    latestDateToInclude: Date()) { [weak self] error in
+                                                    latestDateToInclude: Date()) { [weak self] result in
         // Error handling removed for brevity
-        onCompletion?(error)
+        onCompletion?(result)
     }
 
     ServiceLocator.storesManager.dispatch(action)


### PR DESCRIPTION
## Description

This PR updates StatsActionV4 + related Store and Remotes to use Result, so the state of response is more limited with less optional parameters.

## Test

1. Check CI status for unit tests.
2. Run app and verify stats works well.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
