### PR TITLE
Shipping Labels: Smoother navigation bar transition for UIHostingViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -395,6 +395,11 @@ private extension ShippingLabelFormViewController {
         }
 
         let hostingVC = UIHostingController(rootView: packageDetails)
+        // Hack to make transition of navigation bar smooth
+        hostingVC.title = Localization.packageDetailsNavigationBarTitle
+        let doneButton = UIBarButtonItem(title: Localization.packageDetailsDoneButton, style: .done, target: nil, action: nil)
+        doneButton.isEnabled = false
+        hostingVC.navigationItem.rightBarButtonItem = doneButton
         navigationController?.show(hostingVC, sender: nil)
     }
 
@@ -424,6 +429,11 @@ private extension ShippingLabelFormViewController {
                                                               editable: true)
         }
         let hostingVC = UIHostingController(rootView: carriersView)
+        // Hack to make transition of navigation bar smooth
+        hostingVC.title = Localization.carrierAndRatesNavigationBarTitle
+        let doneButton = UIBarButtonItem(title: Localization.carrierAndRatesDoneButton, style: .done, target: nil, action: nil)
+        doneButton.isEnabled = false
+        hostingVC.navigationItem.rightBarButtonItem = doneButton
         navigationController?.show(hostingVC, sender: nil)
     }
 
@@ -439,6 +449,11 @@ private extension ShippingLabelFormViewController {
         }
 
         let hostingVC = UIHostingController(rootView: paymentMethod)
+        // Hack to make the transition of navigation bar smooth
+        hostingVC.title = Localization.paymentMethodNavigationBarTitle
+        let doneButton = UIBarButtonItem(title: Localization.paymentMethodDoneButton, style: .done, target: nil, action: nil)
+        doneButton.isEnabled = false
+        hostingVC.navigationItem.rightBarButtonItem = doneButton
         navigationController?.show(hostingVC, sender: nil)
     }
 
@@ -564,5 +579,14 @@ private extension ShippingLabelFormViewController {
         static let noticeUnableToFetchCountries = NSLocalizedString("Unable to fetch countries.",
                                                                     comment: "Unable to fetch countries action failed in Shipping Label Form")
         static let noticeRetryAction = NSLocalizedString("Retry", comment: "Retry Action")
+        static let paymentMethodNavigationBarTitle = NSLocalizedString("Payment Method",
+                                                                       comment: "Navigation bar title in the Shipping Label Payment Method screen")
+        static let paymentMethodDoneButton = NSLocalizedString("Done", comment: "Done navigation button in the Shipping Label Payment Method screen")
+        static let packageDetailsNavigationBarTitle = NSLocalizedString("Package Details",
+                                             comment: "Navigation bar title of shipping label package details screen")
+        static let packageDetailsDoneButton = NSLocalizedString("Done", comment: "Done navigation button in the Package Details screen in Shipping Label flow")
+        static let carrierAndRatesNavigationBarTitle = NSLocalizedString("Carrier and Rates",
+                                                                         comment: "Navigation bar title of shipping label carrier and rates screen")
+        static let carrierAndRatesDoneButton = NSLocalizedString("Done", comment: "Done navigation button in shipping label carrier and rates screen")
     }
 }


### PR DESCRIPTION
Fixes #4336 

# Description
This PR aims to make the transition in navigation bar of UIHostingViewController smoother.

# Solution
As discussed in #4336, it seems that Apple is not supporting the transition animation of pushing SwiftUI view into an existing navigation controller stack that was instantiated with UIKit. This causes an abrupt appearance of the title and navigation bar items of the SwiftUI view, as they take some time to be rendered after its hosting view controller is pushed into the stack. So I had to do 2 steps before pushing the hosting view controller:
- Set title for the embedding hosting view controller.
- Set a fake navigation bar button without any action.

The title and the bar button will be replaced by the actual one rendered by the SwiftUI view. Therefore we have our desired views in place when the controller is in transition, and still have proper feature after the view is rendered.

# Demo
<img src="https://user-images.githubusercontent.com/5533851/124939584-6d802280-e033-11eb-8a1f-cd574fd1e492.gif" width=400 />


# Problem
If you look closely at the demo, you'll see that the color of the bar button in disabled state is different between UIKit and SwiftUI. This is a facepalm to me - I can't seem to get around that but I think this is still better than the old transition issue.

# Testing
- Navigate to Shipping Labels Creation form
- Navigate to SwiftUI views: package details, carrier & rates, payment methods
- Notice that the title and bar buttons of these views are visible during the transition.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
