### PR TITLE
[Mobile Payments] Show Collect Payment button only for eligible orders with a total amount greater than zero

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -67,7 +67,7 @@ extension Order {
         let customerNote = customerNote ?? self.customerNote
         let dateCreated = dateCreated ?? self.dateCreated
         let dateModified = dateModified ?? self.dateModified
-        let datePaid = datePaid ?? self.datePaid
+        let datePaid = datePaid ?? nil
         let discountTotal = discountTotal ?? self.discountTotal
         let discountTax = discountTax ?? self.discountTax
         let shippingTotal = shippingTotal ?? self.shippingTotal

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -45,7 +45,8 @@ final class OrderDetailsDataSource: NSObject {
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForCardPresentPayment: Bool {
-        return isOrderStatusEligibleForCardPayment() &&
+        return isOrderAmountEligibleForCardPayment() &&
+            isOrderStatusEligibleForCardPayment() &&
             isOrderPaymentMethodEligibleForCardPayment() &&
             hasCardPresentEligiblePaymentGatewayAccount()
     }
@@ -1422,6 +1423,14 @@ extension OrderDetailsDataSource {
 // MARK: - Private Payments Logic
 
 private extension OrderDetailsDataSource {
+    func isOrderAmountEligibleForCardPayment() -> Bool {
+        guard let totalAmount = currencyFormatter.convertToDecimal(from: order.total) else {
+            return false
+        }
+
+        return totalAmount.decimalValue > 0
+    }
+
     func isOrderStatusEligibleForCardPayment() -> Bool {
         (order.status == .pending || order.status == .onHold || order.status == .processing)
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1424,6 +1424,11 @@ extension OrderDetailsDataSource {
 
 private extension OrderDetailsDataSource {
     func isOrderAmountEligibleForCardPayment() -> Bool {
+        // If the order is paid, it is not eligible.
+        guard order.datePaid == nil else {
+            return false
+        }
+
         guard let totalAmount = currencyFormatter.convertToDecimal(from: order.total) else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -193,6 +193,50 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
+    func test_collect_payment_button_is_not_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_zero() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, total: "0", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_greater_than_zero() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, total: "1", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
 }
 
 // MARK: - Test Data

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -133,7 +133,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -155,7 +155,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, paymentMethodID: "stripe")
+        let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -177,7 +177,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, paymentMethodID: "stripe")
+        let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "stripe")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -199,7 +199,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, total: "0", paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "0", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -221,7 +221,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, total: "1", paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "1", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -231,6 +231,28 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_not_visible_if_date_paid_is_not_nil() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, datePaid: Date(), total: "0", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
 
         // Clean up
         storageManager.viewStorage.deleteObject(account)


### PR DESCRIPTION
Closes #4254 partially

As noted in #4254 the "Collect Payment" button is available for orders with a total amount of zero. On example might be an order containing only free products, or an order with a coupon for a 100% discount applied.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/124585058-ee1c0480-de22-11eb-922b-abf11d118dc6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/124585061-eeb49b00-de22-11eb-941d-c2814fd3eed9.png" width="350"/> |

## Changes
* Add logic to check that the total order amount is greater than zero, and hide the button if it isn't.
* Check also that the order has not been paid. 

## How to test
* Create an order. Make it be a total amount of zero (for example, by applying a 100% coupon code)
* Navigate to the order details screen. The Collect Payment button should not be visible.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
