### PR TITLE
[Order Fulfillment][Part 2] Update Review Order screen with Products section

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -166,6 +166,24 @@ extension OrderItem {
     }
 }
 
+extension OrderItemAttribute {
+    public func copy(
+        metaID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        value: CopiableProp<String> = .copy
+    ) -> OrderItemAttribute {
+        let metaID = metaID ?? self.metaID
+        let name = name ?? self.name
+        let value = value ?? self.value
+
+        return OrderItemAttribute(
+            metaID: metaID,
+            name: name,
+            value: value
+        )
+    }
+}
+
 extension Product {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -115,6 +115,57 @@ extension Order {
     }
 }
 
+extension OrderItem {
+    public func copy(
+        itemID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        variationID: CopiableProp<Int64> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        price: CopiableProp<NSDecimalNumber> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        subtotal: CopiableProp<String> = .copy,
+        subtotalTax: CopiableProp<String> = .copy,
+        taxClass: CopiableProp<String> = .copy,
+        taxes: CopiableProp<[OrderItemTax]> = .copy,
+        total: CopiableProp<String> = .copy,
+        totalTax: CopiableProp<String> = .copy,
+        attributes: CopiableProp<[OrderItemAttribute]> = .copy
+    ) -> OrderItem {
+        let itemID = itemID ?? self.itemID
+        let name = name ?? self.name
+        let productID = productID ?? self.productID
+        let variationID = variationID ?? self.variationID
+        let quantity = quantity ?? self.quantity
+        let price = price ?? self.price
+        let sku = sku ?? self.sku
+        let subtotal = subtotal ?? self.subtotal
+        let subtotalTax = subtotalTax ?? self.subtotalTax
+        let taxClass = taxClass ?? self.taxClass
+        let taxes = taxes ?? self.taxes
+        let total = total ?? self.total
+        let totalTax = totalTax ?? self.totalTax
+        let attributes = attributes ?? self.attributes
+
+        return OrderItem(
+            itemID: itemID,
+            name: name,
+            productID: productID,
+            variationID: variationID,
+            quantity: quantity,
+            price: price,
+            sku: sku,
+            subtotal: subtotal,
+            subtotalTax: subtotalTax,
+            taxClass: taxClass,
+            taxes: taxes,
+            total: total,
+            totalTax: totalTax,
+            attributes: attributes
+        )
+    }
+}
+
 extension Product {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -184,6 +184,54 @@ extension OrderItemAttribute {
     }
 }
 
+extension OrderItemRefund {
+    public func copy(
+        itemID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        variationID: CopiableProp<Int64> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        price: CopiableProp<NSDecimalNumber> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        subtotal: CopiableProp<String> = .copy,
+        subtotalTax: CopiableProp<String> = .copy,
+        taxClass: CopiableProp<String> = .copy,
+        taxes: CopiableProp<[OrderItemTaxRefund]> = .copy,
+        total: CopiableProp<String> = .copy,
+        totalTax: CopiableProp<String> = .copy
+    ) -> OrderItemRefund {
+        let itemID = itemID ?? self.itemID
+        let name = name ?? self.name
+        let productID = productID ?? self.productID
+        let variationID = variationID ?? self.variationID
+        let quantity = quantity ?? self.quantity
+        let price = price ?? self.price
+        let sku = sku ?? self.sku
+        let subtotal = subtotal ?? self.subtotal
+        let subtotalTax = subtotalTax ?? self.subtotalTax
+        let taxClass = taxClass ?? self.taxClass
+        let taxes = taxes ?? self.taxes
+        let total = total ?? self.total
+        let totalTax = totalTax ?? self.totalTax
+
+        return OrderItemRefund(
+            itemID: itemID,
+            name: name,
+            productID: productID,
+            variationID: variationID,
+            quantity: quantity,
+            price: price,
+            sku: sku,
+            subtotal: subtotal,
+            subtotalTax: subtotalTax,
+            taxClass: taxClass,
+            taxes: taxes,
+            total: total,
+            totalTax: totalTax
+        )
+    }
+}
+
 extension Product {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -630,6 +678,48 @@ extension ProductVariation {
             shippingClass: shippingClass,
             shippingClassID: shippingClassID,
             menuOrder: menuOrder
+        )
+    }
+}
+
+extension Refund {
+    public func copy(
+        refundID: CopiableProp<Int64> = .copy,
+        orderID: CopiableProp<Int64> = .copy,
+        siteID: CopiableProp<Int64> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        amount: CopiableProp<String> = .copy,
+        reason: CopiableProp<String> = .copy,
+        refundedByUserID: CopiableProp<Int64> = .copy,
+        isAutomated: NullableCopiableProp<Bool> = .copy,
+        createAutomated: NullableCopiableProp<Bool> = .copy,
+        items: CopiableProp<[OrderItemRefund]> = .copy,
+        shippingLines: NullableCopiableProp<[ShippingLine]> = .copy
+    ) -> Refund {
+        let refundID = refundID ?? self.refundID
+        let orderID = orderID ?? self.orderID
+        let siteID = siteID ?? self.siteID
+        let dateCreated = dateCreated ?? self.dateCreated
+        let amount = amount ?? self.amount
+        let reason = reason ?? self.reason
+        let refundedByUserID = refundedByUserID ?? self.refundedByUserID
+        let isAutomated = isAutomated ?? self.isAutomated
+        let createAutomated = createAutomated ?? self.createAutomated
+        let items = items ?? self.items
+        let shippingLines = shippingLines ?? self.shippingLines
+
+        return Refund(
+            refundID: refundID,
+            orderID: orderID,
+            siteID: siteID,
+            dateCreated: dateCreated,
+            amount: amount,
+            reason: reason,
+            refundedByUserID: refundedByUserID,
+            isAutomated: isAutomated,
+            createAutomated: createAutomated,
+            items: items,
+            shippingLines: shippingLines
         )
     }
 }

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order's Item Entity.
 ///
