### PR TITLE
[Order Fulfillment][Part 3] Add customer section to Review Order screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -278,23 +278,23 @@ private extension ReviewOrderViewController {
         static let productsSectionTitle = NSLocalizedString("Products",
                                                             comment: "Product section title in Review Order screen if there is more than one product.")
         static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
-                static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
-                static let customerNoteTitle = NSLocalizedString("Customer Provided Note", comment: "Customer note row title")
-                static let shippingAddressTitle = NSLocalizedString("Shipping Address", comment: "Shipping Address title for customer info section")
-                static let noAddressCellTitle = NSLocalizedString(
-                    "No address specified.",
-                    comment: "Order details > customer info > shipping details. This is where the address would normally display."
-                )
-                static let shippingMethodTitle = NSLocalizedString("Shipping Method", comment: "Shipping method title for customer info section")
-                static let showBillingTitle = NSLocalizedString("View Billing Information",
-                                                                comment: "Button on bottom of Customer's information to show the billing details")
-                static let showBillingAccessibilityLabel = NSLocalizedString(
-                    "View Billing Information",
-                    comment: "Accessibility label for the 'View Billing Information' button"
-                )
-                static let showBillingAccessibilityHint = NSLocalizedString(
-                    "Show the billing details for this order.",
-                    comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
-                )
+        static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
+        static let customerNoteTitle = NSLocalizedString("Customer Provided Note", comment: "Customer note row title")
+        static let shippingAddressTitle = NSLocalizedString("Shipping Address", comment: "Shipping Address title for customer info section")
+        static let noAddressCellTitle = NSLocalizedString(
+            "No address specified.",
+            comment: "Order details > customer info > shipping details. This is where the address would normally display."
+        )
+        static let shippingMethodTitle = NSLocalizedString("Shipping Method", comment: "Shipping method title for customer info section")
+        static let showBillingTitle = NSLocalizedString("View Billing Information",
+                                                        comment: "Button on bottom of Customer's information to show the billing details")
+        static let showBillingAccessibilityLabel = NSLocalizedString(
+            "View Billing Information",
+            comment: "Accessibility label for the 'View Billing Information' button"
+        )
+        static let showBillingAccessibilityHint = NSLocalizedString(
+            "Show the billing details for this order.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -185,20 +185,17 @@ private extension ReviewOrderViewController {
     /// Setup: Customer Note Cell
     ///
     private func setupCustomerNoteCell(_ cell: UITableViewCell, with note: String) {
-        guard let cell = cell as? ImageAndTitleAndTextTableViewCell else {
+        guard let cell = cell as? CustomerNoteTableViewCell else {
             fatalError("⛔ Incorrect cell type for Customer Note cell")
         }
 
-        cell.update(with: .imageAndTitleOnly(fontStyle: .body),
-                    data: .init(title: note,
-                                textTintColor: .text,
-                                image: .quoteImage,
-                                imageTintColor: .text,
-                                numberOfLinesForTitle: 0,
-                                isActionable: false))
-
-        cell.isAccessibilityElement = true
-        cell.accessibilityLabel = note
+        cell.headline = viewModel.customerNoteTitle
+        let localizedBody = String.localizedStringWithFormat(
+            NSLocalizedString("“%@”",
+                              comment: "Customer note, wrapped in quotes"),
+            note)
+        cell.body = localizedBody
+        cell.selectionStyle = .none
     }
 
     /// Setup: Address Cell

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -115,10 +115,10 @@ extension ReviewOrderViewController: UITableViewDelegate {
         case let headerView as TwoColumnSectionHeaderView:
             switch section.category {
             case .customerInformation:
-                headerView.leftText = viewModel.customerSectionTitle
+                headerView.leftText = Localization.customerSectionTitle
                 headerView.rightText = nil
             case .tracking:
-                headerView.leftText = viewModel.trackingSectionTitle
+                headerView.leftText = Localization.trackingSectionTitle
                 headerView.rightText = nil
             case .products:
                 assertionFailure("Unexpected category of type \(headerView.self)")
@@ -190,7 +190,7 @@ private extension ReviewOrderViewController {
             fatalError("⛔ Incorrect cell type for Customer Note cell")
         }
 
-        cell.headline = viewModel.customerNoteTitle
+        cell.headline = Localization.customerNoteTitle
         let localizedBody = String.localizedStringWithFormat(
             NSLocalizedString("“%@”",
                               comment: "Customer note, wrapped in quotes"),
@@ -205,9 +205,9 @@ private extension ReviewOrderViewController {
         guard let cell = cell as? CustomerInfoTableViewCell else {
             fatalError("⛔ Incorrect cell type for Address cell")
         }
-        cell.title = viewModel.shippingAddressTitle
+        cell.title = Localization.shippingAddressTitle
         cell.name = address?.fullNameWithCompany
-        cell.address = address?.formattedPostalAddress ?? viewModel.noAddressCellTitle
+        cell.address = address?.formattedPostalAddress ?? Localization.noAddressCellTitle
     }
 
     /// Setup: Shipping Method cell
@@ -217,7 +217,7 @@ private extension ReviewOrderViewController {
             fatalError("⛔ Incorrect cell type for Shipping Method cell")
         }
 
-        cell.headline = viewModel.shippingMethodTitle
+        cell.headline = Localization.shippingMethodTitle
         cell.body = method?.strippedHTML
         cell.selectionStyle = .none
     }
@@ -228,14 +228,14 @@ private extension ReviewOrderViewController {
         guard let cell = cell as? WooBasicTableViewCell else {
             fatalError("⛔ Incorrect cell type for Billing Detail cell")
         }
-        cell.bodyLabel?.text = viewModel.showBillingTitle
+        cell.bodyLabel?.text = Localization.showBillingTitle
         cell.applyPlainTextStyle()
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
 
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = viewModel.showBillingAccessibilityLabel
-        cell.accessibilityHint = viewModel.showBillingAccessibilityHint
+        cell.accessibilityLabel = Localization.showBillingAccessibilityLabel
+        cell.accessibilityHint = Localization.showBillingAccessibilityHint
     }
 }
 
@@ -277,5 +277,24 @@ private extension ReviewOrderViewController {
         static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
         static let productsSectionTitle = NSLocalizedString("Products",
                                                             comment: "Product section title in Review Order screen if there is more than one product.")
+        static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
+                static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
+                static let customerNoteTitle = NSLocalizedString("Customer Provided Note", comment: "Customer note row title")
+                static let shippingAddressTitle = NSLocalizedString("Shipping Address", comment: "Shipping Address title for customer info section")
+                static let noAddressCellTitle = NSLocalizedString(
+                    "No address specified.",
+                    comment: "Order details > customer info > shipping details. This is where the address would normally display."
+                )
+                static let shippingMethodTitle = NSLocalizedString("Shipping Method", comment: "Shipping method title for customer info section")
+                static let showBillingTitle = NSLocalizedString("View Billing Information",
+                                                                comment: "Button on bottom of Customer's information to show the billing details")
+                static let showBillingAccessibilityLabel = NSLocalizedString(
+                    "View Billing Information",
+                    comment: "Accessibility label for the 'View Billing Information' button"
+                )
+                static let showBillingAccessibilityHint = NSLocalizedString(
+                    "Show the billing details for this order.",
+                    comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
+                )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -254,7 +254,6 @@ private extension ReviewOrderViewController {
     /// Show billing information screen
     ///
     func billingInformationTapped() {
-        ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
         let billingInformationViewController = BillingInformationViewController(order: viewModel.order)
         navigationController?.pushViewController(billingInformationViewController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -111,6 +111,17 @@ extension ReviewOrderViewController: UITableViewDelegate {
             case .customerInformation, .tracking:
                 assertionFailure("Unexpected category of type \(headerView.self)")
             }
+        case let headerView as TwoColumnSectionHeaderView:
+            switch section.category {
+            case .customerInformation:
+                headerView.leftText = viewModel.customerSectionTitle
+                headerView.rightText = nil
+            case .tracking:
+                headerView.leftText = viewModel.trackingSectionTitle
+                headerView.rightText = nil
+            case .products:
+                assertionFailure("Unexpected category of type \(headerView.self)")
+            }
         default:
             assertionFailure("Unexpected headerView type \(headerView.self)")
             return nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.xib
@@ -19,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gOf-hh-Od4">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="gOf-hh-Od4">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -23,7 +23,7 @@ final class ReviewOrderViewModel {
 
     /// The order for review
     ///
-    private(set) var order: Order
+    let order: Order
 
     /// Products in the order
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -93,6 +93,12 @@ extension ReviewOrderViewModel {
         Localization.trackingSectionTitle
     }
 
+    /// Title for Customer Note cell
+    ///
+    var customerNoteTitle: String {
+        Localization.customerNoteTitle
+    }
+
     /// Title for Shipping Address cell
     ///
     var shippingAddressTitle: String {
@@ -300,6 +306,7 @@ private extension ReviewOrderViewModel {
                                                             comment: "Product section title in Review Order screen if there is more than one product.")
         static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
         static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
+        static let customerNoteTitle = NSLocalizedString("Customer Provided Note", comment: "Customer note row title")
         static let shippingAddressTitle = NSLocalizedString("Shipping Address", comment: "Shipping Address title for customer info section")
         static let noAddressCellTitle = NSLocalizedString(
             "No address specified.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -264,7 +264,7 @@ extension ReviewOrderViewModel {
 
     /// Row types for Review Order screen
     ///
-    enum Row: Equatable {
+    enum Row {
         case orderItem(item: OrderItem)
         case customerNote(text: String)
         case shippingAddress(address: Address)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -12,7 +12,7 @@ final class ReviewOrderViewModel {
 
     /// The order for review
     ///
-    private let order: Order
+    let order: Order
 
     /// Products in the order
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -81,6 +81,18 @@ extension ReviewOrderViewModel {
         order.items.count > 0 ? Localization.productsSectionTitle : Localization.productSectionTitle
     }
 
+    /// Title for Customer section
+    ///
+    var customerSectionTitle: String {
+        return Localization.customerSectionTitle
+    }
+
+    /// Title for Tracking section
+    ///
+    var trackingSectionTitle: String {
+        return Localization.trackingSectionTitle
+    }
+
     /// Sections for order table view
     ///
     var sections: [Section] {
@@ -203,5 +215,7 @@ private extension ReviewOrderViewModel {
         static let productSectionTitle = NSLocalizedString("Product", comment: "Product section title in Review Order screen if there is one product.")
         static let productsSectionTitle = NSLocalizedString("Products",
                                                             comment: "Product section title in Review Order screen if there is more than one product.")
+        static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
+        static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -72,60 +72,6 @@ final class ReviewOrderViewModel {
 //
 extension ReviewOrderViewModel {
 
-    /// Title for Customer section
-    ///
-    var customerSectionTitle: String {
-        Localization.customerSectionTitle
-    }
-
-    /// Title for Tracking section
-    ///
-    var trackingSectionTitle: String {
-        Localization.trackingSectionTitle
-    }
-
-    /// Title for Customer Note cell
-    ///
-    var customerNoteTitle: String {
-        Localization.customerNoteTitle
-    }
-
-    /// Title for Shipping Address cell
-    ///
-    var shippingAddressTitle: String {
-        Localization.shippingAddressTitle
-    }
-
-    /// Title for Shipping Address if no address found
-    ///
-    var noAddressCellTitle: String {
-        Localization.noAddressCellTitle
-    }
-
-    /// Title for Shipping Method cell
-    ///
-    var shippingMethodTitle: String {
-        Localization.shippingMethodTitle
-    }
-
-    /// Title for Show Billing cell
-    ///
-    var showBillingTitle: String {
-        Localization.showBillingTitle
-    }
-
-    /// Accessibility Label for Show Billing title
-    ///
-    var showBillingAccessibilityLabel: String {
-        Localization.showBillingAccessibilityLabel
-    }
-
-    /// Accessibility Hint for Show Billing title
-    ///
-    var showBillingAccessibilityHint: String {
-        Localization.showBillingAccessibilityHint
-    }
-
     /// Sections for order table view
     ///
     var sections: [Section] {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -23,7 +23,7 @@ final class ReviewOrderViewModel {
 
     /// The order for review
     ///
-    private let order: Order
+    private(set) var order: Order
 
     /// Products in the order
     ///
@@ -55,12 +55,6 @@ final class ReviewOrderViewModel {
         return ResultsController<StorageAddOnGroup>(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
 
-    /// First Shipping method from an order
-    ///
-    private var shippingMethod: String {
-        return order.shippingLines.first?.methodTitle ?? String()
-    }
-
     init(order: Order,
          products: [Product],
          showAddOns: Bool,
@@ -90,13 +84,49 @@ extension ReviewOrderViewModel {
     /// Title for Customer section
     ///
     var customerSectionTitle: String {
-        return Localization.customerSectionTitle
+        Localization.customerSectionTitle
     }
 
     /// Title for Tracking section
     ///
     var trackingSectionTitle: String {
-        return Localization.trackingSectionTitle
+        Localization.trackingSectionTitle
+    }
+
+    /// Title for Shipping Address cell
+    ///
+    var shippingAddressTitle: String {
+        Localization.shippingAddressTitle
+    }
+
+    /// Title for Shipping Address if no address found
+    ///
+    var noAddressCellTitle: String {
+        Localization.noAddressCellTitle
+    }
+
+    /// Title for Shipping Method cell
+    ///
+    var shippingMethodTitle: String {
+        Localization.shippingMethodTitle
+    }
+
+    /// Title for Show Billing cell
+    ///
+    var showBillingTitle: String {
+        Localization.showBillingTitle
+    }
+
+    /// Accessibility Label for Show Billing title
+    ///
+    var showBillingAccessibilityLabel: String {
+        Localization.showBillingAccessibilityLabel
+    }
+
+    /// Accessibility Hint for Show Billing title
+    ///
+    var showBillingAccessibilityHint: String {
+        Localization.showBillingAccessibilityHint
     }
 
     /// Sections for order table view
@@ -127,6 +157,21 @@ extension ReviewOrderViewModel {
         let product = filterProduct(for: item)
         let addOns = filterAddons(for: item)
         return ProductDetailsCellViewModel(item: item, currency: order.currency, product: product, hasAddOns: !addOns.isEmpty)
+    }
+}
+
+// MARK: - Order details
+private extension ReviewOrderViewModel {
+    /// Shipping address of the order
+    ///
+    var shippingAddress: Address? {
+        order.shippingAddress
+    }
+
+    /// First Shipping method from an order
+    ///
+    var shippingMethod: String {
+        return order.shippingLines.first?.methodTitle ?? String()
     }
 }
 
@@ -161,14 +206,14 @@ private extension ReviewOrderViewModel {
                     order.items.first(where: { $0.productID == product.productID}) != nil
                 }
                 .allSatisfy { $0.virtual == true }
-            guard let shippingAddress = order.shippingAddress, !orderContainsOnlyVirtualProducts else {
+            guard let shippingAddress = shippingAddress, !orderContainsOnlyVirtualProducts else {
                 return nil
             }
             return Row.shippingAddress(address: shippingAddress)
         }()
 
-        // TODO: billing row?
-        let rows = [noteRow, shippingMethodRow, addressRow].compactMap { $0 }
+        let billingRow: Row = .billingDetail
+        let rows = [noteRow, addressRow, shippingMethodRow, billingRow].compactMap { $0 }
         return .init(category: .customerInformation, rows: rows)
     }
 
@@ -274,5 +319,21 @@ private extension ReviewOrderViewModel {
                                                             comment: "Product section title in Review Order screen if there is more than one product.")
         static let customerSectionTitle = NSLocalizedString("Customer", comment: "Customer info section title in Review Order screen")
         static let trackingSectionTitle = NSLocalizedString("Tracking", comment: "Tracking section title in Review Order screen")
+        static let shippingAddressTitle = NSLocalizedString("Shipping Address", comment: "Shipping Address title for customer info section")
+        static let noAddressCellTitle = NSLocalizedString(
+            "No address specified.",
+            comment: "Order details > customer info > shipping details. This is where the address would normally display."
+        )
+        static let shippingMethodTitle = NSLocalizedString("Shipping Method", comment: "Shipping method title for customer info section")
+        static let showBillingTitle = NSLocalizedString("View Billing Information",
+                                                        comment: "Button on bottom of Customer's information to show the billing details")
+        static let showBillingAccessibilityLabel = NSLocalizedString(
+            "View Billing Information",
+            comment: "Accessibility label for the 'View Billing Information' button"
+        )
+        static let showBillingAccessibilityHint = NSLocalizedString(
+            "Show the billing details for this order.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -132,7 +132,8 @@ extension ReviewOrderViewModel {
     /// Sections for order table view
     ///
     var sections: [Section] {
-        return [productSection, customerSection, trackingSection].filter { !$0.rows.isEmpty }
+        // TODO: Add tracking section
+        return [productSection, customerSection].filter { !$0.rows.isEmpty }
     }
 
     /// Filter product for an order item
@@ -216,26 +217,6 @@ private extension ReviewOrderViewModel {
         let rows = [noteRow, addressRow, shippingMethodRow, billingRow].compactMap { $0 }
         return .init(category: .customerInformation, rows: rows)
     }
-
-    /// Tracking section setup
-    ///
-    var trackingSection: Section {
-        // TODO: add order tracking & trackingIsReachable
-        let trackingRow: Row? = {
-//                guard !orderTracking.isEmpty else { return nil }
-            return nil
-        }()
-
-        let trackingAddRow: Row? = {
-            // Hide the section if the shipment
-            // tracking plugin is not installed
-//                guard trackingIsReachable else { return nil }
-            return Row.trackingAdd
-        }()
-
-        let rows = [trackingRow, trackingAddRow].compactMap { $0 }
-        return .init(category: .tracking, rows: rows)
-    }
 }
 
 // MARK: - Section and row types for Review Order table view
@@ -277,7 +258,7 @@ extension ReviewOrderViewModel {
 
     /// Row types for Review Order screen
     ///
-    enum Row {
+    enum Row: Equatable {
         case orderItem(item: OrderItem)
         case customerNote(text: String)
         case shippingAddress(address: Address)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -34,7 +34,7 @@ class ReviewOrderViewModelTests: XCTestCase {
 
     func test_productDetailsCellViewModel_returns_correct_item_details() {
         // Given
-        let item = OrderItem.fake().copy(productID: productID)
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1)
         let order = Order.fake().copy(status: .processing, items: [item])
         let product = Product().copy(productID: productID)
 
@@ -50,7 +50,7 @@ class ReviewOrderViewModelTests: XCTestCase {
 
     func test_productDetailsCellViewModel_returns_no_addOns_if_view_model_receives_showAddOns_as_false() {
         // Given
-        let item = OrderItem.fake().copy(productID: productID)
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1)
         let order = Order.fake().copy(status: .processing, items: [item])
         let product = Product().copy(productID: productID)
 
@@ -67,7 +67,7 @@ class ReviewOrderViewModelTests: XCTestCase {
         // Given
         let addOnName = "Test"
         let itemAttribute = OrderItemAttribute.fake().copy(name: addOnName)
-        let item = OrderItem.fake().copy(productID: productID, attributes: [itemAttribute])
+        let item = OrderItem.fake().copy(productID: productID, quantity: 1, attributes: [itemAttribute])
         let order = Order.fake().copy(siteID: siteID, status: .processing, items: [item])
         let addOn = ProductAddOn.fake().copy(name: addOnName)
         let product = Product().copy(productID: productID, addOns: [addOn])
@@ -112,7 +112,7 @@ class ReviewOrderViewModelTests: XCTestCase {
             }
             return false
         })
-        XCTAssertNotNil(productRow)        
+        XCTAssertNotNil(productRow)
     }
 
     func test_customerSection_does_not_contain_customer_note_cell_if_there_is_no_note() {
@@ -222,7 +222,8 @@ class ReviewOrderViewModelTests: XCTestCase {
                 return true
             }
             return false
-         }
+        })
+        XCTAssertNil(customerAddressRow)
     }
 
     func test_customerSection_does_not_contain_shipping_address_cell_if_there_is_virtual_product_and_shipping_address() {
@@ -244,7 +245,7 @@ class ReviewOrderViewModelTests: XCTestCase {
             }
             return false
         })
-        XCTAssertNotNil(customerAddressRow)        
+        XCTAssertNotNil(customerAddressRow)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Review Order/ReviewOrderViewModelTests.swift
@@ -76,6 +76,139 @@ class ReviewOrderViewModelTests: XCTestCase {
         // TODO: fix failed test
 //        XCTAssertEqual(productCellModel.hasAddOns, true)
     }
+
+    func test_customerSection_does_not_contain_customer_note_cell_if_there_is_no_note() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, customerNote: nil, items: [item])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerNoteRow = customerSection?.rows.first(where: {
+            if case .customerNote = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNil(customerNoteRow)
+    }
+
+    func test_customerSection_contains_customer_note_cell_if_there_is_non_empty_note() {
+        // Given
+        let note = "Test"
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, customerNote: note, items: [item])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerNoteRow = customerSection?.rows.first(where: {
+            if case .customerNote = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNotNil(customerNoteRow)
+    }
+
+    func test_customerSection_does_not_contain_shipping_method_cell_if_there_is_no_shippingLines() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item], shippingLines: [])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerShippingMethodRow = customerSection?.rows.first(where: {
+            if case .shippingMethod = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNil(customerShippingMethodRow)
+    }
+
+    func test_customerSection_contains_shipping_method_cell_if_there_exist_shippingLines() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item], shippingLines: [ShippingLine.fake()])
+        let product = Product().copy(productID: productID)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerShippingMethodRow = customerSection?.rows.first(where: {
+            if case .shippingMethod = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNotNil(customerShippingMethodRow)
+    }
+
+    func test_customerSection_does_not_contain_shipping_address_cell_if_there_are_only_virtual_products() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item])
+        let product = Product().copy(productID: productID, virtual: true)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerAddressRow = customerSection?.rows.first(where: {
+            if case .shippingAddress = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNil(customerAddressRow)
+    }
+
+    func test_customerSection_does_not_contain_shipping_address_cell_if_there_is_virtual_product_and_shipping_address() {
+        // Given
+        let item = OrderItem.fake().copy(productID: productID)
+        let order = Order.fake().copy(status: .processing, items: [item], shippingAddress: Address.fake())
+        let product = Product().copy(productID: productID, virtual: false)
+
+        // When
+        let viewModel = ReviewOrderViewModel(order: order, products: [product], showAddOns: false)
+
+        // Then
+        let customerSection = viewModel.sections.first(where: { $0.category == .customerInformation })
+        XCTAssertNotNil(customerSection)
+
+        let customerAddressRow = customerSection?.rows.first(where: {
+            if case .shippingAddress = $0 {
+                return true
+            }
+            return false
+        })
+        XCTAssertNotNil(customerAddressRow)
+    }
 }
 
 // MARK: - Storage helper


### PR DESCRIPTION
Part 3 of #4136 
For more context there's [part 1](https://github.com/woocommerce/woocommerce-ios/pull/4534), [part 2](https://github.com/woocommerce/woocommerce-ios/pull/4535), [part 4](https://github.com/woocommerce/woocommerce-ios/pull/4549), [part 5](https://github.com/woocommerce/woocommerce-ios/pull/4567).

# Description
This PR follows up #4535 to add new section Customer Information to the Review Order screen.

# Solution
- ReviewOrderViewModel was updated to config rows for Customer section. This section should contains the following rows:
  - Customer note if order has additional note
  - Shipping address if order has at least one non-virtual product
  - Shipping method if order has shipping info
  - View billing info
- ReviewOrderViewController was updated to config styling and content for cells based on row information.

# Screenshots
| Customer section with note only | Customer section with Shipping Details |
|----|----|
|<img src="https://user-images.githubusercontent.com/5533851/124456843-621fc380-ddb5-11eb-8844-9a94511007ab.png" width=400 />|<img src="https://user-images.githubusercontent.com/5533851/124456848-63e98700-ddb5-11eb-91c5-f1835980281d.png" width=400 />|

# Testing
- Navigate to Orders tab
- Select an order with In Progress status
- Select Mark Order Complete
- You should then be navigated to Review Order screen with two sections Product and Customer Information.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
