### PR TITLE
[CPP Onboarding] Feature flag for In-Person Payments

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -17,6 +17,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentKnownReader:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .cardPresentOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -37,4 +37,8 @@ enum FeatureFlag: Int {
     /// Automatically Reconnect to a Known Card Reader
     ///
     case cardPresentKnownReader
+
+    /// Card-Present Payments Onboarding
+    ///
+    case cardPresentOnboarding
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -206,6 +206,17 @@ private extension SettingsViewController {
         canCollectPayments = paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
     }
 
+    private var storeSettingsRows: [Row] {
+        var result = [Row]()
+        if canCollectPayments {
+            result.append(.cardReadersV2)
+        }
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentOnboarding) {
+            result.append(.inPersonPayments)
+        }
+        return result
+    }
+
     func configureTableViewFooter() {
         // `tableView.tableFooterView` can't handle a footerView that uses autolayout only.
         // Hence the container view with a defined frame.
@@ -276,10 +287,10 @@ private extension SettingsViewController {
         }
 
         // Store Settings
-        if canCollectPayments {
+        if storeSettingsRows.isNotEmpty {
             sections.append(
                 Section(title: storeSettingsTitle,
-                        rows: [.cardReadersV2],
+                        rows: storeSettingsRows,
                         footerHeight: UITableView.automaticDimension)
             )
         }
@@ -327,6 +338,8 @@ private extension SettingsViewController {
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .cardReadersV2:
             configureCardReadersV2(cell: cell)
+        case let cell as BasicTableViewCell where row == .inPersonPayments:
+            configureInPersonPayments(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
@@ -377,6 +390,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Manage Card Reader", comment: "Navigates to Card Reader management screen")
+    }
+
+    func configureInPersonPayments(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("In-Person Payments", comment: "Navigates to In-Person Payments screen")
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -518,6 +537,10 @@ private extension SettingsViewController {
         show(viewController, sender: self)
     }
 
+    func inPersonPaymentsWasPressed() {
+        // To be implemented
+    }
+
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
@@ -654,6 +677,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .cardReadersV2:
             cardReadersV2WasPressed()
+        case .inPersonPayments:
+            inPersonPaymentsWasPressed()
         case .privacy:
             privacyWasPressed()
         case .betaFeatures:
@@ -696,6 +721,7 @@ private enum Row: CaseIterable {
     case plugins
     case support
     case cardReadersV2
+    case inPersonPayments
     case logout
     case privacy
     case betaFeatures
@@ -716,6 +742,8 @@ private enum Row: CaseIterable {
         case .support:
             return BasicTableViewCell.self
         case .cardReadersV2:
+            return BasicTableViewCell.self
+        case .inPersonPayments:
             return BasicTableViewCell.self
         case .logout:
             return BasicTableViewCell.self


### PR DESCRIPTION
Part of #4611 

As a first step in the Onboarding project for In-Person Payments, this introduces a new feature flag for this feature. There is not much UI for it yet, but I've added the new entry in the settings menu so it can be tested.

## To test

1. Go to settings
2. If you have a store that can take payments, you should see both Manage Card Reader and In-Person Payments
3. If you have a store that can't take payments, you should see In-Person Payments only
4. Tapping In-Person Payments doesn't work yet

<img src="https://user-images.githubusercontent.com/8739/125589551-08da3ed7-398b-49e6-a458-ea21b560136d.png" width="450">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
