### PR TITLE
[CPP Onboarding] Initial structure

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -532,9 +532,18 @@ public extension StorageType {
         return firstObject(ofType: SitePlugin.self, matching: predicate)
     }
 
+    /// Returns all payment gateway accounts for a provided `siteID`
+    ///
+    func loadPaymentGatewayAccounts(siteID: Int64) -> [PaymentGatewayAccount] {
+        let predicate = \PaymentGatewayAccount.siteID == siteID
+        let descriptor = NSSortDescriptor(keyPath: \PaymentGatewayAccount.gatewayID, ascending: true)
+        return allObjects(ofType: PaymentGatewayAccount.self, matching: predicate, sortedBy: [descriptor])
+    }
+
     /// Returns a payment gateway account with a specified `siteID` and `gatewayID`
     ///
     func loadPaymentGatewayAccount(siteID: Int64, gatewayID: String) -> PaymentGatewayAccount? {
         let predicate = \PaymentGatewayAccount.siteID == siteID && \PaymentGatewayAccount.gatewayID == gatewayID
         return firstObject(ofType: PaymentGatewayAccount.self, matching: predicate)
-    }}
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsPresentingViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import SwiftUI
 
 final class CardReaderSettingsPresentingViewController: UIViewController {
 
@@ -68,6 +69,26 @@ private extension CardReaderSettingsPresentingViewController {
 
     private func configureNavigation() {
         title = Localization.screenTitle
+    }
+}
+
+// MARK: - SwiftUI compatibility
+//
+
+/// SwiftUI wrapper for CardReaderSettingsPresentingViewController
+///
+struct CardReaderSettingsPresentingView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> some UIViewController {
+        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
+            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
+        }
+
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
+        viewController.configure(viewModelsAndViews: viewModelsAndViews)
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
-    init() {
-        super.init(rootView: InPersonPaymentsView())
+    init(viewModel: InPersonPaymentsViewModel) {
+        super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
     }
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {
@@ -11,9 +11,18 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
 }
 
 struct InPersonPaymentsView: View {
+    @StateObject var viewModel: InPersonPaymentsViewModel
+
     var body: some View {
-        InPersonPaymentsUnavailableView()
-            .navigationTitle(Localization.title)
+        Group {
+            switch viewModel.state {
+            case .completed:
+                CardReaderSettingsPresentingView()
+            default:
+                InPersonPaymentsUnavailableView()
+            }
+        }
+        .navigationTitle(Localization.title)
     }
 }
 
@@ -37,7 +46,7 @@ private enum Localization {
 struct InPersonPaymentsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            InPersonPaymentsView()
+            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(initialState: .genericError))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -1,0 +1,10 @@
+import Yosemite
+import Combine
+
+final class InPersonPaymentsViewModel: ObservableObject {
+    @Published var state: CardPresentPaymentOnboardingState
+
+    init(initialState: CardPresentPaymentOnboardingState) {
+        state = initialState
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -538,8 +538,15 @@ private extension SettingsViewController {
     }
 
     func inPersonPaymentsWasPressed() {
-        let viewController = InPersonPaymentsViewController()
-        show(viewController, sender: self)
+        guard let siteID = self.siteID else {
+            return
+        }
+        let action = CardPresentPaymentAction.checkOnboardingState(siteID: siteID) { [weak self] state in
+            let viewModel = InPersonPaymentsViewModel(initialState: state)
+            let viewController = InPersonPaymentsViewController(viewModel: viewModel)
+            self?.show(viewController, sender: self)
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     func privacyWasPressed() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1223,6 +1223,7 @@
 		E12FB786266E0CAE0039E9C2 /* ApllicationLogDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */; };
 		E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */; };
 		E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */; };
+		E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
@@ -2542,6 +2543,7 @@
 		E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApllicationLogDetailView.swift; sourceTree = "<group>"; };
 		E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewController.swift; sourceTree = "<group>"; };
 		E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsUnavailableView.swift; sourceTree = "<group>"; };
