### PR TITLE
Shipping Labels: networking layer for supporting the `data/countries` endpoint

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -107,6 +107,17 @@ extension Address {
         )
     }
 }
+extension Country {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Country {
+        .init(
+            code: .fake(),
+            name: .fake(),
+            states: .fake()
+        )
+    }
+}
 extension CreateProductVariation {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1294,6 +1305,16 @@ extension StatGranularity {
         .day
     }
 }
+extension StateOfACountry {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> StateOfACountry {
+        .init(
+            code: .fake(),
+            name: .fake()
+        )
+    }
+}
 extension StatsGranularityV4 {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1358,5 +1379,19 @@ extension UploadableMedia {
             filename: .fake(),
             mimeType: .fake()
         )
+    }
+}
+extension WCPayAccountStatusEnum {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayAccountStatusEnum {
+        .complete
+    }
+}
+extension WCPayPaymentIntentStatusEnum {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WCPayPaymentIntentStatusEnum {
+        .requiresPaymentMethod
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -158,6 +158,11 @@
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
 		451274A625276C82009911FF /* product-variation.json in Resources */ = {isa = PBXBuildFile; fileRef = 451274A525276C82009911FF /* product-variation.json */; };
+		45150A9A268340D2006922EA /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A99268340D2006922EA /* Country.swift */; };
+		45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9B2683417A006922EA /* StateOfACountry.swift */; };
+		45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9D26836A57006922EA /* CountryListMapper.swift */; };
+		45150AA026837357006922EA /* CountryListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45150A9F26837357006922EA /* CountryListMapperTests.swift */; };
+		45150AA2268373F8006922EA /* countries.json in Resources */ = {isa = PBXBuildFile; fileRef = 45150AA1268373F8006922EA /* countries.json */; };
 		45152809257A7C6E0076B03C /* ProductAttributesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */; };
 		4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */; };
 		45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45152810257A81730076B03C /* ProductAttributeMapper.swift */; };
@@ -219,6 +224,8 @@
 		45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D685F923D0C3CF005F87D0 /* product-search-sku.json */; };
 		45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */; };
 		45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3EEBA237009CF00A826AC /* ShippingLine.swift */; };
+		45E461BC26837CC500011BF2 /* DataRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E461BB26837CC500011BF2 /* DataRemote.swift */; };
+		45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E461BD26837DB900011BF2 /* DataRemoteTests.swift */; };
 		45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */; };
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
 		45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */; };
@@ -689,6 +696,11 @@
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
 		451274A525276C82009911FF /* product-variation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation.json"; sourceTree = "<group>"; };
+		45150A99268340D2006922EA /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
+		45150A9B2683417A006922EA /* StateOfACountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateOfACountry.swift; sourceTree = "<group>"; };
+		45150A9D26836A57006922EA /* CountryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapper.swift; sourceTree = "<group>"; };
+		45150A9F26837357006922EA /* CountryListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListMapperTests.swift; sourceTree = "<group>"; };
+		45150AA1268373F8006922EA /* countries.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = countries.json; sourceTree = "<group>"; };
 		45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributesRemote.swift; sourceTree = "<group>"; };
 		4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeListMapper.swift; sourceTree = "<group>"; };
 		45152810257A81730076B03C /* ProductAttributeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeMapper.swift; sourceTree = "<group>"; };
@@ -750,6 +762,8 @@
 		45D685F923D0C3CF005F87D0 /* product-search-sku.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-search-sku.json"; sourceTree = "<group>"; };
 		45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapperTests.swift; sourceTree = "<group>"; };
 		45E3EEBA237009CF00A826AC /* ShippingLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLine.swift; sourceTree = "<group>"; };
+		45E461BB26837CC500011BF2 /* DataRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRemote.swift; sourceTree = "<group>"; };
+		45E461BD26837DB900011BF2 /* DataRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRemoteTests.swift; sourceTree = "<group>"; };
 		45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapperTest.swift; sourceTree = "<group>"; };
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
 		45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemoteTests.swift; sourceTree = "<group>"; };
@@ -1248,6 +1262,7 @@
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
+				45E461BD26837DB900011BF2 /* DataRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
@@ -1369,6 +1384,7 @@
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				2685C0FD263B5D8900D9EE97 /* AddOnGroupRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
+				45E461BB26837CC500011BF2 /* DataRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
@@ -1437,6 +1453,8 @@
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
 				2685C0D1263B069500D9EE97 /* AddOnGroup.swift */,
