### PR TITLE
Improve "send feedback" loading indicator UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LoadingView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LoadingView.swift
@@ -20,6 +20,7 @@ final class LoadingView: UIView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.alignment = .center
+        stackView.distribution = .equalCentering
         stackView.spacing = Layout.stackViewSpacing
         return stackView
     }()
@@ -92,7 +93,7 @@ extension LoadingView {
 // MARK: Constants
 private extension LoadingView {
     enum Layout {
-        static let stackViewEdges = UIEdgeInsets(top: 38, left: 54, bottom: 48, right: 54)
+        static let stackViewEdges = UIEdgeInsets(top: 20, left: 20, bottom: 35, right: 20)
         static let stackViewSpacing = CGFloat(40)
         static let indicatorScaleFactor = CGFloat(2.5)
         static let cornerRadius = CGFloat(14.5)


### PR DESCRIPTION
Fixes #4501 
# Description
The aim of this issue is to improve the design of the loader in Send feedback action and to check the colors.

# Testing
- Open the app in dark mode, with a store.
- Go to settings.
- Tap on Send feedback button.
- Check the loader design.

# Videos
iPhone 11
![Simulator Screen Recording - iPhone 11 Pro - 2021-07-06 at 17 30 14](https://user-images.githubusercontent.com/11411847/124628602-eab76600-de80-11eb-9c42-b2ccccf2d7e0.gif)

iPhone SE
![Simulator Screen Recording - iPhone SE (2nd generation) - 2021-07-06 at 17 35 51](https://user-images.githubusercontent.com/11411847/124628642-f73bbe80-de80-11eb-80f0-0aae710b4b8d.gif)

Related to the color, I can confirm that the app is using WooCommerce Purple 30 for dark mode color.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
