### PR TITLE
Variations: Show notice after creating a variation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -614,11 +614,14 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
             progressViewController.dismiss(animated: true)
 
             guard let self = self else { return }
-            guard let updatedProduct = try? result.get() else {
-                return self.noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
+            switch result {
+            case .success(let updatedProduct):
+                self.noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))
+                self.product = updatedProduct
+            case .failure(let error):
+                self.noticePresenter.enqueue(notice: .init(title: Localization.generateVariationError, feedbackType: .error))
+                DDLogError("⛔️ Error generating variation: \(error)")
             }
-
-            self.product = updatedProduct
         }
     }
 }


### PR DESCRIPTION
fixes #4452 

# Why

It was reported during testing 7.0 that it will be nice to show a success notice after creating variations. Previously we displayed the notice but only after creating the first variation.

# How

- Show a notice using `noticePresenter` after creating a variation in `ProductVariationsViewController`.

- Added a local `DDLOG` if an error happened.

# Demo

![Simulator Screen Recording - iPhone 12 - 2021-07-07 at 16 57 43](https://user-images.githubusercontent.com/562080/124829125-2e27d800-df46-11eb-9c60-f815c4afeec2.gif)


# Testing Steps

- Launch the app and navigate to a variable product with variations
- Tap on the variations row
- Tap on the "generate variation" button
- See that after a successful generation a "Success Notice" is shown.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
