### PR TITLE
[Mobile Payments] Add KnownReadersProvider protocol and KnownReadersStoredList which implements it

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersProvider.swift
@@ -7,12 +7,9 @@ import Combine
 ///
 protocol CardReaderSettingsKnownReadersProvider {
 
-    /// We can't use a @Published wrapper for knownReaders as part of a protocol declaration, but we can
-    /// require its synthesized methods explicitly
+    /// Publishes changes to the known reader list.
     ///
-    var knownReaders: [String] { get }
-    var knownReadersPublished: Published<[String]> { get }
-    var knownReadersPublisher: Published<[String]>.Publisher { get }
+    var knownReaders: AnyPublisher<[String], Never> { get }
 
     /// Remember a reader. Asynchronous.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersProvider.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Combine
+
+/// Defines a protocol for wrappers around AppSettingsStore for "Known" Card Readers to confom to
+/// Allows us to support multiple implementations/dependency injection, and avoid introducing
+/// Combine into the Storage layer
+///
+protocol CardReaderSettingsKnownReadersProvider {
+
+    /// We can't use a @Published wrapper for knownReaders as part of a protocol declaration, but we can
+    /// require its synthesized methods explicitly
+    ///
+    var knownReaders: [String] { get }
+    var knownReadersPublished: Published<[String]> { get }
+    var knownReadersPublisher: Published<[String]>.Publisher { get }
+
+    /// Remember a reader. Asynchronous.
+    ///
+    func rememberCardReader(cardReaderID: String)
+
+    /// Forget a reader. Asynchronous.
+    ///
+    func forgetCardReader(cardReaderID: String)
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersStoredList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsKnownReadersStoredList.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Yosemite
+import Combine
+
+/// Combine aware wrapper around AppSettingsActions for Known Card Readers
+///
+final class CardReaderSettingsKnownReadersStoredList: CardReaderSettingsKnownReadersProvider {
+    private let stores: StoresManager
+
+    @Published private(set) var knownReaders: [String]
+    var knownReadersPublished: Published<[String]> { _knownReaders }
+    var knownReadersPublisher: Published<[String]>.Publisher { $knownReaders }
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+        self.knownReaders = []
+
+        self.loadReaders()
+    }
+
+    func rememberCardReader(cardReaderID: String) {
+        let action = AppSettingsAction.rememberCardReader(cardReaderID: cardReaderID, onCompletion: { [weak self] _ in
+            self?.loadReaders()
+        })
+        stores.dispatch(action)
+    }
+
+    func forgetCardReader(cardReaderID: String) {
+        let action = AppSettingsAction.forgetCardReader(cardReaderID: cardReaderID, onCompletion: { [weak self] _ in
+            self?.loadReaders()
+        })
+        stores.dispatch(action)
+    }
+
+    private func loadReaders() {
+        let action = AppSettingsAction.loadCardReaders(onCompletion: { [weak self] result in
+            switch result {
+            case .success(let readers):
+                self?.knownReaders = readers
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing known readers: \(error)")
+            }
+        })
+        stores.dispatch(action)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -464,6 +464,10 @@
 		314265AC26459F7300500598 /* CardReaderSettingsUnknownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */; };
 		314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */; };
 		3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */; };
+		314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314DC4BC268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift */; };
+		314DC4BF268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314DC4BE268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift */; };
+		314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStoredListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314DC4C0268D28B100444C9E /* CardReaderSettingsKnownReadersStoredListTests.swift */; };
+		314DC4C3268D2F1000444C9E /* MockAppSettingsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314DC4C2268D2F1000444C9E /* MockAppSettingsStoresManager.swift */; };
 		31595CAD25E966380033F0FF /* ConnectedReaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */; };
 		316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */; };
 		3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */; };
@@ -1754,6 +1758,10 @@
 		314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewController.swift; sourceTree = "<group>"; };
 		314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewController.swift; sourceTree = "<group>"; };
 		3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsViewModelPresenter.swift; sourceTree = "<group>"; };
+		314DC4BC268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsKnownReadersProvider.swift; sourceTree = "<group>"; };
+		314DC4BE268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsKnownReadersStoredList.swift; sourceTree = "<group>"; };
+		314DC4C0268D28B100444C9E /* CardReaderSettingsKnownReadersStoredListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsKnownReadersStoredListTests.swift; sourceTree = "<group>"; };
+		314DC4C2268D2F1000444C9E /* MockAppSettingsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettingsStoresManager.swift; sourceTree = "<group>"; };
 		31595CAC25E966380033F0FF /* ConnectedReaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectedReaderTableViewCell.xib; sourceTree = "<group>"; };
 		316837D925CCA90C00E36B2F /* OrderStatusListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListDataSource.swift; sourceTree = "<group>"; };
 		3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsConnectedViewModel.swift; sourceTree = "<group>"; };
@@ -3707,6 +3715,8 @@
 				314265AB26459F7300500598 /* CardReaderSettingsUnknownViewController.swift */,
 				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
 				3142663E2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift */,
