### PR TITLE
[Mobile Payments] Prevents crash when reconnecting to a reader

### DIFF
--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -7,6 +7,12 @@ extension String {
 
     /// Convert HTML to an attributed string
     ///
+    /// This method uses `NSAttributedString.init(data:options:documentAttributes:)` with a documentType value of html. Internally it uses WebKit so it should only be called from the main thread.
+    ///
+    /// Even then, the implementation seems to suspend the execution while WebKit is loading and might continue processing other events in the run loop.
+    ///
+    /// See [#4527](https://github.com/woocommerce/woocommerce-ios/pull/4527) for an example of the problems this can cause.
+    ///
     var htmlToAttributedString: NSAttributedString {
         guard let data = data(using: .utf8) else { return NSAttributedString() }
         do {

--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -7,7 +7,8 @@ extension String {
 
     /// Convert HTML to an attributed string
     ///
-    /// This method uses `NSAttributedString.init(data:options:documentAttributes:)` with a documentType value of html. Internally it uses WebKit so it should only be called from the main thread.
+    /// This method uses `NSAttributedString.init(data:options:documentAttributes:)` with a documentType value of html.
+    /// Internally it uses WebKit so it should only be called from the main thread.
     ///
     /// Even then, the implementation seems to suspend the execution while WebKit is loading and might continue processing other events in the run loop.
     ///

--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -14,6 +14,7 @@ extension String {
     /// See [#4527](https://github.com/woocommerce/woocommerce-ios/pull/4527) for an example of the problems this can cause.
     ///
     var htmlToAttributedString: NSAttributedString {
+        precondition(Thread.isMainThread, "htmlToAttributedString should only be called from the main thread")
         guard let data = data(using: .utf8) else { return NSAttributedString() }
         do {
             return try NSAttributedString(data: data,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -405,7 +405,7 @@ private extension CardReaderSettingsUnknownViewController {
             comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
         )
 
-        static var learnMore: NSAttributedString = {
+        static let learnMore: NSAttributedString = {
             let learnMoreText = NSLocalizedString(
                 "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
                 comment: "A label prompting users to learn more about card readers with an embedded hyperlink"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewController.swift
@@ -405,7 +405,7 @@ private extension CardReaderSettingsUnknownViewController {
             comment: "Settings > Manage Card Reader > Connect > A button to begin a search for a reader"
         )
 
-        static var learnMore: NSAttributedString {
+        static var learnMore: NSAttributedString = {
             let learnMoreText = NSLocalizedString(
                 "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
                 comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
@@ -422,6 +422,6 @@ private extension CardReaderSettingsUnknownViewController {
             learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
 
             return learnMoreAttrText
-        }
+        }()
     }
 }


### PR DESCRIPTION
Fixes #4521 

This was a hard one to track, and I don't understand all the moving pieces, but the essence of it is that, when we use `htmlToAttributedString` to create the attributed string for the "Learn more" footer, this will internally load webkit. While it's loading, the NSAttributedString internals will return control of the execution to the run loop, which might start running async blocks of code.

In this particular case, this can lead to situations where the table view is recreating its cells, and a callback to one of the StripeTerminal methods gets executed and attempts to update the UI. I didn't find the specific problem, but we would likely have several instances where there was a UI callback while the UI was in an inconsistent state.

This commit doesn't solve the issue perfectly, as it would still happen the first time the cell is rendered, but at least any subsequent calls will be cached. At least this fixes the crash, although we might want to reconsider this approach in the future, and maybe use something simpler like markdown for links in translations, or process them at build time.


## To test

1. Launch the app in landscape orientation on iPhone (I can't reproduce on iPad)
2. Go to Settings > Manage Card Readers
3. Tap on Connect Card Reader
4. Turn on your reader, and connect to it when prompted
5. Tap on Disconnect
6. Go back to the settings screen and enter Manage Card Readers again
7. Tap on Connect Card Reader and connect when prompted
8. The app shouldn't crash now

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
