### PR TITLE
[Mobile Payments] Fix crash when attempting to collect payment while retrying (7.0 Backport)

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -42,9 +42,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true, completion: {[weak self] in
-            self?.primaryAction()
-        })
+        primaryAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -6,70 +6,78 @@ import WordPressUI
 /// presented to provide user-facing feedback about the progress
 /// of the payment collection process
 final class OrderDetailsPaymentAlerts {
-    private var modalController: CardPresentPaymentsModalViewController?
+    private weak var presentingController: UIViewController?
+
+    // Storing this as a weak variable means that iOS should automatically set this to nil
+    // when the VC is dismissed, unless there is a retain cycle somewhere else.
+    private weak var _modalController: CardPresentPaymentsModalViewController?
+    private var modalController: CardPresentPaymentsModalViewController {
+        if let controller = _modalController {
+            return controller
+        } else {
+            let controller = CardPresentPaymentsModalViewController(viewModel: readerIsReady())
+            _modalController = controller
+            return controller
+        }
+    }
+
     private var name: String = ""
     private var amount: String = ""
 
-    func readerIsReady(from: UIViewController, title: String, amount: String) {
+    init(presentingController: UIViewController) {
+        self.presentingController = presentingController
+    }
+
+    func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
+        let controller = modalController
+        controller.setViewModel(viewModel)
+        if controller.presentingViewController == nil {
+            controller.modalPresentationStyle = .custom
+            controller.transitioningDelegate = AppDelegate.shared.tabBarController
+            presentingController?.present(controller, animated: true)
+        }
+    }
+
+    func readerIsReady(title: String, amount: String) {
         self.name = title
         self.amount = amount
 
         // Initial presentation of the modal view controller. We need to provide
         // a customer name and an amount.
         let viewModel = readerIsReady()
-        let newAlert = CardPresentPaymentsModalViewController(viewModel: viewModel)
-        modalController = newAlert
-        modalController?.modalPresentationStyle = .custom
-        modalController?.transitioningDelegate = AppDelegate.shared.tabBarController
-        from.present(newAlert, animated: true)
+        presentViewModel(viewModel: viewModel)
     }
 
     func tapOrInsertCard() {
         let viewModel = tapOrInsert()
-        modalController?.setViewModel(viewModel)
+        presentViewModel(viewModel: viewModel)
     }
 
     func removeCard() {
         let viewModel = remove()
-        modalController?.setViewModel(viewModel)
+        presentViewModel(viewModel: viewModel)
     }
 
     func processingPayment() {
         let viewModel = processing()
-        modalController?.setViewModel(viewModel)
+        presentViewModel(viewModel: viewModel)
     }
 
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
         let viewModel = successViewModel(printReceipt: printReceipt, emailReceipt: emailReceipt)
-        modalController?.setViewModel(viewModel)
+        presentViewModel(viewModel: viewModel)
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void) {
         let viewModel = errorViewModel(amount: amount, error: error, tryAgain: tryAgain)
-        modalController?.setViewModel(viewModel)
+        presentViewModel(viewModel: viewModel)
     }
 
     func nonRetryableError(from: UIViewController?, error: Error) {
         let viewModel = nonRetryableErrorViewModel(amount: amount, error: error)
-
-        guard modalController == nil else {
-            modalController?.setViewModel(viewModel)
-            return
-        }
-
-        let newAlert = CardPresentPaymentsModalViewController(viewModel: viewModel)
-
-        modalController = newAlert
-        modalController?.modalPresentationStyle = .custom
-        modalController?.transitioningDelegate = AppDelegate.shared.tabBarController
-        from?.present(newAlert, animated: true)
-    }
-
-    func dismiss() {
-        modalController?.dismiss(animated: true, completion: nil)
+        presentViewModel(viewModel: viewModel)
     }
 }
-
 
 private extension OrderDetailsPaymentAlerts {
     func readerIsReady() -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -53,7 +53,9 @@ final class CardPresentPaymentsModalViewController: UIViewController {
     func setViewModel(_ newViewModel: CardPresentPaymentsModalViewModel) {
         self.viewModel = newViewModel
 
-        populateContent()
+        if isViewLoaded {
+            populateContent()
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -58,7 +58,7 @@ final class OrderDetailsViewController: UIViewController {
     /// Orchestrates what needs to be presented in the modal views
     /// that provide user-facing feedback about the card present payment process.
     private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
-        OrderDetailsPaymentAlerts()
+        OrderDetailsPaymentAlerts(presentingController: self)
     }()
 
     /// Subscription that listens for connected readers while we are trying to connect to one to capture payment
@@ -616,8 +616,7 @@ private extension OrderDetailsViewController {
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
         let value = currencyFormatter.formatAmount(viewModel.order.total, with: unit) ?? ""
 
-        paymentAlerts.readerIsReady(from: self,
-                                    title: viewModel.collectPaymentFrom,
+        paymentAlerts.readerIsReady(title: viewModel.collectPaymentFrom,
                                     amount: value)
 
         ServiceLocator.analytics.track(.collectPaymentTapped)


### PR DESCRIPTION
Backport of #4540 to 7.0. I tried applying some of the simpler commits only, but while that prevented the crash, it still left the app in an inconsistent state where it wasn't possible to capture payments anymore.

Fixes #4537 

There were a few things that went wrong in this crash, and I've tried to address all of them to be extra safe. Because the first modal was dismissed when tapping on retry, we were able to tap on collect payment again. Then we got a modal alert immediately, warning us that there was an operation in progress (the retry). When the VC tried to present the `readerIsReady` alert, that modal couldn't be presented because there was another modal being presented. When the reader sent a message for the user to tap or insert their card, it tried to replace the alert's view model and `populateContent`, but because the modal was never presented, the view hadn't loaded yet, and it's `IBOutlets` were `nil`.

So there are three separate fixes:

- With 2ce42d3, we don't dismiss the modal when retry is tapped, as it should present another one right away.
- With 241fd85, `CardPresentPaymentsModalViewController` will only try to call `populateContent` if the view has been loaded. It will always call `populateContent` from `viewDidLoad` anyway, so it's harmless to skip it.
- 01d9188 is a bit more complicated, but it will let go of the assumption that the modal is always presented from the `CardPresentModalReaderIsReady` model, and will handle presentation automatically whenever a new view model is set.

One side effect is that now a modal can be replaced with a different one. For instance, when a payment fails, if you quickly double tap the retry button, you'll get a brief alert saying that the system is busy, then it will show the "reader is ready" alert. I think this is probably OK, but I'd love a second opinion on whether that could have unintended consequences.

## To test

I tested the steps in #4537, but I also encourage trying many possible states of the payment flow (canceling from modals, double tapping things,...)

1. Go to an order with a total amount ending in `.75` (or any other amount that will cause payment to fail)
2. Tap on Collect payment.
3. Connect to a reader and tap the card.
4. The app will show an error saying it couldn't collect payment.
5. Tap retry, the modal will dismiss.
6. Quickly tap on Collect Payment on the order screen before a new modal pops up.
7. The app should not crash

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
