### PR TITLE
Handle optional `delivery_days` field in Shipping Labels Carrier and Rates

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
@@ -16,7 +16,7 @@ public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
     public let hasTracking: Bool
     public let isSelected: Bool
     public let isPickupFree: Bool
-    public let deliveryDays: Int64
+    public let deliveryDays: Int64?
     public let deliveryDateGuaranteed: Bool
 
     public init(title: String,
@@ -30,7 +30,7 @@ public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
                 hasTracking: Bool,
                 isSelected: Bool,
                 isPickupFree: Bool,
-                deliveryDays: Int64,
+                deliveryDays: Int64?,
                 deliveryDateGuaranteed: Bool) {
         self.title = title
         self.insurance = insurance
@@ -65,7 +65,7 @@ extension ShippingLabelCarrierRate: Codable {
         let hasTracking = try container.decode(Bool.self, forKey: .hasTracking)
         let isSelected = try container.decode(Bool.self, forKey: .isSelected)
         let isPickupFree = try container.decode(Bool.self, forKey: .isPickupFree)
-        let deliveryDays = try container.decode(Int64.self, forKey: .deliveryDays)
+        let deliveryDays = try container.decodeIfPresent(Int64.self, forKey: .deliveryDays)
         let deliveryDateGuaranteed = try container.decode(Bool.self, forKey: .deliveryDateGuaranteed)
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
@@ -31,8 +31,10 @@ struct ShippingLabelCarrierRow: View {
                         Text(viewModel.price)
                             .bodyStyle()
                     }
-                    Text(viewModel.subtitle)
-                        .footnoteStyle()
+                    if let subtitle = viewModel.subtitle {
+                        Text(subtitle)
+                            .footnoteStyle()
+                    }
                     Text(viewModel.extraInfo)
                         .footnoteStyle()
                         .fixedSize(horizontal: false, vertical: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -47,7 +47,7 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
 
         title = rate.title
         let formatString = rate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
-        subtitle = String(format: formatString, rate.deliveryDays)
+        subtitle = String(format: formatString, rate.deliveryDays?.description ?? "-")
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
@@ -120,9 +120,9 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
 private extension ShippingLabelCarrierRowViewModel {
     enum Localization {
         static let businessDaySingular =
-            NSLocalizedString("%1$d business day", comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
+            NSLocalizedString("%1$@ business day", comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
         static let businessDaysPlural =
-            NSLocalizedString("%1$d business days", comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
+            NSLocalizedString("%1$@ business days", comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let tracking = NSLocalizedString("Includes %1$@ tracking",
                                                 comment: "Includes tracking of a specific carrier in Shipping Labels > Carrier and Rates")
         static let insurance = NSLocalizedString("Insurance (up to %1$@)",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -11,7 +11,7 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
     private let adultSignatureRate: ShippingLabelCarrierRate?
 
     let title: String
-    let subtitle: String
+    let subtitle: String?
     let price: String
     let carrierLogo: UIImage?
 
@@ -47,7 +47,12 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
 
         title = rate.title
         let formatString = rate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
-        subtitle = String(format: formatString, rate.deliveryDays?.description ?? "-")
+        if let deliveryDays = rate.deliveryDays {
+            subtitle = String(format: formatString, deliveryDays)
+        }
+        else {
+            subtitle = nil
+        }
 
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
@@ -120,9 +125,9 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
 private extension ShippingLabelCarrierRowViewModel {
     enum Localization {
         static let businessDaySingular =
-            NSLocalizedString("%1$@ business day", comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
+            NSLocalizedString("%1$d business day", comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
         static let businessDaysPlural =
-            NSLocalizedString("%1$@ business days", comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
+            NSLocalizedString("%1$d business days", comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let tracking = NSLocalizedString("Includes %1$@ tracking",
                                                 comment: "Includes tracking of a specific carrier in Shipping Labels > Carrier and Rates")
         static let insurance = NSLocalizedString("Insurance (up to %1$@)",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -54,12 +54,12 @@ final class ShippingLabelFormViewModel {
 
         for option in packagesResponse.predefinedOptions {
             if let predefinedPackage = option.predefinedPackages.first(where: { $0.id == selectedPackageID }) {
-                    return ShippingLabelPackageSelected(boxID: predefinedPackage.id,
-                                                        length: predefinedPackage.getLength(),
-                                                        width: predefinedPackage.getWidth(),
-                                                        height: predefinedPackage.getHeight(),
-                                                        weight: predefinedPackage.getWidth(),
-                                                        isLetter: predefinedPackage.isLetter)
+                return ShippingLabelPackageSelected(boxID: predefinedPackage.id,
+                                                    length: predefinedPackage.getLength(),
+                                                    width: predefinedPackage.getWidth(),
+                                                    height: predefinedPackage.getHeight(),
+                                                    weight: predefinedPackage.getWidth(),
+                                                    isLetter: predefinedPackage.isLetter)
             }
         }
 
@@ -211,9 +211,13 @@ final class ShippingLabelFormViewModel {
         let price = currencyFormatter.formatAmount(Decimal(rate)) ?? ""
 
         let formatString = selectedRate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
-        let shippingDays = String(format: formatString, selectedRate.deliveryDays?.description ?? "-")
 
-        return selectedRate.title + "\n" + price + " - " + shippingDays
+        var shippingDays = ""
+        if let deliveryDays = selectedRate.deliveryDays {
+            shippingDays = " - " + String(format: formatString, deliveryDays)
+        }
+
+        return selectedRate.title + "\n" + price + shippingDays
     }
 
     /// Returns the body of the Payment Methods cell.
@@ -550,9 +554,9 @@ private extension ShippingLabelFormViewModel {
                                                           comment: "Total package weight label in Shipping Label form. %1$@ is a placeholder for the weight")
         static let carrierAndRatesPlaceholder = NSLocalizedString("Select your shipping carrier and rates",
                                                                   comment: "Placeholder in Shipping Label form for the Carrier and Rates row.")
-        static let businessDaySingular = NSLocalizedString("%1$@ business day",
+        static let businessDaySingular = NSLocalizedString("%1$d business day",
                                                            comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
-        static let businessDaysPlural = NSLocalizedString("%1$@ business days",
+        static let businessDaysPlural = NSLocalizedString("%1$d business days",
                                                           comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let paymentMethodPlaceholder = NSLocalizedString("Add a new credit card",
                                                                 comment: "Placeholder in Shipping Label form for the Payment Method row.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -211,7 +211,7 @@ final class ShippingLabelFormViewModel {
         let price = currencyFormatter.formatAmount(Decimal(rate)) ?? ""
 
         let formatString = selectedRate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
-        let shippingDays = String(format: formatString, selectedRate.deliveryDays)
+        let shippingDays = String(format: formatString, selectedRate.deliveryDays?.description ?? "-")
 
         return selectedRate.title + "\n" + price + " - " + shippingDays
     }
@@ -550,9 +550,9 @@ private extension ShippingLabelFormViewModel {
                                                           comment: "Total package weight label in Shipping Label form. %1$@ is a placeholder for the weight")
         static let carrierAndRatesPlaceholder = NSLocalizedString("Select your shipping carrier and rates",
                                                                   comment: "Placeholder in Shipping Label form for the Carrier and Rates row.")
-        static let businessDaySingular = NSLocalizedString("%1$d business day",
+        static let businessDaySingular = NSLocalizedString("%1$@ business day",
                                                            comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
-        static let businessDaysPlural = NSLocalizedString("%1$d business days",
+        static let businessDaysPlural = NSLocalizedString("%1$@ business days",
                                                           comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let paymentMethodPlaceholder = NSLocalizedString("Add a new credit card",
                                                                 comment: "Placeholder in Shipping Label form for the Payment Method row.")


### PR DESCRIPTION
It seems that the field `delivery_days` returned in Shipping Labels Carrier and Rates sometimes can be `null`. So, in this PR I changed the property to make it optional.

Discussion here: C026HH75ECA/p1624969958004300

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
