### PR TITLE
Shipping Labels: Customize print label screen for purchase flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -501,6 +501,15 @@ private extension OrderDetailsViewController {
             coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)
+            shippingLabelFormVC.onLabelPurchase = { [weak self] isOrderComplete in
+                if isOrderComplete {
+                    _ = self?.viewModel.markCompleted()
+                }
+            }
+            shippingLabelFormVC.onLabelSave = { [weak self] in
+                guard let self = self else { return }
+                self.navigationController?.popToViewController(self, animated: true)
+            }
             navigationController?.show(shippingLabelFormVC, sender: self)
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -497,7 +497,7 @@ private extension OrderDetailsViewController {
                 assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
                 return
             }
-            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: navigationController)
+            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .reprint, sourceViewController: navigationController)
             coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -290,11 +290,11 @@ private extension ShippingLabelFormViewController {
             let discountInfoVC = ShippingLabelDiscountInfoViewController()
             let bottomSheet = BottomSheetViewController(childViewController: discountInfoVC)
             bottomSheet.show(from: self, sourceView: cell)
-        } onSwitchChange: { (switchIsOn) in
-            self.shouldMarkOrderComplete = switchIsOn
-        } onButtonTouchUp: {
-            self.displayPurchaseProgressView()
-            self.viewModel.purchaseLabel { [weak self] result in
+        } onSwitchChange: { [weak self] (switchIsOn) in
+            self?.shouldMarkOrderComplete = switchIsOn
+        } onButtonTouchUp: { [weak self] in
+            self?.displayPurchaseProgressView()
+            self?.viewModel.purchaseLabel { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -430,7 +430,9 @@ private extension ShippingLabelFormViewController {
         }
 
         // TODO: Customize the reprint shipping label VC
-        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel, sourceViewController: navigationController)
+        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
+                                                             printType: .print,
+                                                             sourceViewController: navigationController)
         printCoordinator.showPrintUI()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -299,12 +299,13 @@ private extension ShippingLabelFormViewController {
                 switch result {
                 case .success:
                     self.onLabelPurchase?(self.shouldMarkOrderComplete)
+                    self.dismiss(animated: true)
                     self.displayPrintShippingLabelVC()
                 case .failure:
                     // TODO: Implement and display error screen for purchase failures
+                    self.dismiss(animated: true)
                     break
                 }
-                self.dismiss(animated: true)
             }
         }
         cell.isOn = false
@@ -437,12 +438,19 @@ private extension ShippingLabelFormViewController {
         present(inProgressViewController, animated: true)
     }
 
