### PR TITLE
[CPP Onboarding] Generic error page

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct InPersonPaymentsUnavailableView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: 42) {
+            Text(Localization.unavailable)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Image(uiImage: .paymentErrorImage)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 180.0)
+            Text(Localization.acceptCash)
+                .font(.callout)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "In-Person Payments",
+        comment: "Title for the In-Person Payments settings screen"
+    )
+
+    static let unavailable = NSLocalizedString(
+        "In-Person Payments is currently unavailable",
+        comment: "Title for the error screen when In-Person Payments is unavailable"
+    )
+
+    static let acceptCash = NSLocalizedString(
+        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
+        comment: "Generic error message when In-Person Payments is unavailable"
+    )
+}
+
+struct InPersonPaymentsUnavailableView_Previews: PreviewProvider {
+    static var previews: some View {
+        InPersonPaymentsUnavailableView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -19,11 +19,6 @@ struct InPersonPaymentsUnavailableView: View {
 }
 
 private enum Localization {
-    static let title = NSLocalizedString(
-        "In-Person Payments",
-        comment: "Title for the In-Person Payments settings screen"
-    )
-
     static let unavailable = NSLocalizedString(
         "In-Person Payments is currently unavailable",
         comment: "Title for the error screen when In-Person Payments is unavailable"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
+    init() {
+        super.init(rootView: InPersonPaymentsView())
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct InPersonPaymentsView: View {
+    var body: some View {
+        InPersonPaymentsUnavailableView()
+            .navigationTitle(Localization.title)
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "In-Person Payments",
+        comment: "Title for the In-Person Payments settings screen"
+    )
+
+    static let unavailable = NSLocalizedString(
+        "In-Person Payments is currently unavailable",
+        comment: "Title for the error screen when In-Person Payments is unavailable"
+    )
+
+    static let acceptCash = NSLocalizedString(
+        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
+        comment: "Generic error message when In-Person Payments is unavailable"
+    )
+}
+
+struct InPersonPaymentsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            InPersonPaymentsView()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -22,16 +22,6 @@ private enum Localization {
         "In-Person Payments",
         comment: "Title for the In-Person Payments settings screen"
     )
-
-    static let unavailable = NSLocalizedString(
-        "In-Person Payments is currently unavailable",
-        comment: "Title for the error screen when In-Person Payments is unavailable"
-    )
-
-    static let acceptCash = NSLocalizedString(
-        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
-        comment: "Generic error message when In-Person Payments is unavailable"
-    )
 }
 
 struct InPersonPaymentsView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -538,7 +538,8 @@ private extension SettingsViewController {
     }
 
     func inPersonPaymentsWasPressed() {
-        // To be implemented
+        let viewController = InPersonPaymentsViewController()
+        show(viewController, sender: self)
     }
 
     func privacyWasPressed() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1221,6 +1221,8 @@
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
 		E12FB786266E0CAE0039E9C2 /* ApllicationLogDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */; };
+		E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */; };
+		E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
@@ -2538,6 +2540,8 @@
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApllicationLogDetailView.swift; sourceTree = "<group>"; };
+		E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewController.swift; sourceTree = "<group>"; };
+		E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsUnavailableView.swift; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
@@ -5570,6 +5574,7 @@
 				74C6FEA321C2F189009286B6 /* About */,
 				02D4564A231D059E008CF0A9 /* Beta features */,
 				318853452639FE7F00F66A9C /* CardReadersV2 */,
+				E138D4F2269ED99A006EA5C6 /* In-Person Payments */,
 				CE27257A219249B5002B22EB /* Help */,
 				CE22E3F821714639005A6BEF /* Privacy */,
 				027D4A8B2526FD1700108626 /* SettingsViewController.swift */,
@@ -5933,6 +5938,15 @@
 				E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		E138D4F2269ED99A006EA5C6 /* In-Person Payments */ = {
+			isa = PBXGroup;
+			children = (
+				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
+				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
+			);
+			path = "In-Person Payments";
 			sourceTree = "<group>";
 		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
@@ -6709,6 +6723,7 @@
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
+				E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */,
 				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,
 				CE2A9FC623BFFADE002BEC1C /* RefundedProductsViewModel.swift in Sources */,
 				02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */,
@@ -6716,6 +6731,7 @@
 				0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */,
 				DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */,
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,
+				E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */,
 				CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */,
 				0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */,
 				748C7782211E294000814F2C /* Double+Woo.swift in Sources */,


### PR DESCRIPTION
Part of #4611

This PR adds a temporary screen to show when In-Person Payments is unavailable. In this first PR, it will always show unavailable, and as the rest of the checks are progressively implemented, this screen should appear less and less, until it's eventually replaced with the definitive design for generic errors. For now, I've taking a few elements from the designs that would make this generic enough.

## To test

1. Go to settings
2. Tap on In-Person Payments
3. You should see this screen, regardless of whether your store supports payments

<img src="https://user-images.githubusercontent.com/8739/125597764-83d35ed5-0639-4370-82dd-6f5ca4c26ecc.png" width="400">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
