### PR TITLE
Shipping Labels: fixed navigation title showed in tab bar in Package Details and Package List screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -6,48 +6,53 @@ struct ShippingLabelPackageList: View {
     @Environment(\.presentationMode) var presentation
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
+        NavigationView {
+            ScrollView {
+                LazyVStack(spacing: 0) {
 
-                /// Custom Packages
-                ///
-                if viewModel.showCustomPackagesHeader {
-                    ListHeaderView(text: Localization.customPackageHeader.uppercased(), alignment: .left)
-                        .background(Color(.listBackground))
-                }
-                ForEach(viewModel.customPackages, id: \.title) { package in
-                    let selected = package == viewModel.selectedCustomPackage
-                    SelectableItemRow(title: package.title, subtitle: package.dimensions + " \(viewModel.dimensionUnit)", selected: selected).onTapGesture {
-                        viewModel.didSelectPackage(package.title)
+                    /// Custom Packages
+                    ///
+                    if viewModel.showCustomPackagesHeader {
+                        ListHeaderView(text: Localization.customPackageHeader.uppercased(), alignment: .left)
+                            .background(Color(.listBackground))
                     }
-                    Divider().padding(.leading, Constants.dividerPadding)
-                }
-
-                /// Predefined Packages
-                ///
-                ForEach(viewModel.predefinedOptions, id: \.title) { option in
-
-                    ListHeaderView(text: option.title.uppercased(), alignment: .left)
-                        .background(Color(.listBackground))
-                    ForEach(option.predefinedPackages) { package in
-                        let selected = package == viewModel.selectedPredefinedPackage
+                    ForEach(viewModel.customPackages, id: \.title) { package in
+                        let selected = package == viewModel.selectedCustomPackage
                         SelectableItemRow(title: package.title, subtitle: package.dimensions + " \(viewModel.dimensionUnit)", selected: selected).onTapGesture {
-                            viewModel.didSelectPackage(package.id)
+                            viewModel.didSelectPackage(package.title)
                         }
                         Divider().padding(.leading, Constants.dividerPadding)
                     }
+
+                    /// Predefined Packages
+                    ///
+                    ForEach(viewModel.predefinedOptions, id: \.title) { option in
+
+                        ListHeaderView(text: option.title.uppercased(), alignment: .left)
+                            .background(Color(.listBackground))
+                        ForEach(option.predefinedPackages) { package in
+                            let selected = package == viewModel.selectedPredefinedPackage
+                            SelectableItemRow(title: package.title,
+                                              subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
+                                              selected: selected).onTapGesture {
+                                viewModel.didSelectPackage(package.id)
+                            }
+                            Divider().padding(.leading, Constants.dividerPadding)
+                        }
+                    }
                 }
+                .background(Color(.systemBackground))
             }
-            .background(Color(.systemBackground))
+            .background(Color(.listBackground))
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarItems(trailing: Button(action: {
+                viewModel.confirmPackageSelection()
+                presentation.wrappedValue.dismiss()
+            }, label: {
+                Text(Localization.doneButton)
+            }))
         }
-        .background(Color(.listBackground))
-        .navigationTitle(Localization.title)
-        .navigationBarItems(trailing: Button(action: {
-            viewModel.confirmPackageSelection()
-            presentation.wrappedValue.dismiss()
-        }, label: {
-            Text(Localization.doneButton)
-        }))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -53,7 +53,7 @@ struct ShippingLabelPackageDetails: View {
             .background(Color(.systemBackground))
         }
         .background(Color(.listBackground))
-        .navigationTitle("Title Of the view")
+        .navigationTitle(Localization.title)
         .navigationBarItems(trailing: Button(action: {
             onCompletion(viewModel.selectedPackageID, viewModel.totalWeight)
             presentation.wrappedValue.dismiss()
@@ -66,6 +66,8 @@ struct ShippingLabelPackageDetails: View {
 
 private extension ShippingLabelPackageDetails {
     enum Localization {
+        static let title = NSLocalizedString("Package Details",
+                                             comment: "Navigation bar title of shipping label package details screen")
         static let itemsToFulfillHeader = NSLocalizedString("ITEMS TO FULFILL", comment: "Header section items to fulfill in Shipping Label Package Detail")
         static let packageDetailsHeader = NSLocalizedString("PACKAGE DETAILS", comment: "Header section package details in Shipping Label Package Detail")
         static let packageSelected = NSLocalizedString("Package Selected",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -34,13 +34,10 @@ struct ShippingLabelPackageDetails: View {
 
                 TitleAndValueRow(title: Localization.packageSelected, value: viewModel.selectedPackageName, selectable: true) {
                     showingAddPackage.toggle()
-                }
+                }.sheet(isPresented: $showingAddPackage, content: {
+                    ShippingLabelPackageList(viewModel: viewModel)
+                })
 
-                NavigationLink(
-                    destination:
-                        ShippingLabelPackageList(viewModel: viewModel),
-                    isActive: $showingAddPackage) { EmptyView()
-                }
                 Divider()
 
                 TitleAndTextFieldRow(title: Localization.totalPackageWeight,
@@ -56,6 +53,7 @@ struct ShippingLabelPackageDetails: View {
             .background(Color(.systemBackground))
         }
         .background(Color(.listBackground))
+        .navigationTitle("Title Of the view")
         .navigationBarItems(trailing: Button(action: {
             onCompletion(viewModel.selectedPackageID, viewModel.totalWeight)
             presentation.wrappedValue.dismiss()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -513,9 +513,6 @@ private extension ShippingLabelFormViewController {
                                                               comment: "Title of the cell Payment Method inside Create Shipping Label form")
         static let continueButtonInCells = NSLocalizedString("Continue",
                                                              comment: "Continue button inside every cell inside Create Shipping Label form")
-        static let navigationBarTitlePackageDetails =
-            NSLocalizedString("Package Details",
-                              comment: "Navigation bar title of shipping label package details screen")
         // Purchase progress view
         static let purchaseProgressTitle = NSLocalizedString("Purchasing Label", comment: "Title of the in-progress UI while purchasing a shipping label")
         static let purchaseProgressMessage = NSLocalizedString("Please wait", comment: "Message of the in-progress UI while purchasing a shipping label")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -368,8 +368,6 @@ private extension ShippingLabelFormViewController {
         }
 
         let hostingVC = UIHostingController(rootView: packageDetails)
-        hostingVC.title = Localization.navigationBarTitlePackageDetails
-
         navigationController?.show(hostingVC, sender: nil)
     }
 


### PR DESCRIPTION
Fixes #3995 

## Description
In this PR, I fixed the issue that we have in the Package Details and Package List screens, implemented both in SwiftUI, where the navigation title was showed also in the tab bar as UITabBarButtonLabel. 
We didn't found any working solution, and we spent a lot of time looking for a solution that wasn't a workaround. I also contacted Apple, and I opened a radar about this issue that seems a bug on the Apple side, previously solved. Unfortunately, there was a regression, so the issue is still present, and there are some users that complain about it. You can read more on the issue I opened originally: https://github.com/woocommerce/woocommerce-ios/issues/3995

The best solution I have found, other than a real alternative fix, is to present the Package List screen as a modal screen. This doesn't compromise the functionality of the screen, it works fine, and the problem does not arise because it has nothing to do with the current navigation flow.
The majority of the changes are because of the indentation since I needed to embed the content of `PackageList` inside a `NavigationView`.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Fill out all sections of the Create Shipping Label form, until you get to "Package Details".
6. Open "Package Details" and select a package.
7. You should not see a "Label" of the title of the view in lower-left corner.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-07-05 at 10 39 58](https://user-images.githubusercontent.com/495617/124442885-78aa2880-dd7d-11eb-85a4-5b20f538a73a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-05 at 10 25 03](https://user-images.githubusercontent.com/495617/124442898-7ba51900-dd7d-11eb-932e-37a1f2d5f662.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
