### PR TITLE
Fixed the package weight in Shipping Label Creation form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -43,12 +43,14 @@ final class ShippingLabelFormViewModel {
             return nil
         }
 
+        let weight = Double(truncating: (Decimal(string: totalPackageWeight ?? "0") as  NSNumber?) ?? 0)
+
         if let customPackage = packagesResponse.customPackages.first(where: { $0.title == selectedPackageID }) {
             return ShippingLabelPackageSelected(boxID: customPackage.title,
                                                 length: customPackage.getLength(),
                                                 width: customPackage.getWidth(),
                                                 height: customPackage.getHeight(),
-                                                weight: customPackage.getWidth(),
+                                                weight: weight,
                                                 isLetter: customPackage.isLetter)
         }
 
@@ -58,7 +60,7 @@ final class ShippingLabelFormViewModel {
                                                     length: predefinedPackage.getLength(),
                                                     width: predefinedPackage.getWidth(),
                                                     height: predefinedPackage.getHeight(),
-                                                    weight: predefinedPackage.getWidth(),
+                                                    weight: weight,
                                                     isLetter: predefinedPackage.isLetter)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -43,7 +43,7 @@ final class ShippingLabelFormViewModel {
             return nil
         }
 
-        let weight = Double(truncating: (Decimal(string: totalPackageWeight ?? "0") as  NSNumber?) ?? 0)
+        let weight = Double(totalPackageWeight ?? "0") ?? .zero
 
         if let customPackage = packagesResponse.customPackages.first(where: { $0.title == selectedPackageID }) {
             return ShippingLabelPackageSelected(boxID: customPackage.title,


### PR DESCRIPTION
Fixes #4514 

## Description
@rachelmcr noticed that the rates we're offering in the iOS app don't match the same rates we offer in the Android app or web client.
The reason was that we were sending the wrong weight for the selected package to the endpoint for getting the carriers and rates. Instead of using the package weight that's entered in "Package Details," we're setting the weight as the package width.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Fill out all sections of the Create Shipping Label form, until you get to "Shipping Carrier and Rates".
6. Open "Shipping Carrier and Rates" and notice what rates you are offered there. (You can follow the same steps in the Android app or web client and notice that different rates are offered there.)
7. Go back to the "Package Details" section and change the package weight. Check the "Shipping Carrier and Rates" section again and notice that the rates have changed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
