### PR TITLE
[Mobile Payments] Add actions for remembering, forgetting and recalling card readers

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -8,16 +8,19 @@ extension GeneralAppSettings {
     public func copy(
         installationDate: NullableCopiableProp<Date> = .copy,
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
-        isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy
+        isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
+        knownCardReaders: CopiableProp<[String]> = .copy
     ) -> GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
+        let knownCardReaders = knownCardReaders ?? self.knownCardReaders
 
         return GeneralAppSettings(
             installationDate: installationDate,
             feedbacks: feedbacks,
-            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled
+            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+            knownCardReaders: knownCardReaders
         )
     }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -24,10 +24,16 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isViewAddOnsSwitchEnabled: Bool
 
-    public init(installationDate: Date?, feedbacks: [FeedbackType: FeedbackSettings], isViewAddOnsSwitchEnabled: Bool) {
+    /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
+    /// e.g. ["CHB204909005931"]
+    ///
+    public let knownCardReaders: [String]
+
+    public init(installationDate: Date?, feedbacks: [FeedbackType: FeedbackSettings], isViewAddOnsSwitchEnabled: Bool, knownCardReaders: [String]) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
+        self.knownCardReaders = knownCardReaders
     }
 
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
@@ -47,6 +53,11 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             _, new in new
         }
 
-        return GeneralAppSettings(installationDate: installationDate, feedbacks: updatedFeedbacks, isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled)
+        return GeneralAppSettings(
+            installationDate: installationDate,
+            feedbacks: updatedFeedbacks,
+            isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+            knownCardReaders: knownCardReaders
+        )
     }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -6,7 +6,7 @@ class GeneralAppSettingsTests: XCTestCase {
     func test_it_returns_the_correct_status_of_a_stored_feedback() {
         // Given
         let feedback = FeedbackSettings(name: .general, status: .dismissed)
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: feedback], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: feedback], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -17,7 +17,7 @@ class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_returns_pending_status_of_a_non_stored_feedback() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -29,7 +29,12 @@ class GeneralAppSettingsTests: XCTestCase {
     func test_it_replaces_feedback_when_feedback_exists() {
         // Given
         let existingFeedback = FeedbackSettings(name: .general, status: .dismissed)
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: existingFeedback], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(
+            installationDate: nil,
+            feedbacks: [.general: existingFeedback],
+            isViewAddOnsSwitchEnabled: false,
+            knownCardReaders: []
+        )
 
         // When
         let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))
@@ -41,7 +46,7 @@ class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_adds_new_feedback_when_replacing_empty_feedback_store() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
 
         // When
         let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		26E5A09225A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */; };
 		26FB056A25F6CB7600A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056925F6CB7600A40B26 /* Fakes.framework */; };
 		312A3D6E266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */; };
+		312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */; };
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
 		3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703092670295300EF253A /* PaymentGatewayAccountStore.swift */; };
 		3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */; };
@@ -492,6 +493,7 @@
 		26E5A09125A8A453000DF8F6 /* ProductAttributeTermStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermStoreTests.swift; sourceTree = "<group>"; };
 		26FB056925F6CB7600A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		312A3D6D266AEA6900D28BC9 /* PaymentGatewayAccount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentGatewayAccount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+CardReaderSettings.swift"; sourceTree = "<group>"; };
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
 		314703092670295300EF253A /* PaymentGatewayAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStore.swift; sourceTree = "<group>"; };
 		3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayAccount+PaymentGatewayAccount.swift"; sourceTree = "<group>"; };
@@ -1206,6 +1208,7 @@
 				578CE7862475D6FA00492EBF /* ProductReview */,
 				D87F615D2265B1BC0031A13B /* AppSettingsStoreTests.swift */,
 				0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */,
+				312DB64C268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift */,
 				02DA641A2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift */,
 				458C6DE725ACC554009B300D /* AppSettingsStoreTests+ProductsSettings.swift */,
 				B5BC736720D1AA8F00B5B6FA /* AccountStoreTests.swift */,
@@ -1892,6 +1895,7 @@
 				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockAcountStore.swift in Sources */,
