### PR TITLE
Add Review Order screen (previously known as Fulfill Order)

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -17,6 +17,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentKnownReader:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .reviewOrder:
+            return false
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -37,4 +37,8 @@ enum FeatureFlag: Int {
     /// Automatically Reconnect to a Known Card Reader
     ///
     case cardPresentKnownReader
+
+    /// Show Review order screen upon marking order complete
+    ///
+    case reviewOrder
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -512,9 +512,15 @@ private extension OrderDetailsViewController {
     func markOrderCompleteWasPressed() {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
 
-        let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products)
-        let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
-        navigationController?.pushViewController(controller, animated: true)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.reviewOrder) {
+            let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products)
+            let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
+            navigationController?.pushViewController(controller, animated: true)
+        } else {
+            let fulfillmentProcess = viewModel.markCompleted()
+            let presenter = OrderFulfillmentNoticePresenter()
+            presenter.present(process: fulfillmentProcess)
+        }
     }
 
     func trackingWasPressed(at indexPath: IndexPath) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -513,7 +513,7 @@ private extension OrderDetailsViewController {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.reviewOrder) {
-            let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products)
+            let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
             let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
             navigationController?.pushViewController(controller, animated: true)
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -512,10 +512,9 @@ private extension OrderDetailsViewController {
     func markOrderCompleteWasPressed() {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
 
-        let fulfillmentProcess = viewModel.markCompleted()
-
-        let presenter = OrderFulfillmentNoticePresenter()
-        presenter.present(process: fulfillmentProcess)
+        let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order)
+        let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     func trackingWasPressed(at indexPath: IndexPath) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -512,7 +512,7 @@ private extension OrderDetailsViewController {
     func markOrderCompleteWasPressed() {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
 
-        let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order)
+        let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -5,7 +5,13 @@ import UIKit
 ///
 final class ReviewOrderViewController: UIViewController {
 
+    /// View model to provide order info for review
+    ///
     private let viewModel: ReviewOrderViewModel
+    
+    /// Table view to display order details
+    ///
+    @IBOutlet private var tableView: UITableView!
 
     init(viewModel: ReviewOrderViewModel) {
         self.viewModel = viewModel
@@ -20,6 +26,7 @@ final class ReviewOrderViewController: UIViewController {
         super.viewDidLoad()
 
         configureNavigation()
+        configureTableView()
     }
 
 }
@@ -30,4 +37,6 @@ private extension ReviewOrderViewController {
     func configureNavigation() {
         title = viewModel.screenTitle
     }
+
+    func configureTableView() {}
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -13,14 +13,6 @@ final class ReviewOrderViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
-    /// Shortcut to access Row enum of the view model
-    ///
-    private typealias Row = ReviewOrderViewModel.Row
-
-    /// Shortcut to access Section enum of the view model
-    ///
-    private typealias Section = ReviewOrderViewModel.Section
-
     init(viewModel: ReviewOrderViewModel) {
         self.viewModel = viewModel
         super.init(nibName: Self.nibName, bundle: nil)
@@ -51,12 +43,12 @@ private extension ReviewOrderViewController {
     /// Configs for table view
     ///
     func configureTableView() {
-        for headerType in Section.allCases.map({ $0.headerType }) {
+        for headerType in viewModel.allHeaderTypes {
             tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
         }
 
-        for rowType in Row.allRowTypes {
-            tableView.registerNib(for: rowType)
+        for cellType in viewModel.allCellTypes {
+            tableView.registerNib(for: cellType)
         }
 
         view.backgroundColor = .listBackground

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -1,7 +1,21 @@
 import UIKit
 
+/// View Control for Review Order screen
+/// This screen is shown when Mark Order Complete button is tapped
+///
 final class ReviewOrderViewController: UIViewController {
-
+    
+    private let viewModel: ReviewOrderViewModel
+    
+    init(viewModel: ReviewOrderViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: Self.nibName, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -4,18 +4,18 @@ import UIKit
 /// This screen is shown when Mark Order Complete button is tapped
 ///
 final class ReviewOrderViewController: UIViewController {
-    
+
     private let viewModel: ReviewOrderViewModel
-    
+
     init(viewModel: ReviewOrderViewModel) {
         self.viewModel = viewModel
         super.init(nibName: Self.nibName, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -62,6 +62,7 @@ private extension ReviewOrderViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.dataSource = self
+        tableView.delegate = self
     }
 }
 
@@ -81,6 +82,56 @@ extension ReviewOrderViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: row.cellType.reuseIdentifier, for: indexPath)
         setup(cell: cell, for: row, at: indexPath)
         return cell
+    }
+}
+
+// MARK: - UITableViewDelegate conformance
+//
+extension ReviewOrderViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return CGFloat.leastNormalMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let section = viewModel.sections[safe: section] else {
+            return nil
+        }
+
+        let reuseIdentifier = section.headerType.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) else {
+            assertionFailure("Could not find section header view for reuseIdentifier \(reuseIdentifier)")
+            return nil
+        }
+
+        switch headerView {
+        case let headerView as PrimarySectionHeaderView:
+            switch section.category {
+            case .products:
+                headerView.configure(title: viewModel.productionSectionTitle)
+            case .customerInformation, .tracking:
+                assertionFailure("Unexpected category of type \(headerView.self)")
+            }
+        case let headerView as TwoColumnSectionHeaderView:
+            switch section.category {
+            case .customerInformation:
+                headerView.leftText = viewModel.customerSectionTitle
+                headerView.rightText = nil
+            case .tracking:
+                headerView.leftText = viewModel.trackingSectionTitle
+                headerView.rightText = nil
+            case .products:
+                assertionFailure("Unexpected category of type \(headerView.self)")
+            }
+        default:
+            assertionFailure("Unexpected headerView type \(headerView.self)")
+            return nil
+        }
+
+        return headerView
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -19,7 +19,15 @@ final class ReviewOrderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        configureNavigation()
     }
 
+}
+
+// MARK: - UI Configuration
+//
+private extension ReviewOrderViewController {
+    func configureNavigation() {
+        title = viewModel.screenTitle
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -185,8 +185,6 @@ private extension ReviewOrderViewController {
     /// Some magic numbers for table view UI 🪄
     ///
     enum Constants {
-        static let headerDefaultHeight = CGFloat(130)
-        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -8,7 +8,7 @@ final class ReviewOrderViewController: UIViewController {
     /// View model to provide order info for review
     ///
     private let viewModel: ReviewOrderViewModel
-    
+
     /// Table view to display order details
     ///
     @IBOutlet private var tableView: UITableView!
@@ -38,5 +38,28 @@ private extension ReviewOrderViewController {
         title = viewModel.screenTitle
     }
 
-    func configureTableView() {}
+    func configureTableView() {
+        for section in Section.allCases {
+            tableView.register(section.headerType.loadNib(), forHeaderFooterViewReuseIdentifier: section.headerType.reuseIdentifier)
+        }
+    }
+}
+
+// MARK: - Sections for the order review
+//
+private extension ReviewOrderViewController {
+    enum Section: CaseIterable {
+        case products
+        case customerInformation
+        case tracking
+
+        var headerType: UITableViewHeaderFooterView.Type {
+            switch self {
+            case .products:
+                return PrimarySectionHeaderView.self
+            case .customerInformation, .tracking:
+                return TwoColumnSectionHeaderView.self
+            }
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -13,6 +13,14 @@ final class ReviewOrderViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
+    /// Shortcut to access Row enum of the view model
+    ///
+    private typealias Row = ReviewOrderViewModel.Row
+
+    /// Shortcut to access Section enum of the view model
+    ///
+    private typealias Section = ReviewOrderViewModel.Section
+
     init(viewModel: ReviewOrderViewModel) {
         self.viewModel = viewModel
         super.init(nibName: Self.nibName, bundle: nil)
@@ -47,7 +55,7 @@ private extension ReviewOrderViewController {
             tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
         }
 
-        for rowType in Row.allCases.map({ $0.rowType }) {
+        for rowType in Row.allRowTypes {
             tableView.registerNib(for: rowType)
         }
 
@@ -62,54 +70,6 @@ private extension ReviewOrderViewController {
 // MARK: - Sections and Rows for the order review
 //
 private extension ReviewOrderViewController {
-    /// Section types for Review Order screen
-    ///
-    enum Section: CaseIterable {
-        case products
-        case customerInformation
-        case tracking
-
-        var headerType: UITableViewHeaderFooterView.Type {
-            switch self {
-            case .products:
-                return PrimarySectionHeaderView.self
-            case .customerInformation, .tracking:
-                return TwoColumnSectionHeaderView.self
-            }
-        }
-    }
-
-    /// Row types for Review Order screen
-    ///
-    enum Row: CaseIterable {
-        case orderItem
-        case customerNote
-        case shippingAddress
-        case shippingMethod
-        case billingDetail
-        case tracking
-        case trackingAdd
-
-        var rowType: UITableViewCell.Type {
-            switch self {
-            case .orderItem:
-                return ProductDetailsTableViewCell.self
-            case .customerNote:
-                return CustomerNoteTableViewCell.self
-            case .shippingAddress:
-                return CustomerInfoTableViewCell.self
-            case .shippingMethod:
-                return CustomerNoteTableViewCell.self
-            case .billingDetail:
-                return WooBasicTableViewCell.self
-            case .tracking:
-                return OrderTrackingTableViewCell.self
-            case .trackingAdd:
-                return LeftImageTableViewCell.self
-            }
-        }
-    }
-
     /// Some magic numbers for table view UI 🪄
     ///
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 /// View Control for Review Order screen
 /// This screen is shown when Mark Order Complete button is tapped
@@ -8,6 +9,10 @@ final class ReviewOrderViewController: UIViewController {
     /// View model to provide order info for review
     ///
     private let viewModel: ReviewOrderViewModel
+
+    /// Image service needed for order item cells
+    ///
+    private let imageService: ImageService = ServiceLocator.imageService
 
     /// Table view to display order details
     ///
@@ -56,6 +61,70 @@ private extension ReviewOrderViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.dataSource = self
+    }
+}
+
+// MARK: - UITableViewDatasource conformance
+//
+extension ReviewOrderViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = viewModel.sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.cellType.reuseIdentifier, for: indexPath)
+        setup(cell: cell, for: row, at: indexPath)
+        return cell
+    }
+}
+
+// MARK: - Setup cells for the table view
+//
+private extension ReviewOrderViewController {
+    /// Setup a given UITableViewCell instance to actually display the specified Row's Payload.
+    ///
+    func setup(cell: UITableViewCell, for row: ReviewOrderViewModel.Row, at indexPath: IndexPath) {
+        switch row {
+        case .orderItem(let item):
+            setupOrderItemCell(cell, with: item)
+        default:
+            // TODO: setup
+            break
+        }
+    }
+
+    /// Setup: Order item Cell
+    ///
+    private func setupOrderItemCell(_ cell: UITableViewCell, with item: OrderItem) {
+        guard let cell = cell as? ProductDetailsTableViewCell else {
+            fatalError()
+        }
+
+        let itemViewModel = viewModel.cellViewModel(for: item)
+        cell.configure(item: itemViewModel, imageService: imageService)
+        cell.onViewAddOnsTouchUp = { [weak self] in
+            guard let self = self else { return }
+            self.itemAddOnsButtonTapped(addOns: self.viewModel.filterAddons(for: item))
+        }
+    }
+}
+
+// MARK: - Actions
+//
+private extension ReviewOrderViewController {
+    /// Show addon list screen
+    ///
+    func itemAddOnsButtonTapped(addOns: [OrderItemAttribute]) {
+        let addOnsViewModel = OrderAddOnListI1ViewModel(attributes: addOns)
+        let addOnsController = OrderAddOnsListViewController(viewModel: addOnsViewModel)
+        let navigationController = WooNavigationController(rootViewController: addOnsController)
+        present(navigationController, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class ReviewOrderViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -34,20 +34,36 @@ final class ReviewOrderViewController: UIViewController {
 // MARK: - UI Configuration
 //
 private extension ReviewOrderViewController {
+    /// Configs for navigation bar
+    ///
     func configureNavigation() {
         title = viewModel.screenTitle
     }
 
+    /// Configs for table view
+    ///
     func configureTableView() {
-        for section in Section.allCases {
-            tableView.register(section.headerType.loadNib(), forHeaderFooterViewReuseIdentifier: section.headerType.reuseIdentifier)
+        for headerType in Section.allCases.map({ $0.headerType }) {
+            tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
         }
+
+        for rowType in Row.allCases.map({ $0.rowType }) {
+            tableView.registerNib(for: rowType)
+        }
+
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+        tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
     }
 }
 
-// MARK: - Sections for the order review
+// MARK: - Sections and Rows for the order review
 //
 private extension ReviewOrderViewController {
+    /// Section types for Review Order screen
+    ///
     enum Section: CaseIterable {
         case products
         case customerInformation
@@ -61,5 +77,45 @@ private extension ReviewOrderViewController {
                 return TwoColumnSectionHeaderView.self
             }
         }
+    }
+
+    /// Row types for Review Order screen
+    ///
+    enum Row: CaseIterable {
+        case orderItem
+        case customerNote
+        case shippingAddress
+        case shippingMethod
+        case billingDetail
+        case tracking
+        case trackingAdd
+
+        var rowType: UITableViewCell.Type {
+            switch self {
+            case .orderItem:
+                return ProductDetailsTableViewCell.self
+            case .customerNote:
+                return CustomerNoteTableViewCell.self
+            case .shippingAddress:
+                return CustomerInfoTableViewCell.self
+            case .shippingMethod:
+                return CustomerNoteTableViewCell.self
+            case .billingDetail:
+                return WooBasicTableViewCell.self
+            case .tracking:
+                return OrderTrackingTableViewCell.self
+            case .trackingAdd:
+                return LeftImageTableViewCell.self
+            }
+        }
+    }
+
+    /// Some magic numbers for table view UI 🪄
+    ///
+    enum Constants {
+        static let headerDefaultHeight = CGFloat(130)
+        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+        static let rowHeight = CGFloat(38)
+        static let sectionHeight = CGFloat(44)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReviewOrderViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
@@ -1,22 +1,43 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReviewOrderViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReviewOrderViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="gOf-hh-Od4" id="NI9-6s-VGQ"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gOf-hh-Od4">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </tableView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="gOf-hh-Od4" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ICl-mR-8Cf"/>
+                <constraint firstItem="gOf-hh-Od4" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="Riu-Mt-hYn"/>
+                <constraint firstItem="gOf-hh-Od4" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="kqK-J5-A4q"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="gOf-hh-Od4" secondAttribute="bottom" id="yGb-qH-3N0"/>
+            </constraints>
+            <point key="canvasLocation" x="40.579710144927539" y="65.625"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -40,11 +40,11 @@ final class ReviewOrderViewModel {
     /// Indicates if the product cell will be configured with add on information or not.
     /// Property provided while "view add-ons" feature is in development.
     ///
-    var showAddOns = false
+    private let showAddOns: Bool
 
     /// Site's add-on groups.
     ///
-    var addOnGroups: [AddOnGroup] {
+    private var addOnGroups: [AddOnGroup] {
         return addOnGroupResultsController.fetchedObjects
     }
 
@@ -57,10 +57,12 @@ final class ReviewOrderViewModel {
 
     init(order: Order,
          products: [Product],
+         showAddOns: Bool,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.order = order
         self.products = products
+        self.showAddOns = showAddOns
         self.stores = stores
         self.storageManager = storageManager
     }
@@ -103,7 +105,7 @@ extension ReviewOrderViewModel {
     /// Filter product for an order item
     ///
     func filterProduct(for item: OrderItem) -> Product? {
-        products.filter({ $0.productID == item.productOrVariationID }).first
+        products.first(where: { $0.productID == item.productID })
     }
 
     /// Filter addons for an order item
@@ -119,7 +121,7 @@ extension ReviewOrderViewModel {
     /// Cell model for an order item
     ///
     func cellViewModel(for item: OrderItem) -> ProductDetailsCellViewModel {
-        let product = products.filter({ $0.productID == item.productOrVariationID }).first
+        let product = filterProduct(for: item)
         let addOns = filterAddons(for: item)
         return ProductDetailsCellViewModel(item: item, currency: order.currency, product: product, hasAddOns: !addOns.isEmpty)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -6,7 +6,7 @@ final class ReviewOrderViewModel {
     /// Quick access to header types for table view registration
     ///
     let allHeaderTypes: [UITableViewHeaderFooterView.Type] = {
-        Section.SectionType.allCases.map { $0.headerType }
+        Section.Category.allCases.map { $0.headerType }
     }()
 
     /// Quick access cell types for table view registration
@@ -88,7 +88,7 @@ private extension ReviewOrderViewModel {
     ///
     var productSection: Section {
         let rows = order.items.map { Row.orderItem(item: $0) }
-        return .init(type: .products, rows: rows)
+        return .init(category: .products, rows: rows)
     }
 
     /// Customer section setup
@@ -121,7 +121,7 @@ private extension ReviewOrderViewModel {
         // TODO: billing row?
 
         let rows = [noteRow, shippingMethodRow, addressRow].compactMap { $0 }
-        return .init(type: .customerInformation, rows: rows)
+        return .init(category: .customerInformation, rows: rows)
     }
 
     /// Tracking section setup
@@ -141,7 +141,7 @@ private extension ReviewOrderViewModel {
         }()
 
         let rows = [trackingRow, trackingAddRow].compactMap { $0 }
-        return .init(type: .tracking, rows: rows)
+        return .init(category: .tracking, rows: rows)
     }
 }
 
@@ -151,7 +151,7 @@ extension ReviewOrderViewModel {
     struct Section {
         /// Section types for Review Order screen
         ///
-        enum SectionType: CaseIterable {
+        enum Category: CaseIterable {
             case products
             case customerInformation
             case tracking
@@ -166,11 +166,11 @@ extension ReviewOrderViewModel {
             }
         }
 
-        let type: SectionType
+        let category: Category
         let rows: [Row]
 
-        init(type: SectionType, rows: [Row]) {
-            self.type = type
+        init(category: Category, rows: [Row]) {
+            self.category = category
             self.rows = rows
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -160,9 +160,16 @@ extension ReviewOrderViewModel {
             case tracking
         }
 
+        /// Category of the section
+        ///
         let category: Category
+
+        /// Rows in the section
+        ///
         let rows: [Row]
 
+        /// UITableViewHeaderFooterView type for each section
+        ///
         var headerType: UITableViewHeaderFooterView.Type {
             switch category {
             case .products:
@@ -189,6 +196,8 @@ extension ReviewOrderViewModel {
         case tracking
         case trackingAdd
 
+        /// UITableViewCell type for each row type
+        ///
         var cellType: UITableViewCell.Type {
             switch self {
             case .orderItem:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -58,6 +58,67 @@ extension ReviewOrderViewModel {
     }
 }
 
+// MARK: - Section and row types for Review Order table view
+//
+extension ReviewOrderViewModel {
+    /// Section types for Review Order screen
+    ///
+    enum Section: CaseIterable {
+        case products
+        case customerInformation
+        case tracking
+
+        var headerType: UITableViewHeaderFooterView.Type {
+            switch self {
+            case .products:
+                return PrimarySectionHeaderView.self
+            case .customerInformation, .tracking:
+                return TwoColumnSectionHeaderView.self
+            }
+        }
+    }
+
+    /// Row types for Review Order screen
+    ///
+    enum Row {
+        case orderItem(item: OrderItem)
+        case customerNote(text: String)
+        case shippingAddress(address: Address)
+        case shippingMethod
+        case billingDetail
+        case tracking
+        case trackingAdd
+
+        var rowType: UITableViewCell.Type {
+            switch self {
+            case .orderItem:
+                return ProductDetailsTableViewCell.self
+            case .customerNote:
+                return CustomerNoteTableViewCell.self
+            case .shippingAddress:
+                return CustomerInfoTableViewCell.self
+            case .shippingMethod:
+                return CustomerNoteTableViewCell.self
+            case .billingDetail:
+                return WooBasicTableViewCell.self
+            case .tracking:
+                return OrderTrackingTableViewCell.self
+            case .trackingAdd:
+                return LeftImageTableViewCell.self
+            }
+        }
+
+        static let allRowTypes: [UITableViewCell.Type] = {
+            [ProductDetailsTableViewCell.self,
+             CustomerNoteTableViewCell.self,
+             CustomerInfoTableViewCell.self,
+             WooBasicTableViewCell.self,
+             OrderTrackingTableViewCell.self,
+             LeftImageTableViewCell.self]
+        }()
+    }
+}
+
 // MARK: - Localization
 //
 private extension ReviewOrderViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -6,15 +6,15 @@ final class ReviewOrderViewModel {
     /// The order for review
     ///
     private let order: Order
-    
+
     /// StorageManager to load details of order from storage
     ///
     private let storageManager: StorageManagerType
-    
+
     /// Reference to the StoresManager to dispatch Yosemite Actions.
     ///
     private let stores: StoresManager
-    
+
     init(order: Order,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -23,3 +23,19 @@ final class ReviewOrderViewModel {
         self.storageManager = storageManager
     }
 }
+
+// MARK: - Data source for review order controller
+//
+extension ReviewOrderViewModel {
+    var screenTitle: String {
+        Localization.screenTitle
+    }
+}
+
+// MARK: - Localization
+//
+private extension ReviewOrderViewModel {
+    enum Localization {
+        static let screenTitle = NSLocalizedString("Review Order", comment: "Title of Review Order screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+final class ReviewOrderViewModel {
+    /// The order for review
+    ///
+    private let order: Order
+    
+    /// StorageManager to load details of order from storage
+    ///
+    private let storageManager: StorageManagerType
+    
+    /// Reference to the StoresManager to dispatch Yosemite Actions.
+    ///
+    private let stores: StoresManager
+    
+    init(order: Order,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.order = order
+        self.stores = stores
+        self.storageManager = storageManager
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -6,7 +6,8 @@ final class ReviewOrderViewModel {
     /// Quick access to header types for table view registration
     ///
     let allHeaderTypes: [UITableViewHeaderFooterView.Type] = {
-        Section.Category.allCases.map { $0.headerType }
+        [PrimarySectionHeaderView.self,
+         TwoColumnSectionHeaderView.self]
     }()
 
     /// Quick access cell types for table view registration
@@ -207,19 +208,19 @@ extension ReviewOrderViewModel {
             case products
             case customerInformation
             case tracking
-
-            var headerType: UITableViewHeaderFooterView.Type {
-                switch self {
-                case .products:
-                    return PrimarySectionHeaderView.self
-                case .customerInformation, .tracking:
-                    return TwoColumnSectionHeaderView.self
-                }
-            }
         }
 
         let category: Category
         let rows: [Row]
+
+        var headerType: UITableViewHeaderFooterView.Type {
+            switch category {
+            case .products:
+                return PrimarySectionHeaderView.self
+            case .customerInformation, .tracking:
+                return TwoColumnSectionHeaderView.self
+            }
+        }
 
         init(category: Category, rows: [Row]) {
             self.category = category

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -96,7 +96,8 @@ extension ReviewOrderViewModel {
     /// Sections for order table view
     ///
     var sections: [Section] {
-        return [productSection, customerSection, trackingSection].filter { !$0.rows.isEmpty }
+        // TODO: add other sections: Customer Info and Tracking
+        return [productSection].filter { !$0.rows.isEmpty }
     }
 
     /// Filter product for an order item
@@ -142,59 +143,6 @@ private extension ReviewOrderViewModel {
     var productSection: Section {
         let rows = order.items.map { Row.orderItem(item: $0) }
         return .init(category: .products, rows: rows)
-    }
-
-    /// Customer section setup
-    ///
-    var customerSection: Section {
-        let noteRow: Row? = {
-            guard let note = order.customerNote, !note.isEmpty else {
-                return nil
-            }
-            return Row.customerNote(text: note)
-        }()
-
-        let shippingMethodRow: Row? = {
-            guard order.shippingLines.count > 0 else { return nil }
-            return Row.shippingMethod(method: shippingMethod)
-        }()
-
-        let addressRow: Row? = {
-            let orderContainsOnlyVirtualProducts = products
-                .filter { (product) -> Bool in
-                    order.items.first(where: { $0.productID == product.productID}) != nil
-                }
-                .allSatisfy { $0.virtual == true }
-            guard let shippingAddress = order.shippingAddress, !orderContainsOnlyVirtualProducts else {
-                return nil
-            }
-            return Row.shippingAddress(address: shippingAddress)
-        }()
-
-        // TODO: billing row?
-
-        let rows = [noteRow, shippingMethodRow, addressRow].compactMap { $0 }
-        return .init(category: .customerInformation, rows: rows)
-    }
-
-    /// Tracking section setup
-    ///
-    var trackingSection: Section {
-        // TODO: add order tracking & trackingIsReachable
-        let trackingRow: Row? = {
-//                guard !orderTracking.isEmpty else { return nil }
-            return nil
-        }()
-
-        let trackingAddRow: Row? = {
-            // Hide the section if the shipment
-            // tracking plugin is not installed
-//                guard trackingIsReachable else { return nil }
-            return Row.trackingAdd
-        }()
-
-        let rows = [trackingRow, trackingAddRow].compactMap { $0 }
-        return .init(category: .tracking, rows: rows)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -27,8 +27,29 @@ final class ReviewOrderViewModel {
 // MARK: - Data source for review order controller
 //
 extension ReviewOrderViewModel {
+    /// Title for Review Order screen
+    ///
     var screenTitle: String {
         Localization.screenTitle
+    }
+
+    /// Title for Product section
+    ///
+    var productionSectionTitle: String {
+        // TODO: pluralize this! 👀
+        Localization.productsSectionTitle
+    }
+
+    /// Title for Customer section
+    ///
+    var customerSectionTitle: String {
+        return Localization.customerSectionTitle
+    }
+
+    /// Title for Tracking section
+    ///
+    var trackingSectionTitle: String {
+        return Localization.trackingSectionTitle
     }
 }
 
@@ -37,5 +58,10 @@ extension ReviewOrderViewModel {
 private extension ReviewOrderViewModel {
     enum Localization {
         static let screenTitle = NSLocalizedString("Review Order", comment: "Title of Review Order screen")
+        static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
+        static let productsSectionTitle = NSLocalizedString("Products",
+                                                            comment: "Product section title in Review Order screen if there is more than one product.")
+        static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
+        static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -7,6 +7,10 @@ final class ReviewOrderViewModel {
     ///
     private let order: Order
 
+    /// Products in the order
+    ///
+    private let products: [Product]
+
     /// StorageManager to load details of order from storage
     ///
     private let storageManager: StorageManagerType
@@ -16,9 +20,11 @@ final class ReviewOrderViewModel {
     private let stores: StoresManager
 
     init(order: Order,
+         products: [Product],
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.order = order
+        self.products = products
         self.stores = stores
         self.storageManager = storageManager
     }
@@ -36,8 +42,7 @@ extension ReviewOrderViewModel {
     /// Title for Product section
     ///
     var productionSectionTitle: String {
-        // TODO: pluralize this! 👀
-        Localization.productsSectionTitle
+        order.items.count > 0 ? Localization.productsSectionTitle : Localization.productSectionTitle
     }
 
     /// Title for Customer section

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1203,6 +1203,7 @@
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
+		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2509,6 +2510,7 @@
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
+		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5864,6 +5866,7 @@
 			children = (
 				DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */,
 				DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */,
+				DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */,
 			);
 			path = "Review Order";
 			sourceTree = "<group>";
@@ -6672,6 +6675,7 @@
 				02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */,
 				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
 				0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */,
+				DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */,
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,
 				CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */,
 				0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1201,6 +1201,8 @@
 		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
+		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
+		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2505,6 +2507,8 @@
 		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
+		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
+		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5379,6 +5383,7 @@
 			children = (
 				CEE006072077D14C0079161F /* OrderDetailsViewController.swift */,
 				B53B3F36219C75AC00DF1EB6 /* OrderLoaderViewController.swift */,
+				DE1B030A268DCFF200804330 /* Review Order */,
 				26578C3F26277AA700A15097 /* AddOns */,
 				CE35F10F2343E694007B2A6B /* Order Summary Section */,
 				CE35F1112343E6C1007B2A6B /* Product List Section */,
@@ -5854,6 +5859,15 @@
 			path = "Stripe Integration Tests";
 			sourceTree = "<group>";
 		};
+		DE1B030A268DCFF200804330 /* Review Order */ = {
+			isa = PBXGroup;
+			children = (
+				DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */,
+				DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */,
+			);
+			path = "Review Order";
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -6207,6 +6221,7 @@
 				02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */,
 				D8EE9693264D328A0033B2F9 /* ReceiptViewController.xib in Resources */,
 				B56DB3D42049BFAA00D4AA8E /* Assets.xcassets in Resources */,
+				DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */,
 				45FDDD66267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib in Resources */,
 				E1D4E84526776AD900256B83 /* HeadlineTableViewCell.xib in Resources */,
 				CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */,
@@ -6830,6 +6845,7 @@
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
 				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,
+				DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */,
 				0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */,


### PR DESCRIPTION
Part of #4136 

# Description
This PR aims to add new Review Order screen that should appears after selecting "Mark Order Complete" button on Order Detail screen. The objective is to let user take a final look at the order details and decide if they're ready to notify users that order is fulfilled.

# Solution
- The old Fulfill Order screen was removed in March, so this task is to bring the similar screen back. Since the product list is a bit different and the old approach was plain MVC, I chose to rewrite the feature with MVVM for better testability and readability.
- To keep the PR small, this PR only includes the setup of new Review Order screen and product section. To avoid blocking other teammate, I'm putting the changes behind a feature flag named `reviewOrder`. This flag will be removed and the release notes will be updated when the feature is complete.

# Screenshot

# Testing


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