+				45150A99268340D2006922EA /* Country.swift */,
+				45150A9B2683417A006922EA /* StateOfACountry.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -1501,6 +1519,7 @@
 				2683D70F24456EE4002A1589 /* categories-extra.json */,
 				2683D70D24456DB7002A1589 /* categories-empty.json */,
 				45B204BB24890B1200FE6526 /* category.json */,
+				45150AA1268373F8006922EA /* countries.json */,
 				266C7F9125AD3C87006ED243 /* attribute-term.json */,
 				26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */,
 				74C9477F2193A6C60024CB60 /* comment-moderate-approved.json */,
@@ -1655,6 +1674,7 @@
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				2685C0F9263B5D5300D9EE97 /* AddOnGroupMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
+				45150A9D26836A57006922EA /* CountryListMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
@@ -1779,6 +1799,7 @@
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				2685C0D9263B551300D9EE97 /* AddOnGroupMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
+				45150A9F26837357006922EA /* CountryListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
@@ -2020,6 +2041,7 @@
 				028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */,
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */,
+				45150AA2268373F8006922EA /* countries.json in Resources */,
 				743E84F422172D0A00FAC9D7 /* shipment_tracking_multiple.json in Resources */,
 				02698CF624C17FC1005337C4 /* product-alternative-types.json in Resources */,
 				57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */,
@@ -2252,6 +2274,7 @@
 				2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */,
 				CE430672234B9EB20073CBFF /* OrderItemTax.swift in Sources */,
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
+				45E461BC26837CC500011BF2 /* DataRemote.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
 				CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
@@ -2269,6 +2292,7 @@
 				26B2F74524C5573F0065CCC8 /* LeaderboardListMapper.swift in Sources */,
 				24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */,
 				31D27C812602889C002EDB1D /* SitePluginsRemote.swift in Sources */,
+				45150A9A268340D2006922EA /* Country.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */,
 				456930AB264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift in Sources */,
@@ -2428,6 +2452,7 @@
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
 				CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
+				45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
@@ -2439,6 +2464,7 @@
 				B59325D5217E4206000B0E8E /* NoteRange.swift in Sources */,
 				26B2F74324C545D50065CCC8 /* Leaderboard.swift in Sources */,
 				458C6DE425AC72A1009B300D /* StoredProductSettings.swift in Sources */,
+				45150A9C2683417A006922EA /* StateOfACountry.swift in Sources */,
 				B59325C7217E22FC000B0E8E /* Note.swift in Sources */,
 				CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */,
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
@@ -2461,6 +2487,7 @@
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,
+				45150AA026837357006922EA /* CountryListMapperTests.swift in Sources */,
 				74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */,
 				D8FBFF1C22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift in Sources */,
 				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
