### PR TITLE
[Mobile Payments] Hide the collect payment button when the net amount pending does not match the total order amount

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1429,6 +1429,10 @@ private extension OrderDetailsDataSource {
             return false
         }
 
+        guard let totalAmount = currencyFormatter.convertToDecimal(from: order.total), totalAmount.decimalValue > 0 else {
+            return false
+        }
+
         // If there is a discrepancy between the orderTotal and the remaining amount to collect, it is not eligible
         // This is a temporary solution that will exclude, for example:
         // * orders that have been partially refunded.

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1429,11 +1429,13 @@ private extension OrderDetailsDataSource {
             return false
         }
 
-        guard let totalAmount = currencyFormatter.convertToDecimal(from: order.total) else {
-            return false
-        }
-
-        return totalAmount.decimalValue > 0
+        // If there is a discrepancy between the orderTotal and the remaining amount to collect, it is not eligible
+        // This is a temporary solution that will exclude, for example:
+        // * orders that have been partially refunded.
+        // * orders where the merchant has applied a discount manually
+        // * in general, all orders where we might want to capture a payment for less than the total order amount
+        let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
+        return !paymentViewModel.hasBeenPartiallyCharged
     }
 
     func isOrderStatusEligibleForCardPayment() -> Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -173,6 +173,12 @@ final class OrderPaymentDetailsViewModel {
         return order.coupons
     }
 
+    /// Signals whether the net amount for the order matches the total order amount
+    ///
+    var hasBeenPartiallyCharged: Bool {
+        return totalValue != netAmount
+    }
+
     init(order: Order, refund: Refund? = nil, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.order = order
         self.refund = refund

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -177,4 +177,16 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
 
         XCTAssertTrue(refundAmount.hasPrefix("-"))
     }
+
+    func test_has_been_partially_charged_returns_true_when_there_is_a_partial_refund() {
+        XCTAssertTrue(orderWithAPIRefundsViewModel.hasBeenPartiallyCharged)
+    }
+
+    func test_has_been_partially_charged_returns_true_when_there_is_a_transient_refund() {
+        XCTAssertTrue(orderWithTransientRefundsViewModel.hasBeenPartiallyCharged)
+    }
+
+    func test_has_been_partially_charged_returns_false_when_there_are_no_refunds() {
+        XCTAssertFalse(viewModel.hasBeenPartiallyCharged)
+    }
 }


### PR DESCRIPTION
Closes #4583 , at least until we have a better long term solution for it.

At this point in time, we can only collect payment for the full total order amount. Customizing the actual dollar amount that we charge using a credit card is not yet possible. That is a functionality that requires careful consideration and that we will attack as a full project.

In the meantime, a way to avoid overcharging customers that have already paid partially for their orders, or that want to pay for an order that has partially refunded is to hide the "Collect Payment " button for all orders where the total amount to charge does not match the total order amount.

|  | Before | After |
| ---- | ---- | ---- |
| Total amount pending | <img src="https://user-images.githubusercontent.com/2722505/125288458-2c666780-e2ec-11eb-81e3-ec1f85e9a334.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/125288457-2bcdd100-e2ec-11eb-86de-f890815e60c2.png" width="350"/> |
| Partial refund | <img src="https://user-images.githubusercontent.com/2722505/125288413-1eb0e200-e2ec-11eb-951a-721b8c539762.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/125288415-1f497880-e2ec-11eb-9a18-eaa23e69973f.png" width="350"/> |


## Changes
* Tweak the logic in OrderDetailsDataSource to mark the order as not eligible when the order has been partially charged
* Added a property to OrderPaymentDetailsViewModel to encapsulate what "being partially charged" means


## How to test
* Create a few orders. Leave at least one of them as it was created originally, and edit the others on the store admin to add partial refunds, total refunds, and whatever else you can come up with that makes the pending amount differ from the total order amount.
* Check that the "Collect Payment" button in the order details screen is available only or orders where the pending amount matches the total order amount




Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
