### PR TITLE
[Mobile Payments] Add feature flag for card present known reader work

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -15,6 +15,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sitePlugins:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .cardPresentKnownReader:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -33,4 +33,8 @@ enum FeatureFlag: Int {
     /// Site Plugin list entry point on Settings screen
     ///
     case sitePlugins
+
+    /// Automatically Reconnect to a Known Card Reader
+    ///
+    case cardPresentKnownReader
 }


### PR DESCRIPTION
This PR is the first in a series of PRs to add automatic reconnection to known card readers for in-person payments.

This PR simply adds the feature flag for the feature. No user facing changes nor unit test changes.

The sequence of planned PRs can be found here: https://github.com/woocommerce/woocommerce-ios/issues/3559#issuecomment-868872729 (The next PR will add actions to AppSettingsStore to add a known reader ID, forget a known reader ID and get all the known reader IDs.)

To test:
- This PR simply adds the flag. No changes to automated tests, nothing user facing to test.
- Best you can do is ensure linting and unit tests pass.

Related:

p91TBi-5t5-p2

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
