### PR TITLE
Fix: typo and sync status in Shipping Labels carrier and rates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -83,7 +83,7 @@ private extension ShippingLabelCarriers {
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in shipping label carrier and rates screen")
         static let emptyStateTitle = NSLocalizedString("No shipping rates available",
                                                        comment: "Error state title in shipping label carrier and rates screen")
-        static let emptyStateDescription = NSLocalizedString("Please double check your package dimensions and weight" +
+        static let emptyStateDescription = NSLocalizedString("Please double check your package dimensions and weight " +
                                                                 "or try using a different package in Package Details.",
                                                              comment: "Error state description in shipping label carrier and rates screen")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
@@ -129,7 +129,12 @@ private extension ShippingLabelCarriersViewModel {
             switch result {
             case .success(let response):
                 self.generateRows(response: response)
-                self.syncStatus = .success
+                if self.rows.isEmpty {
+                    self.syncStatus = .error
+                }
+                else {
+                    self.syncStatus = .success
+                }
             case .failure:
                 self.rows = []
                 self.syncStatus = .error


### PR DESCRIPTION
Fixes #4377
Fixes #4482 (partially fixed because it seems that the second issue is no more reproducible)

This PR fixes two things:
1) There was a missing space where it says `weightor`. #4482 
2) Now if the API of carrier and rates returns an empty array, it will be considered as an error and the empty state screen will be shown. #4377 

## Testing
1. Go to Orders in the app and open an order that meets the criteria for shipping labels.
2. Tap the "Create Shipping Labels" button.
3. In either the "Ship from" or "Ship to" section, add an emoji such as 💸  to one of the address fields.
4. Continue through the shipping label sections until you get to Shipping Carrier and Rates.
5. Tap on the "Shipping Carrier and Rates" cell and notice that an empty screen loads display an error message. Make also sure that the typo `weightor` is no more here.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
