### PR TITLE
Fix missing tracking section on orders

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Fix: Orders for a variable product with different configurations of a single variation will now show each order item separately. [https://github.com/woocommerce/woocommerce-ios/pull/4445]
 - [*] If the Orders, Products, or Reviews lists can't load, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4400, https://github.com/woocommerce/woocommerce-ios/pull/4407]
 - [*] Fix: Stats tabs are now displayed and ordered correctly in RTL languages. [https://github.com/woocommerce/woocommerce-ios/pull/4444]
+- [*] Fix: Missing "Add Tracking" button in orders details. [https://github.com/woocommerce/woocommerce-ios/pull/4520]
 
 
 6.9

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -335,7 +335,7 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        syncTrackingsHidingAddButtonIfNecessary {
+        syncTrackingsEnablingAddButtonIfReachable {
             group.leave()
         }
 
@@ -404,7 +404,7 @@ private extension OrderDetailsViewController {
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 
-    func syncTrackingsHidingAddButtonIfNecessary(onCompletion: (() -> Void)? = nil) {
+    func syncTrackingsEnablingAddButtonIfReachable(onCompletion: (() -> Void)? = nil) {
         syncTracking { [weak self] error in
             if error == nil {
                 self?.viewModel.trackingIsReachable = true

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -107,16 +107,6 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
-
-    private func syncTrackingsHidingAddButtonIfNecessary() {
-        syncTracking { [weak self] error in
-            if error == nil {
-                self?.viewModel.trackingIsReachable = true
-            }
-
-            self?.reloadTableViewSectionsAndData()
-        }
-    }
 }
 
 
@@ -345,7 +335,7 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        syncTracking { _ in
+        syncTrackingsHidingAddButtonIfNecessary {
             group.leave()
         }
 
@@ -412,6 +402,17 @@ private extension OrderDetailsViewController {
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
+    }
+
+    func syncTrackingsHidingAddButtonIfNecessary(onCompletion: (() -> Void)? = nil) {
+        syncTracking { [weak self] error in
+            if error == nil {
+                self?.viewModel.trackingIsReachable = true
+            }
+
+            self?.reloadTableViewSectionsAndData()
+            onCompletion?()
+        }
     }
 
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/4519

## Description

Due to a change in 6.9 order sync refactor - tracking section was always disabled. This PR fixes it by bringing back `trackingIsReachable` var update in order data sync flow.

## Screenshots

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-07-01 at 11 55 58](https://user-images.githubusercontent.com/3132438/124097178-f9a6ae80-da63-11eb-989f-c1fb4d32ee4e.png)|![Simulator Screen Shot - iPhone 12 - 2021-07-01 at 11 57 19](https://user-images.githubusercontent.com/3132438/124097185-fca19f00-da63-11eb-83b0-d7957c519f08.png)

## Test

1. Make sure the WooCommerce Shipment Tracking extension is enabled.
2. Launch the app and go to Orders.
3. Select an order and ensure the Tracking section is displayed.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
