### PR TITLE
Shipping Labels: changing shipping addresses or package details now remove selected rate

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -385,8 +385,8 @@ private extension ShippingLabelFormViewController {
                                                                                selectedAdultSignatureRate) in
             self?.viewModel.handleCarrierAndRatesValueChanges(selectedRate: selectedRate,
                                                               selectedSignatureRate: selectedSignatureRate,
-                                                              selectedAdultSignatureRate: selectedAdultSignatureRate)
-
+                                                              selectedAdultSignatureRate: selectedAdultSignatureRate,
+                                                              editable: true)
         }
         let hostingVC = UIHostingController(rootView: carriersView)
         navigationController?.show(hostingVC, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -129,12 +129,20 @@ final class ShippingLabelFormViewModel {
         originAddress = address
         let dateState: ShippingLabelFormViewController.DataState = validated ? .validated : .pending
         updateRowState(type: .shipFrom, dataState: dateState, displayMode: .editable)
+
+        // We reset the carrier and rates selected because if the address change
+        // the carrier and rate change accordingly
+        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
     }
 
     func handleDestinationAddressValueChanges(address: ShippingLabelAddress?, validated: Bool) {
         destinationAddress = address
         let dateState: ShippingLabelFormViewController.DataState = validated ? .validated : .pending
         updateRowState(type: .shipTo, dataState: dateState, displayMode: .editable)
+
+        // We reset the carrier and rates selected because if the address change
+        // the carrier and rate change accordingly
+        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
     }
 
     func handlePackageDetailsValueChanges(selectedPackageID: String?, totalPackageWeight: String?) {
@@ -150,16 +158,17 @@ final class ShippingLabelFormViewModel {
 
     func handleCarrierAndRatesValueChanges(selectedRate: ShippingLabelCarrierRate?,
                                            selectedSignatureRate: ShippingLabelCarrierRate?,
-                                           selectedAdultSignatureRate: ShippingLabelCarrierRate?) {
+                                           selectedAdultSignatureRate: ShippingLabelCarrierRate?,
+                                           editable: Bool) {
         self.selectedRate = selectedRate
         self.selectedSignatureRate = selectedSignatureRate
         self.selectedAdultSignatureRate = selectedAdultSignatureRate
 
-        guard selectedRate != nil else {
-            updateRowState(type: .shippingCarrierAndRates, dataState: .pending, displayMode: .editable)
+        guard selectedRate != nil || selectedSignatureRate != nil || selectedAdultSignatureRate != nil else {
+            updateRowState(type: .shippingCarrierAndRates, dataState: .pending, displayMode: editable ? .editable : .disabled)
             return
         }
-        updateRowState(type: .shippingCarrierAndRates, dataState: .validated, displayMode: .editable)
+        updateRowState(type: .shippingCarrierAndRates, dataState: .validated, displayMode: editable ? .editable : .disabled)
     }
 
     func handlePaymentMethodValueChanges(settings: ShippingLabelAccountSettings, editable: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -154,6 +154,10 @@ final class ShippingLabelFormViewModel {
             return
         }
         updateRowState(type: .packageDetails, dataState: .validated, displayMode: .editable)
+
+        // We reset the carrier and rates selected because if the package change
+        // the carrier and rate change accordingly
+        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
     }
 
     func handleCarrierAndRatesValueChanges(selectedRate: ShippingLabelCarrierRate?,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -61,6 +61,38 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.originAddress, expectedShippingAddress)
     }
 
+    func test_handleOriginAddressValueChanges_reset_carrier_and_rates_selection() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil)
+        let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                           name: "Skylar Ferry",
+                                                           phone: "12345",
+                                                           country: "United States",
+                                                           state: "CA",
+                                                           address1: "60 29th",
+                                                           address2: "Street #343",
+                                                           city: "San Francisco",
+                                                           postcode: "94121-2303")
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
+                                                                     selectedSignatureRate: nil,
+                                                                     selectedAdultSignatureRate: nil,
+                                                                     editable: true)
+        XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
+
+        // When
+        shippingLabelFormViewModel.handleOriginAddressValueChanges(address: expectedShippingAddress, validated: true)
+
+        // Then
+        XCTAssertNil(shippingLabelFormViewModel.selectedRate)
+
+        let rows = shippingLabelFormViewModel.state.sections.first?.rows
+        let row = rows?.first { $0.type == .shippingCarrierAndRates }
+        XCTAssertEqual(row?.dataState, .pending)
+        XCTAssertEqual(row?.displayMode, .disabled)
+    }
+
     func test_handleDestinationAddressValueChanges_returns_updated_ShippingLabelAddress() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
