### PR TITLE
[Mobile Payments] Fix modals in landscape

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -11,6 +11,7 @@ final class CardPresentPaymentsModalViewController: UIViewController {
 
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var mainStackView: UIStackView!
+    @IBOutlet weak var primaryActionButtonsStackView: UIStackView!
     @IBOutlet private weak var topTitleLabel: UILabel!
     @IBOutlet private weak var topSubtitleLabel: UILabel!
     @IBOutlet private weak var bottomTitleLabel: UILabel!
@@ -62,12 +63,15 @@ final class CardPresentPaymentsModalViewController: UIViewController {
 
     private func resetHeightAndWidth() {
         if traitCollection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact)) {
-            mainStackView.axis = .horizontal
+            primaryActionButtonsStackView.axis = .horizontal
+            imageView.isHidden = true
+
             mainStackView.distribution = .fillProportionally
             heightConstraint.constant = Constants.modalWidth
             widthConstraint.constant = Constants.modalHeight
         } else {
-            mainStackView.axis = .vertical
+            primaryActionButtonsStackView.axis = .vertical
+            imageView.isHidden = false
             mainStackView.distribution = .fill
             heightConstraint.constant = Constants.modalHeight
             widthConstraint.constant = Constants.modalWidth

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -55,7 +55,7 @@
                                         </label>
                                     </subviews>
                                 </stackView>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
                                     <rect key="frame" x="89" y="81" width="134" height="117"/>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
@@ -130,7 +130,7 @@
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="height" secondItem="8Tg-Q2-wkH" secondAttribute="height" constant="-64" id="VJR-wO-lUP"/>
                         <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="32" id="lVZ-pu-Fmb"/>
-                        <constraint firstAttribute="height" priority="250" constant="581" id="n7H-7U-izh"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="250" constant="382" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
                         <constraint firstAttribute="width" priority="250" constant="280" id="uaz-2N-7M4"/>
                         <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="20" id="ufT-Yf-gsb"/>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -19,6 +19,7 @@
                 <outlet property="heightConstraint" destination="n7H-7U-izh" id="cbE-Eb-VuR"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
                 <outlet property="mainStackView" destination="jIt-xb-rrN" id="mSC-3J-47R"/>
+                <outlet property="primaryActionButtonsStackView" destination="mhI-fa-Yzw" id="dx9-oe-Pnq"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
                 <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
                 <outlet property="topSubtitleLabel" destination="aVs-Lf-QTr" id="uKV-ox-li8"/>
@@ -33,10 +34,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="31" y="162.5" width="352" height="581"/>
+                    <rect key="frame" x="31" y="186.5" width="352" height="533"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="20" y="32" width="312" height="517"/>
+                            <rect key="frame" x="20" y="32" width="312" height="469"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="135.5" y="0.0" width="41.5" height="49"/>
@@ -76,49 +77,54 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="319" width="312" height="198"/>
+                                    <rect key="frame" x="0.0" y="319" width="312" height="150"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                                            <rect key="frame" x="16" y="20" width="280" height="170"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
+                                            <rect key="frame" x="0.0" y="0.0" width="312" height="150"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
-                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="40"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                    <state key="normal" title="Primary Action Button">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </state>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                    </userDefinedRuntimeAttributes>
-                                                </button>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
-                                                    <rect key="frame" x="0.0" y="60" width="280" height="40"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                    <state key="normal" title="Secondary Action Button">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </state>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                                    </userDefinedRuntimeAttributes>
-                                                </button>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
+                                                    <rect key="frame" x="0.0" y="0.0" width="312" height="100"/>
+                                                    <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
+                                                            <rect key="frame" x="0.0" y="0.0" width="312" height="40"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                            <state key="normal" title="Primary Action Button">
+                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </state>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </button>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
+                                                            <rect key="frame" x="0.0" y="60" width="312" height="40"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                            <state key="normal" title="Secondary Action Button">
+                                                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </state>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </button>
+                                                    </subviews>
+                                                </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="120" width="280" height="50"/>
+                                                    <rect key="frame" x="0.0" y="100" width="312" height="50"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="mhI-fa-Yzw" secondAttribute="trailing" constant="16" id="8gH-vs-D9H"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="mhI-fa-Yzw" secondAttribute="bottom" id="PGb-Bi-220"/>
-                                        <constraint firstItem="mhI-fa-Yzw" firstAttribute="top" secondItem="10Z-y1-ZQ6" secondAttribute="top" constant="20" id="elI-Eo-HER"/>
-                                        <constraint firstItem="mhI-fa-Yzw" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" constant="16" id="vz3-FU-z4g"/>
+                                        <constraint firstAttribute="bottom" secondItem="o73-de-cj4" secondAttribute="bottom" id="0Lj-9r-YQS"/>
+                                        <constraint firstItem="o73-de-cj4" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" id="IYM-BA-7mY"/>
+                                        <constraint firstItem="o73-de-cj4" firstAttribute="top" secondItem="10Z-y1-ZQ6" secondAttribute="top" id="YFA-8t-f2d"/>
+                                        <constraint firstAttribute="trailing" secondItem="o73-de-cj4" secondAttribute="trailing" id="nhS-Yt-Ser"/>
                                     </constraints>
                                 </view>
                             </subviews>


### PR DESCRIPTION
Closes #4474

This is still not a perfect solution for the modals in Portrait mode, but it seems to provide a good enough solution for modals in landscape (on phones) and all orientations on tablets. This PR also prevents the illustration from changing sizes.

As mentioned here: https://github.com/woocommerce/woocommerce-ios/pull/4479#issuecomment-870571015 we want to hide the illustration and change the orientation of the action buttons in landscape mode.

I think we should target the frozen build for this, and then iterate again on portrait in a separate PR.

There are still two issues: 
* the width of the modal when a reader is found is wider than it should
* the modal in portrait mode shrinks a bit after the first modal (the one with the cancel button). I haven't been able to figure out why yet

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/123332728-e436ff00-d50e-11eb-83f0-df9775137f40.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123970068-ce9a5d00-d986-11eb-809d-4f0b595edd1c.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/123332729-e4cf9580-d50e-11eb-8381-82d7e79c8aba.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123970193-e96cd180-d986-11eb-8dbd-7acb1ce8e9e8.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/2722505/123332730-e4cf9580-d50e-11eb-880f-985462759a92.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/123970277-fc7fa180-d986-11eb-87f0-7ad005df38ff.png" width="350"/> |

In portrait, notice how there is still a change in height:
<img src="https://user-images.githubusercontent.com/2722505/123970604-410b3d00-d987-11eb-9fef-b5796aaf5adc.png" width="350"/>
<img src="https://user-images.githubusercontent.com/2722505/123970605-41a3d380-d987-11eb-92ff-71e7e98cd644.png" width="350"/>


But on the bright side, things look better on iPad as well:
<img src="https://user-images.githubusercontent.com/2722505/123970779-6f891800-d987-11eb-86d2-f24b88c78fd0.png" width="350"/>
<img src="https://user-images.githubusercontent.com/2722505/123970782-6f891800-d987-11eb-92cf-3d00f94ec222.png" width="350"/>
<img src="https://user-images.githubusercontent.com/2722505/123970783-7021ae80-d987-11eb-93e5-caaf97c4e8c2.png" width="350"/>
<img src="https://user-images.githubusercontent.com/2722505/123970784-7021ae80-d987-11eb-9d75-e7d53950a062.png" width="350"/>

## Changes
* Fixed width and height for illustration
* Updated the way the action buttons are laid out, wrapping the primary and secondary button in their own stack view
* When the orientation changes, change the axis of the stack view wrapping the buttons and hide the illustration, instead of changing the axis of the outermost stack view 

## How to test
* Try to connect to a reader and collect a payment, both in portrait and landscape orientations, both on iPad and iPhone


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
