### PR TITLE
[Mobile Payments] Unbreak modals in landscape just a tad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -63,16 +63,15 @@ final class CardPresentPaymentsModalViewController: UIViewController {
     private func resetHeightAndWidth() {
         if traitCollection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact)) {
             mainStackView.axis = .horizontal
-            mainStackView.distribution = .fillProportionally
             heightConstraint.constant = Constants.modalWidth
             widthConstraint.constant = Constants.modalHeight
         } else {
             mainStackView.axis = .vertical
-            mainStackView.distribution = .fill
             heightConstraint.constant = Constants.modalHeight
             widthConstraint.constant = Constants.modalWidth
         }
 
+        mainStackView.distribution = .fill
         heightConstraint.priority = .defaultHigh
         widthConstraint.priority = .defaultHigh
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -132,7 +132,7 @@
                         <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="32" id="lVZ-pu-Fmb"/>
                         <constraint firstAttribute="height" priority="250" constant="581" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
-                        <constraint firstAttribute="width" priority="250" constant="280" id="uaz-2N-7M4"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="280" id="uaz-2N-7M4"/>
                         <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="20" id="ufT-Yf-gsb"/>
                     </constraints>
                 </view>


### PR DESCRIPTION
Closes #4474 

During the review of #4467 we noticed that some modals were severely broken in landscape. Such is life.

This PR attempts to unbreak those modals a little bit. Yes, the width is still not constant, but we are getting closer.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/123332728-e436ff00-d50e-11eb-83f0-df9775137f40.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123332732-e5682c00-d50e-11eb-900a-12afad274465.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/123332729-e4cf9580-d50e-11eb-8381-82d7e79c8aba.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123332734-e5682c00-d50e-11eb-94db-baa8cd0072a2.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/123332730-e4cf9580-d50e-11eb-880f-985462759a92.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123332735-e5682c00-d50e-11eb-891a-7797e6cb4e60.png" width="350"/> |


## Changes
* Changed some constraints and changed the distribution property of the stack view in landscape mode

## How to test
1. Set up a store for In-Person Payments:  P91TBi-5ee-p2
2. Connect to a reader.
3. Navigate to an order eligible for In-Person Payments
4. Go thought the flow to collect a payment.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