-public struct OrderItem: Decodable, Hashable, GeneratedFakeable {
+public struct OrderItem: Decodable, Hashable, GeneratedFakeable, GeneratedCopiable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Currently, the use case is
 /// 1. When an order item is a variation and the attributes are its variation attributes.
 /// 2. Product Add-Ons are stored as attributes.
-public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable {
+public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let metaID: Int64
     public let name: String
     public let value: String

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order Item that was refunded or will be refunded.
 ///
-public struct OrderItemRefund: Codable, GeneratedFakeable {
+public struct OrderItemRefund: Codable, GeneratedFakeable, GeneratedCopiable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a decoded Refund entity.
 ///
-public struct Refund: Codable, GeneratedFakeable {
+public struct Refund: Codable, GeneratedFakeable, GeneratedCopiable {
     public let refundID: Int64
     public let orderID: Int64
     public let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -513,7 +513,7 @@ private extension OrderDetailsViewController {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.reviewOrder) {
-            let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products)
+            let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
             let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel)
             navigationController?.pushViewController(controller, animated: true)
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -52,6 +52,25 @@ private extension ReviewOrderViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.dataSource = self
+    }
+}
+
+// MARK: - UITableViewDatasource conformance
+//
+extension ReviewOrderViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = viewModel.sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.cellType.reuseIdentifier, for: indexPath)
+        return cell
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -32,6 +32,7 @@ final class ReviewOrderViewController: UIViewController {
 
         configureNavigation()
         configureTableView()
+        configureViewModel()
     }
 
 }