+				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,
 				2614E12D24C745B2007CEE60 /* LeaderboardStatsConverterTests.swift in Sources */,
 				02DA641B2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift in Sources */,
 				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -113,4 +113,20 @@ public enum AppSettingsAction: Action {
     /// Loads the most recent state for the Order Add-ons beta feature switch
     ///
     case loadOrderAddOnsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Remember the given card reader (to support automatic reconnection)
+    /// where `cardReaderID` is a String e.g. "CHB204909005931"
+    ///
+    case rememberCardReader(cardReaderID: String, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Forget the given card reader (i.e. automatic reconnection is no longer desired)
+    /// where `cardReaderID` is a String e.g. "CHB204909005931"
+    ///
+    case forgetCardReader(cardReaderID: String, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Loads the list of all known (remembered) readers (i.e. card readers that, if discovered, should be reconnected automatically)
+    /// E.g.  ["CHB204909005931"]
+    /// Note: will pass [] to the completion if there are no known readers
+    ///
+    case loadCardReaders(onCompletion: (Result<[String], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -157,6 +157,12 @@ public class AppSettingsStore: Store {
             setOrderAddOnsFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadOrderAddOnsSwitchState(onCompletion: let onCompletion):
             loadOrderAddOnsSwitchState(onCompletion: onCompletion)
+        case .rememberCardReader(cardReaderID: let cardReaderID, onCompletion: let onCompletion):
+            rememberCardReader(cardReaderID: cardReaderID, onCompletion: onCompletion)
+        case .forgetCardReader(cardReaderID: let cardReaderID, onCompletion: let onCompletion):
+            forgetCardReader(cardReaderID: cardReaderID, onCompletion: onCompletion)
+        case .loadCardReaders(onCompletion: let onCompletion):
+            loadCardReaders(onCompletion: onCompletion)
         }
     }
 }
@@ -235,7 +241,7 @@ private extension AppSettingsStore {
     /// Load the `GeneralAppSettings` from file or create an empty one if it doesn't exist.
     func loadOrCreateGeneralAppSettings() -> GeneralAppSettings {
         guard let settings: GeneralAppSettings = try? fileStorage.data(for: generalAppSettingsFileURL) else {
-            return GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false)
+            return GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
         }
 
         return settings
@@ -244,6 +250,61 @@ private extension AppSettingsStore {
     /// Save the `GeneralAppSettings` to the appropriate file.
     func saveGeneralAppSettings(_ settings: GeneralAppSettings) throws {
         try fileStorage.write(settings, to: generalAppSettingsFileURL)
+    }
+}
+
+// MARK: - Card Reader Actions
+//
+private extension AppSettingsStore {
+    /// Remember the given card reader (to support automatic reconnection)
+    /// where `cardReaderID` is a String e.g. "CHB204909005931"
+    ///
+    func rememberCardReader(cardReaderID: String, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings()
+
+            guard !settings.knownCardReaders.contains(cardReaderID) else {
+                return onCompletion(.success(()))
+            }
+
+            let knownCardReadersToSave = settings.knownCardReaders + [cardReaderID]
+            let settingsToSave = settings.copy(knownCardReaders: knownCardReadersToSave)
+            try saveGeneralAppSettings(settingsToSave)
+
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    /// Forget the given card reader (i.e. automatic reconnection is no longer desired)
+    /// where `cardReaderID` is a String e.g. "CHB204909005931"
+    ///
+    func forgetCardReader(cardReaderID: String, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings()
+
+            guard settings.knownCardReaders.contains(cardReaderID) else {
+                return onCompletion(.success(()))
+            }
+
+            let knownCardReadersToSave = settings.knownCardReaders.filter { $0 != cardReaderID }
+            let settingsToSave = settings.copy(knownCardReaders: knownCardReadersToSave)
+            try saveGeneralAppSettings(settingsToSave)
+
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    /// Loads the list of all known (remembered) readers (i.e. card readers that, if discovered, should be reconnected automatically)
+    /// E.g.  ["CHB204909005931"]
+    /// Note: will pass [] to the completion if there are no known readers
+    ///
+    func loadCardReaders(onCompletion: (Result<[String], Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.knownCardReaders))
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -157,7 +157,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_true_if_no_settings_are_found() throws {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
@@ -217,7 +217,12 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
 
     func createAppSetting(instalationDate: Date?, feedbackType: FeedbackType, feedbackSatus: FeedbackSettings.Status) -> GeneralAppSettings {
         let feedback = FeedbackSettings(name: feedbackType, status: feedbackSatus)
-        let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(
+            installationDate: instalationDate,
+            feedbacks: [feedback.name: feedback],
+            isViewAddOnsSwitchEnabled: false,
+            knownCardReaders: []
+        )
         return settings
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+CardReaderSettings.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+CardReaderSettings.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@testable import Yosemite
+@testable import Storage
+
+/// Mock constants
+///
+private struct TestConstants {
+    static let mockReaderID = "CHB204909005931"
+}
+
+final class AppSettingsStoreTests_CardReaderSettings: XCTestCase {
+
+    /// Mock Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock File Storage: Load data in memory
+    ///
+    private var fileStorage: MockInMemoryStorage!
+
+    /// Test subject
+    ///
+    private var subject: AppSettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+        fileStorage = MockInMemoryStorage()
+        subject = AppSettingsStore(dispatcher: dispatcher, storageManager: storageManager, fileStorage: fileStorage)
+    }
+
+    override func tearDown() {
+        dispatcher = nil
+        storageManager = nil
+        fileStorage = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_loading_card_readers_without_previous_data_returns_empty_array() {
+
+        let expectation = self.expectation(description: #function)
+
+        let loadAction = AppSettingsAction.loadCardReaders { result in
+            XCTAssertTrue(result.isSuccess)
+            if case .success(let readers) = result {
+                XCTAssertTrue(readers.isEmpty)
+                expectation.fulfill()
+            }
+        }
+
+        subject.onAction(loadAction)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_remember_card_reader_remembers_the_card_reader() {
+
+        let expectation = self.expectation(description: #function)
+
+        let loadAction = AppSettingsAction.loadCardReaders { result in
+            XCTAssertTrue(result.isSuccess)
+            if case .success(let readers) = result {
+                XCTAssertTrue(readers.contains(TestConstants.mockReaderID))
+                expectation.fulfill()
+            }
+        }
+
+        let rememberAction = AppSettingsAction.rememberCardReader(cardReaderID: TestConstants.mockReaderID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            self.subject.onAction(loadAction)
+        })
+
+        subject.onAction(rememberAction)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_forget_card_reader_forgets_the_card_reader() {
+
+        let expectation = self.expectation(description: #function)
+
+        let loadAction = AppSettingsAction.loadCardReaders { result in
+            XCTAssertTrue(result.isSuccess)
+            if case .success(let readers) = result {
+                XCTAssertFalse(readers.contains(TestConstants.mockReaderID))
+                expectation.fulfill()
+            }
+        }
+
+        let forgetAction = AppSettingsAction.forgetCardReader(cardReaderID: TestConstants.mockReaderID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            self.subject.onAction(loadAction)
+        })
+
+        let rememberAction = AppSettingsAction.rememberCardReader(cardReaderID: TestConstants.mockReaderID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            self.subject.onAction(forgetAction)
+        })
+
+        subject.onAction(rememberAction)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -458,7 +458,12 @@ private extension AppSettingsStoreTests {
 
     func createAppSettingAndGeneralFeedback(installationDate: Date?, feedbackStatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
         let feedback = FeedbackSettings(name: .general, status: feedbackStatus)
-        let settings = GeneralAppSettings(installationDate: installationDate, feedbacks: [feedback.name: feedback], isViewAddOnsSwitchEnabled: false)
+        let settings = GeneralAppSettings(
+            installationDate: installationDate,
+            feedbacks: [feedback.name: feedback],
+            isViewAddOnsSwitchEnabled: false,
+            knownCardReaders: []
+        )
         return (settings, feedback)
     }
 }


### PR DESCRIPTION
This is the next PR in a series of PRs for the "automatically reconnect to known card readers" feature

This PR adds the actions needed for the feature. Although there are no user facing changes there are unit test changes and new unit tests to cover the actions.

Note: `rake generate` was required for sourcery copiable

The sequence of planned PRs can be found here: https://github.com/woocommerce/woocommerce-ios/issues/3559#issuecomment-868872729

The next PR will define a protocol that a subsequent PR will create a conforming object for which will initiate these actions.

To test:
- Nothing user facing to test
- Ensure linting passes
- Ensure new unit tests pass in AppSettingsStoreTests_CardReaderSettings
- Ensure existing unit tests pass especially GeneralAppSettingsTests and InAppFeedbackCardVisibilityUseCaseTests

Related:

p91TBi-5t5-p2

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