@@ -2469,6 +2496,7 @@
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
 				311976E02602BD4B006AC56C /* SitePluginsMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
+				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/CountryListMapper.swift
+++ b/Networking/Networking/Mapper/CountryListMapper.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+
+/// Mapper: Country Collection
+///
+struct CountryListMapper: Mapper {
+
+    /// (Attempts) to convert an instance of Data into an array of Country Entities.
+    ///
+    func map(response: Data) throws -> [Country] {
+        return try JSONDecoder().decode(CountryListEnvelope.self, from: response).data
+    }
+}
+
+
+/// CountryListEnvelope Disposable Entity:
+/// This entity allows us to parse [Country] with JSONDecoder.
+///
+private struct CountryListEnvelope: Decodable {
+    let data: [Country]
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}

--- a/Networking/Networking/Model/Country.swift
+++ b/Networking/Networking/Model/Country.swift
@@ -4,6 +4,8 @@ import Codegen
 /// Represents a Country Entity.
 ///
 public struct Country: Decodable, Equatable, GeneratedFakeable {
+
+    // ISO-3166 two letter country code, e.g. CA for Canada
     public let code: String
     public let name: String
     public let states: [StateOfACountry]

--- a/Networking/Networking/Model/Country.swift
+++ b/Networking/Networking/Model/Country.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Codegen
+
+/// Represents a Country Entity.
+///
+public struct Country: Decodable, Equatable, GeneratedFakeable {
+    public let code: String
+    public let name: String
+    public let states: [StateOfACountry]
+
+    /// Country struct initializer.
+    ///
+    public init(code: String, name: String, states: [StateOfACountry]) {
+        self.code = code
+        self.name = name
+        self.states = states
+    }
+}
+
+
+/// Defines all of the Country's CodingKeys.
+///
+private extension Country {
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case name
+        case states
+    }
+}

--- a/Networking/Networking/Model/StateOfACountry.swift
+++ b/Networking/Networking/Model/StateOfACountry.swift
@@ -4,6 +4,8 @@ import Codegen
 /// Represents a State Entity within a Country.
 ///
 public struct StateOfACountry: Decodable, Equatable, GeneratedFakeable {
+
+    // E.g., ON for Ontario. Note: Not always two letters.
     public let code: String
     public let name: String
 

--- a/Networking/Networking/Model/StateOfACountry.swift
+++ b/Networking/Networking/Model/StateOfACountry.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Codegen
+
+/// Represents a State Entity within a Country.
+///
+public struct StateOfACountry: Decodable, Equatable, GeneratedFakeable {
+    public let code: String
+    public let name: String
+
+    /// StateOfACountry struct initializer.
+    ///
+    public init(code: String, name: String) {
+        self.code = code
+        self.name = name
+    }
+}
+
+
+/// Defines all of the StateOfACountry's CodingKeys.
+///
+private extension StateOfACountry {
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case name
+    }
+}

--- a/Networking/Networking/Remote/DataRemote.swift
+++ b/Networking/Networking/Remote/DataRemote.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Data Remote Endpoints.
+public final class DataRemote: Remote {
+
+    /// Loads all the countries.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the countries.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadCountries(siteID: Int64, completion: @escaping (Result<[Country], Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: Path.countries)
+        let mapper = CountryListMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: Constant
+private extension DataRemote {
+    enum Path {
+        static let countries = "data/countries"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
@@ -14,11 +14,12 @@ class CountryListMapperTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(countries.count, 2)
-        XCTAssertEqual(countries.first?.code, "PY")
-        XCTAssertEqual(countries.first?.name, "Paraguay")
-        XCTAssertEqual(countries.first?.states.count, 18)
-        XCTAssertEqual(countries.first?.states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
+        XCTAssertEqual(countries.count, 3)
+        XCTAssertEqual(countries.first?.states.isEmpty, true)
+        XCTAssertEqual(countries[1].code, "PY")
+        XCTAssertEqual(countries[1].name, "Paraguay")
+        XCTAssertEqual(countries[1].states.count, 18)
+        XCTAssertEqual(countries[1].states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `CountryListMapperTests`
+///
+class CountryListMapperTests: XCTestCase {
+
+    /// Verifies that the Country List is parsed correctly.
+    ///
+    func test_countries_are_properly_parsed() {
+        guard let countries = mapCountriesResponse() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(countries.count, 2)
+        XCTAssertEqual(countries.first?.code, "PY")
+        XCTAssertEqual(countries.first?.name, "Paraguay")
+        XCTAssertEqual(countries.first?.states.count, 18)
+        XCTAssertEqual(countries.first?.states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
+    }
+}
+
+/// Private Helpers
+///
+private extension CountryListMapperTests {
+
+    /// Returns the CountryListMapperTests output upon receiving `filename` (Data Encoded)
+    ///
+    func mapCountries(from filename: String) -> [Country]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! CountryListMapper().map(response: response)
+    }
+
+    /// Returns the CountryListMapper output upon receiving `countries`
+    ///
+    func mapCountriesResponse() -> [Country]? {
+        return mapCountries(from: "countries")
+    }
+}

--- a/Networking/NetworkingTests/Remote/DataRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DataRemoteTests.swift
@@ -34,11 +34,11 @@ class DataRemoteTests: XCTestCase {
 
         // Then
         let countries = try XCTUnwrap(result.get())
-        XCTAssertEqual(countries.count, 2)
-        XCTAssertEqual(countries.first?.code, "PY")
-        XCTAssertEqual(countries.first?.name, "Paraguay")
-        XCTAssertEqual(countries.first?.states.count, 18)
-        XCTAssertEqual(countries.first?.states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
+        XCTAssertEqual(countries.count, 3)
+        XCTAssertEqual(countries[1].code, "PY")
+        XCTAssertEqual(countries[1].name, "Paraguay")
+        XCTAssertEqual(countries[1].states.count, 18)
+        XCTAssertEqual(countries[1].states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
     }
 
     func test_loadCountries_returns_error_on_failure() throws {

--- a/Networking/NetworkingTests/Remote/DataRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DataRemoteTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Networking
+
+
+/// DataRemote Unit Tests
+///
+class DataRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    func test_loadCountries_returns_countries_on_success() throws {
+        // Given
+        let remote = DataRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "data/countries", filename: "countries")
+
+        // When
+        let result: Result<[Country], Error> = waitFor { promise in
+            remote.loadCountries(siteID: self.sampleSiteID) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        let countries = try XCTUnwrap(result.get())
+        XCTAssertEqual(countries.count, 2)
+        XCTAssertEqual(countries.first?.code, "PY")
+        XCTAssertEqual(countries.first?.name, "Paraguay")
+        XCTAssertEqual(countries.first?.states.count, 18)
+        XCTAssertEqual(countries.first?.states.first, StateOfACountry(code: "PY-ASU", name: "Asunción"))
+    }
+
+    func test_loadCountries_returns_error_on_failure() throws {
+        // Given
+        let remote = DataRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "data/countries", filename: "generic_error")
+
+        // When
+        let result: Result<[Country], Error> = waitFor { promise in
+            remote.loadCountries(siteID: self.sampleSiteID) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
+}

--- a/Networking/NetworkingTests/Responses/countries.json
+++ b/Networking/NetworkingTests/Responses/countries.json
@@ -1,0 +1,328 @@
+{
+    "data": [
+        {
+            "code": "PY",
+            "name": "Paraguay",
+            "states": [
+                {
+                    "code": "PY-ASU",
+                    "name": "Asunción"
+                },
+                {
+                    "code": "PY-1",
+                    "name": "Concepción"
+                },
+                {
+                    "code": "PY-2",
+                    "name": "San Pedro"
+                },
+                {
+                    "code": "PY-3",
+                    "name": "Cordillera"
+                },
+                {
+                    "code": "PY-4",
+                    "name": "Guairá"
+                },
+                {
+                    "code": "PY-5",
+                    "name": "Caaguazú"
+                },
+                {
+                    "code": "PY-6",
+                    "name": "Caazapá"
+                },
+                {
+                    "code": "PY-7",
+                    "name": "Itapúa"
+                },
+                {
+                    "code": "PY-8",
+                    "name": "Misiones"
+                },
+                {
+                    "code": "PY-9",
+                    "name": "Paraguarí"
+                },
+                {
+                    "code": "PY-10",
+                    "name": "Alto Paraná"
+                },
+                {
+                    "code": "PY-11",
+                    "name": "Central"
+                },
+                {
+                    "code": "PY-12",
+                    "name": "Ñeembucú"
+                },
+                {
+                    "code": "PY-13",
+                    "name": "Amambay"
+                },
+                {
+                    "code": "PY-14",
+                    "name": "Canindeyú"
+                },
+                {
+                    "code": "PY-15",
+                    "name": "Presidente Hayes"
+                },
+                {
+                    "code": "PY-16",
+                    "name": "Alto Paraguay"
+                },
+                {
+                    "code": "PY-17",
+                    "name": "Boquerón"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries/py"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries"
+                    }
+                ]
+            }
+        },
+        {
+            "code": "US",
+            "name": "United States (US)",
+            "states": [
+                {
+                    "code": "AL",
+                    "name": "Alabama"
+                },
+                {
+                    "code": "AK",
+                    "name": "Alaska"
+                },
+                {
+                    "code": "AZ",
+                    "name": "Arizona"
+                },
+                {
+                    "code": "AR",
+                    "name": "Arkansas"
+                },
+                {
+                    "code": "CA",
+                    "name": "California"
+                },
+                {
+                    "code": "CO",
+                    "name": "Colorado"
+                },
+                {
+                    "code": "CT",
+                    "name": "Connecticut"
+                },
+                {
+                    "code": "DE",
+                    "name": "Delaware"
+                },
+                {
+                    "code": "DC",
+                    "name": "District Of Columbia"
+                },
+                {
+                    "code": "FL",
+                    "name": "Florida"
+                },
+                {
+                    "code": "GA",
+                    "name": "Georgia"
+                },
+                {
+                    "code": "HI",
+                    "name": "Hawaii"
+                },
+                {
+                    "code": "ID",
+                    "name": "Idaho"
+                },
+                {
+                    "code": "IL",
+                    "name": "Illinois"
+                },
+                {
+                    "code": "IN",
+                    "name": "Indiana"
+                },
+                {
+                    "code": "IA",
+                    "name": "Iowa"
+                },
+                {
+                    "code": "KS",
+                    "name": "Kansas"
+                },
+                {
+                    "code": "KY",
+                    "name": "Kentucky"
+                },
+                {
+                    "code": "LA",
+                    "name": "Louisiana"
+                },
+                {
+                    "code": "ME",
+                    "name": "Maine"
+                },
+                {
+                    "code": "MD",
+                    "name": "Maryland"
+                },
+                {
+                    "code": "MA",
+                    "name": "Massachusetts"
+                },
+                {
+                    "code": "MI",
+                    "name": "Michigan"
+                },
+                {
+                    "code": "MN",
+                    "name": "Minnesota"
+                },
+                {
+                    "code": "MS",
+                    "name": "Mississippi"
+                },
+                {
+                    "code": "MO",
+                    "name": "Missouri"
+                },
+                {
+                    "code": "MT",
+                    "name": "Montana"
+                },
+                {
+                    "code": "NE",
+                    "name": "Nebraska"
+                },
+                {
+                    "code": "NV",
+                    "name": "Nevada"
+                },
+                {
+                    "code": "NH",
+                    "name": "New Hampshire"
+                },
+                {
+                    "code": "NJ",
+                    "name": "New Jersey"
+                },
+                {
+                    "code": "NM",
+                    "name": "New Mexico"
+                },
+                {
+                    "code": "NY",
+                    "name": "New York"
+                },
+                {
+                    "code": "NC",
+                    "name": "North Carolina"
+                },
+                {
+                    "code": "ND",
+                    "name": "North Dakota"
+                },
+                {
+                    "code": "OH",
+                    "name": "Ohio"
+                },
+                {
+                    "code": "OK",
+                    "name": "Oklahoma"
+                },
+                {
+                    "code": "OR",
+                    "name": "Oregon"
+                },
+                {
+                    "code": "PA",
+                    "name": "Pennsylvania"
+                },
+                {
+                    "code": "RI",
+                    "name": "Rhode Island"
+                },
+                {
+                    "code": "SC",
+                    "name": "South Carolina"
+                },
+                {
+                    "code": "SD",
+                    "name": "South Dakota"
+                },
+                {
+                    "code": "TN",
+                    "name": "Tennessee"
+                },
+                {
+                    "code": "TX",
+                    "name": "Texas"
+                },
+                {
+                    "code": "UT",
+                    "name": "Utah"
+                },
+                {
+                    "code": "VT",
+                    "name": "Vermont"
+                },
+                {
+                    "code": "VA",
+                    "name": "Virginia"
+                },
+                {
+                    "code": "WA",
+                    "name": "Washington"
+                },
+                {
+                    "code": "WV",
+                    "name": "West Virginia"
+                },
+                {
+                    "code": "WI",
+                    "name": "Wisconsin"
+                },
+                {
+                    "code": "WY",
+                    "name": "Wyoming"
+                },
+                {
+                    "code": "AA",
+                    "name": "Armed Forces (AA)"
+                },
+                {
+                    "code": "AE",
+                    "name": "Armed Forces (AE)"
+                },
+                {
+                    "code": "AP",
+                    "name": "Armed Forces (AP)"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries/us"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/countries.json
+++ b/Networking/NetworkingTests/Responses/countries.json
@@ -1,6 +1,23 @@
 {
     "data": [
         {
+            "code": "AT",
+            "name": "Austria",
+            "states": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries/at"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://mywootesting.mystagingwebsite.com/wp-json/wc/v3/data/countries"
+                    }
+                ]
+            }
+        },
+        {
             "code": "PY",
             "name": "Paraguay",
             "states": [


### PR DESCRIPTION
Part of #4464 

## Description
In this PR, I implemented the remote endpoint [data/countries](https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-continent-data) that will be used to fetch all the countries and the states, which will be implemented in the Shipping Label Address Validation screen. The Yosemite/Storage layers will be implemented in future PRs.
Note: more than 300 LOC are because of the JSON file `countries.json`.

## Testing
- Just CI, for the moment the endpoint is not used in the rest of the codebase.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
