### PR TITLE
Shipping Label: Handle missing service_name in shipping label

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
@@ -32,6 +32,7 @@ public struct ShippingLabel: Equatable, GeneratedCopiable, GeneratedFakeable {
     public let trackingNumber: String
 
     /// The name of service for the shipping label (e.g. "USPS - Media Mail").
+    /// Can sometimes be empty, see: https://github.com/woocommerce/woocommerce-ios/issues/4568
     public let serviceName: String
 
     /// The amount that is refundable.
@@ -115,7 +116,7 @@ extension ShippingLabel: Decodable {
         let rate = try container.decode(Double.self, forKey: .rate)
         let currency = try container.decode(String.self, forKey: .currency)
         let trackingNumber = try container.decode(String.self, forKey: .trackingNumber)
-        let serviceName = try container.decode(String.self, forKey: .serviceName)
+        let serviceName = try container.decodeIfPresent(String.self, forKey: .serviceName) ?? ""
         let refund = try container.decodeIfPresent(ShippingLabelRefund.self, forKey: .refund)
         let refundableAmount = try container.decode(Double.self, forKey: .refundableAmount)
 


### PR DESCRIPTION
Fixes: #4568

## Description

In rare cases, a shipping label can be missing its `service_name`. This was causing the Order Details screen to not show any shipping labels for an order, even if the order had one or more labels. This PR updates the `ShippingLabel` model to handle when `service_name` is `nil`, defaulting to an empty string.

Usual behavior (with `service_name`) | Missing `service_name` (order details) | Missing `service_name` (shipment details)
-|-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-07-07 at 16 14 23](https://user-images.githubusercontent.com/8658164/124790873-7396d600-df43-11eb-8821-3880ef9c93af.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-07 at 16 46 45](https://user-images.githubusercontent.com/8658164/124791028-9aeda300-df43-11eb-8fa5-af61af2f899a.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-07 at 16 46 55](https://user-images.githubusercontent.com/8658164/124791034-9c1ed000-df43-11eb-9bfb-5246ed9e9de3.png)

@pmusolino I'm requesting a review from you because I'm not sure how to reproduce the original issue and I know you can see this issue on your store.

## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more orders with a purchased shipping label with a missing `service_name`.
2. Open an order detail for an order with such a label (with a missing `service_name`).
3. Confirm all the labels appear in the order detail.
4. Tap "View Shipment Details" for the label with a missing `service_name` and confirm the details appear.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