+		E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewModel.swift; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
@@ -5945,6 +5947,7 @@
 			children = (
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
+				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -6680,6 +6683,7 @@
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
 				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
+				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		DEFD6D9326443A4000E51E0D /* SitePluginAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */; };
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
+		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -682,6 +683,7 @@
 		DEFD6D9226443A4000E51E0D /* SitePluginAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginAction.swift; sourceTree = "<group>"; };
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -794,6 +796,7 @@
 			isa = PBXGroup;
 			children = (
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
+				E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1657,6 +1660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7492FADD217FAF5C00ED2C69 /* SettingStore.swift in Sources */,
+				E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */,
 				02C254FA2563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift in Sources */,
 				02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */,
 				B52E0032211A440D00700FDE /* Order+ReadOnlyType.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -4,6 +4,10 @@
 import Combine
 
 public enum CardPresentPaymentAction: Action {
+    /// Checks the onboarding state for a site.
+    ///
+    case checkOnboardingState(siteID: Int64, onCompletion: (CardPresentPaymentOnboardingState) -> Void)
+
     /// Start the Card Reader discovery process.
     ///
     case startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: ([CardReader]) -> Void, onError: (Error) -> Void)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -42,7 +42,8 @@ public enum CardPresentPaymentOnboardingState {
     ///
     case stripeAccountOverdueRequirement
 
-    /// The Stripe account was rejected by Stripe. This can happen for example when the account is flagged as fraudulent or the merchant violates the terms of service.
+    /// The Stripe account was rejected by Stripe.
+    /// This can happen for example when the account is flagged as fraudulent or the merchant violates the terms of service.
     ///
     case stripeAccountRejected
 

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -1,0 +1,56 @@
+/// Represents the possible states for onboarding to In-Person payments
+public enum CardPresentPaymentOnboardingState {
+    /// All the requirements are met and the feature is ready to use
+    ///
+    case completed
+
+    /// Store is not located in one of the supported countries.
+    ///
+    case countryNotSupported
+
+    /// WCPay plugin is not installed on the store.
+    ///
+    case wcpayNotInstalled
+
+    /// WCPay plugin is installed on the store, but the version is out-dated and doesn't contain required APIs for card present payments.
+    ///
+    case wcpayUnsupportedVersion
+
+    /// WCPay is installed on the store but is not activated.
+    ///
+    case wcpayNotActivated
+
+    /// WCPay is installed and activated but requires to be setup first.
+    ///
+    case wcpaySetupNotCompleted
+
+    /// This is a bit special case: WCPay is set to "dev mode" but the connected Stripe account is in live mode.
+    /// Connecting to a reader or accepting payments is not supported in this state.
+    ///
+    case wcpayInTestModeWithLiveStripeAccount
+
+    /// The connected Stripe account has not been reviewed by Stripe yet. This is a temporary state and the user needs to wait.
+    ///
+    case stripeAccountUnderReview
+
+    /// There are some pending requirements on the connected Stripe account. The merchant still has some time before the deadline to fix them expires.
+    /// In-person payments should work without issues.
+    ///
+    case stripeAccountPendingRequirement
+
+    /// There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting payments is not supported in this state.
+    ///
+    case stripeAccountOverdueRequirement
+
+    /// The Stripe account was rejected by Stripe. This can happen for example when the account is flagged as fraudulent or the merchant violates the terms of service.
+    ///
+    case stripeAccountRejected
+
+    /// Generic error - for example, one of the requests failed.
+    ///
+    case genericError
+
+    /// Internet connection is not available.
+    ///
+    case noConnectionError
+}

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -39,6 +39,8 @@ public final class CardPresentPaymentStore: Store {
         }
 
         switch action {
+        case .checkOnboardingState(let siteID, let onCompletion):
+            checkOnboardingState(siteID: siteID, onCompletion: onCompletion)
         case .startCardReaderDiscovery(let siteID, let onReaderDiscovered, let onError):
             startCardReaderDiscovery(siteID: siteID, onReaderDiscovered: onReaderDiscovered, onError: onError)
         case .cancelCardReaderDiscovery(let completion):
@@ -75,6 +77,19 @@ public final class CardPresentPaymentStore: Store {
 // MARK: - Services
 //
 private extension CardPresentPaymentStore {
+    func checkOnboardingState(siteID: Int64, onCompletion: (CardPresentPaymentOnboardingState) -> Void) {
+        let canCollectPayments = storageManager.viewStorage
+            .loadPaymentGatewayAccounts(siteID: siteID)
+            .contains(where: \.isCardPresentEligible)
+        let state: CardPresentPaymentOnboardingState
+        if canCollectPayments {
+            state = .completed
+        } else {
+            state = .genericError
+        }
+        onCompletion(state)
+    }
+
     func startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: @escaping (_ readers: [CardReader]) -> Void, onError: @escaping (Error) -> Void) {
         do {
             try cardReaderService.start(WCPayTokenProvider(siteID: siteID, remote: self.remote))


### PR DESCRIPTION
Part of #4611
This should be merged after #4613, and includes the changes in that PR. ⚠️ This needs to retarget develop once #4613 is merged

This PR adds the basic structure to perform the necessary checks for In-Person Payments. There is a new `enum` with all the possible states, and a new `checkOnboardingState` action to evaluate the current state. Currently, it only performs the same checks that `SettingsViewController` was already doing to decide if the Manage Card Readers button was visible. That is, if there is a WCPay account that's set up and eligible for card-present payments.

If that's the case, the In-Person Payments screen will embed the existing screen to connect a card reader. Otherwise, it will show the generic error introduced in #4613.

## To test

Go to Settings > In-Person Payments:
1. With a store correctly set up for payments, you should see the option to connect to a reader
2. With a store that's not set up for payments, you should see a generic error

Available | Unavailable
-|-
![Screen Shot 2021-07-14 at 13 23 58](https://user-images.githubusercontent.com/8739/125615308-34f7e896-7a2b-4b45-af9d-28328c4f114f.png)|![Screen Shot 2021-07-14 at 13 24 11](https://user-images.githubusercontent.com/8739/125615325-a610e6e8-a2f9-4939-b3c3-b7dd1ec99851.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
