### PR TITLE
Inform translators of the constraints of the "99+" string

### DIFF
--- a/WooCommerce/Classes/Extensions/NumberFormatter+LocalizedOrNinetyNinePlus.swift
+++ b/WooCommerce/Classes/Extensions/NumberFormatter+LocalizedOrNinetyNinePlus.swift
@@ -15,7 +15,8 @@ extension NumberFormatter {
     private enum Constants {
         static let ninetyNinePlus = NSLocalizedString(
             "99+",
-            comment: "Shown when there are more than 99 items of something (e.g. Processing Orders)."
+            comment: "Please limit to 3 characters if possible. This is used if " +
+                "there are more than 99 items like in the Orders tab."
         )
     }
 }

--- a/WooCommerce/Classes/Extensions/NumberFormatter+LocalizedOrNinetyNinePlus.swift
+++ b/WooCommerce/Classes/Extensions/NumberFormatter+LocalizedOrNinetyNinePlus.swift
@@ -16,7 +16,7 @@ extension NumberFormatter {
         static let ninetyNinePlus = NSLocalizedString(
             "99+",
             comment: "Please limit to 3 characters if possible. This is used if " +
-                "there are more than 99 items like in the Orders tab."
+                "there are more than 99 items in a tab, like Orders."
         )
     }
 }


### PR DESCRIPTION
Closes #4502. 

Eli reported this unsightly Spanish translation of "99+". 

<img src="https://user-images.githubusercontent.com/1119271/123890989-6d867100-d915-11eb-963b-8e55427591e8.png" width="300">

## Findings

We originally thought that it's a problem in the logic to determine whether to display 99+ or not. But it looks like it's just a problem in the translation. 

https://github.com/woocommerce/woocommerce-ios/blob/fc83fa9638f013457ac653774c67581471deeadc/WooCommerce/Resources/es.lproj/Localizable.strings#L149-L150

## Solution

I wanted to solve this in a future-proof way. I asked Platform (p1625777265302800-slack-CC7L49W13) and they said that changing the comment would make GlotPress fetch this again and request new translations for "99+". So I did that and changed the comment and provided a (hopefully) helpful instruction for our dear translators. 

## Testing

You can verify that the new `comment` is used by running this in the root of the project (make sure your Python version is less than 3.0):

```
./Scripts/localize.py
```

And then verify that the comment was replaced:

```
git diff WooCommerce/Resources/en.lproj/Localizable.strings
```

I'll also make sure that this is sent to GlotPress when the time comes to make a release. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

