### PR TITLE
Variations Hide price-warning row borders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -46,7 +46,7 @@ private extension ProductVariationFormActionsFactory {
         let canEditInventorySettingsRow = editable && productVariation.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowPriceSettingsRow ? .priceSettings(editable: editable): nil,
+            shouldShowPriceSettingsRow ? .priceSettings(editable: editable, hideSeparator: shouldShowNoPriceWarningRow): nil,
             shouldShowNoPriceWarningRow ? .noPriceWarning: nil,
             .attributes(editable: editable),
             .status(editable: editable),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -60,7 +60,7 @@ private extension DefaultProductFormTableViewModel {
     func settingsRows(product: EditableProductModel, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
         return actions.compactMap { action in
             switch action {
-            case .priceSettings(let editable):
+            case .priceSettings(let editable, _):
                 return .price(viewModel: priceSettingsRow(product: product, isEditable: editable), isEditable: editable)
             case .reviews:
                 return .reviews(viewModel: reviewsRow(product: product), ratingCount: product.ratingCount, averageRating: product.averageRating)
@@ -84,8 +84,8 @@ private extension DefaultProductFormTableViewModel {
                 return .sku(viewModel: skuRow(product: product.product, isEditable: editable), isEditable: editable)
             case .groupedProducts(let editable):
                 return .groupedProducts(viewModel: groupedProductsRow(product: product.product, isEditable: editable), isEditable: editable)
-            case .variations:
-                return .variations(viewModel: variationsRow(product: product.product))
+            case .variations(let hideSeparator):
+                return .variations(viewModel: variationsRow(product: product.product, hideSeparator: hideSeparator))
             case .downloadableFiles(let editable):
                 return .downloadableFiles(viewModel: downloadsRow(product: product, isEditable: editable), isEditable: editable)
             case .linkedProducts(let editable):
@@ -104,8 +104,9 @@ private extension DefaultProductFormTableViewModel {
     func settingsRows(productVariation: EditableProductVariationModel, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
         return actions.compactMap { action in
             switch action {
-            case .priceSettings(let editable):
-                return .price(viewModel: variationPriceSettingsRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
+            case .priceSettings(let editable, let hideSeparator):
+                return .price(viewModel: variationPriceSettingsRow(productVariation: productVariation, isEditable: editable, hideSeparator: hideSeparator),
+                              isEditable: editable)
             case .attributes(let editable):
                 return .attributes(viewModel: variationAttributesRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .shippingSettings(let editable):
@@ -168,14 +169,17 @@ private extension DefaultProductFormTableViewModel {
                                                         isActionable: isEditable)
     }
 
-    func variationPriceSettingsRow(productVariation: EditableProductVariationModel, isEditable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
+    func variationPriceSettingsRow(productVariation: EditableProductVariationModel,
+                                   isEditable: Bool,
+                                   hideSeparator: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let priceViewModel = priceSettingsRow(product: productVariation, isEditable: isEditable)
         let tintColor = productVariation.isEnabledAndMissingPrice ? UIColor.warning: nil
         return .init(icon: priceViewModel.icon,
                      title: priceViewModel.title,
                      details: priceViewModel.details,
                      tintColor: tintColor,
-                     isActionable: priceViewModel.isActionable)
+                     isActionable: priceViewModel.isActionable,
+                     hideSeparator: hideSeparator)
     }
 
     func reviewsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
@@ -381,11 +385,11 @@ private extension DefaultProductFormTableViewModel {
 
     // MARK: Variable products only
 
-    func variationsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+    func variationsRow(product: Product, hideSeparator: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.variationsImage
         let title = product.variations.isEmpty ? Localization.addVariationsTitle : Localization.variationsTitle
         let details = Localization.variationsDetail(count: product.variations.count)
-        return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details, isActionable: true)
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details, isActionable: true, hideSeparator: hideSeparator)
     }
 
     // MARK: Product variation only

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -5,7 +5,7 @@ enum ProductFormEditAction: Equatable {
     case images(editable: Bool)
     case name(editable: Bool)
     case description(editable: Bool)
-    case priceSettings(editable: Bool)
+    case priceSettings(editable: Bool, hideSeparator: Bool)
     case reviews
     case productType(editable: Bool)
     case inventorySettings(editable: Bool)
@@ -21,7 +21,7 @@ enum ProductFormEditAction: Equatable {
     // Grouped products only
     case groupedProducts(editable: Bool)
     // Variable products only
-    case variations
+    case variations(hideSeparator: Bool)
     // Variation only
     case variationName
     case noPriceWarning
@@ -109,7 +109,7 @@ private extension ProductFormActionsFactory {
         let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
-            .priceSettings(editable: editable),
+            .priceSettings(editable: editable, hideSeparator: false),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: canEditInventorySettingsRow),
@@ -131,7 +131,7 @@ private extension ProductFormActionsFactory {
         let canEditProductType = formType != .add && editable
 
         let actions: [ProductFormEditAction?] = [
-            .priceSettings(editable: editable),
+            .priceSettings(editable: editable, hideSeparator: false),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowExternalURLRow ? .externalURL(editable: editable): nil,
             shouldShowSKURow ? .sku(editable: editable): nil,
@@ -176,7 +176,7 @@ private extension ProductFormActionsFactory {
         }()
 
         let actions: [ProductFormEditAction?] = [
-            .variations,
+            .variations(hideSeparator: shouldShowNoPriceWarningRow),
             shouldShowNoPriceWarningRow ? .noPriceWarning : nil,
             shouldShowAttributesRow ? .attributes(editable: editable) : nil,
             shouldShowReviewsRow ? .reviews: nil,
@@ -197,7 +197,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowPriceSettingsRow ? .priceSettings(editable: false): nil,
+            shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
             .categories(editable: editable),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -273,6 +273,7 @@ private extension ProductFormTableViewDataSource {
                     data: .init(title: viewModel.title,
                                 image: viewModel.icon,
                                 numberOfLinesForTitle: 0,
-                                isActionable: false))
+                                isActionable: false,
+                                showsSeparator: false))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -9,7 +9,8 @@ private extension ProductFormSection.SettingsRow.ViewModel {
                                                            image: icon,
                                                            imageTintColor: tintColor ?? .textSubtle,
                                                            numberOfLinesForText: numberOfLinesForDetails,
-                                                           isActionable: isActionable)
+                                                           isActionable: isActionable,
+                                                           showsSeparator: !hideSeparator)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -49,14 +49,22 @@ enum ProductFormSection: Equatable {
             let tintColor: UIColor?
             let numberOfLinesForDetails: Int
             let isActionable: Bool
+            let hideSeparator: Bool
 
-            init(icon: UIImage, title: String?, details: String?, tintColor: UIColor? = nil, numberOfLinesForDetails: Int = 0, isActionable: Bool = true) {
+            init(icon: UIImage,
+                 title: String?,
+                 details: String?,
+                 tintColor: UIColor? = nil,
+                 numberOfLinesForDetails: Int = 0,
+                 isActionable: Bool = true,
+                 hideSeparator: Bool = false) {
                 self.icon = icon
                 self.title = title
                 self.details = details
                 self.tintColor = tintColor
                 self.numberOfLinesForDetails = numberOfLinesForDetails
                 self.isActionable = isActionable
+                self.hideSeparator = hideSeparator
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -29,7 +29,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: false),
                                                                        .inventorySettings(editable: false),
@@ -53,7 +53,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: false),
@@ -76,7 +76,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
                                                                        .reviews,
                                                                        .externalURL(editable: false),
                                                                        .sku(editable: false),
@@ -103,7 +103,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
                                                                        .reviews,
                                                                        .categories(editable: false),
                                                                        .tags(editable: false),
@@ -183,7 +183,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .name(editable: false), .description(editable: false)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations,
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations(hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: false),
                                                                        .inventorySettings(editable: false),
@@ -207,7 +207,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations,
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations(hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: false),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+VisibilityTests.swift
@@ -14,7 +14,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true)))
+        XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true, hideSeparator: false)))
     }
 
     func testPriceRowIsVisibleForProductWithoutPriceData() {
@@ -26,7 +26,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true)))
+        XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings(editable: true, hideSeparator: false)))
     }
 
     // MARK: - Inventory

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -17,7 +17,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
@@ -44,7 +44,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
@@ -71,7 +71,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
@@ -97,7 +97,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
@@ -122,7 +122,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .shippingSettings(editable: true),
                                                                        .inventorySettings(editable: true),
@@ -149,7 +149,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
@@ -176,7 +176,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .inventorySettings(editable: true),
                                                                        .categories(editable: true),
@@ -202,7 +202,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .externalURL(editable: true),
                                                                        .linkedProducts(editable: true),
@@ -248,7 +248,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [
-            .variations,
+            .variations(hideSeparator: false),
             .reviews,
             .shippingSettings(editable: true),
             .inventorySettings(editable: true),
@@ -274,7 +274,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [
-            .variations,
+            .variations(hideSeparator: true),
             .noPriceWarning,
             .reviews,
             .shippingSettings(editable: true),
@@ -323,7 +323,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [
-            .priceSettings(editable: false),
+            .priceSettings(editable: false, hideSeparator: false),
             .reviews,
             .inventorySettings(editable: false),
             .linkedProducts(editable: true),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
@@ -26,7 +26,7 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         let factory = ProductVariationFormActionsFactory(productVariation: model, editable: false)
 
         // Assert
-        XCTAssertFalse(factory.settingsSectionActions().contains(.priceSettings(editable: false)))
+        XCTAssertFalse(factory.settingsSectionActions().contains(.priceSettings(editable: false, hideSeparator: true)))
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -44,7 +44,7 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: false), .variationName, .description(editable: false)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
                                                                        .attributes(editable: false),
                                                                        .status(editable: false),
                                                                        .shippingSettings(editable: false),
@@ -64,7 +64,7 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         let factory = ProductVariationFormActionsFactory(productVariation: model, editable: true)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
                                                                        .inventorySettings(editable: false)]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -16,7 +16,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
                                                                        .shippingSettings(editable: true),
@@ -39,7 +39,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
                                                                        .shippingSettings(editable: true),
@@ -62,7 +62,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
                                                                        .inventorySettings(editable: true)]
@@ -84,7 +84,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
                                                                        .inventorySettings(editable: true)]
