### PR TITLE
Shipping Labels: Customize print label screen for purchase flow

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelSettings.swift
@@ -7,7 +7,7 @@ public struct ShippingLabelSettings: Equatable, GeneratedFakeable {
     public let siteID: Int64
     public let orderID: Int64
 
-    /// The default paper size for reprinting a shipping label.
+    /// The default paper size for printing a shipping label.
     public let paperSize: ShippingLabelPaperSize
 
     public init(siteID: Int64, orderID: Int64, paperSize: ShippingLabelPaperSize) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -497,8 +497,8 @@ private extension OrderDetailsViewController {
                 assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
                 return
             }
-            let coordinator = ReprintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: navigationController)
-            coordinator.showReprintUI()
+            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: navigationController)
+            coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)
             navigationController?.show(shippingLabelFormVC, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -501,6 +501,15 @@ private extension OrderDetailsViewController {
             coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)
+            shippingLabelFormVC.onLabelPurchase = { [weak self] isOrderComplete in
+                if isOrderComplete {
+                    _ = self?.viewModel.markCompleted()
+                }
+            }
+            shippingLabelFormVC.onLabelSave = { [weak self] in
+                guard let self = self else { return }
+                self.navigationController?.popToViewController(self, animated: true)
+            }
             navigationController?.show(shippingLabelFormVC, sender: self)
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -497,7 +497,7 @@ private extension OrderDetailsViewController {
                 assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
                 return
             }
-            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: navigationController)
+            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .reprint, sourceViewController: navigationController)
             coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -432,7 +432,9 @@ private extension ShippingLabelFormViewController {
         }
 
         // TODO: Customize the reprint shipping label VC
-        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel, sourceViewController: navigationController)
+        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
+                                                             printType: .print,
+                                                             sourceViewController: navigationController)
         printCoordinator.showPrintUI()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -432,8 +432,8 @@ private extension ShippingLabelFormViewController {
         }
 
         // TODO: Customize the reprint shipping label VC
-        let printCoordinator = ReprintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel, sourceViewController: navigationController)
-        printCoordinator.showReprintUI()
+        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel, sourceViewController: navigationController)
+        printCoordinator.showPrintUI()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -299,12 +299,13 @@ private extension ShippingLabelFormViewController {
                 switch result {
                 case .success:
                     self.onLabelPurchase?(self.shouldMarkOrderComplete)
+                    self.dismiss(animated: true)
                     self.displayPrintShippingLabelVC()
                 case .failure:
                     // TODO: Implement and display error screen for purchase failures
+                    self.dismiss(animated: true)
                     break
                 }
-                self.dismiss(animated: true)
             }
         }
         cell.isOn = false
@@ -439,12 +440,19 @@ private extension ShippingLabelFormViewController {
         present(inProgressViewController, animated: true)
     }
 
