### PR TITLE
[Mobile Payments] Use "cancel style" for secondary modal buttons

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -68,37 +68,6 @@ extension UIButton {
         setBackgroundImage(disabledBackgroundImage, for: .disabled)
     }
 
-    /// Applies the Secondary Button Style: Solid BG, always light!
-    ///
-    func applySecondaryLightButtonStyle() {
-        contentEdgeInsets = Style.defaultEdgeInsets
-        layer.borderColor = UIColor.primaryButtonBorder.cgColor
-        layer.borderWidth = Style.defaultBorderWidth
-        layer.cornerRadius = Style.defaultCornerRadius
-        titleLabel?.applyHeadlineStyle()
-        enableMultipleLines()
-        titleLabel?.textAlignment = .center
-
-        setTitleColor(.black, for: .normal)
-        setTitleColor(.black, for: .highlighted)
-        setTitleColor(.buttonDisabledTitle, for: .disabled)
-
-        let normalBackgroundImage = UIImage.renderBackgroundImage(fill: .secondaryLightButtonBackground,
-                                                                  border: .secondaryLightButtonBackground)
-            .applyTintColorToiOS13(.secondaryLightButtonBackground)
-        setBackgroundImage(normalBackgroundImage, for: .normal)
-
-        let highlightedBackgroundImage = UIImage.renderBackgroundImage(fill: .primaryButtonDownBackground,
-                                                                       border: .primaryButtonDownBorder)
-            .applyTintColorToiOS13(.primaryButtonDownBackground)
-        setBackgroundImage(highlightedBackgroundImage, for: .highlighted)
-
-        let disabledBackgroundImage = UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
-                                                                    border: .buttonDisabledBorder)
-            .applyTintColorToiOS13(.buttonDisabledBorder) // Use border as tint color since the background is clear
-        setBackgroundImage(disabledBackgroundImage, for: .disabled)
-    }
-
     /// Applies the Link Button Style: Clear BG / Brand Text Color
     ///
     func applyLinkButtonStyle() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -142,11 +142,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleSecondaryButton() {
-        if viewModel.actionsMode == .secondaryOnlyAction {
-            secondaryButton.applyPaymentsModalCancelButtonStyle()
-        } else {
-            secondaryButton.applySecondaryLightButtonStyle()
-        }
+        secondaryButton.applyPaymentsModalCancelButtonStyle()
         secondaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         secondaryButton.titleLabel?.minimumScaleFactor = 0.5
     }


### PR DESCRIPTION
Fixes #4507 

The secondary button in the payment modals was showing the wrong colors while pressed:

Normal | Highlighted
-|-
![IMG_DBF20042A5B5-1](https://user-images.githubusercontent.com/8739/124579788-c1321680-de4f-11eb-9ca1-31aab4b30f68.jpeg)|![IMG_6391](https://user-images.githubusercontent.com/8739/124579811-c5f6ca80-de4f-11eb-9766-faf35dfca6f7.PNG)

I started trying to fix the background, but then I realized that the designs didn't have this kind of borderless button, so I switched it to the alternate "ModalCancelButtonStyle".

## Screenshots (when pressed)

Before:

Light|Dark
-|-
![IMG_6391](https://user-images.githubusercontent.com/8739/124580000-f76f9600-de4f-11eb-8383-d887dccb2e5c.PNG)|![IMG_6392](https://user-images.githubusercontent.com/8739/124580011-f9395980-de4f-11eb-98d9-f776efb56987.PNG)

After:

Light|Dark
-|-
![IMG_0004](https://user-images.githubusercontent.com/8739/124580057-05251b80-de50-11eb-9880-48cae98ec048.PNG)|![IMG_0005](https://user-images.githubusercontent.com/8739/124580065-06eedf00-de50-11eb-9f81-7ee4bab3a7e8.PNG)

## To test

This is used in several modals, but the easiest one to test:

1. Go to Settings > Manage Card Reader
2. Tap on Connect Card Reader
3. Turn on the reader and wait for the alert to show it's avaiable
4. Press and old Keep Searching

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
