### PR TITLE
Fix: leading and trailing padding in Product List

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+7.2
+-----
+- [*] Fix: leading and trailing padding in Product List, when the screen is in landscape mode. [https://github.com/woocommerce/woocommerce-ios/pull/4593]
+
 7.1
 -----
 - [***] Merchants from US can create shipping labels for physical orders from the app. The feature supports for now only orders where the shipping address is in the US. [https://github.com/woocommerce/woocommerce-ios/pull/4578]

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -333,7 +333,7 @@ private extension ProductsViewController {
     func configureTableView() {
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToAllEdges(tableView)
+        view.pinSubviewToSafeArea(tableView)
 
         tableView.dataSource = self
         tableView.delegate = self


### PR DESCRIPTION
Fixes #4511 

## Description
Fixed the leading and trailing padding in Product List, when the screen is in landscape mode.

## Testing
Make sure the product list in landscape now has the correct leading/trailing padding.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-07-12 at 15 34 27](https://user-images.githubusercontent.com/495617/125300309-30b17580-e32a-11eb-86f1-19b5d06da570.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-12 at 15 47 48](https://user-images.githubusercontent.com/495617/125300323-3313cf80-e32a-11eb-897c-2e2e047e33f6.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
