### PR TITLE
Fix: TopBannerView color with `info` type

### DIFF
--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -51,7 +51,8 @@ extension UIColor {
     /// Info. Green with Shade 40
     ///
     static var info: UIColor {
-        return .withColorStudio(.green, shade: .shade40)
+        return UIColor(light: .withColorStudio(.green, shade: .shade50),
+                       dark: .withColorStudio(.orange, shade: .shade30))
     }
 
     /// Blue. Blue-50 (< iOS 13 and Light Mode) and Blue-30 (Dark Mode)

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -55,6 +55,13 @@ extension UIColor {
                        dark: .withColorStudio(.orange, shade: .shade30))
     }
 
+    /// Info. Green-80 (< iOS 13 and Light Mode) and Orange-70 (Dark Mode)
+    ///
+    static var infoBackground: UIColor {
+        return UIColor(light: .withColorStudio(.green, shade: .shade80),
+                       dark: .withColorStudio(.orange, shade: .shade70))
+    }
+
     /// Blue. Blue-50 (< iOS 13 and Light Mode) and Blue-30 (Dark Mode)
     ///
     static var blue: UIColor {

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -244,7 +244,7 @@ private extension TopBannerView {
         case .warning:
             return .warningBackground
         case .info:
-            return .withColorStudio(.green, shade: .shade5)
+            return .infoBackground
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -233,6 +233,8 @@ private extension TopBannerView {
             iconImageView.tintColor = .info
         }
         backgroundColor = backgroundColor(for: type)
+        titleLabel.textColor = textColor(for: type)
+        infoLabel.textColor = textColor(for: type)
     }
 
     func backgroundColor(for bannerType: TopBannerViewModel.BannerType) -> UIColor {
@@ -243,6 +245,17 @@ private extension TopBannerView {
             return .warningBackground
         case .info:
             return .withColorStudio(.green, shade: .shade5)
+        }
+    }
+
+    func textColor(for bannerType: TopBannerViewModel.BannerType) -> UIColor {
+        switch bannerType {
+        case .normal:
+            return .text
+        case .warning:
+            return .text
+        case .info:
+            return .white
         }
     }
 


### PR DESCRIPTION
Fixes #4465 

## Description
In dark mode, a TopBannerView with .info type has white text against a light green background. This makes the text hard to read.
I updated it according to the [new specifications](https://github.com/woocommerce/woocommerce-ios/issues/4465#issuecomment-866894336).

## Testing
1. Put your device in light mode.
2. Launch the app in debug mode (because of the Shipping Labels feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields until you get to the "Shipping Carrier and Rates" screen. Notice the new banner background color and text.

Repeat the procedure with dark mode enabled.


## Screenshots
| Light mode             |  Dark mode |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 14 29 47](https://user-images.githubusercontent.com/495617/124600914-8805a080-de67-11eb-9696-2782623e18e0.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 14 31 29](https://user-images.githubusercontent.com/495617/124600920-8a67fa80-de67-11eb-8ebd-d0d57c80a7c4.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
