### PR TITLE
[Docs] Add bundle install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 
     ```bash
-    bundle exec rake dependencies
+    bundle install && bundle exec rake dependencies
     ```
 
     This command installs the required tools like [CocoaPods](https://cocoapods.org/). And then it installs the iOS project dependencies using CocoaPods.


### PR DESCRIPTION
When following the project setup guide, I encountered an error while running `rake dependencies`:

```bash
$ bundle exec rake dependencies
Could not find rake-12.3.3 in any of the sources
Run `bundle install` to install missing gems.
```

Adding `bundle install` before would make the setup process smoother. 🙂 

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.