### PR TITLE
Move Fastlane secrets outside of repository

### DIFF
--- a/.configure
+++ b/.configure
@@ -5,7 +5,7 @@
   "files_to_copy": [
     {
       "file": "shared/google_cloud_keys.json",
-      "destination": ".configure-files/google_cloud_keys.json",
+      "destination": "~/.configure/woocommerce-ios/secrets/google_cloud_keys.json",
       "encrypt": true
     },
     {

--- a/.configure
+++ b/.configure
@@ -15,7 +15,7 @@
     },
     {
       "file": "iOS/WCiOS/project.env",
-      "destination": ".configure-files/project.env",
+      "destination": "~/.configure/woocommerce-ios/secrets/project.env",
       "encrypt": true
     },
     {

--- a/.configure
+++ b/.configure
@@ -20,7 +20,7 @@
     },
     {
       "file": "iOS/app_store_connect_fastlane_api_key.json",
-      "destination": ".configure-files/app_store_connect_fastlane_api_key.json",
+      "destination": "~/.configure/woocommerce-ios/secrets/app_store_connect_fastlane_api_key.json",
       "encrypt": true
     }
   ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,8 @@ fastlane_require 'dotenv'
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
 USER_ENV_FILE_PATH = File.join(Dir.home, '.wcios-env.default')
-PROJECT_ENV_FILE_PATH = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secrets', 'project.env')
+SECRETS_DIR = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secrets')
+PROJECT_ENV_FILE_PATH = File.join(SECRETS_DIR, 'project.env')
 
 # Constants
 FASTLANE_DIR = __dir__
@@ -359,7 +360,10 @@ platform :ios do
           method: 'app-store'
         })
 
-    testflight(skip_waiting_for_build_processing: true)
+    testflight(
+      skip_waiting_for_build_processing: true,
+      api_key_path: File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
+    )
     sh('cd .. && rm WooCommerce.ipa')
 
     sentry_upload_dsym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ fastlane_require 'dotenv'
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
 USER_ENV_FILE_PATH = File.join(Dir.home, '.wcios-env.default')
-PROJECT_ENV_FILE_PATH = File.expand_path(File.join(Dir.pwd, '../.configure-files/project.env'))
+PROJECT_ENV_FILE_PATH = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secrets', 'project.env')
 
 # Constants
 FASTLANE_DIR = __dir__

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,9 +1,9 @@
 # This Matchfile has the shared properties used for all signing types
 
 # Store certs/profiles encrypted in Google Cloud
-storage_mode("google_cloud")
-google_cloud_bucket_name("a8c-fastlane-match")
-google_cloud_keys_file(".configure-files/google_cloud_keys.json")
+storage_mode('google_cloud')
+google_cloud_bucket_name('a8c-fastlane-match')
+google_cloud_keys_file('.configure-files/google_cloud_keys.json')
 
 # Use the decrypted API Key for authentication
-api_key_path ".configure-files/app_store_connect_fastlane_api_key.json"
+api_key_path '.configure-files/app_store_connect_fastlane_api_key.json'

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -3,7 +3,8 @@
 # Store certs/profiles encrypted in Google Cloud
 storage_mode('google_cloud')
 google_cloud_bucket_name('a8c-fastlane-match')
-google_cloud_keys_file('.configure-files/google_cloud_keys.json')
+secrets_directory = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secrets')
+google_cloud_keys_file(File.join(secrets_directory, 'google_cloud_keys.json'))
 
 # Use the decrypted API Key for authentication
 api_key_path '.configure-files/app_store_connect_fastlane_api_key.json'

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -7,4 +7,4 @@ secrets_directory = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secret
 google_cloud_keys_file(File.join(secrets_directory, 'google_cloud_keys.json'))
 
 # Use the decrypted API Key for authentication
-api_key_path '.configure-files/app_store_connect_fastlane_api_key.json'
+api_key_path(File.join(secrets_directory, 'app_store_connect_fastlane_api_key.json'))


### PR DESCRIPTION
Moves the Fastlane-related secrets outside of the repository into `~/.configure/woocommerce-ios/secrets/`

To test locally, checkout this branch, run `bundle exec run configure_apply` and then inspect the content of `~/.configure/woocommerce-ios/secrets/`:

```
$ ls ~/.configure/woocommerce-ios/secrets
app_store_connect_fastlane_api_key.json
google_cloud_keys.json
project.env
```

I also opened #4610 to test these changes. It exercises each secret by:

1. Loading Fastlane, which checks the `project.env` location
2. Calling `match` for each build configuration, to test the `google_cloud_keys.json` location
3. Making a build and uploading it to TestFlight, to test the ASC API key JSON location. _This is expected to [fail](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/12963/workflows/7167d4bd-8e36-4f02-b63f-f64cdfd7a155/jobs/23871) because a build with the same version and build number already exists in on App Store Connect, but the fact that we get that error is validation that the API key file can be found._

---


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