@@ -82,6 +114,39 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.destinationAddress, expectedShippingAddress)
     }
+
+    func test_handleDestinationAddressValueChanges_reset_carrier_and_rates_selection() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil)
+        let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
+                                                           name: "Skylar Ferry",
+                                                           phone: "12345",
+                                                           country: "United States",
+                                                           state: "CA",
+                                                           address1: "60 29th",
+                                                           address2: "Street #343",
+                                                           city: "San Francisco",
+                                                           postcode: "94121-2303")
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
+                                                                     selectedSignatureRate: nil,
+                                                                     selectedAdultSignatureRate: nil,
+                                                                     editable: true)
+        XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
+
+        // When
+        shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: expectedShippingAddress, validated: true)
+
+        // Then
+        XCTAssertNil(shippingLabelFormViewModel.selectedRate)
+
+        let rows = shippingLabelFormViewModel.state.sections.first?.rows
+        let row = rows?.first { $0.type == .shippingCarrierAndRates }
+        XCTAssertEqual(row?.dataState, .pending)
+        XCTAssertEqual(row?.displayMode, .disabled)
+    }
+
 
     func test_handlePackageDetailsValueChanges_returns_updated_data() {
         // Given
@@ -111,7 +176,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
                                                                      selectedSignatureRate: MockShippingLabelCarrierRate.makeRate(title: "UPS"),
-                                                                     selectedAdultSignatureRate: nil)
+                                                                     selectedAdultSignatureRate: nil,
+                                                                     editable: true)
 
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.selectedRate, MockShippingLabelCarrierRate.makeRate())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -147,7 +147,6 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(row?.displayMode, .disabled)
     }
 
-
     func test_handlePackageDetailsValueChanges_returns_updated_data() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
@@ -162,6 +161,32 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackageID, expectedPackageID)
         XCTAssertEqual(shippingLabelFormViewModel.totalPackageWeight, expectedPackageWeight)
+    }
+
+    func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil)
+        let expectedPackageID = "my-package-id"
+        let expectedPackageWeight = "55"
+
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
+                                                                     selectedSignatureRate: nil,
+                                                                     selectedAdultSignatureRate: nil,
+                                                                     editable: true)
+        XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
+
+        // When
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+
+        // Then
+        XCTAssertNil(shippingLabelFormViewModel.selectedRate)
+
+        let rows = shippingLabelFormViewModel.state.sections.first?.rows
+        let row = rows?.first { $0.type == .shippingCarrierAndRates }
+        XCTAssertEqual(row?.dataState, .pending)
+        XCTAssertEqual(row?.displayMode, .editable)
     }
 
     func test_handleCarrierAndRatesValueChanges_returns_updated_data() {


### PR DESCRIPTION
Fixes #4513 

## Description
Previously, if you go through the full shipping label flow (without completing the purchase), and then make a change to the Ship from address, Ship to address, or Package Details, the rate you previously selected in the Shipping Carrier and Rates section remains selected.
Now, the selected rate will be invalidated/removed if you make changes to those previous sections. That way you have to select "Shipping Carrier and Rates" again and new rates can be offered based on the changes you made.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Fill out all sections of the Create Shipping Label form, until you see the Shipping Label Order Summary.
6. Select "Ship from", "Ship to", or "Package Details" and make a change. (For example, change the package weight.)
7. Notice that the selected rate in "Shipping Carrier and Rates" is removed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
