### PR TITLE
Show appropriate message when saving a product.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -177,6 +177,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     func isShippingEnabled() -> Bool {
         product.downloadable == false && product.virtual == false
     }
+
+    var existsRemotely: Bool {
+        product.existsRemotely
+    }
 }
 
 extension EditableProductModel: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -204,6 +204,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     func isShippingEnabled() -> Bool {
         productVariation.downloadable == false && productVariation.virtual == false
     }
+
+    var existsRemotely: Bool {
+        true // Variations are always created remotely
+    }
 }
 
 extension EditableProductVariationModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -67,6 +67,9 @@ protocol ProductFormDataModel {
     var crossSellIDs: [Int64] { get }
 
     var hasAddOns: Bool { get }
+
+    /// True if a product has been saved remotely.
+    var existsRemotely: Bool { get }
 }
 
 // MARK: Helpers that can be derived from `ProductFormDataModel`

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -74,11 +74,14 @@ extension ProductFormViewController {
 
     // MARK: - Progress
 
-    /// Progress view for save action
+    /// Progress view for save action.
+    /// Shows "Publish" when the product does not exists remotely and it's gonna be published for the first time.
+    /// Shows "Publish" when the product is going to be published from a different status (eg: draft).
+    /// Shows "Save" for all other cases
     ///
-    func showSavingProgress(for productStatus: ProductStatus) {
-        switch productStatus {
-        case .publish:
+    func showSavingProgress(previousStatus: ProductStatus, newStatus: ProductStatus, existsRemotely: Bool) {
+        switch newStatus {
+        case .publish where !existsRemotely || previousStatus != .publish:
             displayInProgressView(title: Localization.ProgressView.productPublishingTitle, message: Localization.ProgressView.productPublishingMessage)
         default:
             displayInProgressView(title: Localization.ProgressView.productSavingTitle, message: Localization.ProgressView.productSavingMessage)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -75,15 +75,11 @@ extension ProductFormViewController {
     // MARK: - Progress
 
     /// Progress view for save action.
-    /// Shows "Publish" when the product does not exists remotely and it's gonna be published for the first time.
-    /// Shows "Publish" when the product is going to be published from a different status (eg: draft).
-    /// Shows "Save" for all other cases
-    ///
-    func showSavingProgress(previousStatus: ProductStatus, newStatus: ProductStatus, existsRemotely: Bool) {
-        switch newStatus {
-        case .publish where !existsRemotely || previousStatus != .publish:
+    func showSavingProgress(_ messageType: SaveMessageType) {
+        switch messageType {
+        case .publish:
             displayInProgressView(title: Localization.ProgressView.productPublishingTitle, message: Localization.ProgressView.productPublishingMessage)
-        default:
+        case .save:
             displayInProgressView(title: Localization.ProgressView.productSavingTitle, message: Localization.ProgressView.productSavingMessage)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -604,7 +604,8 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func saveProduct(status: ProductStatus? = nil) {
         let productStatus = status ?? product.status
-        showSavingProgress(previousStatus: viewModel.originalProductModel.status, newStatus: productStatus, existsRemotely: product.existsRemotely)
+        let messageType = viewModel.saveMessageType(for: productStatus)
+        showSavingProgress(messageType)
 
         saveImagesAndProductRemotely(status: status)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -604,7 +604,7 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func saveProduct(status: ProductStatus? = nil) {
         let productStatus = status ?? product.status
-        showSavingProgress(for: productStatus)
+        showSavingProgress(previousStatus: viewModel.originalProductModel.status, newStatus: productStatus, existsRemotely: product.existsRemotely)
 
         saveImagesAndProductRemotely(status: status)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -15,6 +15,12 @@ enum ActionButtonType {
     case more
 }
 
+/// The type of save message when saving a product.
+enum SaveMessageType {
+    case publish
+    case save
+}
+
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).
 ///
 protocol ProductFormViewModelProtocol {
@@ -138,5 +144,18 @@ protocol ProductFormViewModelProtocol {
 extension ProductFormViewModelProtocol {
     func shouldShowMoreOptionsMenu() -> Bool {
         canSaveAsDraft() || canEditProductSettings() || canViewProductInStore() || canShareProduct() || canDeleteProduct()
+    }
+
+    /// Returns `.publish` when the product does not exists remotely and it's gonna be published for the first time.
+    /// Returns `.publish` when the product is going to be published from a different status (eg: from draft).
+    /// Returns `.save` for any other case.
+    ///
+    func saveMessageType(for productStatus: ProductStatus) -> SaveMessageType {
+        switch productStatus {
+        case .publish where !productModel.existsRemotely || originalProductModel.status != .publish:
+            return .publish
+        default:
+            return .save
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -416,6 +416,54 @@ final class ProductFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(canShowPublishOption)
     }
+
+    func test_publish_message_is_shown_when_publishing_an_new_product() {
+        // Given
+        let product = Product.fake().copy(statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // When
+        let messageType = viewModel.saveMessageType(for: .publish)
+
+        // Then
+        assertEqual(messageType, .publish)
+    }
+
+    func test_publish_message_is_shown_when_publishing_a_draft_product() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let messageType = viewModel.saveMessageType(for: .publish)
+
+        // Then
+        assertEqual(messageType, .publish)
+    }
+
+    func test_save_message_is_shown_when_updating_a_published_product() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.publish.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let messageType = viewModel.saveMessageType(for: .publish)
+
+        // Then
+        assertEqual(messageType, .save)
+    }
+
+    func test_save_message_is_shown_when_updating_a_draft_product() {
+        // Given
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // When
+        let messageType = viewModel.saveMessageType(for: .draft)
+
+        // Then
+        assertEqual(messageType, .save)
+    }
 }
 
 private extension ProductFormViewModelTests {


### PR DESCRIPTION
fix #4453 

# Why

It was reported that the "Saving" message when saving a product or a variation is not correct in all cases. Basically, we were showing a "Publish" message the product to be saved had a `published` status and a "Save" message for any other cases.

This PR updates the code to follow these rules:

- Show `Publish` when the product does not exist remotely and it's gonna be published for the first time.

- Show `Publish` when the product is going to be published and had a different status (eg: from draft).

- Show `Save` for any other case.

# How 

- Created a `saveMessageType()` method in `ProductFormViewModelProtocol` that decides which is the correct message type to show.

- Update `ProductFormViewController` to use the method created above.

# Demos

**Publish New Product**

https://user-images.githubusercontent.com/562080/124296203-4ef3c600-db1f-11eb-873b-6c4ebdba106a.mov

**Publish a draft product**

https://user-images.githubusercontent.com/562080/124296200-4e5b2f80-db1f-11eb-95b9-a68e66905793.mov

**Update Published Product** 

https://user-images.githubusercontent.com/562080/124296181-4ac7a880-db1f-11eb-92cb-2b32b3de9a78.mov

**Update Variation**

https://user-images.githubusercontent.com/562080/124296206-50bd8980-db1f-11eb-87f6-b852768f1d5e.mov


# Testing Steps

- Create a new product and see that when tapping the publish button a "publish" message is shown.

- Publish a draft product and see that when tapping the publish button a "publish" message is shown.

- Update a published product and see that when tapping the save button a "save" message is shown.

- Update a product variation and see that when tapping the save button a "save" message is shown.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
