### PR TITLE
Shipping Labels: Fix mapping error when polling for shipping label status

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1184,6 +1184,13 @@ extension ShippingLabelStatus {
         .purchased
     }
 }
+extension ShippingLabelStatusPollingResponse {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelStatusPollingResponse {
+        .pending
+    }
+}
 extension ShippingLabelStoreOptions {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1184,13 +1184,6 @@ extension ShippingLabelStatus {
         .purchased
     }
 }
-extension ShippingLabelStatusPollingResponse {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> ShippingLabelStatusPollingResponse {
-        .pending
-    }
-}
 extension ShippingLabelStoreOptions {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
+		CCB573AA268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */; };
 		CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */; };
 		CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */; };
 		CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */; };
@@ -968,6 +969,7 @@
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
+		CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusPollingResponse.swift; sourceTree = "<group>"; };
 		CCF48AD3262864CB0034EA83 /* ShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CCF48B1D26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethod.swift; sourceTree = "<group>"; };
 		CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentCardType.swift; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 			children = (
 				02C2548325635BD000A04423 /* ShippingLabelPaperSize.swift */,
 				02C254AB2563781800A04423 /* ShippingLabelStatus.swift */,
+				CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */,
 				02C254AF256378D000A04423 /* ShippingLabelRefundStatus.swift */,
 				CCF48B23262890BB0034EA83 /* ShippingLabelPaymentCardType.swift */,
 			);
@@ -2405,6 +2408,7 @@
 				26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */,
 				CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */,
 				26455E2725F669EA008A1D32 /* ProductAttributeTermListMapper.swift in Sources */,
