### PR TITLE
Issue/4519 hotfix missing tracking section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,10 @@
 -----
 
 
+6.9.1
+-----
+Fix: Missing "Add Tracking" button in orders details. [https://github.com/woocommerce/woocommerce-ios/pull/4522]
+
 6.9
 -----
 - [*] Order Detail: now we display a loader on top, to communicate that the order detail view has not yet been fully loaded. [https://github.com/woocommerce/woocommerce-ios/pull/4396]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -107,16 +107,6 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
-
-    private func syncTrackingsHidingAddButtonIfNecessary() {
-        syncTracking { [weak self] error in
-            if error == nil {
-                self?.viewModel.trackingIsReachable = true
-            }
-
-            self?.reloadTableViewSectionsAndData()
-        }
-    }
 }
 
 
@@ -345,7 +335,7 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        syncTracking { _ in
+        syncTrackingsHidingAddButtonIfNecessary {
             group.leave()
         }
 
@@ -418,6 +408,17 @@ private extension OrderDetailsViewController {
         }
 
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
+    }
+
+    func syncTrackingsHidingAddButtonIfNecessary(onCompletion: (() -> Void)? = nil) {
+        syncTracking { [weak self] error in
+            if error == nil {
+                self?.viewModel.trackingIsReachable = true
+            }
+
+            self?.reloadTableViewSectionsAndData()
+            onCompletion?()
+        }
     }
 
     func checkShippingLabelCreationEligibility(onCompletion: (() -> Void)? = nil) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -335,7 +335,7 @@ private extension OrderDetailsViewController {
         }
 
         group.enter()
-        syncTrackingsHidingAddButtonIfNecessary {
+        syncTrackingsEnablingAddButtonIfReachable {
             group.leave()
         }
 
@@ -410,7 +410,7 @@ private extension OrderDetailsViewController {
         viewModel.syncSavedReceipts(onCompletion: onCompletion)
     }
 
-    func syncTrackingsHidingAddButtonIfNecessary(onCompletion: (() -> Void)? = nil) {
+    func syncTrackingsEnablingAddButtonIfReachable(onCompletion: (() -> Void)? = nil) {
         syncTracking { [weak self] error in
             if error == nil {
                 self?.viewModel.trackingIsReachable = true


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/4519, duplicate of https://github.com/woocommerce/woocommerce-ios/pull/4520 (different target branch)

## Description

Due to a change in 6.9 order sync refactor - tracking section was always disabled. This PR fixes it by bringing back `trackingIsReachable` var update in order data sync flow.

## Screenshots

before | after
--|--
![Simulator Screen Shot - iPhone 12 - 2021-07-01 at 11 55 58](https://user-images.githubusercontent.com/3132438/124097178-f9a6ae80-da63-11eb-989f-c1fb4d32ee4e.png)|![Simulator Screen Shot - iPhone 12 - 2021-07-01 at 11 57 19](https://user-images.githubusercontent.com/3132438/124097185-fca19f00-da63-11eb-83b0-d7957c519f08.png)

## Test

1. Make sure the WooCommerce Shipment Tracking extension is enabled.
2. Launch the app and go to Orders.
3. Select an order and ensure the Tracking section is displayed.

---

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
