### PR TITLE
Login: Make sure account settings and site plan are synced immediately on login

### DIFF
--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -121,6 +121,10 @@ class DefaultStoresManager: StoresManager {
 
         group.enter()
         synchronizeAccount { _ in
+            group.enter()
+            self.synchronizeAccountSettings { _ in
+                group.leave()
+            }
             group.leave()
         }
 
@@ -130,10 +134,7 @@ class DefaultStoresManager: StoresManager {
         }
 
         group.notify(queue: .main) {
-            // Wait to synchronize account settings because it depends on the userID from synchronizeAccount
-            self.synchronizeAccountSettings { _ in
-                onCompletion?()
-            }
+            onCompletion?()
         }
 
         return self

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -129,11 +129,6 @@ class DefaultStoresManager: StoresManager {
             group.leave()
         }
 
-        group.enter()
-        synchronizeSitePlan { _ in
-            group.leave()
-        }
-
         group.notify(queue: .main) {
             // Wait to synchronize account settings because it depends on the userID from synchronizeAccount
             self.synchronizeAccountSettings { _ in
@@ -315,6 +310,14 @@ private extension DefaultStoresManager {
             group.leave()
         }
         dispatch(productSettingsAction)
+
+        group.enter()
+        synchronizeSitePlan { result in
+            if case let .failure(error) = result {
+                errors.append(error)
+            }
+            group.leave()
+        }
 
         group.notify(queue: .main) {
             if errors.isEmpty {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -271,18 +271,6 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
-    /// Synchronizes the WordPress.com Site Plan.
-    ///
-    func synchronizeSitePlan(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        guard let siteID = sessionManager.defaultSite?.siteID else {
-            onCompletion(.failure(StoresManagerError.missingDefaultSite))
-            return
-        }
-
-        let action = AccountAction.synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
-        dispatch(action)
-    }
-
     /// Synchronizes the settings for the specified site, if possible.
     ///
     func synchronizeSettings(with siteID: Int64, onCompletion: @escaping () -> Void) {
@@ -313,12 +301,13 @@ private extension DefaultStoresManager {
         dispatch(productSettingsAction)
 
         group.enter()
-        synchronizeSitePlan { result in
+        let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
             if case let .failure(error) = result {
                 errors.append(error)
             }
             group.leave()
         }
+        dispatch(sitePlanAction)
 
         group.notify(queue: .main) {
             if errors.isEmpty {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -120,9 +120,9 @@ class DefaultStoresManager: StoresManager {
         let group = DispatchGroup()
 
         group.enter()
-        synchronizeAccount { _ in
+        synchronizeAccount { [weak self] _ in
             group.enter()
-            self.synchronizeAccountSettings { _ in
+            self?.synchronizeAccountSettings { _ in
                 group.leave()
             }
             group.leave()

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -125,11 +125,6 @@ class DefaultStoresManager: StoresManager {
         }
 
         group.enter()
-        synchronizeAccountSettings { _ in
-            group.leave()
-        }
-
-        group.enter()
         synchronizeSites { _ in
             group.leave()
         }
@@ -140,7 +135,10 @@ class DefaultStoresManager: StoresManager {
         }
 
         group.notify(queue: .main) {
-            onCompletion?()
+            // Wait to synchronize account settings because it depends on the userID from synchronizeAccount
+            self.synchronizeAccountSettings { _ in
+                onCompletion?()
+            }
         }
 
         return self


### PR DESCRIPTION
Fixes: #4600

## Description

During login, we expect to synchronize the account, account settings, sites, and site plan. However, the account settings and site plan were never being synced immediately on login (only later, e.g. after the app was relaunched). They were being synced too soon — they depend on the default account user ID and default site ID, which weren't yet set.

This PR changes the timing of when those are synced:

* Account settings are synced only after the account is synced, to ensure the default account is set.
* Site plan is synced along with other site settings. This ensures the site ID is available before starting that sync (which, during the login flow, happens after the login epilogue is shown).

## Changes

In `DefaultStoresManager`:

* `synchronizeAccountSettings` is moved to the `synchronizeAccount` closure (still within `synchronizeEntities`) to ensure it is called after the account sync is complete.
* `synchronizeSitePlan` is moved from `synchronizeEntities` (which is called before the default site is selected in the login flow) to `synchronizeSettings` (which is called after the default site is selected in the login flow).

## Testing

* Launch the app and make sure you're logged out.
* Log in to your account.
* Confirm your account settings are synced immediately upon login. The easiest way to confirm this is to check that your Tracks preference is set with either `🔵 Tracking started.` or `🔴 Tracking opt-out complete.` logged in the console.
* Confirm your site plan is synced immediately upon confirming your selected site in the login epilogue screen. I believe the site plan is only used when opening a support ticket (to add a tag to the support ticket with your site plan), so the easiest way to confirm this is probably to set a breakpoint on `synchronizeSitePlan` to be sure it's being called.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