+    /// Removes the Shipping Label Form from the navigation stack and displays the Print Shipping Label screen.
+    /// This prevents navigating back to the purchase form after successfully purchasing the label.
+    ///
     func displayPrintShippingLabelVC() {
         guard let purchasedShippingLabel = viewModel.purchasedShippingLabel,
               let navigationController = navigationController else {
             return
         }
 
+        if let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
+            let viewControllersExcludingSelf = Array(navigationController.viewControllers[0..<indexOfSelf])
+            navigationController.setViewControllers(viewControllersExcludingSelf, animated: false)
+        }
         let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
                                                              printType: .print,
                                                              sourceViewController: navigationController,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -7,16 +7,20 @@ final class PrintShippingLabelCoordinator {
     private let shippingLabel: ShippingLabel
     private let stores: StoresManager
     private let analytics: Analytics
+    private let printType: PrintType
 
     /// - Parameter shippingLabel: The shipping label to print.
+    /// - Parameter printType: Whether the label is being printed for the first time or reprinted.
     /// - Parameter sourceViewController: The view controller that shows the print UI in the first place.
     /// - Parameter stores: Handles Yosemite store actions.
     /// - Parameter analytics: Tracks analytics events.
     init(shippingLabel: ShippingLabel,
+         printType: PrintType,
          sourceViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.shippingLabel = shippingLabel
+        self.printType = printType
         self.sourceViewController = sourceViewController
         self.stores = stores
         self.analytics = analytics
@@ -26,7 +30,7 @@ final class PrintShippingLabelCoordinator {
     /// `self` is retained in the action callbacks so that the coordinator has the same life cycle as the main view controller
     /// (`PrintShippingLabelViewController`).
     func showPrintUI() {
-        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel)
+        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel, printType: printType)
 
         printViewController.onAction = { actionType in
             switch actionType {
@@ -46,6 +50,13 @@ final class PrintShippingLabelCoordinator {
         // Since the print UI could make an API request for printing data, disables the bottom bar (tab bar) to simplify app states.
         printViewController.hidesBottomBarWhenPushed = true
         sourceViewController.show(printViewController, sender: sourceViewController)
+    }
+}
+
+extension PrintShippingLabelCoordinator {
+    enum PrintType {
+        case print
+        case reprint
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -1,15 +1,15 @@
 import UIKit
 import Yosemite
 
-/// Coordinates navigation actions for reprinting a shipping label.
-final class ReprintShippingLabelCoordinator {
+/// Coordinates navigation actions for printing a shipping label.
+final class PrintShippingLabelCoordinator {
     private let sourceViewController: UIViewController
     private let shippingLabel: ShippingLabel
     private let stores: StoresManager
     private let analytics: Analytics
 
-    /// - Parameter shippingLabel: The shipping label to reprint.
-    /// - Parameter sourceViewController: The view controller that shows the reprint UI in the first place.
+    /// - Parameter shippingLabel: The shipping label to print.
+    /// - Parameter sourceViewController: The view controller that shows the print UI in the first place.
     /// - Parameter stores: Handles Yosemite store actions.
     /// - Parameter analytics: Tracks analytics events.
     init(shippingLabel: ShippingLabel,
@@ -22,20 +22,20 @@ final class ReprintShippingLabelCoordinator {
         self.analytics = analytics
     }
 
-    /// Shows the main screen for reprinting a shipping label.
+    /// Shows the main screen for printing a shipping label.
     /// `self` is retained in the action callbacks so that the coordinator has the same life cycle as the main view controller
-    /// (`ReprintShippingLabelViewController`).
-    func showReprintUI() {
-        let reprintViewController = ReprintShippingLabelViewController(shippingLabel: shippingLabel)
+    /// (`PrintShippingLabelViewController`).
+    func showPrintUI() {
+        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel)
 
-        reprintViewController.onAction = { actionType in
+        printViewController.onAction = { actionType in
             switch actionType {
             case .showPaperSizeSelector(let paperSizeOptions, let selectedPaperSize, let onSelection):
                 self.showPaperSizeSelector(paperSizeOptions: paperSizeOptions,
                                            selectedPaperSize: selectedPaperSize,
                                            onPaperSizeSelected: onSelection)
-            case .reprint(let paperSize):
-                self.reprintShippingLabel(paperSize: paperSize)
+            case .print(let paperSize):
+                self.printShippingLabel(paperSize: paperSize)
             case .presentPaperSizeOptions:
                 self.presentPaperSizeOptions()
             case .presentPrintingInstructions:
@@ -43,14 +43,14 @@ final class ReprintShippingLabelCoordinator {
             }
         }
 
-        // Since the reprint UI could make an API request for printing data, disables the bottom bar (tab bar) to simplify app states.
-        reprintViewController.hidesBottomBarWhenPushed = true
-        sourceViewController.show(reprintViewController, sender: sourceViewController)
+        // Since the print UI could make an API request for printing data, disables the bottom bar (tab bar) to simplify app states.
+        printViewController.hidesBottomBarWhenPushed = true
+        sourceViewController.show(printViewController, sender: sourceViewController)
     }
 }
 
 // MARK: Navigation actions
-private extension ReprintShippingLabelCoordinator {
+private extension PrintShippingLabelCoordinator {
     func showPaperSizeSelector(paperSizeOptions: [ShippingLabelPaperSize],
                                selectedPaperSize: ShippingLabelPaperSize?,
                                onPaperSizeSelected: @escaping (ShippingLabelPaperSize?) -> Void) {
@@ -61,28 +61,28 @@ private extension ReprintShippingLabelCoordinator {
         sourceViewController.show(listSelector, sender: sourceViewController)
     }
 
-    func reprintShippingLabel(paperSize: ShippingLabelPaperSize) {
-        presentReprintInProgressUI()
+    func printShippingLabel(paperSize: ShippingLabelPaperSize) {
+        presentPrintInProgressUI()
         requestDocumentForPrinting(paperSize: paperSize) { result in
-            self.dismissReprintInProgressUI()
+            self.dismissPrintInProgressUI()
             switch result {
             case .success(let printData):
                 self.presentAirPrint(printData: printData)
             case .failure(let error):
                 DDLogError("Error generating shipping label document for printing: \(error)")
-                self.presentErrorAlert(title: Localization.reprintErrorAlertTitle)
+                self.presentErrorAlert(title: Localization.printErrorAlertTitle)
             }
         }
     }
 
-    func presentReprintInProgressUI() {
+    func presentPrintInProgressUI() {
         let viewProperties = InProgressViewProperties(title: Localization.inProgressTitle, message: Localization.inProgressMessage)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
         inProgressViewController.modalPresentationStyle = .overCurrentContext
         sourceViewController.present(inProgressViewController, animated: true, completion: nil)
     }
 
-    func dismissReprintInProgressUI() {
+    func dismissPrintInProgressUI() {
         sourceViewController.dismiss(animated: true)
     }
 
@@ -106,8 +106,8 @@ private extension ReprintShippingLabelCoordinator {
 }
 
 // MARK: Store actions
-private extension ReprintShippingLabelCoordinator {
-    /// Requests document data for reprinting a shipping label with the selected paper size.
+private extension PrintShippingLabelCoordinator {
+    /// Requests document data for printing a shipping label with the selected paper size.
     func requestDocumentForPrinting(paperSize: ShippingLabelPaperSize, completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
         analytics.track(.shippingLabelReprintRequested)
         let action = ShippingLabelAction.printShippingLabel(siteID: shippingLabel.siteID,
@@ -120,27 +120,27 @@ private extension ReprintShippingLabelCoordinator {
 }
 
 // MARK: Private helpers
-private extension ReprintShippingLabelCoordinator {
+private extension PrintShippingLabelCoordinator {
     func presentErrorAlert(title: String?) {
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .alert)
         alertController.view.tintColor = .text
 
-        alertController.addCancelActionWithTitle(Localization.reprintErrorAlertDismissAction)
+        alertController.addCancelActionWithTitle(Localization.printErrorAlertDismissAction)
 
         sourceViewController.present(alertController, animated: true)
     }
 }
 
-private extension ReprintShippingLabelCoordinator {
+private extension PrintShippingLabelCoordinator {
     enum Localization {
         static let inProgressTitle = NSLocalizedString("Printing Label",
-                                                       comment: "Title of in-progress modal when requesting shipping label document for reprinting")
+                                                       comment: "Title of in-progress modal when requesting shipping label document for printing")
         static let inProgressMessage = NSLocalizedString("Please wait",
-                                                         comment: "Message of in-progress modal when requesting shipping label document for reprinting")
-        static let reprintErrorAlertTitle = NSLocalizedString("Error previewing shipping label",
-                                                         comment: "Alert title when there is an error requesting shipping label document for reprinting")
-        static let reprintErrorAlertDismissAction = NSLocalizedString(
+                                                         comment: "Message of in-progress modal when requesting shipping label document for printing")
+        static let printErrorAlertTitle = NSLocalizedString("Error previewing shipping label",
+                                                         comment: "Alert title when there is an error requesting shipping label document for printing")
+        static let printErrorAlertDismissAction = NSLocalizedString(
             "OK",
-            comment: "Dismiss button on the alert when there is an error requesting shipping label document for reprinting")
+            comment: "Dismiss button on the alert when there is an error requesting shipping label document for printing")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -8,6 +8,7 @@ final class PrintShippingLabelCoordinator {
     private let stores: StoresManager
     private let analytics: Analytics
     private let printType: PrintType
+    private let onCompletion: (() -> Void)?
 
     /// - Parameter shippingLabel: The shipping label to print.
     /// - Parameter printType: Whether the label is being printed for the first time or reprinted.
@@ -18,12 +19,14 @@ final class PrintShippingLabelCoordinator {
          printType: PrintType,
          sourceViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         onCompletion: (() -> Void)? = nil) {
         self.shippingLabel = shippingLabel
         self.printType = printType
         self.sourceViewController = sourceViewController
         self.stores = stores
         self.analytics = analytics
+        self.onCompletion = onCompletion
     }
 
     /// Shows the main screen for printing a shipping label.
@@ -44,6 +47,8 @@ final class PrintShippingLabelCoordinator {
                 self.presentPaperSizeOptions()
             case .presentPrintingInstructions:
                 self.presentPrintingInstructions()
+            case .saveLabelForLater:
+                self.saveLabelForLater()
             }
         }
 
@@ -113,6 +118,10 @@ private extension PrintShippingLabelCoordinator {
         let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
         let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)
         sourceViewController.present(navigationController, animated: true, completion: nil)
+    }
+
+    func saveLabelForLater() {
+        onCompletion?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -175,6 +175,8 @@ private extension PrintShippingLabelViewController {
         switch cell {
         case let cell as BasicTableViewCell where row == .headerText:
             configureHeaderText(cell: cell)
+        case let cell as ImageTableViewCell where row == .headerImage:
+            configureHeaderImage(cell: cell)
         case let cell as ImageAndTitleAndTextTableViewCell where row == .infoText:
             configureInfoText(cell: cell)
         case let cell as TitleAndValueTableViewCell where row == .paperSize:
@@ -193,10 +195,11 @@ private extension PrintShippingLabelViewController {
     }
 
     func rowsToDisplay() -> [Row] {
-        let shouldShowInfoText = printType == .reprint
+        let isReprint = printType == .reprint
         let rows: [Row?] = [
             .headerText,
-            shouldShowInfoText ? .infoText : nil,
+            isReprint ? nil : .headerImage,
+            isReprint ? .infoText : nil,
             .spacerBetweenInfoTextAndPaperSizeSelector,
             .paperSize,
             .spacerBetweenPaperSizeSelectorAndInfoLinks,
@@ -218,6 +221,11 @@ private extension PrintShippingLabelViewController {
         }
         cell.textLabel?.numberOfLines = 0
         cell.hideSeparator()
+    }
+
+    func configureHeaderImage(cell: ImageTableViewCell) {
+        cell.detailImageView.image = .celebrationImage
+        cell.selectionStyle = .none
     }
 
     func configureInfoText(cell: ImageAndTitleAndTextTableViewCell) {
@@ -301,6 +309,7 @@ private extension PrintShippingLabelViewController {
 private extension PrintShippingLabelViewController {
     enum Row: CaseIterable {
         case headerText
+        case headerImage
         case infoText
         case spacerBetweenInfoTextAndPaperSizeSelector
         case paperSize
@@ -312,6 +321,8 @@ private extension PrintShippingLabelViewController {
             switch self {
             case .headerText:
                 return BasicTableViewCell.self
+            case .headerImage:
+                return ImageTableViewCell.self
             case .infoText:
                 return ImageAndTitleAndTextTableViewCell.self
             case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -189,6 +189,8 @@ extension PrintShippingLabelViewController: UITableViewDelegate {
 private extension PrintShippingLabelViewController {
     func configure(_ cell: UITableViewCell, for row: Row) {
         switch cell {
+        case let cell as SpacerTableViewCell where row == .spacerBetweenHeaderCells:
+            configureSpacerBetweenHeaderCells(cell: cell)
         case let cell as BasicTableViewCell where row == .headerText:
             configureHeaderText(cell: cell)
         case let cell as ImageTableViewCell where row == .headerImage:
@@ -219,8 +221,11 @@ private extension PrintShippingLabelViewController {
         switch printType {
         case .print:
             rows = [
+                .spacerBetweenHeaderCells,
                 .headerText,
+                .spacerBetweenHeaderCells,
                 .headerImage,
+                .spacerBetweenHeaderCells,
                 .paperSize,
                 .spacerBetweenPaperSizeSelectorAndInfoLinks,
                 .printButton,
@@ -286,6 +291,10 @@ private extension PrintShippingLabelViewController {
         cell.configure(height: Constants.verticalSpacingBetweenPaperSizeSelectorAndInfoLinks)
     }
 
+    func configureSpacerBetweenHeaderCells(cell: SpacerTableViewCell) {
+        cell.configure(height: Constants.headerVerticalSpacing)
+    }
+
     func configurePaperSizeOptions(cell: ImageAndTitleAndTextTableViewCell) {
         cell.update(with: .imageAndTitleOnly(fontStyle: .footnote),
                     data: .init(title: Localization.paperSizeOptionsButtonTitle,
@@ -341,6 +350,7 @@ private extension PrintShippingLabelViewController {
         static let verticalSpacingBetweenInfoTextAndPaperSizeSelector = CGFloat(8)
         static let verticalSpacingBetweenPaperSizeSelectorAndInfoLinks = CGFloat(8)
         static let buttonVerticalSpacing = CGFloat(8)
+        static let headerVerticalSpacing = CGFloat(32)
     }
 
     enum Localization {
@@ -366,6 +376,7 @@ private extension PrintShippingLabelViewController {
 
 private extension PrintShippingLabelViewController {
     enum Row: CaseIterable {
+        case spacerBetweenHeaderCells
         case headerText
         case headerImage
         case infoText
@@ -385,7 +396,7 @@ private extension PrintShippingLabelViewController {
                 return ImageTableViewCell.self
             case .infoText:
                 return ImageAndTitleAndTextTableViewCell.self
-            case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks:
+            case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks, .spacerBetweenHeaderCells:
                 return SpacerTableViewCell.self
             case .paperSize:
                 return TitleAndValueTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -47,6 +47,12 @@ final class PrintShippingLabelViewController: UIViewController {
         configureReprintButton()
         observeSelectedPaperSize()
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        onAction?(.saveLabelForLater)
+    }
 }
 
 extension PrintShippingLabelViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -62,6 +62,8 @@ extension PrintShippingLabelViewController {
         case presentPaperSizeOptions
         /// Called when the printing instructions row is selected.
         case presentPrintingInstructions
+        /// Called when the "Save for Later" button is selected.
+        case saveLabelForLater
     }
 }
 
@@ -88,6 +90,10 @@ private extension PrintShippingLabelViewController {
 
     func presentPrintingInstructions() {
         onAction?(.presentPrintingInstructions)
+    }
+
+    func saveLabelForLater() {
+        onAction?(.saveLabelForLater)
     }
 }
 
@@ -318,7 +324,7 @@ private extension PrintShippingLabelViewController {
                        title: Localization.saveButtonTitle,
                        topSpacing: 8,
                        bottomSpacing: 8) {
-            // TODO: Implement "save for later" behavior
+            self.saveLabelForLater()
         }
         cell.hideSeparator()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -317,8 +317,8 @@ private extension PrintShippingLabelViewController {
     func configurePrintButtonRow(cell: ButtonTableViewCell) {
         cell.configure(style: .primary,
                        title: Localization.printButtonTitle,
-                       topSpacing: 8,
-                       bottomSpacing: 8) {
+                       topSpacing: Constants.buttonVerticalSpacing,
+                       bottomSpacing: Constants.buttonVerticalSpacing) {
             self.printShippingLabel()
         }
         cell.hideSeparator()
@@ -328,8 +328,8 @@ private extension PrintShippingLabelViewController {
     func configureSaveButton(cell: ButtonTableViewCell) {
         cell.configure(style: .secondary,
                        title: Localization.saveButtonTitle,
-                       topSpacing: 8,
-                       bottomSpacing: 8) {
+                       topSpacing: Constants.buttonVerticalSpacing,
+                       bottomSpacing: Constants.buttonVerticalSpacing) {
             self.saveLabelForLater()
         }
         cell.hideSeparator()
@@ -340,6 +340,7 @@ private extension PrintShippingLabelViewController {
     enum Constants {
         static let verticalSpacingBetweenInfoTextAndPaperSizeSelector = CGFloat(8)
         static let verticalSpacingBetweenPaperSizeSelectorAndInfoLinks = CGFloat(8)
+        static let buttonVerticalSpacing = CGFloat(8)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -47,12 +47,6 @@ final class PrintShippingLabelViewController: UIViewController {
         configureReprintButton()
         observeSelectedPaperSize()
     }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        onAction?(.saveLabelForLater)
-    }
 }
 
 extension PrintShippingLabelViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -2,13 +2,13 @@ import Combine
 import Yosemite
 import UIKit
 
-/// Allows the user to select a paper size and reprint a shipping label given the selected paper size.
+/// Allows the user to select a paper size and print a shipping label given the selected paper size.
 /// Informational links are displayed for printing instructions and paper size options.
-final class ReprintShippingLabelViewController: UIViewController {
+final class PrintShippingLabelViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet private weak var reprintButton: UIButton!
+    @IBOutlet private weak var printButton: UIButton!
 
-    private let viewModel: ReprintShippingLabelViewModel
+    private let viewModel: PrintShippingLabelViewModel
     private let rows: [Row]
 
     private var selectedPaperSize: ShippingLabelPaperSize?
@@ -20,7 +20,7 @@ final class ReprintShippingLabelViewController: UIViewController {
     var onAction: ((ActionType) -> Void)?
 
     init(shippingLabel: ShippingLabel) {
-        self.viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel)
+        self.viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
         self.rows = [.headerText, .infoText,
                      .spacerBetweenInfoTextAndPaperSizeSelector, .paperSize, .spacerBetweenPaperSizeSelectorAndInfoLinks,
                      .paperSizeOptions, .printingInstructions]
@@ -42,20 +42,20 @@ final class ReprintShippingLabelViewController: UIViewController {
 
         configureNavigationBar()
         configureTableView()
-        configureReprintButton()
+        configurePrintButton()
         observeSelectedPaperSize()
     }
 }
 
-extension ReprintShippingLabelViewController {
-    /// Actions that can be triggered from the reprint UI.
+extension PrintShippingLabelViewController {
+    /// Actions that can be triggered from the print UI.
     enum ActionType {
         /// Called when the paper size row is selected.
         case showPaperSizeSelector(paperSizeOptions: [ShippingLabelPaperSize],
                                    selectedPaperSize: ShippingLabelPaperSize?,
                                    onSelection: (ShippingLabelPaperSize?) -> Void)
-        /// Called when the Reprint CTA is tapped.
-        case reprint(paperSize: ShippingLabelPaperSize)
+        /// Called when the Print CTA is tapped.
+        case print(paperSize: ShippingLabelPaperSize)
         /// Called when the "layout and paper size options" row is selected.
         case presentPaperSizeOptions
         /// Called when the printing instructions row is selected.
@@ -64,12 +64,12 @@ extension ReprintShippingLabelViewController {
 }
 
 // MARK: Action Handling
-private extension ReprintShippingLabelViewController {
-    func reprintShippingLabel() {
+private extension PrintShippingLabelViewController {
+    func printShippingLabel() {
         guard let selectedPaperSize = selectedPaperSize else {
             return
         }
-        onAction?(.reprint(paperSize: selectedPaperSize))
+        onAction?(.print(paperSize: selectedPaperSize))
     }
 
     func showPaperSizeSelector() {
@@ -90,7 +90,7 @@ private extension ReprintShippingLabelViewController {
 }
 
 // MARK: Configuration
-private extension ReprintShippingLabelViewController {
+private extension PrintShippingLabelViewController {
     func configureNavigationBar() {
         navigationItem.title = Localization.navigationBarTitle
     }
@@ -110,11 +110,11 @@ private extension ReprintShippingLabelViewController {
         }
     }
 
-    func configureReprintButton() {
-        reprintButton.applyPrimaryButtonStyle()
-        reprintButton.setTitle(Localization.reprintButtonTitle, for: .normal)
-        reprintButton.on(.touchUpInside) { [weak self] _ in
-            self?.reprintShippingLabel()
+    func configurePrintButton() {
+        printButton.applyPrimaryButtonStyle()
+        printButton.setTitle(Localization.printButtonTitle, for: .normal)
+        printButton.on(.touchUpInside) { [weak self] _ in
+            self?.printShippingLabel()
         }
     }
 
@@ -124,13 +124,13 @@ private extension ReprintShippingLabelViewController {
             guard let self = self else { return }
             self.selectedPaperSize = paperSize
             self.tableView.reloadData()
-            self.reprintButton.isEnabled = paperSize != nil
+            self.printButton.isEnabled = paperSize != nil
         }.store(in: &cancellables)
     }
 }
 
 // MARK: UITableViewDataSource
-extension ReprintShippingLabelViewController: UITableViewDataSource {
+extension PrintShippingLabelViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         rows.count
     }
@@ -146,7 +146,7 @@ extension ReprintShippingLabelViewController: UITableViewDataSource {
 }
 
 // MARK: UITableViewDelegate
-extension ReprintShippingLabelViewController: UITableViewDelegate {
+extension PrintShippingLabelViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
@@ -168,7 +168,7 @@ extension ReprintShippingLabelViewController: UITableViewDelegate {
 }
 
 // MARK: Cell configuration
-private extension ReprintShippingLabelViewController {
+private extension PrintShippingLabelViewController {
     func configure(_ cell: UITableViewCell, for row: Row) {
         switch cell {
         case let cell as BasicTableViewCell where row == .headerText:
@@ -250,7 +250,7 @@ private extension ReprintShippingLabelViewController {
     }
 }
 
-private extension ReprintShippingLabelViewController {
+private extension PrintShippingLabelViewController {
     enum Constants {
         static let verticalSpacingBetweenInfoTextAndPaperSizeSelector = CGFloat(8)
         static let verticalSpacingBetweenPaperSizeSelectorAndInfoLinks = CGFloat(8)
@@ -259,9 +259,9 @@ private extension ReprintShippingLabelViewController {
     enum Localization {
         static let navigationBarTitle = NSLocalizedString("Print Shipping Label",
                                                           comment: "Navigation bar title to print a shipping label")
-        static let reprintButtonTitle = NSLocalizedString("Print Shipping Label",
+        static let printButtonTitle = NSLocalizedString("Print Shipping Label",
                                                           comment: "Button title to generate a shipping label document for printing")
-        static let paperSizeSelectorTitle = NSLocalizedString("Paper Size", comment: "Title of the paper size selector row for reprinting a shipping label")
+        static let paperSizeSelectorTitle = NSLocalizedString("Paper Size", comment: "Title of the paper size selector row for printing a shipping label")
         static let headerText = NSLocalizedString(
             "If there was a printing error when you purchased the label, you can print it again.",
             comment: "Header text when reprinting a shipping label")
@@ -274,7 +274,7 @@ private extension ReprintShippingLabelViewController {
     }
 }
 
-private extension ReprintShippingLabelViewController {
+private extension PrintShippingLabelViewController {
     enum Row: CaseIterable {
         case headerText
         case infoText

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -15,11 +15,14 @@ final class PrintShippingLabelViewController: UIViewController {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// Type of print action offered: printing a new label or reprinting an existing label
+    private var printType: PrintShippingLabelCoordinator.PrintType
+
     /// Closure to be executed when an action is triggered.
     ///
     var onAction: ((ActionType) -> Void)?
 
-    init(shippingLabel: ShippingLabel) {
+    init(shippingLabel: ShippingLabel, printType: PrintShippingLabelCoordinator.PrintType) {
         self.viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
         self.rows = [.headerText, .infoText,
                      .spacerBetweenInfoTextAndPaperSizeSelector, .paperSize, .spacerBetweenPaperSizeSelectorAndInfoLinks,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReprintShippingLabelViewController" customModule="WooCommerce" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PrintShippingLabelViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
-                <outlet property="reprintButton" destination="oIN-xw-L7c" id="QEX-ZK-4Hg"/>
+                <outlet property="printButton" destination="oIN-xw-L7c" id="jxj-Et-jnK"/>
                 <outlet property="tableView" destination="Lwb-OO-Vek" id="1ln-2f-zfn"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -23,18 +24,18 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Lwb-OO-Vek">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="206"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </tableView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ITA-7L-O8W">
-                            <rect key="frame" x="0.0" y="128" width="414" height="690"/>
+                            <rect key="frame" x="0.0" y="206" width="414" height="612"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oIN-xw-L7c">
-                                    <rect key="frame" x="16" y="16" width="382" height="658"/>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oIN-xw-L7c">
+                                    <rect key="frame" x="16" y="16" width="382" height="580"/>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstItem="oIN-xw-L7c" firstAttribute="top" secondItem="ITA-7L-O8W" secondAttribute="top" constant="16" id="1H1-oB-LZ0"/>
                                 <constraint firstAttribute="trailing" secondItem="oIN-xw-L7c" secondAttribute="trailing" constant="16" id="Ij0-pp-eFw"/>
@@ -45,15 +46,20 @@
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="8qq-8l-MSy" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="8rT-at-SIV"/>
                 <constraint firstItem="8qq-8l-MSy" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="gNN-kd-NCE"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="8qq-8l-MSy" secondAttribute="bottom" id="jMu-5c-y84"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="8qq-8l-MSy" secondAttribute="trailing" id="xMg-TJ-ZA9"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="132" y="153"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PrintShippingLabelViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
-                <outlet property="printButton" destination="oIN-xw-L7c" id="jxj-Et-jnK"/>
+                <outlet property="reprintButton" destination="oIN-xw-L7c" id="Bax-S0-S4C"/>
                 <outlet property="tableView" destination="Lwb-OO-Vek" id="1ln-2f-zfn"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
@@ -1,10 +1,10 @@
 import Combine
 import Yosemite
 
-/// View model for `ReprintShippingLabelViewController`.
+/// View model for `PrintShippingLabelViewController`.
 /// Performs and handles actions that might change data for UI display.
-final class ReprintShippingLabelViewModel {
-    /// Paper size options that we support for reprinting a shipping label.
+final class PrintShippingLabelViewModel {
+    /// Paper size options that we support for printing a shipping label.
     /// In the future, the options could be different per geographical region.
     let paperSizeOptions: [ShippingLabelPaperSize] = [.legal, .letter, .label]
 
@@ -22,8 +22,8 @@ final class ReprintShippingLabelViewModel {
 
 // MARK: Public methods
 //
-extension ReprintShippingLabelViewModel {
-    /// Sets the default selected paper size to the one from shipping label settings, if the user has not selected one in the reprint UI.
+extension PrintShippingLabelViewModel {
+    /// Sets the default selected paper size to the one from shipping label settings, if the user has not selected one in the print UI.
     func loadShippingLabelSettingsForDefaultPaperSize() {
         let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabel) { [weak self] settings in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -45,6 +45,10 @@ final class ButtonTableViewCell: UITableViewCell {
         topConstraint.constant = topSpacing
         bottomConstraint.constant = bottomSpacing
     }
+
+    func enableButton(_ enabled: Bool) {
+        button.isEnabled = enabled
+    }
 }
 
 private extension ButtonTableViewCell {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -106,8 +106,8 @@
 		02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */; };
 		02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */; };
 		0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */; };
-		023078FE25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */; };
-		02307924258731B2008EADEE /* ReprintShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02307923258731B2008EADEE /* ReprintShippingLabelViewModel.swift */; };
+		023078FE25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023078FD25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift */; };
+		02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02307923258731B2008EADEE /* PrintShippingLabelViewModel.swift */; };
 		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */; };
 		0235595124496853004BE2B8 /* BottomSheetListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */; };
@@ -124,7 +124,7 @@
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
-		023D69BC2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69BB2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift */; };
+		023D69BC2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69BB2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift */; };
 		023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */; };
 		023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */; };
 		023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */; };
@@ -138,7 +138,7 @@
 		0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465A24EE7637004F531C /* ProductFormEventLoggerProtocol.swift */; };
 		0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465C24EE779D004F531C /* ProductFormEventLogger.swift */; };
 		0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */; };
-		0246405F258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0246405E258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift */; };
+		0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */; };
 		0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */; };
 		02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */; };
 		02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */; };
@@ -174,8 +174,8 @@
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
 		0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */; };
 		0259D5FF2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */; };
-		0259D65D2582248D003B1CD6 /* ReprintShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D65B2582248D003B1CD6 /* ReprintShippingLabelViewController.swift */; };
-		0259D65E2582248D003B1CD6 /* ReprintShippingLabelViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0259D65C2582248D003B1CD6 /* ReprintShippingLabelViewController.xib */; };
+		0259D65D2582248D003B1CD6 /* PrintShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D65B2582248D003B1CD6 /* PrintShippingLabelViewController.swift */; };
+		0259D65E2582248D003B1CD6 /* PrintShippingLabelViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0259D65C2582248D003B1CD6 /* PrintShippingLabelViewController.xib */; };
 		0259EF77246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259EF76246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift */; };
 		025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */; };
 		025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */; };
@@ -1408,8 +1408,8 @@
 		0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHorizontalRulerFormatBarCommand.swift; sourceTree = "<group>"; };
 		02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecInsertMoreFormatBarCommand.swift; sourceTree = "<group>"; };
 		0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecSourceCodeFormatBarCommand.swift; sourceTree = "<group>"; };
-		023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
-		02307923258731B2008EADEE /* ReprintShippingLabelViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelViewModel.swift; sourceTree = "<group>"; };
+		023078FD25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
+		02307923258731B2008EADEE /* PrintShippingLabelViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelViewModel.swift; sourceTree = "<group>"; };
 		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewController.swift; sourceTree = "<group>"; };
 		0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorViewController.xib; sourceTree = "<group>"; };
@@ -1426,7 +1426,7 @@
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
-		023D69BB2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelCoordinator.swift; sourceTree = "<group>"; };
+		023D69BB2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelCoordinator.swift; sourceTree = "<group>"; };
 		023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+LargeTitleWorkaround.swift"; sourceTree = "<group>"; };
 		023EC2DF24DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewModelTests.swift; sourceTree = "<group>"; };
 		023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductSKUValidationStoresManager.swift; sourceTree = "<group>"; };
@@ -1440,7 +1440,7 @@
 		0245465A24EE7637004F531C /* ProductFormEventLoggerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormEventLoggerProtocol.swift; sourceTree = "<group>"; };
 		0245465C24EE779D004F531C /* ProductFormEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormEventLogger.swift; sourceTree = "<group>"; };
 		0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormEventLogger.swift; sourceTree = "<group>"; };
-		0246405E258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelCoordinatorTests.swift; sourceTree = "<group>"; };
+		0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelCoordinatorTests.swift; sourceTree = "<group>"; };
 		0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatterTests.swift; sourceTree = "<group>"; };
 		02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
 		02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkSettingsViewController.xib; sourceTree = "<group>"; };
@@ -1476,8 +1476,8 @@
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
 		0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionView.swift; sourceTree = "<group>"; };
 		0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionsViewController.swift; sourceTree = "<group>"; };
-		0259D65B2582248D003B1CD6 /* ReprintShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprintShippingLabelViewController.swift; sourceTree = "<group>"; };
-		0259D65C2582248D003B1CD6 /* ReprintShippingLabelViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReprintShippingLabelViewController.xib; sourceTree = "<group>"; };
+		0259D65B2582248D003B1CD6 /* PrintShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelViewController.swift; sourceTree = "<group>"; };
+		0259D65C2582248D003B1CD6 /* PrintShippingLabelViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrintShippingLabelViewController.xib; sourceTree = "<group>"; };
 		0259EF76246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsFactoryTests.swift; sourceTree = "<group>"; };
 		025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ChangesTests.swift"; sourceTree = "<group>"; };
 		025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
@@ -2769,7 +2769,7 @@
 			children = (
 				02DFECE525EE33430070F212 /* Create Shipping Label Info */,
 				023D69BA2589BF2500F7DA72 /* Refund Shipping Label */,
-				023D69C52589BF5F00F7DA72 /* Reprint Shipping Label */,
+				023D69C52589BF5F00F7DA72 /* Print Shipping Label */,
 				0298430B259351F100979CAE /* ShippingLabelsTopBannerFactory.swift */,
 				456396A425C81C72001F1A26 /* Create Shipping Label Form */,
 			);
@@ -2903,15 +2903,15 @@
 			path = "Refund Shipping Label";
 			sourceTree = "<group>";
 		};
-		023D69C52589BF5F00F7DA72 /* Reprint Shipping Label */ = {
+		023D69C52589BF5F00F7DA72 /* Print Shipping Label */ = {
 			isa = PBXGroup;
 			children = (
-				02307923258731B2008EADEE /* ReprintShippingLabelViewModel.swift */,
-				0259D65B2582248D003B1CD6 /* ReprintShippingLabelViewController.swift */,
-				0259D65C2582248D003B1CD6 /* ReprintShippingLabelViewController.xib */,
-				023D69BB2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift */,
+				02307923258731B2008EADEE /* PrintShippingLabelViewModel.swift */,
+				0259D65B2582248D003B1CD6 /* PrintShippingLabelViewController.swift */,
+				0259D65C2582248D003B1CD6 /* PrintShippingLabelViewController.xib */,
+				023D69BB2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift */,
 			);
-			path = "Reprint Shipping Label";
+			path = "Print Shipping Label";
 			sourceTree = "<group>";
 		};
 		02404EE52315272C00FF1170 /* Top Banner */ = {
@@ -2928,8 +2928,8 @@
 		02464064258B122A00C10A7D /* Reprint Shipping Label */ = {
 			isa = PBXGroup;
 			children = (
-				023078FD25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift */,
-				0246405E258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift */,
+				023078FD25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift */,
+				0246405E258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift */,
 				023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */,
 			);
 			path = "Reprint Shipping Label";
@@ -6301,7 +6301,7 @@
 				B5FD110E21D3CB8500560344 /* OrderTableViewCell.xib in Resources */,
 				D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */,
 				B59D1EE121907304009D1978 /* ProductReviewTableViewCell.xib in Resources */,
-				0259D65E2582248D003B1CD6 /* ReprintShippingLabelViewController.xib in Resources */,
+				0259D65E2582248D003B1CD6 /* PrintShippingLabelViewController.xib in Resources */,
 				021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */,
 				57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */,
 				D89CFFDE25B44468000E4683 /* ULAccountMismatchViewController.xib in Resources */,
@@ -6724,7 +6724,7 @@
 				02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */,
 				45CDAFAE2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,
-				0259D65D2582248D003B1CD6 /* ReprintShippingLabelViewController.swift in Sources */,
+				0259D65D2582248D003B1CD6 /* PrintShippingLabelViewController.swift in Sources */,
 				D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
 				021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */,
@@ -6735,7 +6735,7 @@
 				57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
 				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
-				02307924258731B2008EADEE /* ReprintShippingLabelViewModel.swift in Sources */,
+				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
@@ -6776,7 +6776,7 @@
 				02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */,
 				D85806292642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,
-				023D69BC2589BF5900F7DA72 /* ReprintShippingLabelCoordinator.swift in Sources */,
+				023D69BC2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift in Sources */,
 				45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */,
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
 				02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */,
@@ -7407,7 +7407,7 @@
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,
-				0246405F258B122100C10A7D /* ReprintShippingLabelCoordinatorTests.swift in Sources */,
+				0246405F258B122100C10A7D /* PrintShippingLabelCoordinatorTests.swift in Sources */,
 				576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */,
 				314DC4C3268D2F1000444C9E /* MockAppSettingsStoresManager.swift in Sources */,
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
@@ -7468,7 +7468,7 @@
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */,
 				57A5D8DF253500F300AA54D6 /* RefundConfirmationViewModelTests.swift in Sources */,
-				023078FE25872CCF008EADEE /* ReprintShippingLabelViewModelTests.swift in Sources */,
+				023078FE25872CCF008EADEE /* PrintShippingLabelViewModelTests.swift in Sources */,
 				027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */,
 				025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */,
 				45A0E4D32566BF2A00D4E8C3 /* LinkedProductsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -3,19 +3,19 @@ import XCTest
 import TestKit
 import Yosemite
 
-final class ReprintShippingLabelCoordinatorTests: XCTestCase {
-    func test_showReprintUI_shows_ReprintShippingLabelViewController() {
+final class PrintShippingLabelCoordinatorTests: XCTestCase {
+    func test_showPrintUI_shows_PrintShippingLabelViewController() {
         // Given
         let viewController = MockSourceViewController()
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: viewController)
 
         // When
-        coordinator.showReprintUI()
+        coordinator.showPrintUI()
 
         // Then
         XCTAssertEqual(viewController.shownViewControllers.count, 1)
-        assertThat(viewController.shownViewControllers[0], isAnInstanceOf: ReprintShippingLabelViewController.self)
+        assertThat(viewController.shownViewControllers[0], isAnInstanceOf: PrintShippingLabelViewController.self)
     }
 
     // MARK: `showPaperSizeSelector`
@@ -23,12 +23,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
     func test_showPaperSizeSelector_shows_ListSelectorViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.showPaperSizeSelector(paperSizeOptions: [.label], selectedPaperSize: nil, onSelection: { _ in }))
+        printViewController.onAction?(.showPaperSizeSelector(paperSizeOptions: [.label], selectedPaperSize: nil, onSelection: { _ in }))
 
         // Then
         XCTAssertEqual(viewController.shownViewControllers.count, 2)
@@ -42,12 +42,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.reprint(paperSize: .label))
+        printViewController.onAction?(.print(paperSize: .label))
 
         // Then
         XCTAssertEqual(viewController.presentedViewControllers.count, 1)
@@ -68,12 +68,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.reprint(paperSize: .label))
+        printViewController.onAction?(.print(paperSize: .label))
 
         // Then
         waitUntil {
@@ -97,12 +97,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.reprint(paperSize: .label))
+        printViewController.onAction?(.print(paperSize: .label))
 
         // Then
         XCTAssertEqual(viewController.presentedViewControllers.count, 1)
@@ -116,15 +116,15 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
 
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
                                                           sourceViewController: viewController,
                                                           stores: stores,
                                                           analytics: analytics)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.reprint(paperSize: .label))
+        printViewController.onAction?(.print(paperSize: .label))
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
@@ -136,12 +136,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPaperSizeOptions_presents_ShippingLabelPaperSizeOptionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.presentPaperSizeOptions)
+        printViewController.onAction?(.presentPaperSizeOptions)
 
         // Then
         XCTAssertEqual(viewController.presentedViewControllers.count, 1)
@@ -154,12 +154,12 @@ final class ReprintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPrintingInstructions_presents_ShippingLabelPrintingInstructionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = ReprintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
-        coordinator.showReprintUI()
-        let reprintViewController = try XCTUnwrap(viewController.shownViewControllers.first as? ReprintShippingLabelViewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        coordinator.showPrintUI()
+        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
         // When
-        reprintViewController.onAction?(.presentPrintingInstructions)
+        printViewController.onAction?(.presentPrintingInstructions)
 
         // Then
         XCTAssertEqual(viewController.presentedViewControllers.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -8,7 +8,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         // Given
         let viewController = MockSourceViewController()
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .print, sourceViewController: viewController)
 
         // When
         coordinator.showPrintUI()
@@ -23,7 +23,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_showPaperSizeSelector_shows_ListSelectorViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -36,13 +36,16 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
                    isAnInstanceOf: ListSelectorViewController<ShippingLabelPaperSizeListSelectorCommand, ShippingLabelPaperSize, BasicTableViewCell>.self)
     }
 
-    // MARK: `reprint`
+    // MARK: `print`
 
-    func test_reprint_without_result_presents_InProgressViewController() throws {
+    func test_print_without_result_presents_InProgressViewController() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -54,7 +57,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         assertThat(viewController.presentedViewControllers[0], isAnInstanceOf: InProgressViewController.self)
     }
 
-    func test_reprint_on_success_dismisses_InProgressViewController() throws {
+    func test_print_on_success_dismisses_InProgressViewController() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let printData = ShippingLabelPrintData(mimeType: "application/pdf", base64Content: "////")
@@ -68,7 +71,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -83,7 +89,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
     }
 
-    func test_reprint_on_failure_presents_error_alert() throws {
+    func test_print_on_failure_presents_error_alert() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let error = SampleError.first
@@ -97,7 +103,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -109,7 +118,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         assertThat(viewController.presentedViewControllers[0], isAnInstanceOf: UIAlertController.self)
     }
 
-    func test_reprint_logs_analytics() throws {
+    func test_print_logs_analytics() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let analyticsProvider = MockAnalyticsProvider()
@@ -117,9 +126,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
 
         let viewController = MockSourceViewController()
         let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
-                                                          sourceViewController: viewController,
-                                                          stores: stores,
-                                                          analytics: analytics)
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores,
+                                                        analytics: analytics)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -136,7 +146,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPaperSizeOptions_presents_ShippingLabelPaperSizeOptionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -154,7 +164,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPrintingInstructions_presents_ShippingLabelPrintingInstructionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelViewModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 
-final class ReprintShippingLabelViewModelTests: XCTestCase {
+final class PrintShippingLabelViewModelTests: XCTestCase {
     private var cancellables = Set<AnyCancellable>()
 
     override func tearDown() {
@@ -17,7 +17,7 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
     func test_paperSizeOptions_contain_all_supported_paper_sizes() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
 
         // When
         let paperSizeOptions = viewModel.paperSizeOptions
@@ -31,7 +31,7 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
     func test_selectedPaperSize_starts_with_nil() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
 
         // When
         var paperSizeValues = [ShippingLabelPaperSize?]()
@@ -47,7 +47,7 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
+        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
         let shippingLabelSettings = ShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID, paperSize: .letter)
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
             switch action {
@@ -74,7 +74,7 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
+        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
         // A4 paper size is not supported in mobile yet.
         let shippingLabelSettings = ShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID, paperSize: .a4)
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
@@ -101,7 +101,7 @@ final class ReprintShippingLabelViewModelTests: XCTestCase {
     func test_updateSelectedPaperSize_sets_selectedPaperSize_to_selected_value() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = ReprintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
         var paperSizeValues = [ShippingLabelPaperSize?]()
         viewModel.$selectedPaperSize.sink { paperSize in
             paperSizeValues.append(paperSize)


### PR DESCRIPTION
Part of #4089

## Description

This customizes the `Print Shipping Label` screen so it can be used in the shipping label purchase flow (in addition to reprinting existing shipping labels).

This PR also hooks up the "Mark this order complete and notify the customer" toggle in the Shipping Label Form, so the order is marked complete when that toggle is enabled.

## Changes

* Refactors the `Print Shipping Label` view controller, view model, and coordinator to use a more general name ("print" instead of "reprint").
* Adds a `PrintType` to `PrintShippingLabelCoordinator`, to handle whether it is printing a new label or reprinting an existing label.
* Customizes `PrintShippingLabelViewController` based on the `PrintType`. The screen doesn't change when reprinting a label, but when printing a label it shows the relevant header text, header image, and "Save for Later" button in addition to the print options.
* Removes the `Shipping Label Form` screen from the navigation stack, so when you tap the back button on the `Print Shipping Label` screen you go back to the order details.
* Hooks up the "Mark this order complete and notify the customer" toggle in the `Shipping Label Form` screen. When the label purchase is successful, if this toggle is enabled the order is marked as complete.

Reprint shipping label (existing labels) | Print shipping label (new purchase) | Print shipping label (after selecting paper size)
-|-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 07 25](https://user-images.githubusercontent.com/8658164/124616754-42000b00-de6e-11eb-896a-9178a10b693b.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 08 16](https://user-images.githubusercontent.com/8658164/124616773-45939200-de6e-11eb-8787-ffb2a4a9cddd.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 08 23](https://user-images.githubusercontent.com/8658164/124616783-475d5580-de6e-11eb-927a-b36884dff3ef.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields in the form.
6. In the Order Summary section, enable the "Mark order complete" toggle and tap the button "Purchase Label".
7. On the Print Shipping Label screen, select the paper size and confirm the "Print Shipping Label" button is enabled and you can tap it to print your label.
8. Confirm you can tap the help text ("See layout ..." and "Don't know how ...") for more information.
9. Confirm you can tap the "Save for Later" button and you are taken back to the order details, which updates to display your purchased shipping label and shows the order with a `Completed` status.

Additional testing:

* Repeat the steps above, but don't enable the "Mark order complete" toggle and confirm your order is not marked as complete.
* Repeat the steps above, but tap the Back button on the Print Shipping Label screen and confirm you are taken back to the order details (not the Shipping Label Form).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