+    /// Removes the Shipping Label Form from the navigation stack and displays the Print Shipping Label screen.
+    /// This prevents navigating back to the purchase form after successfully purchasing the label.
+    ///
     func displayPrintShippingLabelVC() {
         guard let purchasedShippingLabel = viewModel.purchasedShippingLabel,
               let navigationController = navigationController else {
             return
         }
 
+        if let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
+            let viewControllersExcludingSelf = Array(navigationController.viewControllers[0..<indexOfSelf])
+            navigationController.setViewControllers(viewControllersExcludingSelf, animated: false)
+        }
         let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
                                                              printType: .print,
                                                              sourceViewController: navigationController,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -9,6 +9,18 @@ final class ShippingLabelFormViewController: UIViewController {
 
     private let viewModel: ShippingLabelFormViewModel
 
+    /// Can be set to true to mark the order as complete when the label is purchased
+    ///
+    private var shouldMarkOrderComplete = false
+
+    /// Assign this closure to be notified after a shipping label is successfully purchased
+    ///
+    var onLabelPurchase: ((_ isOrderComplete: Bool) -> Void)?
+
+    /// Assign this closure to be notified after a shipping label is saved for later
+    ///
+    var onLabelSave: (() -> Void)?
+
     /// Init
     ///
     init(order: Order) {
@@ -279,18 +291,20 @@ private extension ShippingLabelFormViewController {
             let bottomSheet = BottomSheetViewController(childViewController: discountInfoVC)
             bottomSheet.show(from: self, sourceView: cell)
         } onSwitchChange: { (switchIsOn) in
-            // TODO: Handle order completion
+            self.shouldMarkOrderComplete = switchIsOn
         } onButtonTouchUp: {
             self.displayPurchaseProgressView()
             self.viewModel.purchaseLabel { [weak self] result in
+                guard let self = self else { return }
                 switch result {
                 case .success:
-                    self?.displayPrintShippingLabelVC()
+                    self.onLabelPurchase?(self.shouldMarkOrderComplete)
+                    self.displayPrintShippingLabelVC()
                 case .failure:
                     // TODO: Implement and display error screen for purchase failures
                     break
                 }
-                self?.dismiss(animated: true)
+                self.dismiss(animated: true)
             }
         }
         cell.isOn = false
@@ -429,10 +443,10 @@ private extension ShippingLabelFormViewController {
             return
         }
 
-        // TODO: Customize the reprint shipping label VC
         let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
                                                              printType: .print,
-                                                             sourceViewController: navigationController)
+                                                             sourceViewController: navigationController,
+                                                             onCompletion: onLabelSave)
         printCoordinator.showPrintUI()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -7,16 +7,20 @@ final class PrintShippingLabelCoordinator {
     private let shippingLabel: ShippingLabel
     private let stores: StoresManager
     private let analytics: Analytics
+    private let printType: PrintType
 
     /// - Parameter shippingLabel: The shipping label to print.
+    /// - Parameter printType: Whether the label is being printed for the first time or reprinted.
     /// - Parameter sourceViewController: The view controller that shows the print UI in the first place.
     /// - Parameter stores: Handles Yosemite store actions.
     /// - Parameter analytics: Tracks analytics events.
     init(shippingLabel: ShippingLabel,
+         printType: PrintType,
          sourceViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.shippingLabel = shippingLabel
+        self.printType = printType
         self.sourceViewController = sourceViewController
         self.stores = stores
         self.analytics = analytics
@@ -26,7 +30,7 @@ final class PrintShippingLabelCoordinator {
     /// `self` is retained in the action callbacks so that the coordinator has the same life cycle as the main view controller
     /// (`PrintShippingLabelViewController`).
     func showPrintUI() {
-        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel)
+        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel, printType: printType)
 
         printViewController.onAction = { actionType in
             switch actionType {
@@ -46,6 +50,13 @@ final class PrintShippingLabelCoordinator {
         // Since the print UI could make an API request for printing data, disables the bottom bar (tab bar) to simplify app states.
         printViewController.hidesBottomBarWhenPushed = true
         sourceViewController.show(printViewController, sender: sourceViewController)
+    }
+}
+
+extension PrintShippingLabelCoordinator {
+    enum PrintType {
+        case print
+        case reprint
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -8,6 +8,7 @@ final class PrintShippingLabelCoordinator {
     private let stores: StoresManager
     private let analytics: Analytics
     private let printType: PrintType
+    private let onCompletion: (() -> Void)?
 
     /// - Parameter shippingLabel: The shipping label to print.
     /// - Parameter printType: Whether the label is being printed for the first time or reprinted.
@@ -18,12 +19,14 @@ final class PrintShippingLabelCoordinator {
          printType: PrintType,
          sourceViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         onCompletion: (() -> Void)? = nil) {
         self.shippingLabel = shippingLabel
         self.printType = printType
         self.sourceViewController = sourceViewController
         self.stores = stores
         self.analytics = analytics
+        self.onCompletion = onCompletion
     }
 
     /// Shows the main screen for printing a shipping label.
@@ -44,6 +47,8 @@ final class PrintShippingLabelCoordinator {
                 self.presentPaperSizeOptions()
             case .presentPrintingInstructions:
                 self.presentPrintingInstructions()
+            case .saveLabelForLater:
+                self.saveLabelForLater()
             }
         }
 
@@ -113,6 +118,10 @@ private extension PrintShippingLabelCoordinator {
         let printingInstructionsViewController = ShippingLabelPrintingInstructionsViewController()
         let navigationController = WooNavigationController(rootViewController: printingInstructionsViewController)
         sourceViewController.present(navigationController, animated: true, completion: nil)
+    }
+
+    func saveLabelForLater() {
+        onCompletion?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -175,6 +175,8 @@ private extension PrintShippingLabelViewController {
         switch cell {
         case let cell as BasicTableViewCell where row == .headerText:
             configureHeaderText(cell: cell)
+        case let cell as ImageTableViewCell where row == .headerImage:
+            configureHeaderImage(cell: cell)
         case let cell as ImageAndTitleAndTextTableViewCell where row == .infoText:
             configureInfoText(cell: cell)
         case let cell as TitleAndValueTableViewCell where row == .paperSize:
@@ -193,10 +195,11 @@ private extension PrintShippingLabelViewController {
     }
 
     func rowsToDisplay() -> [Row] {
-        let shouldShowInfoText = printType == .reprint
+        let isReprint = printType == .reprint
         let rows: [Row?] = [
             .headerText,
-            shouldShowInfoText ? .infoText : nil,
+            isReprint ? nil : .headerImage,
+            isReprint ? .infoText : nil,
             .spacerBetweenInfoTextAndPaperSizeSelector,
             .paperSize,
             .spacerBetweenPaperSizeSelectorAndInfoLinks,
@@ -218,6 +221,11 @@ private extension PrintShippingLabelViewController {
         }
         cell.textLabel?.numberOfLines = 0
         cell.hideSeparator()
+    }
+
+    func configureHeaderImage(cell: ImageTableViewCell) {
+        cell.detailImageView.image = .celebrationImage
+        cell.selectionStyle = .none
     }
 
     func configureInfoText(cell: ImageAndTitleAndTextTableViewCell) {
@@ -301,6 +309,7 @@ private extension PrintShippingLabelViewController {
 private extension PrintShippingLabelViewController {
     enum Row: CaseIterable {
         case headerText
+        case headerImage
         case infoText
         case spacerBetweenInfoTextAndPaperSizeSelector
         case paperSize
@@ -312,6 +321,8 @@ private extension PrintShippingLabelViewController {
             switch self {
             case .headerText:
                 return BasicTableViewCell.self
+            case .headerImage:
+                return ImageTableViewCell.self
             case .infoText:
                 return ImageAndTitleAndTextTableViewCell.self
             case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -189,6 +189,8 @@ extension PrintShippingLabelViewController: UITableViewDelegate {
 private extension PrintShippingLabelViewController {
     func configure(_ cell: UITableViewCell, for row: Row) {
         switch cell {
+        case let cell as SpacerTableViewCell where row == .spacerBetweenHeaderCells:
+            configureSpacerBetweenHeaderCells(cell: cell)
         case let cell as BasicTableViewCell where row == .headerText:
             configureHeaderText(cell: cell)
         case let cell as ImageTableViewCell where row == .headerImage:
@@ -219,8 +221,11 @@ private extension PrintShippingLabelViewController {
         switch printType {
         case .print:
             rows = [
+                .spacerBetweenHeaderCells,
                 .headerText,
+                .spacerBetweenHeaderCells,
                 .headerImage,
+                .spacerBetweenHeaderCells,
                 .paperSize,
                 .spacerBetweenPaperSizeSelectorAndInfoLinks,
                 .printButton,
@@ -286,6 +291,10 @@ private extension PrintShippingLabelViewController {
         cell.configure(height: Constants.verticalSpacingBetweenPaperSizeSelectorAndInfoLinks)
     }
 
+    func configureSpacerBetweenHeaderCells(cell: SpacerTableViewCell) {
+        cell.configure(height: Constants.headerVerticalSpacing)
+    }
+
     func configurePaperSizeOptions(cell: ImageAndTitleAndTextTableViewCell) {
         cell.update(with: .imageAndTitleOnly(fontStyle: .footnote),
                     data: .init(title: Localization.paperSizeOptionsButtonTitle,
@@ -341,6 +350,7 @@ private extension PrintShippingLabelViewController {
         static let verticalSpacingBetweenInfoTextAndPaperSizeSelector = CGFloat(8)
         static let verticalSpacingBetweenPaperSizeSelectorAndInfoLinks = CGFloat(8)
         static let buttonVerticalSpacing = CGFloat(8)
+        static let headerVerticalSpacing = CGFloat(32)
     }
 
     enum Localization {
@@ -366,6 +376,7 @@ private extension PrintShippingLabelViewController {
 
 private extension PrintShippingLabelViewController {
     enum Row: CaseIterable {
+        case spacerBetweenHeaderCells
         case headerText
         case headerImage
         case infoText
@@ -385,7 +396,7 @@ private extension PrintShippingLabelViewController {
                 return ImageTableViewCell.self
             case .infoText:
                 return ImageAndTitleAndTextTableViewCell.self
-            case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks:
+            case .spacerBetweenInfoTextAndPaperSizeSelector, .spacerBetweenPaperSizeSelectorAndInfoLinks, .spacerBetweenHeaderCells:
                 return SpacerTableViewCell.self
             case .paperSize:
                 return TitleAndValueTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -47,6 +47,12 @@ final class PrintShippingLabelViewController: UIViewController {
         configureReprintButton()
         observeSelectedPaperSize()
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        onAction?(.saveLabelForLater)
+    }
 }
 
 extension PrintShippingLabelViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -6,6 +6,9 @@ import UIKit
 /// Informational links are displayed for printing instructions and paper size options.
 final class PrintShippingLabelViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
+
+    /// Reprint button: Used to pin button to bottom of screen (below the table) when reprinting an existing label
+    ///
     @IBOutlet weak var reprintButton: UIButton!
 
     private let viewModel: PrintShippingLabelViewModel
@@ -211,7 +214,7 @@ private extension PrintShippingLabelViewController {
     }
 
     func rowsToDisplay() -> [Row] {
-        var rows: [Row?]
+        var rows: [Row]
         switch printType {
         case .print:
             rows = [
@@ -238,7 +241,7 @@ private extension PrintShippingLabelViewController {
                 .printingInstructions
             ]
         }
-        return rows.compactMap { $0 }
+        return rows.map { $0 }
     }
 
     func configureHeaderText(cell: BasicTableViewCell) {
@@ -250,6 +253,7 @@ private extension PrintShippingLabelViewController {
         case .reprint:
             cell.textLabel?.text = Localization.reprintHeaderText
             cell.textLabel?.applyBodyStyle()
+            cell.textLabel?.textAlignment = .natural
         }
         cell.textLabel?.numberOfLines = 0
         cell.hideSeparator()
@@ -321,8 +325,8 @@ private extension PrintShippingLabelViewController {
         cell.configure(style: .primary,
                        title: Localization.printButtonTitle,
                        topSpacing: Constants.buttonVerticalSpacing,
-                       bottomSpacing: Constants.buttonVerticalSpacing) {
-            self.printShippingLabel()
+                       bottomSpacing: Constants.buttonVerticalSpacing) { [weak self] in
+            self?.printShippingLabel()
         }
         cell.hideSeparator()
         cell.enableButton(selectedPaperSize != nil)
@@ -332,8 +336,8 @@ private extension PrintShippingLabelViewController {
         cell.configure(style: .secondary,
                        title: Localization.saveButtonTitle,
                        topSpacing: Constants.buttonVerticalSpacing,
-                       bottomSpacing: Constants.buttonVerticalSpacing) {
-            self.saveLabelForLater()
+                       bottomSpacing: Constants.buttonVerticalSpacing) { [weak self] in
+            self?.saveLabelForLater()
         }
         cell.hideSeparator()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -62,6 +62,8 @@ extension PrintShippingLabelViewController {
         case presentPaperSizeOptions
         /// Called when the printing instructions row is selected.
         case presentPrintingInstructions
+        /// Called when the "Save for Later" button is selected.
+        case saveLabelForLater
     }
 }
 
@@ -88,6 +90,10 @@ private extension PrintShippingLabelViewController {
 
     func presentPrintingInstructions() {
         onAction?(.presentPrintingInstructions)
+    }
+
+    func saveLabelForLater() {
+        onAction?(.saveLabelForLater)
     }
 }
 
@@ -318,7 +324,7 @@ private extension PrintShippingLabelViewController {
                        title: Localization.saveButtonTitle,
                        topSpacing: 8,
                        bottomSpacing: 8) {
-            // TODO: Implement "save for later" behavior
+            self.saveLabelForLater()
         }
         cell.hideSeparator()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -317,8 +317,8 @@ private extension PrintShippingLabelViewController {
     func configurePrintButtonRow(cell: ButtonTableViewCell) {
         cell.configure(style: .primary,
                        title: Localization.printButtonTitle,
-                       topSpacing: 8,
-                       bottomSpacing: 8) {
+                       topSpacing: Constants.buttonVerticalSpacing,
+                       bottomSpacing: Constants.buttonVerticalSpacing) {
             self.printShippingLabel()
         }
         cell.hideSeparator()
@@ -328,8 +328,8 @@ private extension PrintShippingLabelViewController {
     func configureSaveButton(cell: ButtonTableViewCell) {
         cell.configure(style: .secondary,
                        title: Localization.saveButtonTitle,
-                       topSpacing: 8,
-                       bottomSpacing: 8) {
+                       topSpacing: Constants.buttonVerticalSpacing,
+                       bottomSpacing: Constants.buttonVerticalSpacing) {
             self.saveLabelForLater()
         }
         cell.hideSeparator()
@@ -340,6 +340,7 @@ private extension PrintShippingLabelViewController {
     enum Constants {
         static let verticalSpacingBetweenInfoTextAndPaperSizeSelector = CGFloat(8)
         static let verticalSpacingBetweenPaperSizeSelectorAndInfoLinks = CGFloat(8)
+        static let buttonVerticalSpacing = CGFloat(8)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -47,12 +47,6 @@ final class PrintShippingLabelViewController: UIViewController {
         configureReprintButton()
         observeSelectedPaperSize()
     }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        onAction?(.saveLabelForLater)
-    }
 }
 
 extension PrintShippingLabelViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -15,11 +15,14 @@ final class PrintShippingLabelViewController: UIViewController {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// Type of print action offered: printing a new label or reprinting an existing label
+    private var printType: PrintShippingLabelCoordinator.PrintType
+
     /// Closure to be executed when an action is triggered.
     ///
     var onAction: ((ActionType) -> Void)?
 
-    init(shippingLabel: ShippingLabel) {
+    init(shippingLabel: ShippingLabel, printType: PrintShippingLabelCoordinator.PrintType) {
         self.viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
         self.rows = [.headerText, .infoText,
                      .spacerBetweenInfoTextAndPaperSizeSelector, .paperSize, .spacerBetweenPaperSizeSelectorAndInfoLinks,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PrintShippingLabelViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
-                <outlet property="printButton" destination="oIN-xw-L7c" id="jxj-Et-jnK"/>
+                <outlet property="reprintButton" destination="oIN-xw-L7c" id="Bax-S0-S4C"/>
                 <outlet property="tableView" destination="Lwb-OO-Vek" id="1ln-2f-zfn"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ButtonTableViewCell.swift
@@ -45,6 +45,10 @@ final class ButtonTableViewCell: UITableViewCell {
         topConstraint.constant = topSpacing
         bottomConstraint.constant = bottomSpacing
     }
+
+    func enableButton(_ enabled: Bool) {
+        button.isEnabled = enabled
+    }
 }
 
 private extension ButtonTableViewCell {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -8,7 +8,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         // Given
         let viewController = MockSourceViewController()
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .print, sourceViewController: viewController)
 
         // When
         coordinator.showPrintUI()
@@ -23,7 +23,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_showPaperSizeSelector_shows_ListSelectorViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -36,13 +36,16 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
                    isAnInstanceOf: ListSelectorViewController<ShippingLabelPaperSizeListSelectorCommand, ShippingLabelPaperSize, BasicTableViewCell>.self)
     }
 
-    // MARK: `reprint`
+    // MARK: `print`
 
-    func test_reprint_without_result_presents_InProgressViewController() throws {
+    func test_print_without_result_presents_InProgressViewController() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -54,7 +57,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         assertThat(viewController.presentedViewControllers[0], isAnInstanceOf: InProgressViewController.self)
     }
 
-    func test_reprint_on_success_dismisses_InProgressViewController() throws {
+    func test_print_on_success_dismisses_InProgressViewController() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let printData = ShippingLabelPrintData(mimeType: "application/pdf", base64Content: "////")
@@ -68,7 +71,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -83,7 +89,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
     }
 
-    func test_reprint_on_failure_presents_error_alert() throws {
+    func test_print_on_failure_presents_error_alert() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let error = SampleError.first
@@ -97,7 +103,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController, stores: stores)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -109,7 +118,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         assertThat(viewController.presentedViewControllers[0], isAnInstanceOf: UIAlertController.self)
     }
 
-    func test_reprint_logs_analytics() throws {
+    func test_print_logs_analytics() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let analyticsProvider = MockAnalyticsProvider()
@@ -117,9 +126,10 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
 
         let viewController = MockSourceViewController()
         let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
-                                                          sourceViewController: viewController,
-                                                          stores: stores,
-                                                          analytics: analytics)
+                                                        printType: .print,
+                                                        sourceViewController: viewController,
+                                                        stores: stores,
+                                                        analytics: analytics)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -136,7 +146,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPaperSizeOptions_presents_ShippingLabelPaperSizeOptionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 
@@ -154,7 +164,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPrintingInstructions_presents_ShippingLabelPrintingInstructionsViewController() throws {
         // Given
         let viewController = MockSourceViewController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), sourceViewController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(), printType: .print, sourceViewController: viewController)
         coordinator.showPrintUI()
         let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
 


### PR DESCRIPTION
Part of #4089
Relies on #4561

## Description

This customizes the `Print Shipping Label` screen so it can be used in the shipping label purchase flow (in addition to reprinting existing shipping labels).

This PR also hooks up the "Mark this order complete and notify the customer" toggle in the Shipping Label Form, so the order is marked complete when that toggle is enabled.

## Changes

* Adds a `PrintType` to `PrintShippingLabelCoordinator`, to handle whether it is printing a new label or reprinting an existing label.
* Customizes `PrintShippingLabelViewController` based on the `PrintType`. The screen doesn't change when reprinting a label, but when printing a label it shows the relevant header text, header image, and "Save for Later" button in addition to the print options.
* Removes the `Shipping Label Form` screen from the navigation stack, so when you tap the back button on the `Print Shipping Label` screen you go back to the order details.
* Hooks up the "Mark this order complete and notify the customer" toggle in the `Shipping Label Form` screen. When the label purchase is successful, if this toggle is enabled the order is marked as complete.

Reprint shipping label (existing labels) | Print shipping label (new purchase) | Print shipping label (after selecting paper size)
-|-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 07 25](https://user-images.githubusercontent.com/8658164/124616754-42000b00-de6e-11eb-896a-9178a10b693b.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 08 16](https://user-images.githubusercontent.com/8658164/124616773-45939200-de6e-11eb-8787-ffb2a4a9cddd.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-06 at 15 08 23](https://user-images.githubusercontent.com/8658164/124616783-475d5580-de6e-11eb-927a-b36884dff3ef.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields in the form.
6. In the Order Summary section, enable the "Mark order complete" toggle and tap the button "Purchase Label".
7. On the Print Shipping Label screen, select the paper size and confirm the "Print Shipping Label" button is enabled and you can tap it to print your label.
8. Confirm you can tap the help text ("See layout ..." and "Don't know how ...") for more information.
9. Confirm you can tap the "Save for Later" button and you are taken back to the order details, which updates to display your purchased shipping label and shows the order with a `Completed` status.

Additional testing:

* Repeat the steps above, but don't enable the "Mark order complete" toggle and confirm your order is not marked as complete.
* Repeat the steps above, but tap the Back button on the Print Shipping Label screen and confirm you are taken back to the order details (not the Shipping Label Form).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
