### PR TITLE
Shipping Labels: Display notice if shipping label purchase fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -302,9 +302,8 @@ private extension ShippingLabelFormViewController {
                     self.dismiss(animated: true)
                     self.displayPrintShippingLabelVC()
                 case .failure:
-                    // TODO: Implement and display error screen for purchase failures
                     self.dismiss(animated: true)
-                    break
+                    self.displayLabelPurchaseErrorNotice()
                 }
             }
         }
@@ -456,6 +455,15 @@ private extension ShippingLabelFormViewController {
                                                              sourceViewController: navigationController,
                                                              onCompletion: onLabelSave)
         printCoordinator.showPrintUI()
+    }
+
+    /// Enqueues the `Label Purchase Error` Notice.
+    ///
+    private func displayLabelPurchaseErrorNotice() {
+        let message = NSLocalizedString("Error purchasing the label", comment: "Notice displayed when the label purchase fails")
+        let notice = Notice(title: message, feedbackType: .error)
+
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 


### PR DESCRIPTION
Closes: #4089

## Description

If purchasing a shipping label fails, an error notice is now displayed on the Shipping Label Form screen. You can then retry the purchase using the primary "Purchase Label" button.

(Additional internal context/discussion around this behavior: p1625657125006100-slack-C026HH75ECA)

## Changes

* Adds a `Notice` with the error message (no action) that is displayed after the purchase progress view is dismissed.

<img src="https://user-images.githubusercontent.com/8658164/124758356-64555f80-df26-11eb-89ea-677fc178a16d.gif" width="300px">


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (because of the feature flag).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Complete all the fields in the form.
6. Disable your internet connection (or otherwise ensure the purchase will fail).
7. In the Order Summary section, tap the button "Purchase Label".
8. Confirm the purchase progress view appears, and after it is dismissed the error notice is displayed.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.