### PR TITLE
[Mobile Payments] Add Known Readers Provider to Settings VM Ordered List and pass into VMs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -90,7 +90,7 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
-        cell.serialNumberLabel?.text = viewModel?.connectedReaderSerialNumber
+        cell.nameLabel?.text = viewModel?.connectedReaderID
         cell.batteryLevelLabel?.text = viewModel?.connectedReaderBatteryLevel
         cell.selectionStyle = .none
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -11,7 +11,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var connectedReaders = [CardReader]()
     private var knownReadersProvider: CardReaderSettingsKnownReadersProvider?
 
-    var connectedReaderSerialNumber: String?
+    var connectedReaderID: String?
     var connectedReaderBatteryLevel: String?
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReadersProvider: CardReaderSettingsKnownReadersProvider? = nil) {
@@ -39,12 +39,12 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
 
     private func updateProperties() {
         guard connectedReaders.count > 0 else {
-            connectedReaderSerialNumber = nil
+            connectedReaderID = nil
             connectedReaderBatteryLevel = nil
             return
         }
 
-        connectedReaderSerialNumber = connectedReaders[0].serial
+        connectedReaderID = connectedReaders[0].id
 
         guard let batteryLevel = connectedReaders[0].batteryLevel else {
             connectedReaderBatteryLevel = Localization.unknownBatteryStatus
@@ -61,18 +61,15 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     func disconnectReader() {
         ServiceLocator.analytics.track(.cardReaderDisconnectTapped)
 
-        let readerSerialNumberToDisconnect = connectedReaderSerialNumber
-        let action = CardPresentPaymentAction.disconnect() { [readerSerialNumberToDisconnect, weak self] result in
+        if connectedReaderID != nil {
+            knownReadersProvider?.forgetCardReader(cardReaderID: connectedReaderID!)
+        }
+
+        let action = CardPresentPaymentAction.disconnect() { result in
             guard result.isSuccess else {
                 DDLogError("Unexpected error when disconnecting reader")
                 return
             }
-
-            guard let readerSerialNumberToDisconnect = readerSerialNumberToDisconnect else {
-                return
-            }
-
-            self?.knownReadersProvider?.forgetCardReader(cardReaderID: readerSerialNumberToDisconnect)
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -119,7 +119,7 @@ private extension CardReaderSettingsUnknownViewController {
             return
         }
 
-        guard let name = viewModel.foundReaderSerialNumber else {
+        guard let name = viewModel.foundReaderID else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -18,7 +18,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
 
     private var noConnectedReaders: CardReaderSettingsTriState = .isUnknown
     private var noKnownReaders: CardReaderSettingsTriState = .isUnknown
-
+    private var knownReadersProvider: CardReaderSettingsKnownReadersProvider?
     private var siteID: Int64 = Int64.min
 
     private var foundReader: CardReader?
@@ -32,9 +32,10 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         foundReader?.serial
     }
 
-    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?) {
+    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReadersProvider: CardReaderSettingsKnownReadersProvider? = nil) {
         self.didChangeShouldShow = didChangeShouldShow
         self.siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
+        self.knownReadersProvider = knownReadersProvider
         beginObservation()
     }
 
@@ -125,11 +126,10 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         discoveryState = .connectingToReader
 
         ServiceLocator.analytics.track(.cardReaderConnectionTapped)
-        let action = CardPresentPaymentAction.connect(reader: foundReader) { result in
-            /// Nothing to do here because, when the observed connectedReaders mutates, the
-            /// connected view will be shown automatically.
+        let action = CardPresentPaymentAction.connect(reader: foundReader) { [weak self] result in
             switch result {
             case .success(let reader):
+                self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.serial)
                 // If the reader does not have a battery, or the battery level is unknown, it will be nil
                 let properties = reader.batteryLevel
                     .map { ["battery_level": $0] }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -28,8 +28,8 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
             didUpdate?()
         }
     }
-    var foundReaderSerialNumber: String? {
-        foundReader?.serial
+    var foundReaderID: String? {
+        foundReader?.id
     }
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?, knownReadersProvider: CardReaderSettingsKnownReadersProvider? = nil) {
@@ -129,7 +129,7 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         let action = CardPresentPaymentAction.connect(reader: foundReader) { [weak self] result in
             switch result {
             case .success(let reader):
-                self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.serial)
+                self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.id)
                 // If the reader does not have a battery, or the battery level is unknown, it will be nil
                 let properties = reader.batteryLevel
                     .map { ["battery_level": $0] }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsViewModelsOrderedList.swift
@@ -15,7 +15,18 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
 
     var onPriorityChanged: ((CardReaderSettingsViewModelAndView?) -> ())?
 
+    private var knownReadersProvider: CardReaderSettingsKnownReadersProvider?
+
     init() {
+        /// Initialize dependencies for viewmodels first, then viewmodels
+        ///
+
+        /// Enable remembering readers by feature flag
+        ///
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentKnownReader) {
+            knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
+        }
+
         /// Instantiate and add each viewmodel related to card reader settings to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top
         /// of the array. The first viewmodel to return true for shouldShow is given
@@ -27,7 +38,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                 viewModel: CardReaderSettingsUnknownViewModel(
                     didChangeShouldShow: { [weak self] state in
                         self?.onDidChangeShouldShow(state)
-                    }
+                    },
+                    knownReadersProvider: knownReadersProvider
                 ),
                 viewIdentifier: "CardReaderSettingsUnknownViewController"
             )
@@ -37,7 +49,8 @@ final class CardReaderSettingsViewModelsOrderedList: CardReaderSettingsPrioritiz
                 viewModel: CardReaderSettingsConnectedViewModel(
                     didChangeShouldShow: { [weak self] state in
                         self?.onDidChangeShouldShow(state)
-                    }
+                    },
+                    knownReadersProvider: knownReadersProvider
                 ),
                 viewIdentifier: "CardReaderSettingsConnectedViewController"
             )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
 final class ConnectedReaderTableViewCell: UITableViewCell {
-    @IBOutlet weak var serialNumberLabel: UILabel!
+    @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var batteryLevelLabel: UILabel!
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTableViewCells/ConnectedReaderTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHB204999999999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URa-xk-ZnX">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHB204999999999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URa-xk-ZnX" userLabel="Name Label">
                         <rect key="frame" x="20" y="9" width="374" height="21"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="jdk-QY-NJg"/>
@@ -47,7 +46,7 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="batteryLevelLabel" destination="rws-DM-4n4" id="1o2-Jn-wjZ"/>
-                <outlet property="serialNumberLabel" destination="URa-xk-ZnX" id="I1s-v2-Qh2"/>
+                <outlet property="nameLabel" destination="URa-xk-ZnX" id="1KX-pN-ZaW"/>
             </connections>
             <point key="canvasLocation" x="24.637681159420293" y="115.51339285714285"/>
         </tableViewCell>


### PR DESCRIPTION
Work in progress. I'll rebase this against develop after #4517 is merged to develop

This is the next PR in a series of PRs for the "automatically reconnect to known card readers" feature

This PR takes the known readers provider implementation introduced in #4517 and adds it to CardReaderSettingsViewModelsOrderedList, which then passes it, if the feature flag is set, into the VMs that need it (both existing VMs do)

CardReaderSettingsUnknownViewModel uses the KnownReadersProvider to tell it to remember a reader that has been explicitly disconnected from.

And CardReaderSettingsConnectedViewModel uses the KnownReadersProvider to tell it to forget a reader that has been explicitly disconnected from.

The next PR will add a new VM that will manage automatically connecting to a known reader during discovery.

The sequence of planned PRs can be found here: #3559 (comment)

To test:

- Ensure linting passes
- Ensure unit tests pass
- Ensure that after connecting to a reader, that the general-app-settings.plist file on the device includes lines similar to the following:

```
        <key>knownCardReaders</key>
        <array>
                <string>CHB204839002034</string>
        </array>
```

- Ensure that after disconnecting from the reader, that the general-app-settings.plist file on the device knownCardReaders lines look more like this:

```
        <key>knownCardReaders</key>
        <array/>
```

- Modify CardReaderSettingsViewModelsOrderedList to NOT initialize knownReadersProvider (i.e. thereby seeing the behavior when the feature flag is NOT present) and ensure you can connect and disconnect from a card reader without any problems.

- To view the general-app-settings.plist file, use Xcode Devices and Simulators View for your device, tap on Woo and then the gear below it and select Download Container. Within the container, dig down into AppData/Documents and there you'll find it.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