@@ -107,7 +107,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [
-            .priceSettings(editable: true),
+            .priceSettings(editable: true, hideSeparator: false),
             .attributes(editable: true),
             .status(editable: true),
             .inventorySettings(editable: true)
@@ -130,7 +130,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: true),
                                                                        .noPriceWarning,
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -12,7 +12,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -35,7 +35,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
@@ -54,7 +54,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true),
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .reviews,
                                                                        .downloadableFiles(editable: true),
                                                                        .linkedProducts(editable: true),


### PR DESCRIPTION
fix #4450

# Why 

It was reported that the no-price banner row had some visible cell separators that made it look off. This PR removes those separators.

# How

Each cell has its own bottom separator, but the requirement is to remove both separators for the no-`price-warning` cell. 

To accomplish that, apart from removing the `no-price-warning` bottom separator, I'm removing the upper cell bottom separator, which at this moment can only be the `variations` cell for variable products or the `price` cell for a product variation.

The way to pass that information is done via the `ProductFormEditAction` enum all the way through the cell datasource.

# Screenshots

Before | After
--- | ---
<img width="584" alt="bad" src="https://user-images.githubusercontent.com/562080/123995552-1378c080-d994-11eb-975c-3cfeec22fb05.png"> |  <img width="586" alt="good" src="https://user-images.githubusercontent.com/562080/123995547-12e02a00-d994-11eb-81f1-80d46805f686.png">

# Testing steps

- Create a new variable product
- Create a new product variation (don't set the price)
- See that the `no-price-warning` cell does not have borders.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
