### PR TITLE
[Order Fulfillment] Add missing analytics event for tapping Mark Order Complete

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -523,6 +523,11 @@ private extension OrderDetailsViewController {
         let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel) { [weak self] in
             guard let self = self else { return }
+            ServiceLocator.analytics.track(.orderStatusChange, withProperties: [
+                                            "id": self.viewModel.order.orderID,
+                                            "from": self.viewModel.order.status.rawValue,
+                                            "to": OrderStatusEnum.completed.rawValue
+            ])
             let fulfillmentProcess = self.viewModel.markCompleted()
             let presenter = OrderFulfillmentNoticePresenter()
             presenter.present(process: fulfillmentProcess)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -523,11 +523,13 @@ private extension OrderDetailsViewController {
         let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel) { [weak self] in
             guard let self = self else { return }
-            ServiceLocator.analytics.track(.orderStatusChange, withProperties: [
-                                            "id": self.viewModel.order.orderID,
-                                            "from": self.viewModel.order.status.rawValue,
-                                            "to": OrderStatusEnum.completed.rawValue
-            ])
+            ServiceLocator.analytics.track(
+                .orderStatusChange,
+                withProperties: [
+                    "id": self.viewModel.order.orderID,
+                    "from": self.viewModel.order.status.rawValue,
+                    "to": OrderStatusEnum.completed.rawValue
+                ])
             let fulfillmentProcess = self.viewModel.markCompleted()
             let presenter = OrderFulfillmentNoticePresenter()
             presenter.present(process: fulfillmentProcess)


### PR DESCRIPTION
Closes #4590

# Description
This PR aims to add the missing analytics event when tapping Mark Order Complete button on Review Order screen

# Solution
Track this event in the callback block that's triggered when the Mark Order Complete button on Review Order screen is tapped.

# Testing
1. Open Orders tab.
2. Select an order with Processing status.
3. Tap Mark Order Complete.
4. When navigated to Review Order screen, tap Mark Order Complete button at the bottom.
5. Notice the `order_status_change` event sent with correct parameters: from old status "processing" to "completed".

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