+				314DC4BC268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift */,
+				314DC4BE268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift */,
 			);
 			path = CardReadersV2;
 			sourceTree = "<group>";
@@ -3716,6 +3726,7 @@
 			children = (
 				3178C1FC26409360000D771A /* CardReaderSettingsConnectedViewModelTests.swift */,
 				31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */,
+				314DC4C0268D28B100444C9E /* CardReaderSettingsKnownReadersStoredListTests.swift */,
 			);
 			path = CardReaderSettings;
 			sourceTree = "<group>";
@@ -4360,6 +4371,7 @@
 				45AF9DAE265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift */,
 				57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */,
 				31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */,
+				314DC4C2268D2F1000444C9E /* MockAppSettingsStoresManager.swift */,
 				31F21B5F263CB78A0035B50A /* MockCardReader.swift */,
 			);
 			path = Mocks;
@@ -6768,6 +6780,7 @@
 				D8652E582630BFF500350F37 /* OrderDetailsPaymentAlerts.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
+				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift in Sources */,
 				02CB9BE424E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
@@ -6932,6 +6945,7 @@
 				025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
+				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,
@@ -7387,6 +7401,7 @@
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,
 				0246405F258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift in Sources */,
 				576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */,
+				314DC4C3268D2F1000444C9E /* MockAppSettingsStoresManager.swift in Sources */,
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
 				453904F323BB88B5007C4956 /* ProductTaxStatusListSelectorCommandTests.swift in Sources */,
 				02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */,
