### PR TITLE
[Mobile Payments] Fix "Keep Searching" for readers

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -153,14 +153,14 @@ extension StripeCardReaderService: CardReaderService {
                 // Horrible, terrible workaround.
                 // And yet, it is the classic "dispatch to the next run cycle".
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [discoveryLock] in
-                    // When we're done with the completion, we let go of the discovery lock
-                    defer { discoveryLock.unlock() }
                     guard let error = error else {
                         self?.switchStatusToIdle()
+                        discoveryLock.unlock()
                         return promise(.success(()))
                     }
 
                     self?.internalError(error)
+                    discoveryLock.unlock()
                     promise(.failure(error))
                 }
             }


### PR DESCRIPTION
Fixes #4553

In #4339, we implemented a system to restart the discovery process when the Keep Searching button was tapped. Then, in #4351 we introduced a locking mechanism to avoid starting a discovery process if one was already in progress.

I'm not sure if I didn't test that one properly or something else changed since then, but the issue here is that I relied on a `defer` block to release the lock in the `asyncAfter` block so I didn't have to put the `unlock` on each specific case (success/failure). However, using `defer` means that the lock will be released when the current closure is finished, but we are calling the `promise` before that, which will eventually trigger a new discovery process, which will try to acquire the lock and deadlock until it times out a second later, failing with a `busy` error.

Instead of using `defer`, we now manually release the lock right before calling `promise` on each scenario, which seems to work nicely.

## To test

1. Go to Settings > Manage Card Reader
2. Tap on Connect Card Reader
3. Turn on your reader and wait it to be detected
4. Tap Keep Searching
5. Wait a few seconds. The reader should be detected

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