@@ -39,6 +40,12 @@ final class ReviewOrderViewController: UIViewController {
 // MARK: - UI Configuration
 //
 private extension ReviewOrderViewController {
+    func configureViewModel() {
+        viewModel.configureResultsControllers { [weak self] in
+            self?.tableView.reloadData()
+        }
+    }
+
     func configureNavigation() {
         title = Localization.screenTitle
     }
@@ -127,7 +134,7 @@ extension ReviewOrderViewController: UITableViewDelegate {
         case let headerView as PrimarySectionHeaderView:
             switch section.category {
             case .products:
-                let sectionTitle = viewModel.order.items.count > 1 ? Localization.productsSectionTitle : Localization.productSectionTitle
+                let sectionTitle = viewModel.aggregateOrderItems.count > 1 ? Localization.productsSectionTitle : Localization.productSectionTitle
                 headerView.configure(title: sectionTitle)
             case .customerInformation, .tracking:
                 assertionFailure("Unexpected category of type \(headerView.self)")
@@ -158,7 +165,7 @@ private extension ReviewOrderViewController {
 
     /// Setup: Order item Cell
     ///
-    private func setupOrderItemCell(_ cell: UITableViewCell, with item: OrderItem) {
+    private func setupOrderItemCell(_ cell: UITableViewCell, with item: AggregateOrderItem) {
         guard let cell = cell as? ProductDetailsTableViewCell else {
             fatalError()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -142,7 +142,7 @@ private extension ReviewOrderViewController {
             fatalError()
         }
 
-        let itemViewModel = viewModel.cellViewModel(for: item)
+        let itemViewModel = viewModel.productDetailsCellViewModel(for: item)
         cell.configure(item: itemViewModel, imageService: imageService)
         cell.onViewAddOnsTouchUp = { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -44,14 +44,8 @@ private extension ReviewOrderViewController {
     }
 
     func configureTableView() {
-        for headerType in viewModel.allHeaderTypes {
-            tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
-        }
-
-        for cellType in viewModel.allCellTypes {
-            tableView.registerNib(for: cellType)
-        }
-
+        registerHeaderTypes()
+        registerCellTypes()
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
@@ -59,6 +53,32 @@ private extension ReviewOrderViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.dataSource = self
         tableView.delegate = self
+    }
+
+    func registerHeaderTypes() {
+        let allHeaderTypes: [UITableViewHeaderFooterView.Type] = {
+            [PrimarySectionHeaderView.self,
+             TwoColumnSectionHeaderView.self]
+        }()
+
+        for headerType in allHeaderTypes {
+            tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
+        }
+    }
+
+    func registerCellTypes() {
+        let allCellTypes: [UITableViewCell.Type] = {
+            [ProductDetailsTableViewCell.self,
+             CustomerNoteTableViewCell.self,
+             CustomerInfoTableViewCell.self,
+             WooBasicTableViewCell.self,
+             OrderTrackingTableViewCell.self,
+             LeftImageTableViewCell.self]
+        }()
+
+        for cellType in allCellTypes {
+            tableView.registerNib(for: cellType)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -58,6 +58,7 @@ private extension ReviewOrderViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.dataSource = self
+        tableView.delegate = self
     }
 }
 
@@ -77,6 +78,45 @@ extension ReviewOrderViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: row.cellType.reuseIdentifier, for: indexPath)
         setup(cell: cell, for: row, at: indexPath)
         return cell
+    }
+}
+
+// MARK: - UITableViewDelegate conformance
+//
+extension ReviewOrderViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return CGFloat.leastNormalMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let section = viewModel.sections[safe: section] else {
+            return nil
+        }
+
+        let reuseIdentifier = section.headerType.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) else {
+            assertionFailure("Could not find section header view for reuseIdentifier \(reuseIdentifier)")
+            return nil
+        }
+
+        switch headerView {
+        case let headerView as PrimarySectionHeaderView:
+            switch section.category {
+            case .products:
+                headerView.configure(title: viewModel.productionSectionTitle)
+            case .customerInformation, .tracking:
+                assertionFailure("Unexpected category of type \(headerView.self)")
+            }
+        default:
+            assertionFailure("Unexpected headerView type \(headerView.self)")
+            return nil
+        }
+
+        return headerView
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 /// View Control for Review Order screen
 /// This screen is shown when Mark Order Complete button is tapped
@@ -8,6 +9,10 @@ final class ReviewOrderViewController: UIViewController {
     /// View model to provide order info for review
     ///
     private let viewModel: ReviewOrderViewModel
+
+    /// Image service needed for order item cells
+    ///
+    private let imageService: ImageService = ServiceLocator.imageService
 
     /// Table view to display order details
     ///
@@ -70,7 +75,52 @@ extension ReviewOrderViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = viewModel.sections[indexPath.section].rows[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: row.cellType.reuseIdentifier, for: indexPath)
+        setup(cell: cell, for: row, at: indexPath)
         return cell
+    }
+}
+
+// MARK: - Setup cells for the table view
+//
+private extension ReviewOrderViewController {
+    /// Setup a given UITableViewCell instance to actually display the specified Row's Payload.
+    ///
+    func setup(cell: UITableViewCell, for row: ReviewOrderViewModel.Row, at indexPath: IndexPath) {
+        switch row {
+        case .orderItem(let item):
+            setupOrderItemCell(cell, with: item)
+        default:
+            // TODO: setup
+            break
+        }
+    }
+
+    /// Setup: Order item Cell
+    ///
+    private func setupOrderItemCell(_ cell: UITableViewCell, with item: OrderItem) {
+        guard let cell = cell as? ProductDetailsTableViewCell else {
+            fatalError()
+        }
+
+        let itemViewModel = viewModel.cellViewModel(for: item)
+        cell.configure(item: itemViewModel, imageService: imageService)
+        cell.onViewAddOnsTouchUp = { [weak self] in
+            guard let self = self else { return }
+            self.itemAddOnsButtonTapped(addOns: self.viewModel.filterAddons(for: item))
+        }
+    }
+}
+
+// MARK: - Actions
+//
+private extension ReviewOrderViewController {
+    /// Show addon list screen
+    ///
+    func itemAddOnsButtonTapped(addOns: [OrderItemAttribute]) {
+        let addOnsViewModel = OrderAddOnListI1ViewModel(attributes: addOns)
+        let addOnsController = OrderAddOnsListViewController(viewModel: addOnsViewModel)
+        let navigationController = WooNavigationController(rootViewController: addOnsController)
+        present(navigationController, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -40,7 +40,7 @@ final class ReviewOrderViewController: UIViewController {
 //
 private extension ReviewOrderViewController {
     func configureNavigation() {
-        title = viewModel.screenTitle
+        title = Localization.screenTitle
     }
 
     func configureTableView() {
@@ -107,7 +107,8 @@ extension ReviewOrderViewController: UITableViewDelegate {
         case let headerView as PrimarySectionHeaderView:
             switch section.category {
             case .products:
-                headerView.configure(title: viewModel.productionSectionTitle)
+                let sectionTitle = viewModel.order.items.count > 1 ? Localization.productsSectionTitle : Localization.productSectionTitle
+                headerView.configure(title: sectionTitle)
             case .customerInformation, .tracking:
                 assertionFailure("Unexpected category of type \(headerView.self)")
             }
@@ -172,5 +173,14 @@ private extension ReviewOrderViewController {
     enum Constants {
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
+    }
+
+    /// Localized copies
+    ///
+    enum Localization {
+        static let screenTitle = NSLocalizedString("Review Order", comment: "Title of Review Order screen")
+        static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
+        static let productsSectionTitle = NSLocalizedString("Products",
+                                                            comment: "Product section title in Review Order screen if there is more than one product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -38,5 +38,30 @@ private extension ReviewOrderViewController {
         title = viewModel.screenTitle
     }
 
-    func configureTableView() {}
+    func configureTableView() {
+        for headerType in viewModel.allHeaderTypes {
+            tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
+        }
+
+        for cellType in viewModel.allCellTypes {
+            tableView.registerNib(for: cellType)
+        }
+
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+        tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+    }
+}
+
+// MARK: - Miscellanous
+//
+private extension ReviewOrderViewController {
+    /// Some magic numbers for table view UI 🪄
+    ///
+    enum Constants {
+        static let rowHeight = CGFloat(38)
+        static let sectionHeight = CGFloat(44)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -38,6 +38,77 @@ extension ReviewOrderViewModel {
     }
 }
 
+// MARK: - Section and row types for Review Order table view
+//
+extension ReviewOrderViewModel {
+    struct Section {
+        /// Section types for Review Order screen
+        ///
+        enum Category: CaseIterable {
+            case products
+            case customerInformation
+            case tracking
+        }
+
+        /// Category of the section
+        ///
+        let category: Category
+
+        /// Rows in the section
+        ///
+        let rows: [Row]
+
+        /// UITableViewHeaderFooterView type for each section
+        ///
+        var headerType: UITableViewHeaderFooterView.Type {
+            switch category {
+            case .products:
+                return PrimarySectionHeaderView.self
+            case .customerInformation, .tracking:
+                return TwoColumnSectionHeaderView.self
+            }
+        }
+
+        init(category: Category, rows: [Row]) {
+            self.category = category
+            self.rows = rows
+        }
+    }
+
+    /// Row types for Review Order screen
+    ///
+    enum Row {
+        case orderItem(item: OrderItem)
+        case customerNote(text: String)
+        case shippingAddress(address: Address)
+        case shippingMethod(method: String)
+        case billingDetail
+        case tracking
+        case trackingAdd
+
+        /// UITableViewCell type for each row type
+        ///
+        var cellType: UITableViewCell.Type {
+            switch self {
+            case .orderItem:
+                return ProductDetailsTableViewCell.self
+            case .customerNote:
+                return CustomerNoteTableViewCell.self
+            case .shippingAddress:
+                return CustomerInfoTableViewCell.self
+            case .shippingMethod:
+                return CustomerNoteTableViewCell.self
+            case .billingDetail:
+                return WooBasicTableViewCell.self
+            case .tracking:
+                return OrderTrackingTableViewCell.self
+            case .trackingAdd:
+                return LeftImageTableViewCell.self
+            }
+        }
+    }
+}
+
 // MARK: - Localization
 //
 private extension ReviewOrderViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -36,6 +36,30 @@ extension ReviewOrderViewModel {
     var screenTitle: String {
         Localization.screenTitle
     }
+
+    /// Title for Product section
+    ///
+    var productionSectionTitle: String {
+        order.items.count > 0 ? Localization.productsSectionTitle : Localization.productSectionTitle
+    }
+
+    /// Sections for order table view
+    ///
+    var sections: [Section] {
+        // TODO: add other sections: Customer Info and Tracking
+        return [productSection].filter { !$0.rows.isEmpty }
+    }
+}
+
+// MARK: - Sections configuration
+//
+private extension ReviewOrderViewModel {
+    /// Product section setup
+    ///
+    var productSection: Section {
+        let rows = order.items.map { Row.orderItem(item: $0) }
+        return .init(category: .products, rows: rows)
+    }
 }
 
 // MARK: - Section and row types for Review Order table view
@@ -114,5 +138,8 @@ extension ReviewOrderViewModel {
 private extension ReviewOrderViewModel {
     enum Localization {
         static let screenTitle = NSLocalizedString("Review Order", comment: "Title of Review Order screen")
+        static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
+        static let productsSectionTitle = NSLocalizedString("Products",
+                                                            comment: "Product section title in Review Order screen if there is more than one product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -104,9 +104,9 @@ extension ReviewOrderViewModel {
         return AddOnCrossreferenceUseCase(orderItemAttributes: item.attributes, product: product, addOnGroups: addOnGroups).addOnsAttributes()
     }
 
-    /// Cell model for an order item
+    /// Product Details cell view model for an order item
     ///
-    func cellViewModel(for item: OrderItem) -> ProductDetailsCellViewModel {
+    func productDetailsCellViewModel(for item: OrderItem) -> ProductDetailsCellViewModel {
         let product = filterProduct(for: item)
         let addOns = filterAddons(for: item)
         return ProductDetailsCellViewModel(item: item, currency: order.currency, product: product, hasAddOns: !addOns.isEmpty)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -3,24 +3,6 @@ import Yosemite
 import protocol Storage.StorageManagerType
 
 final class ReviewOrderViewModel {
-    /// Quick access to header types for table view registration
-    ///
-    let allHeaderTypes: [UITableViewHeaderFooterView.Type] = {
-        [PrimarySectionHeaderView.self,
-         TwoColumnSectionHeaderView.self]
-    }()
-
-    /// Quick access cell types for table view registration
-    ///
-    let allCellTypes: [UITableViewCell.Type] = {
-        [ProductDetailsTableViewCell.self,
-         CustomerNoteTableViewCell.self,
-         CustomerInfoTableViewCell.self,
-         WooBasicTableViewCell.self,
-         OrderTrackingTableViewCell.self,
-         LeftImageTableViewCell.self]
-    }()
-
     /// The order for review
     ///
     let order: Order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -23,7 +23,7 @@ final class ReviewOrderViewModel {
 
     /// The order for review
     ///
-    private let order: Order
+    let order: Order
 
     /// Products in the order
     ///
@@ -71,15 +71,6 @@ final class ReviewOrderViewModel {
 // MARK: - Data source for review order controller
 //
 extension ReviewOrderViewModel {
-    var screenTitle: String {
-        Localization.screenTitle
-    }
-
-    /// Title for Product section
-    ///
-    var productionSectionTitle: String {
-        order.items.count > 0 ? Localization.productsSectionTitle : Localization.productSectionTitle
-    }
 
     /// Sections for order table view
     ///
@@ -192,16 +183,5 @@ extension ReviewOrderViewModel {
                 return LeftImageTableViewCell.self
             }
         }
-    }
-}
-
-// MARK: - Localization
-//
-private extension ReviewOrderViewModel {
-    enum Localization {
-        static let screenTitle = NSLocalizedString("Review Order", comment: "Title of Review Order screen")
-        static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
-        static let productsSectionTitle = NSLocalizedString("Products",
-                                                            comment: "Product section title in Review Order screen if there is more than one product.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -3,6 +3,24 @@ import Yosemite
 import protocol Storage.StorageManagerType
 
 final class ReviewOrderViewModel {
+    /// Quick access to header types for table view registration
+    ///
+    let allHeaderTypes: [UITableViewHeaderFooterView.Type] = {
+        [PrimarySectionHeaderView.self,
+         TwoColumnSectionHeaderView.self]
+    }()
+
+    /// Quick access cell types for table view registration
+    ///
+    let allCellTypes: [UITableViewCell.Type] = {
+        [ProductDetailsTableViewCell.self,
+         CustomerNoteTableViewCell.self,
+         CustomerInfoTableViewCell.self,
+         WooBasicTableViewCell.self,
+         OrderTrackingTableViewCell.self,
+         LeftImageTableViewCell.self]
+    }()
+
     /// The order for review
     ///
     private let order: Order

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1206,10 +1206,11 @@
 		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
-		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
+		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
+		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2519,10 +2520,11 @@
 		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
-		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
+		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
+		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -4282,6 +4284,7 @@
 		57F34A9F2423D44000E38AFB /* Orders */ = {
 			isa = PBXGroup;
 			children = (
+				DE4B3B2A2692DBF200EEF2D8 /* Review Order */,
 				265284072624ACAF00F91BA1 /* AddOns */,
 				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
@@ -5889,6 +5892,14 @@
 			path = "Review Order";
 			sourceTree = "<group>";
 		};
+		DE4B3B2A2692DBF200EEF2D8 /* Review Order */ = {
+			isa = PBXGroup;
+			children = (
+				DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */,
+			);
+			path = "Review Order";
+			sourceTree = "<group>";
+		};
 		DE8C9464264698E800C94823 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -7324,6 +7335,7 @@
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
+				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Yosemite
 
+import protocol Storage.StorageType
 import protocol Storage.StorageManagerType
 
 @testable import WooCommerce
@@ -10,11 +11,23 @@ class ReviewOrderViewModelTests: XCTestCase {
     private let productID: Int64 = 1_00
     private let siteID: Int64 = 123
 
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: StorageManagerType!
+
+    /// View storage for tests
+    ///
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
+        storageManager = MockStorageManager()
     }
 
     override func tearDownWithError() throws {
+        storageManager = nil
         try super.tearDownWithError()
     }
 
@@ -44,5 +57,36 @@ class ReviewOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(productCellModel.hasAddOns, false)
+    }
+
+    func test_productDetailsCellViewModel_returns_correct_hasAddOns_if_view_model_receives_showAddOns_as_true() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(siteID: siteID, status: .processing, items: [item])
+        let addOn = ProductAddOn.fake()
+        let addOnGroup = AddOnGroup.fake().copy(siteID: siteID, addOns: [addOn])
+        insert(addOnGroup)
+        let product = Product().copy(productID: productID, addOns: [addOn])
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: true, storageManager: storageManager)
+        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
+
+        // Then
+        // TODO: fix failed test
+//        XCTAssertEqual(productCellModel.hasAddOns, true)
+    }
+}
+
+// MARK: - Storage helper
+private extension ReviewOrderViewModelTests {
+    func insert(_ readOnlyAddOnGroup: Yosemite.AddOnGroup) {
+        readOnlyAddOnGroup.addOns.forEach { readOnlyAddOn in
+            let storageAddOn = storage.insertNewObject(ofType: StorageProductAddOn.self)
+            storageAddOn.update(with: readOnlyAddOn)
+        }
+        let group = storage.insertNewObject(ofType: StorageAddOnGroup.self)
+        group.update(with: readOnlyAddOnGroup)
+        storage.saveIfNeeded()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import Yosemite
+
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+
+@testable import WooCommerce
+
+class ReviewOrderViewModelTests: XCTestCase {
+
+    private let productID: Int64 = 1_00
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+
+    func test_productDetailsCellViewModel_returns_correct_item_details() {
+        // Given
+        let item = makeOrderItem(productID: productID)
+        let order = MockOrders().makeOrder(status: .processing, items: [item])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
+
+        // Then
+        XCTAssertEqual(productCellModel.name, item.name)
+    }
+}
+
+private extension ReviewOrderViewModelTests {
+    func makeOrderItem(productID: Int64) -> OrderItem {
+        OrderItem(itemID: 1,
+                  name: "Order Item Name",
+                  productID: productID,
+                  variationID: 0,
+                  quantity: 1,
+                  price: NSDecimalNumber(integerLiteral: 1),
+                  sku: nil,
+                  subtotal: "1",
+                  subtotalTax: "1",
+                  taxClass: "TaxClass",
+                  taxes: [],
+                  total: "1",
+                  totalTax: "1",
+                  attributes: [])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -2,13 +2,13 @@ import XCTest
 import Yosemite
 
 import protocol Storage.StorageManagerType
-import protocol Storage.StorageType
 
 @testable import WooCommerce
 
 class ReviewOrderViewModelTests: XCTestCase {
 
     private let productID: Int64 = 1_00
+    private let siteID: Int64 = 123
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -20,8 +20,8 @@ class ReviewOrderViewModelTests: XCTestCase {
 
     func test_productDetailsCellViewModel_returns_correct_item_details() {
         // Given
-        let item = makeOrderItem(productID: productID)
-        let order = MockOrders().makeOrder(status: .processing, items: [item])
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item])
         let product = Product().copy(productID: productID)
 
         // When
@@ -31,23 +31,18 @@ class ReviewOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(productCellModel.name, item.name)
     }
-}
 
-private extension ReviewOrderViewModelTests {
-    func makeOrderItem(productID: Int64) -> OrderItem {
-        OrderItem(itemID: 1,
-                  name: "Order Item Name",
-                  productID: productID,
-                  variationID: 0,
-                  quantity: 1,
-                  price: NSDecimalNumber(integerLiteral: 1),
-                  sku: nil,
-                  subtotal: "1",
-                  subtotalTax: "1",
-                  taxClass: "TaxClass",
-                  taxes: [],
-                  total: "1",
-                  totalTax: "1",
-                  attributes: [])
+    func test_productDetailsCellViewModel_returns_no_addOns_if_view_model_receives_showAddOns_as_false() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
+
+        // Then
+        XCTAssertEqual(productCellModel.hasAddOns, false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -59,13 +59,13 @@ class ReviewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(productCellModel.hasAddOns, false)
     }
 
-    func test_productDetailsCellViewModel_returns_correct_hasAddOns_if_view_model_receives_showAddOns_as_true() {
+    func test_productDetailsCellViewModel_returns_correct_hasAddOns_if_view_model_receives_showAddOns_as_true_and_there_are_valid_addons() {
         // Given
-        let item = OrderItem.fake().copy(productID: productID)
+        let addOnName = "Test"
+        let itemAttribute = OrderItemAttribute.fake().copy(name: addOnName)
+        let item = OrderItem.fake().copy(productID: productID, attributes: [itemAttribute])
         let order = Order.fake().copy(siteID: siteID, status: .processing, items: [item])
-        let addOn = ProductAddOn.fake()
-        let addOnGroup = AddOnGroup.fake().copy(siteID: siteID, addOns: [addOn])
-        insert(addOnGroup)
+        let addOn = ProductAddOn.fake().copy(name: addOnName)
         let product = Product().copy(productID: productID, addOns: [addOn])
 
         // When
@@ -73,20 +73,6 @@ class ReviewOrderViewModelTests: XCTestCase {
         let productCellModel = viewModel.productDetailsCellViewModel(for: item)
 
         // Then
-        // TODO: fix failed test
-//        XCTAssertEqual(productCellModel.hasAddOns, true)
-    }
-}
-
-// MARK: - Storage helper
-private extension ReviewOrderViewModelTests {
-    func insert(_ readOnlyAddOnGroup: Yosemite.AddOnGroup) {
-        readOnlyAddOnGroup.addOns.forEach { readOnlyAddOn in
-            let storageAddOn = storage.insertNewObject(ofType: StorageProductAddOn.self)
-            storageAddOn.update(with: readOnlyAddOn)
-        }
-        let group = storage.insertNewObject(ofType: StorageAddOnGroup.self)
-        group.update(with: readOnlyAddOnGroup)
-        storage.saveIfNeeded()
+        XCTAssertEqual(productCellModel.hasAddOns, true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -8,6 +8,7 @@ import protocol Storage.StorageManagerType
 
 class ReviewOrderViewModelTests: XCTestCase {
 
+    private let orderID: Int64 = 543
     private let productID: Int64 = 1_00
     private let siteID: Int64 = 123
 
@@ -39,9 +40,11 @@ class ReviewOrderViewModelTests: XCTestCase {
 
         // When
         let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
-        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
 
         // Then
+        let aggregateItem = viewModel.aggregateOrderItems.first
+        XCTAssertNotNil(aggregateItem)
+        let productCellModel = viewModel.productDetailsCellViewModel(for: aggregateItem!)
         XCTAssertEqual(productCellModel.name, item.name)
     }
 
@@ -53,9 +56,10 @@ class ReviewOrderViewModelTests: XCTestCase {
 
         // When
         let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
-        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
 
         // Then
+        let aggregateItem = viewModel.aggregateOrderItems.first!
+        let productCellModel = viewModel.productDetailsCellViewModel(for: aggregateItem)
         XCTAssertEqual(productCellModel.hasAddOns, false)
     }
 
@@ -70,9 +74,57 @@ class ReviewOrderViewModelTests: XCTestCase {
 
         // When
         let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: true, storageManager: storageManager)
-        let productCellModel = viewModel.productDetailsCellViewModel(for: item)
 
         // Then
+        let aggregateItem = viewModel.aggregateOrderItems.first!
+        let productCellModel = viewModel.productDetailsCellViewModel(for: aggregateItem)
         XCTAssertEqual(productCellModel.hasAddOns, true)
+    }
+
+    func test_productSection_contains_only_non_refunded_items() {
+        // Given
+        let productID2: Int64 = 335
+        let itemID1: Int64 = 134
+        let itemID2: Int64 = 432
+
+        let product1 = Product().copy(productID: productID)
+        let product2 = Product().copy(productID: productID2)
+
+        let item1 = OrderItem.fake().copy(itemID: itemID1, productID: product1.productID, quantity: 1)
+        let item2 = OrderItem.fake().copy(itemID: itemID2, productID: product2.productID, quantity: -1)
+        let order = Order.fake().copy(siteID: siteID, orderID: orderID, status: .processing, items: [item1, item2])
+
+        let itemRefund = OrderItemRefund.fake().copy(itemID: item2.itemID, productID: item2.productID)
+        let refund = Refund.fake().copy(orderID: orderID, siteID: siteID, items: [itemRefund])
+        insert(refund)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product1, product2], showAddOns: false, storageManager: storageManager)
+        viewModel.configureResultsControllers {}
+
+        // Then
+        let productSection = viewModel.sections.first(where: { $0.category == .products })
+        XCTAssertNotNil(productSection)
+        let productRow = productSection?.rows.first(where: {
+            if case .orderItem(let item) = $0,
+               item.productID == productID {
+                return true
+            }
+            return false
+        })
+        XCTAssertNotNil(productRow)
+    }
+}
+
+private extension ReviewOrderViewModelTests {
+    func insert(_ readOnlyRefund: Refund) {
+        let storageRefund = storage.insertNewObject(ofType: StorageRefund.self)
+        storageRefund.update(with: readOnlyRefund)
+        storageRefund.items = Set(readOnlyRefund.items.map {
+            let storageItem = storage.insertNewObject(ofType: StorageOrderItemRefund.self)
+            storageItem.update(with: $0)
+            return storageItem
+        })
+        storage.saveIfNeeded()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -81,7 +81,7 @@ class ReviewOrderViewModelTests: XCTestCase {
         XCTAssertEqual(productCellModel.hasAddOns, true)
     }
 
-    func test_productSection_contains_only_non_refunded_items() {
+    func test_product_section_does_not_contain_refunded_items() {
         // Given
         let productID2: Int64 = 335
         let itemID1: Int64 = 134
@@ -105,14 +105,14 @@ class ReviewOrderViewModelTests: XCTestCase {
         // Then
         let productSection = viewModel.sections.first(where: { $0.category == .products })
         XCTAssertNotNil(productSection)
-        let productRow = productSection?.rows.first(where: {
+        let refundedProductRow = productSection?.rows.first(where: {
             if case .orderItem(let item) = $0,
-               item.productID == productID {
+               item.productID == productID2 {
                 return true
             }
             return false
         })
-        XCTAssertNotNil(productRow)
+        XCTAssertNil(refundedProductRow)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -34,7 +34,7 @@ class ReviewOrderViewModelTests: XCTestCase {
 
     func test_productDetailsCellViewModel_returns_correct_item_details() {
         // Given
-        let item = OrderItem.fake().copy(productID: productID)
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1)
         let order = Order.fake().copy(status: .processing, items: [item])
         let product = Product().copy(productID: productID)
 
@@ -50,7 +50,7 @@ class ReviewOrderViewModelTests: XCTestCase {
 
     func test_productDetailsCellViewModel_returns_no_addOns_if_view_model_receives_showAddOns_as_false() {
         // Given
-        let item = OrderItem.fake().copy(productID: productID)
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1)
         let order = Order.fake().copy(status: .processing, items: [item])
         let product = Product().copy(productID: productID)
 
@@ -67,7 +67,7 @@ class ReviewOrderViewModelTests: XCTestCase {
         // Given
         let addOnName = "Test"
         let itemAttribute = OrderItemAttribute.fake().copy(name: addOnName)
-        let item = OrderItem.fake().copy(productID: productID, attributes: [itemAttribute])
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1, attributes: [itemAttribute])
         let order = Order.fake().copy(siteID: siteID, status: .processing, items: [item])
         let addOn = ProductAddOn.fake().copy(name: addOnName)
         let product = Product().copy(productID: productID, addOns: [addOn])


### PR DESCRIPTION
Part 2 of #4136
For more context: [part 1](https://github.com/woocommerce/woocommerce-ios/pull/4534), [part 3](https://github.com/woocommerce/woocommerce-ios/pull/4539), [part 4](https://github.com/woocommerce/woocommerce-ios/pull/4549), [part 5](https://github.com/woocommerce/woocommerce-ios/pull/4567).

# Description
This PR follows up #4534 (please makes sure to review that PR first) and updates Review Order screen with Product section.

# Solution
- ReviewOrderViewModel was updated with new subtypes `Section` and `Row` to define sections and rows of the review order table view.
- The view model acts as data source for the review order table view, so it was updated to config displayed data for the Product section including header title and cell view model.
- Product cell view models require info about add-ons, so the view model was updated to receive `showAddOns` config from Order Details screen. Add-ons are also queried to check if they're available on the products.
- ReviewOrderViewController was updated to config its table view's datasource and delegate. Action to show add-ons was also implemented.

# Screenshot
<img src="https://user-images.githubusercontent.com/5533851/124424597-76ea6000-dd91-11eb-8736-c70db4a2defe.gif" width=400 />

# Testing
- Navigate to Orders tab
- Select an order with In Progress status
- Select Mark Order Complete
- You should then be navigated to Review Order screen with only one section named Products.
- If `showAddOns` config is enabled, the displayed product cells should show option to see add-ons appropriately (like in the gif above).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