+				CCB573AA268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift in Sources */,
 				B524193F21AC5FE400D6FC0A /* DotcomDeviceMapper.swift in Sources */,
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
+++ b/Networking/Networking/Mapper/ShippingLabelStatusMapper.swift
@@ -15,9 +15,9 @@ struct ShippingLabelStatusMapper: Mapper {
     ///
     let orderID: Int64
 
-    /// (Attempts) to convert a dictionary into [ShippingLabel].
+    /// (Attempts) to convert a dictionary into `ShippingLabelStatusPollingResponse`.
     ///
-    func map(response: Data) throws -> [ShippingLabel] {
+    func map(response: Data) throws -> [ShippingLabelStatusPollingResponse] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         decoder.userInfo = [
@@ -46,7 +46,7 @@ private struct ShippingLabelStatusResponse: Decodable {
 /// `Check Shipping Labels Status` endpoint returns the shipping label purchases in the `data.labels` key.
 ///
 private struct ShippingLabelStatusEnvelope: Decodable {
-    let labels: [ShippingLabel]
+    let labels: [ShippingLabelStatusPollingResponse]
 
     private enum CodingKeys: String, CodingKey {
         case labels

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatusPollingResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatusPollingResponse.swift
@@ -5,7 +5,7 @@ import Codegen
 ///
 /// The status endpoint can return a `ShippingLabelPurchase` (for pending or failed purchases) or `ShippingLabel` (for a successful purchase).
 ///
-public enum ShippingLabelStatusPollingResponse: Decodable, GeneratedFakeable {
+public enum ShippingLabelStatusPollingResponse: Decodable {
     case pending(ShippingLabelPurchase)
     case purchased(ShippingLabel)
 

--- a/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatusPollingResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Enums/ShippingLabelStatusPollingResponse.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Codegen
+
+/// Represents the response when polling for a shipping label status.
+///
+/// The status endpoint can return a `ShippingLabelPurchase` (for pending or failed purchases) or `ShippingLabel` (for a successful purchase).
+///
+public enum ShippingLabelStatusPollingResponse: Decodable, GeneratedFakeable {
+    case pending(ShippingLabelPurchase)
+    case purchased(ShippingLabel)
+
+    /// The status of pending or purchased shipping label.
+    ///
+    public var status: ShippingLabelStatus {
+        switch self {
+        case .pending(let purchase):
+            return purchase.status
+        case .purchased(let label):
+            return label.status
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        do {
+            let data = try container.decode(ShippingLabel.self)
+            self = .purchased(data)
+        } catch {
+            let data = try container.decode(ShippingLabelPurchase.self)
+            self = .pending(data)
+        }
+    }
+
+    /// Returns the associated `ShippingLabel` for a purchased shipping label
+    ///
+    public func getPurchasedLabel() -> ShippingLabel? {
+        switch self {
+        case .pending:
+            return nil
+        case .purchased(let label):
+            return label
+        }
+    }
+}

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -46,7 +46,7 @@ public protocol ShippingLabelRemoteProtocol {
     func checkLabelStatus(siteID: Int64,
                              orderID: Int64,
                              labelIDs: [Int64],
-                             completion: @escaping (Result<[ShippingLabel], Error>) -> Void)
+                             completion: @escaping (Result<[ShippingLabelStatusPollingResponse], Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints.
@@ -284,7 +284,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
     public func checkLabelStatus(siteID: Int64,
                                     orderID: Int64,
                                     labelIDs: [Int64],
-                                    completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+                                    completion: @escaping (Result<[ShippingLabelStatusPollingResponse], Error>) -> Void) {
         let labelIDs = labelIDs.map(String.init).joined(separator: ",")
         let path = "\(Path.shippingLabels)/\(orderID)/\(labelIDs)"
         let request = JetpackRequest(wooApiVersion: .wcConnectV1, method: .get, siteID: siteID, path: path)

--- a/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelStatusMapperTests.swift
@@ -11,32 +11,53 @@ class ShippingLabelStatusMapperTests: XCTestCase {
     /// Sample Order ID
     private let sampleOrderID: Int64 = 1234
 
-    /// Verifies that the Shipping Label Purchase is parsed correctly.
+    /// Verifies that the Shipping Label Status Polling Response is parsed correctly when it receives a purchased shipping label.
     ///
-    func test_ShippingLabelPurchase_is_properly_parsed() {
+    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_purchased_label() {
+        // Given
         guard let shippingLabelList = mapLoadShippingLabelStatus(),
-              let shippingLabel = shippingLabelList.first else {
+              let shippingLabelResponse = shippingLabelList.first else {
             XCTFail()
             return
         }
 
-        XCTAssertEqual(shippingLabel.siteID, sampleSiteID)
-        XCTAssertEqual(shippingLabel.orderID, sampleOrderID)
-        XCTAssertEqual(shippingLabel.shippingLabelID, 1825)
-        XCTAssertEqual(shippingLabel.carrierID, "usps")
-        XCTAssertEqual(shippingLabel.dateCreated, Date(timeIntervalSince1970: 1623764362.682))
-        XCTAssertEqual(shippingLabel.packageName, "Small Flat Rate Box")
-        XCTAssertEqual(shippingLabel.rate, 7.9)
-        XCTAssertEqual(shippingLabel.currency, "USD")
-        XCTAssertEqual(shippingLabel.trackingNumber, "9405500205309072644962")
-        XCTAssertEqual(shippingLabel.serviceName, "USPS - Priority Mail")
-        XCTAssertEqual(shippingLabel.refundableAmount, 7.9)
-        XCTAssertEqual(shippingLabel.status, ShippingLabelStatus.purchased)
-        XCTAssertNil(shippingLabel.refund)
-        XCTAssertEqual(shippingLabel.originAddress, ShippingLabelAddress.fake())
-        XCTAssertEqual(shippingLabel.destinationAddress, ShippingLabelAddress.fake())
-        XCTAssertEqual(shippingLabel.productIDs, [89])
-        XCTAssertEqual(shippingLabel.productNames, ["WordPress Pennant"])
+        // Assert
+        XCTAssertEqual(shippingLabelResponse.status, .purchased)
+
+        // Then
+        let shippingLabel = shippingLabelResponse.getPurchasedLabel()
+
+        // Assert
+        XCTAssertEqual(shippingLabel?.siteID, sampleSiteID)
+        XCTAssertEqual(shippingLabel?.orderID, sampleOrderID)
+        XCTAssertEqual(shippingLabel?.shippingLabelID, 1825)
+        XCTAssertEqual(shippingLabel?.carrierID, "usps")
+        XCTAssertEqual(shippingLabel?.dateCreated, Date(timeIntervalSince1970: 1623764362.682))
+        XCTAssertEqual(shippingLabel?.packageName, "Small Flat Rate Box")
+        XCTAssertEqual(shippingLabel?.rate, 7.9)
+        XCTAssertEqual(shippingLabel?.currency, "USD")
+        XCTAssertEqual(shippingLabel?.trackingNumber, "9405500205309072644962")
+        XCTAssertEqual(shippingLabel?.serviceName, "USPS - Priority Mail")
+        XCTAssertEqual(shippingLabel?.refundableAmount, 7.9)
+        XCTAssertEqual(shippingLabel?.status, ShippingLabelStatus.purchased)
+        XCTAssertNil(shippingLabel?.refund)
+        XCTAssertEqual(shippingLabel?.originAddress, ShippingLabelAddress.fake())
+        XCTAssertEqual(shippingLabel?.destinationAddress, ShippingLabelAddress.fake())
+        XCTAssertEqual(shippingLabel?.productIDs, [89])
+        XCTAssertEqual(shippingLabel?.productNames, ["WordPress Pennant"])
+    }
+
+    /// Verifies that the Shipping Label Status Polling Response is parsed correctly when it receives a pending shipping label purchase.
+    ///
+    func test_ShippingLabelStatusPollingResponse_is_properly_parsed_for_pending_label_purchase() {
+        guard let shippingLabelList = mapLoadShippingLabelPurchaseStatus(),
+              let shippingLabelResponse = shippingLabelList.first else {
+            XCTFail()
+            return
+        }
+
+        // Assert
+        XCTAssertEqual(shippingLabelResponse.status, .purchaseInProgress)
     }
 }
 
@@ -46,7 +67,7 @@ private extension ShippingLabelStatusMapperTests {
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShippingLabelStatus(from filename: String) -> [ShippingLabel]? {
+    func mapShippingLabelStatus(from filename: String) -> [ShippingLabelStatusPollingResponse]? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
@@ -56,7 +77,13 @@ private extension ShippingLabelStatusMapperTests {
 
     /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-status-success`
     ///
-    func mapLoadShippingLabelStatus() -> [ShippingLabel]? {
+    func mapLoadShippingLabelStatus() -> [ShippingLabelStatusPollingResponse]? {
         return mapShippingLabelStatus(from: "shipping-label-status-success")
+    }
+
+    /// Returns the ShippingLabelStatusMapper output upon receiving `shipping-label-purchase-success`
+    ///
+    func mapLoadShippingLabelPurchaseStatus() -> [ShippingLabelStatusPollingResponse]? {
+        return mapShippingLabelStatus(from: "shipping-label-purchase-success")
     }
 }

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -418,7 +418,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/\(sampleOrderID)/\(sampleLabelID)", filename: "shipping-label-status-success")
 
         // When
-        let result: Result<[ShippingLabel], Error> = waitFor { promise in
+        let result: Result<[ShippingLabelStatusPollingResponse], Error> = waitFor { promise in
             remote.checkLabelStatus(siteID: self.sampleSiteID,
                                     orderID: self.sampleOrderID,
                                     labelIDs: [sampleLabelID]) { (result) in
@@ -439,7 +439,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "label/\(sampleOrderID)/\(sampleLabelID)", filename: "generic_error")
 
         // When
-        let result: Result<[ShippingLabel], Error> = waitFor { promise in
+        let result: Result<[ShippingLabelStatusPollingResponse], Error> = waitFor { promise in
             remote.checkLabelStatus(siteID: self.sampleSiteID,
                                     orderID: self.sampleOrderID,
                                     labelIDs: [sampleLabelID]) { (result) in

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -97,7 +97,7 @@ final class MockShippingLabelRemote {
     private var purchaseShippingLabelResults = [PurchaseShippingLabelResultKey: Result<[ShippingLabelPurchase], Error>]()
 
     /// The results to return based on the given arguments in `checkLabelStatus`
-    private var checkLabelStatusResults = [CheckLabelStatusResultKey: Result<[ShippingLabel], Error>]()
+    private var checkLabelStatusResults = [CheckLabelStatusResultKey: Result<[ShippingLabelStatusPollingResponse], Error>]()
 
     /// Set the value passed to the `completion` block if `loadShippingLabels` is called.
     func whenLoadingShippingLabels(siteID: Int64,
@@ -198,7 +198,7 @@ final class MockShippingLabelRemote {
     func whenCheckLabelStatus(siteID: Int64,
                               orderID: Int64,
                               labelIDs: [Int64],
-                              thenReturn result: Result<[ShippingLabel], Error>) {
+                              thenReturn result: Result<[ShippingLabelStatusPollingResponse], Error>) {
         let key = CheckLabelStatusResultKey(siteID: siteID)
         checkLabelStatusResults[key] = result
     }
@@ -378,7 +378,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
     func checkLabelStatus(siteID: Int64,
                           orderID: Int64,
                           labelIDs: [Int64],
-                          completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
+                          completion: @escaping (Result<[ShippingLabelStatusPollingResponse], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -690,6 +690,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let mockAddress = ShippingLabelAddress.fake()
         let mockPackages = [ShippingLabelPackagePurchase.fake()]
         let expectedLabel = ShippingLabel.fake().copy(shippingLabelID: 13579)
+        let labelStatusResponse = ShippingLabelStatusPollingResponse.purchased(expectedLabel)
         let remote = MockShippingLabelRemote()
         remote.whenPurchaseShippingLabel(siteID: sampleSiteID,
                                          orderID: sampleOrderID,
@@ -701,7 +702,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         remote.whenCheckLabelStatus(siteID: sampleSiteID,
                                     orderID: sampleOrderID,
                                     labelIDs: [13579],
-                                    thenReturn: .success([expectedLabel]))
+                                    thenReturn: .success([labelStatusResponse]))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
@@ -798,6 +799,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let mockAddress = ShippingLabelAddress.fake()
         let mockPackages = [ShippingLabelPackagePurchase.fake()]
         let expectedLabel = ShippingLabel.fake().copy(shippingLabelID: 13579, status: .purchaseError)
+        let labelStatusResponse = ShippingLabelStatusPollingResponse.purchased(expectedLabel)
         let remote = MockShippingLabelRemote()
         remote.whenPurchaseShippingLabel(siteID: sampleSiteID,
                                          orderID: sampleOrderID,
@@ -809,7 +811,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         remote.whenCheckLabelStatus(siteID: sampleSiteID,
                                     orderID: sampleOrderID,
                                     labelIDs: [13579],
-                                    thenReturn: .success([expectedLabel]))
+                                    thenReturn: .success([labelStatusResponse]))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
@@ -835,6 +837,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let mockAddress = ShippingLabelAddress.fake()
         let mockPackages = [ShippingLabelPackagePurchase.fake()]
         let expectedLabel = ShippingLabel.fake().copy(shippingLabelID: 13579, status: .purchaseInProgress)
+        let labelStatusResponse = ShippingLabelStatusPollingResponse.purchased(expectedLabel)
         let remote = MockShippingLabelRemote()
         remote.whenPurchaseShippingLabel(siteID: sampleSiteID,
                                          orderID: sampleOrderID,
@@ -846,7 +849,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         remote.whenCheckLabelStatus(siteID: sampleSiteID,
                                     orderID: sampleOrderID,
                                     labelIDs: [13579],
-                                    thenReturn: .success([expectedLabel]))
+                                    thenReturn: .success([labelStatusResponse]))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When


### PR DESCRIPTION
Part of: #4089 

## Description

As noted in https://github.com/woocommerce/woocommerce-ios/pull/4475#pullrequestreview-693229634, there was a mapping error when polling the `ShippingLabelRemote.checkLabelStatus` endpoint. This is because that endpoint can return a `ShippingLabel` or `ShippingLabelPurchase`, depending on the status of the label purchase. (It only returns a `ShippingLabel` if the purchase is complete and successful.)

## Changes

This PR introduces the enum `ShippingLabelStatusPollingResponse`:

* In the Networking layer, `ShippingLabelRemote.checkLabelStatus` now returns that enum to handle either possible response.
* In the Yosemite layer, when we poll for the label status in `ShippingLabelStore.pollLabelStatus`, we now check the `ShippingLabelStatusPollingResponse.status` to determine what to do next. If the status is `.purchased`, we use `ShippingLabelStatusPollingResponse.getPurchasedLabel()` to get the associated `ShippingLabel` and return that for use in the UI layer.

## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields in the form.
6. In the Order Summary section, tap the button "Purchase Label".
7. Confirm the purchase is completed and no mapping errors appear in the console.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