@@ -7424,6 +7439,7 @@
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
+				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStoredListTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				578195FC25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockAppSettingsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAppSettingsStoresManager.swift
@@ -7,8 +7,8 @@ final class MockAppSettingsStoresManager: DefaultStoresManager {
 
     private var knownReaders: [String]
 
-    init(sessionManager: SessionManager) {
-        knownReaders = []
+    init(sessionManager: SessionManager, knownReaders: [String] = []) {
+        self.knownReaders = knownReaders
         super.init(sessionManager: sessionManager)
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockAppSettingsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAppSettingsStoresManager.swift
@@ -1,0 +1,37 @@
+import Yosemite
+@testable import WooCommerce
+
+/// Allows mocking for `AppSettingsStoresActions` related to known card readers.
+///
+final class MockAppSettingsStoresManager: DefaultStoresManager {
+
+    private var knownReaders: [String]
+
+    init(sessionManager: SessionManager) {
+        knownReaders = []
+        super.init(sessionManager: sessionManager)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let action = action as? AppSettingsAction {
+            onAppSettingsAction(action: action)
+        } else {
+            super.dispatch(action)
+        }
+    }
+
+    private func onAppSettingsAction(action: AppSettingsAction) {
+        switch action {
+        case .rememberCardReader(let cardReaderID, let onCompletion):
+            knownReaders.append(cardReaderID)
+            onCompletion(Result.success(()))
+        case .forgetCardReader(let cardReaderID, let onCompletion):
+            knownReaders = knownReaders.filter { $0 != cardReaderID }
+            onCompletion(Result.success(()))
+        case .loadCardReaders(let onCompletion):
+            onCompletion(Result.success(knownReaders))
+        default:
+            fatalError("Not available")
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
@@ -10,7 +10,29 @@ private struct TestConstants {
 
 final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
 
-    func test_remembering_a_reader_publishes() {
+    func test_subscribing_publishes_initial_value() {
+        let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
+
+        let expectation = self.expectation(description: #function)
+
+        var cancellable: AnyCancellable?
+        let readerList = CardReaderSettingsKnownReadersStoredList(stores: mockStoresManager)
+
+        var recordedObservations: [[String]] = []
+
+        cancellable = readerList.knownReaders.sink(receiveValue: { readers in
+            recordedObservations.append(readers)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        cancellable?.cancel()
+
+        XCTAssertEqual(recordedObservations, [[]])
+    }
+
+    func test_remembering_a_reader_publishes_change() {
         let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
 
         let expectation = self.expectation(description: #function)
@@ -21,7 +43,7 @@ final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
 
         var recordedObservations: [[String]] = []
 
-        cancellable = readerList.$knownReaders.sink(receiveValue: { readers in
+        cancellable = readerList.knownReaders.sink(receiveValue: { readers in
             recordedObservations.append(readers)
             expectation.fulfill()
         })
@@ -29,12 +51,13 @@ final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
         readerList.rememberCardReader(cardReaderID: TestConstants.mockReaderID)
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+
         cancellable?.cancel()
 
         XCTAssertEqual(recordedObservations, [[], [TestConstants.mockReaderID]])
     }
 
-    func test_forgetting_a_reader_publishes() {
+    func test_forgetting_a_reader_publishes_change() {
         let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
 
         let expectation = self.expectation(description: #function)
@@ -45,7 +68,7 @@ final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
 
         var recordedObservations: [[String]] = []
 
-        cancellable = readerList.$knownReaders.sink(receiveValue: { readers in
+        cancellable = readerList.knownReaders.sink(receiveValue: { readers in
             recordedObservations.append(readers)
             expectation.fulfill()
         })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
@@ -10,7 +10,7 @@ private struct TestConstants {
 
 final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
 
-    func test_subscribing_publishes_initial_value() {
+    func test_subscribing_publishes_initial_empty_value() {
         let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
 
         let expectation = self.expectation(description: #function)
@@ -30,6 +30,29 @@ final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
         cancellable?.cancel()
 
         XCTAssertEqual(recordedObservations, [[]])
+    }
+
+    func test_subscribing_publishes_initial_known_value() {
+        let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance, knownReaders: [TestConstants.mockReaderID])
+
+        let expectation = self.expectation(description: #function)
+        expectation.expectedFulfillmentCount = 1
+
+        var cancellable: AnyCancellable?
+        let readerList = CardReaderSettingsKnownReadersStoredList(stores: mockStoresManager)
+
+        var recordedObservations: [[String]] = []
+
+        cancellable = readerList.knownReaders.sink(receiveValue: { readers in
+            recordedObservations.append(readers)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        cancellable?.cancel()
+
+        XCTAssertEqual(recordedObservations, [[TestConstants.mockReaderID]])
     }
 
     func test_remembering_a_reader_publishes_change() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStoredListTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import Combine
+@testable import WooCommerce
+
+/// Mock constants
+///
+private struct TestConstants {
+    static let mockReaderID = "CHB204909005931"
+}
+
+final class CardReaderSettingsKnownReadersStoredListTests: XCTestCase {
+
+    func test_remembering_a_reader_publishes() {
+        let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
+
+        let expectation = self.expectation(description: #function)
+        expectation.expectedFulfillmentCount = 2
+
+        var cancellable: AnyCancellable?
+        let readerList = CardReaderSettingsKnownReadersStoredList(stores: mockStoresManager)
+
+        var recordedObservations: [[String]] = []
+
+        cancellable = readerList.$knownReaders.sink(receiveValue: { readers in
+            recordedObservations.append(readers)
+            expectation.fulfill()
+        })
+
+        readerList.rememberCardReader(cardReaderID: TestConstants.mockReaderID)
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        cancellable?.cancel()
+
+        XCTAssertEqual(recordedObservations, [[], [TestConstants.mockReaderID]])
+    }
+
+    func test_forgetting_a_reader_publishes() {
+        let mockStoresManager = MockAppSettingsStoresManager(sessionManager: SessionManager.testingInstance)
+
+        let expectation = self.expectation(description: #function)
+        expectation.expectedFulfillmentCount = 3
+
+        var cancellable: AnyCancellable?
+        let readerList = CardReaderSettingsKnownReadersStoredList(stores: mockStoresManager)
+
+        var recordedObservations: [[String]] = []
+
+        cancellable = readerList.$knownReaders.sink(receiveValue: { readers in
+            recordedObservations.append(readers)
+            expectation.fulfill()
+        })
+
+        readerList.rememberCardReader(cardReaderID: TestConstants.mockReaderID)
+        readerList.forgetCardReader(cardReaderID: TestConstants.mockReaderID)
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        cancellable?.cancel()
+
+        XCTAssertEqual(recordedObservations, [[], [TestConstants.mockReaderID], []])
+    }
+}


### PR DESCRIPTION
This is the next PR in a series of PRs for the "automatically reconnect to known card readers" feature

This PR defines a protocol for a known readers provider layer and an implementation that conforms to it, powered by the AppSettingsStore changes introduced in https://github.com/woocommerce/woocommerce-ios/pull/4499

Although there are no user facing changes there are unit test changes to cover the work.

Note that I combined both the protocol and the implementation in a single PR instead of two as originally planned

The sequence of planned PRs can be found here: https://github.com/woocommerce/woocommerce-ios/issues/3559#issuecomment-868872729

The next PR will pass this "known readers list" provider into the card reader settings view models (depending on the feature flag added in https://github.com/woocommerce/woocommerce-ios/pull/4498 )

To test:

Nothing user facing to test
Ensure linting passes
Ensure new unit tests pass

Related:

p91TBi-5t5-p2

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
