### PR TITLE
Auth Role Checks: Part 2.5 - Add accessibility support for role error screen

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
@@ -80,6 +80,7 @@ class RoleErrorViewController: UIViewController {
 
     func configureLinkButton() {
         linkButton.applyLinkButtonStyle(enableMultipleLines: true)
+        linkButton.titleLabel?.textAlignment = .center
         linkButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
         linkButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapAuxiliaryButton()
@@ -88,14 +89,6 @@ class RoleErrorViewController: UIViewController {
 
     func configurePrimaryActionButton() {
         primaryActionButton.applyPrimaryButtonStyle()
-
-        // Since the buttons are vertically stacked, override the font
-        // on iPhone interface idioms so we get a maximum font size to give
-        // space for the content above the button container.
-        if WPDeviceIdentification.isiPhone() {
-            primaryActionButton.titleLabel?.font = StyleManager.headlineSemiBold
-        }
-
         primaryActionButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryActionButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapPrimaryButton()
@@ -104,14 +97,6 @@ class RoleErrorViewController: UIViewController {
 
     func configureSecondaryActionButton() {
         secondaryActionButton.applySecondaryButtonStyle()
-
-        // Since the buttons are vertically stacked, override the font
-        // on iPhone interface idioms so we get a maximum font size to give
-        // space for the content above the button container.
-        if WPDeviceIdentification.isiPhone() {
-            secondaryActionButton.titleLabel?.font = StyleManager.headlineSemiBold
-        }
-
         secondaryActionButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
         secondaryActionButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapSecondaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
@@ -79,16 +79,7 @@ class RoleErrorViewController: UIViewController {
     }
 
     func configureLinkButton() {
-        linkButton.applyLinkButtonStyle()
-
-        // enable multi line for accessibility support
-        linkButton.titleLabel?.textAlignment = .center
-        linkButton.titleLabel?.adjustsFontForContentSizeCategory = true
-        linkButton.titleLabel?.lineBreakMode = .byWordWrapping
-        if let linkTitleLabel = linkButton.titleLabel {
-            linkButton.pinSubviewToAllEdgeMargins(linkTitleLabel)
-        }
-
+        linkButton.applyLinkButtonStyle(enableMultipleLines: true)
         linkButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
         linkButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapAuxiliaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
@@ -4,7 +4,7 @@ import WordPressAuthenticator
 
 /// RoleErrorOutput enables communication from the view model to the view controller.
 /// Note that it's important for the view model to weakly retain the view controller.
-protocol RoleErrorOutput: class {
+protocol RoleErrorOutput: AnyObject {
     /// Updates title and subtitle label text with latest content.
     func refreshTitleLabels()
 
@@ -80,6 +80,15 @@ class RoleErrorViewController: UIViewController {
 
     func configureLinkButton() {
         linkButton.applyLinkButtonStyle()
+
+        // enable multi line for accessibility support
+        linkButton.titleLabel?.textAlignment = .center
+        linkButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        linkButton.titleLabel?.lineBreakMode = .byWordWrapping
+        if let linkTitleLabel = linkButton.titleLabel {
+            linkButton.pinSubviewToAllEdgeMargins(linkTitleLabel)
+        }
+
         linkButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
         linkButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapAuxiliaryButton()
@@ -88,6 +97,14 @@ class RoleErrorViewController: UIViewController {
 
     func configurePrimaryActionButton() {
         primaryActionButton.applyPrimaryButtonStyle()
+
+        // Since the buttons are vertically stacked, override the font
+        // on iPhone interface idioms so we get a maximum font size to give
+        // space for the content above the button container.
+        if WPDeviceIdentification.isiPhone() {
+            primaryActionButton.titleLabel?.font = StyleManager.headlineSemiBold
+        }
+
         primaryActionButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryActionButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapPrimaryButton()
@@ -96,6 +113,14 @@ class RoleErrorViewController: UIViewController {
 
     func configureSecondaryActionButton() {
         secondaryActionButton.applySecondaryButtonStyle()
+
+        // Since the buttons are vertically stacked, override the font
+        // on iPhone interface idioms so we get a maximum font size to give
+        // space for the content above the button container.
+        if WPDeviceIdentification.isiPhone() {
+            secondaryActionButton.titleLabel?.font = StyleManager.headlineSemiBold
+        }
+
         secondaryActionButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
         secondaryActionButton.on(.touchUpInside) { [weak self] _ in
             self?.viewModel.didTapSecondaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.xib
@@ -26,107 +26,132 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nK8-aP-YaK">
-                    <rect key="frame" x="0.0" y="44" width="414" height="692"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U2J-WF-pcf" userLabel="Container View">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="692"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PjD-Kw-iD1" userLabel="Content View">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xZF-VZ-vTL" userLabel="Content Stack View">
-                                    <rect key="frame" x="41" y="171" width="332" height="302.5"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pa8-3V-OTe" userLabel="Top Spacer View">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="169"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="8" id="lgm-jS-xft"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" verticalHuggingPriority="249" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="U2J-WF-pcf" userLabel="Role Error View">
+                                    <rect key="frame" x="0.0" y="169" width="414" height="354.5"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="LtB-cQ-hsK" userLabel="Top Label Stack View">
-                                            <rect key="frame" x="0.0" y="0.0" width="332" height="31.5"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xZF-VZ-vTL" userLabel="Content Stack View">
+                                            <rect key="frame" x="41" y="0.0" width="332" height="302.5"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qti-dQ-ryI" userLabel="Name Label">
-                                                    <rect key="frame" x="0.0" y="0.0" width="332" height="17"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9kP-iV-kxf" userLabel="Role Label">
-                                                    <rect key="frame" x="0.0" y="17" width="332" height="14.5"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="LtB-cQ-hsK" userLabel="Top Label Stack View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="332" height="31.5"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qti-dQ-ryI" userLabel="Name Label">
+                                                            <rect key="frame" x="0.0" y="0.0" width="332" height="17"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9kP-iV-kxf" userLabel="Role Label">
+                                                            <rect key="frame" x="0.0" y="17" width="332" height="14.5"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="woo-incorrect-role-error" translatesAutoresizingMaskIntoConstraints="NO" id="w7Q-ul-F52" userLabel="Error Image View">
+                                                    <rect key="frame" x="0.0" y="55.5" width="332" height="206"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="middleTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nPH-Hd-nTV" userLabel="Description Label">
+                                                    <rect key="frame" x="0.0" y="285.5" width="332" height="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </stackView>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="woo-incorrect-role-error" translatesAutoresizingMaskIntoConstraints="NO" id="w7Q-ul-F52" userLabel="Error Image View">
-                                            <rect key="frame" x="0.0" y="55.5" width="332" height="206"/>
-                                        </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="middleTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nPH-Hd-nTV" userLabel="Description Label">
-                                            <rect key="frame" x="0.0" y="285.5" width="332" height="17"/>
+                                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="UjK-5a-gOc">
+                                            <rect key="frame" x="165.5" y="326.5" width="83" height="28"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                            <state key="normal" title="Action Button"/>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="trailing" constant="21" id="3hQ-u8-fME"/>
+                                        <constraint firstItem="UjK-5a-gOc" firstAttribute="centerX" secondItem="U2J-WF-pcf" secondAttribute="centerX" id="D7P-Ti-b4g"/>
+                                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="top" secondItem="U2J-WF-pcf" secondAttribute="top" id="Fwx-m5-kEH"/>
+                                        <constraint firstItem="UjK-5a-gOc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="21" id="MfM-sh-OHf"/>
+                                        <constraint firstAttribute="trailing" secondItem="xZF-VZ-vTL" secondAttribute="trailing" constant="41" id="amH-b6-qf2"/>
+                                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="leading" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="41" id="fee-El-ZNE"/>
+                                        <constraint firstAttribute="bottom" secondItem="UjK-5a-gOc" secondAttribute="bottom" id="iRt-D3-2u5"/>
+                                        <constraint firstItem="UjK-5a-gOc" firstAttribute="top" secondItem="xZF-VZ-vTL" secondAttribute="bottom" constant="24" id="yJR-iK-mZx"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b0t-AG-PAs" userLabel="Bottom Spacer View">
+                                    <rect key="frame" x="0.0" y="523.5" width="414" height="168.5"/>
+                                </view>
+                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k2k-VX-DIG" userLabel="Action Stack View">
+                                    <rect key="frame" x="16" y="692" width="382" height="116"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="12a-pO-tKA" userLabel="Primary Action Button">
+                                            <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="VSp-UD-zdS"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                            <state key="normal" title="Primary Action Button"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="B7H-Ml-KIN" userLabel="Secondary Action Button">
+                                            <rect key="frame" x="0.0" y="66" width="382" height="50"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="3Dh-sW-kMS"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <state key="normal" title="Secondary Action Button"/>
+                                        </button>
                                     </subviews>
                                 </stackView>
-                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="UjK-5a-gOc">
-                                    <rect key="frame" x="165.5" y="497.5" width="83" height="28"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                    <state key="normal" title="Action Button"/>
-                                </button>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstItem="UjK-5a-gOc" firstAttribute="centerX" secondItem="U2J-WF-pcf" secondAttribute="centerX" id="FIW-yW-kGi"/>
-                                <constraint firstItem="xZF-VZ-vTL" firstAttribute="top" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="top" constant="8" id="HSI-gY-tY3"/>
-                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="bottom" constant="16" id="IPs-OG-tu4"/>
-                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="trailing" constant="8" id="Pml-DI-rWB"/>
-                                <constraint firstAttribute="trailing" secondItem="xZF-VZ-vTL" secondAttribute="trailing" constant="41" id="amH-b6-qf2"/>
-                                <constraint firstItem="xZF-VZ-vTL" firstAttribute="leading" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="41" id="fee-El-ZNE"/>
-                                <constraint firstItem="UjK-5a-gOc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="8" id="iAw-w5-jea"/>
-                                <constraint firstItem="UjK-5a-gOc" firstAttribute="top" secondItem="xZF-VZ-vTL" secondAttribute="bottom" constant="24" id="yJR-iK-mZx"/>
+                                <constraint firstItem="b0t-AG-PAs" firstAttribute="leading" secondItem="PjD-Kw-iD1" secondAttribute="leading" id="52i-5x-NTF"/>
+                                <constraint firstAttribute="trailing" secondItem="b0t-AG-PAs" secondAttribute="trailing" id="GF5-ko-O0p"/>
+                                <constraint firstItem="k2k-VX-DIG" firstAttribute="leading" secondItem="PjD-Kw-iD1" secondAttribute="leading" constant="16" id="GKx-OG-qMt"/>
+                                <constraint firstItem="k2k-VX-DIG" firstAttribute="top" secondItem="b0t-AG-PAs" secondAttribute="bottom" id="N66-rZ-sTv"/>
+                                <constraint firstAttribute="trailing" secondItem="Pa8-3V-OTe" secondAttribute="trailing" id="WAM-4h-Ylm"/>
+                                <constraint firstItem="U2J-WF-pcf" firstAttribute="top" secondItem="Pa8-3V-OTe" secondAttribute="bottom" id="XFd-pE-lOP"/>
+                                <constraint firstAttribute="bottom" secondItem="k2k-VX-DIG" secondAttribute="bottom" constant="10" id="Xfy-hN-PTI"/>
+                                <constraint firstAttribute="trailing" secondItem="U2J-WF-pcf" secondAttribute="trailing" id="kFk-JP-9JG"/>
+                                <constraint firstAttribute="trailing" secondItem="k2k-VX-DIG" secondAttribute="trailing" constant="16" id="lGl-W9-fWQ"/>
+                                <constraint firstItem="Pa8-3V-OTe" firstAttribute="top" secondItem="PjD-Kw-iD1" secondAttribute="top" id="nLE-VT-7uM"/>
+                                <constraint firstItem="U2J-WF-pcf" firstAttribute="leading" secondItem="PjD-Kw-iD1" secondAttribute="leading" id="p7f-25-6bg"/>
+                                <constraint firstItem="b0t-AG-PAs" firstAttribute="top" secondItem="U2J-WF-pcf" secondAttribute="bottom" id="qTl-rj-1He"/>
+                                <constraint firstItem="Pa8-3V-OTe" firstAttribute="leading" secondItem="PjD-Kw-iD1" secondAttribute="leading" id="s6N-JH-RPu"/>
+                                <constraint firstItem="b0t-AG-PAs" firstAttribute="height" secondItem="Pa8-3V-OTe" secondAttribute="height" id="z6g-UG-4km"/>
                             </constraints>
                         </view>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="U2J-WF-pcf" firstAttribute="width" secondItem="nK8-aP-YaK" secondAttribute="width" id="N5i-xI-dqt"/>
-                        <constraint firstItem="U2J-WF-pcf" firstAttribute="top" secondItem="nK8-aP-YaK" secondAttribute="top" id="cNK-FU-SlG"/>
-                        <constraint firstItem="U2J-WF-pcf" firstAttribute="height" secondItem="nK8-aP-YaK" secondAttribute="height" priority="250" id="frK-jG-ZEZ"/>
-                        <constraint firstItem="U2J-WF-pcf" firstAttribute="leading" secondItem="nK8-aP-YaK" secondAttribute="leading" id="h5P-wh-NhO"/>
-                        <constraint firstAttribute="trailing" secondItem="U2J-WF-pcf" secondAttribute="trailing" id="qHd-35-RUs"/>
-                        <constraint firstAttribute="bottom" secondItem="U2J-WF-pcf" secondAttribute="bottom" id="qIZ-F8-DX0"/>
-                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="centerY" secondItem="nK8-aP-YaK" secondAttribute="centerY" priority="250" constant="-24" id="xEQ-Jn-hBz"/>
+                        <constraint firstAttribute="trailing" secondItem="PjD-Kw-iD1" secondAttribute="trailing" id="1AX-LH-5qG"/>
+                        <constraint firstItem="PjD-Kw-iD1" firstAttribute="top" secondItem="nK8-aP-YaK" secondAttribute="top" id="Vfo-e7-Hhc"/>
+                        <constraint firstAttribute="bottom" secondItem="PjD-Kw-iD1" secondAttribute="bottom" id="VoJ-hP-AsD"/>
+                        <constraint firstItem="PjD-Kw-iD1" firstAttribute="leading" secondItem="nK8-aP-YaK" secondAttribute="leading" id="haZ-hu-m5f"/>
+                        <constraint firstItem="PjD-Kw-iD1" firstAttribute="height" secondItem="nK8-aP-YaK" secondAttribute="height" priority="249" id="q3f-Ss-AML"/>
+                        <constraint firstItem="PjD-Kw-iD1" firstAttribute="width" secondItem="nK8-aP-YaK" secondAttribute="width" id="xla-fj-j0u"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="YpA-KD-o5W"/>
                     <viewLayoutGuide key="frameLayoutGuide" id="Bpc-nJ-3vI"/>
                 </scrollView>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k2k-VX-DIG" userLabel="Action Stack View">
-                    <rect key="frame" x="16" y="736" width="382" height="116"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="12a-pO-tKA" userLabel="Primary Action Button">
-                            <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="VSp-UD-zdS"/>
-                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="75" id="l1C-XA-dGo"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                            <state key="normal" title="Primary Action Button"/>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="B7H-Ml-KIN" userLabel="Secondary Action Button">
-                            <rect key="frame" x="0.0" y="66" width="382" height="50"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="3Dh-sW-kMS"/>
-                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="100" id="p77-uc-gSj"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                            <state key="normal" title="Secondary Action Button"/>
-                        </button>
-                    </subviews>
-                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="k2k-VX-DIG" secondAttribute="bottom" constant="10" id="2LQ-vM-Emq"/>
                 <constraint firstItem="nK8-aP-YaK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="FPy-iG-ETO"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="nK8-aP-YaK" secondAttribute="trailing" id="I8y-Tb-azC"/>
-                <constraint firstItem="k2k-VX-DIG" firstAttribute="top" secondItem="nK8-aP-YaK" secondAttribute="bottom" id="NOJ-ga-Epw"/>
-                <constraint firstItem="k2k-VX-DIG" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="TpY-t0-XXR"/>
                 <constraint firstItem="nK8-aP-YaK" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Vzn-0l-vXP"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="k2k-VX-DIG" secondAttribute="trailing" constant="16" id="jKk-KK-qLP"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="nK8-aP-YaK" secondAttribute="bottom" id="c6g-2f-jSp"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="124.55357142857142"/>
         </view>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -25,93 +25,107 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U2J-WF-pcf" userLabel="Container View">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nK8-aP-YaK">
                     <rect key="frame" x="0.0" y="44" width="414" height="692"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xZF-VZ-vTL" userLabel="Content Stack View">
-                            <rect key="frame" x="41" y="166.5" width="332" height="311"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U2J-WF-pcf" userLabel="Container View">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="692"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="LtB-cQ-hsK" userLabel="Top Label Stack View">
-                                    <rect key="frame" x="0.0" y="0.0" width="332" height="36.5"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xZF-VZ-vTL" userLabel="Content Stack View">
+                                    <rect key="frame" x="41" y="171" width="332" height="302.5"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qti-dQ-ryI" userLabel="Name Label">
-                                            <rect key="frame" x="0.0" y="0.0" width="332" height="20.5"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9kP-iV-kxf" userLabel="Role Label">
-                                            <rect key="frame" x="0.0" y="20.5" width="332" height="16"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="LtB-cQ-hsK" userLabel="Top Label Stack View">
+                                            <rect key="frame" x="0.0" y="0.0" width="332" height="31.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qti-dQ-ryI" userLabel="Name Label">
+                                                    <rect key="frame" x="0.0" y="0.0" width="332" height="17"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9kP-iV-kxf" userLabel="Role Label">
+                                                    <rect key="frame" x="0.0" y="17" width="332" height="14.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="woo-incorrect-role-error" translatesAutoresizingMaskIntoConstraints="NO" id="w7Q-ul-F52" userLabel="Error Image View">
+                                            <rect key="frame" x="0.0" y="55.5" width="332" height="206"/>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="middleTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nPH-Hd-nTV" userLabel="Description Label">
+                                            <rect key="frame" x="0.0" y="285.5" width="332" height="17"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                 </stackView>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="woo-incorrect-role-error" translatesAutoresizingMaskIntoConstraints="NO" id="w7Q-ul-F52" userLabel="Error Image View">
-                                    <rect key="frame" x="0.0" y="60.5" width="332" height="206"/>
-                                </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="middleTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nPH-Hd-nTV" userLabel="Description Label">
-                                    <rect key="frame" x="0.0" y="290.5" width="332" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="UjK-5a-gOc">
+                                    <rect key="frame" x="165.5" y="497.5" width="83" height="28"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                    <state key="normal" title="Action Button"/>
+                                </button>
                             </subviews>
-                        </stackView>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="UjK-5a-gOc">
-                            <rect key="frame" x="157.5" y="501.5" width="99" height="32"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="398" id="eiJ-fe-mF0"/>
+                                <constraint firstItem="UjK-5a-gOc" firstAttribute="centerX" secondItem="U2J-WF-pcf" secondAttribute="centerX" id="FIW-yW-kGi"/>
+                                <constraint firstItem="xZF-VZ-vTL" firstAttribute="top" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="top" constant="8" id="HSI-gY-tY3"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="bottom" constant="16" id="IPs-OG-tu4"/>
+                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="trailing" constant="8" id="Pml-DI-rWB"/>
+                                <constraint firstAttribute="trailing" secondItem="xZF-VZ-vTL" secondAttribute="trailing" constant="41" id="amH-b6-qf2"/>
+                                <constraint firstItem="xZF-VZ-vTL" firstAttribute="leading" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="41" id="fee-El-ZNE"/>
+                                <constraint firstItem="UjK-5a-gOc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="8" id="iAw-w5-jea"/>
+                                <constraint firstItem="UjK-5a-gOc" firstAttribute="top" secondItem="xZF-VZ-vTL" secondAttribute="bottom" constant="24" id="yJR-iK-mZx"/>
                             </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                            <state key="normal" title="Action Button"/>
-                        </button>
+                        </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstItem="UjK-5a-gOc" firstAttribute="centerX" secondItem="U2J-WF-pcf" secondAttribute="centerX" id="FIW-yW-kGi"/>
-                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="top" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="top" constant="8" id="HSI-gY-tY3"/>
-                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="bottom" constant="16" id="IPs-OG-tu4"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UjK-5a-gOc" secondAttribute="trailing" constant="8" id="Pml-DI-rWB"/>
-                        <constraint firstAttribute="trailing" secondItem="xZF-VZ-vTL" secondAttribute="trailing" constant="41" id="amH-b6-qf2"/>
-                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="leading" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="41" id="fee-El-ZNE"/>
-                        <constraint firstItem="UjK-5a-gOc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="U2J-WF-pcf" secondAttribute="leading" constant="8" id="iAw-w5-jea"/>
-                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="centerY" secondItem="U2J-WF-pcf" secondAttribute="centerY" priority="750" constant="-24" id="wLI-4N-MXz"/>
-                        <constraint firstItem="UjK-5a-gOc" firstAttribute="top" secondItem="xZF-VZ-vTL" secondAttribute="bottom" constant="24" id="yJR-iK-mZx"/>
+                        <constraint firstItem="U2J-WF-pcf" firstAttribute="width" secondItem="nK8-aP-YaK" secondAttribute="width" id="N5i-xI-dqt"/>
+                        <constraint firstItem="U2J-WF-pcf" firstAttribute="top" secondItem="nK8-aP-YaK" secondAttribute="top" id="cNK-FU-SlG"/>
+                        <constraint firstItem="U2J-WF-pcf" firstAttribute="height" secondItem="nK8-aP-YaK" secondAttribute="height" priority="250" id="frK-jG-ZEZ"/>
+                        <constraint firstItem="U2J-WF-pcf" firstAttribute="leading" secondItem="nK8-aP-YaK" secondAttribute="leading" id="h5P-wh-NhO"/>
+                        <constraint firstAttribute="trailing" secondItem="U2J-WF-pcf" secondAttribute="trailing" id="qHd-35-RUs"/>
+                        <constraint firstAttribute="bottom" secondItem="U2J-WF-pcf" secondAttribute="bottom" id="qIZ-F8-DX0"/>
+                        <constraint firstItem="xZF-VZ-vTL" firstAttribute="centerY" secondItem="nK8-aP-YaK" secondAttribute="centerY" priority="250" constant="-24" id="xEQ-Jn-hBz"/>
                     </constraints>
-                </view>
+                    <viewLayoutGuide key="contentLayoutGuide" id="YpA-KD-o5W"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="Bpc-nJ-3vI"/>
+                </scrollView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k2k-VX-DIG" userLabel="Action Stack View">
                     <rect key="frame" x="16" y="736" width="382" height="116"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="12a-pO-tKA" userLabel="Primary Action Button">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="12a-pO-tKA" userLabel="Primary Action Button">
                             <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="50" id="VSp-UD-zdS"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="VSp-UD-zdS"/>
+                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="75" id="l1C-XA-dGo"/>
                             </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <state key="normal" title="Primary Action Button"/>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B7H-Ml-KIN" userLabel="Secondary Action Button">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="B7H-Ml-KIN" userLabel="Secondary Action Button">
                             <rect key="frame" x="0.0" y="66" width="382" height="50"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="3Dh-sW-kMS"/>
+                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="100" id="p77-uc-gSj"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <state key="normal" title="Secondary Action Button"/>
                         </button>
                     </subviews>
-                    <constraints>
-                        <constraint firstItem="B7H-Ml-KIN" firstAttribute="height" secondItem="12a-pO-tKA" secondAttribute="height" id="djM-KN-xZ1"/>
-                    </constraints>
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="U2J-WF-pcf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="1iC-Dr-GrJ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="k2k-VX-DIG" secondAttribute="bottom" constant="10" id="2LQ-vM-Emq"/>
-                <constraint firstItem="U2J-WF-pcf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="JKO-bi-eM0"/>
-                <constraint firstItem="k2k-VX-DIG" firstAttribute="top" secondItem="U2J-WF-pcf" secondAttribute="bottom" id="Jqo-se-c1i"/>
+                <constraint firstItem="nK8-aP-YaK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="FPy-iG-ETO"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="nK8-aP-YaK" secondAttribute="trailing" id="I8y-Tb-azC"/>
+                <constraint firstItem="k2k-VX-DIG" firstAttribute="top" secondItem="nK8-aP-YaK" secondAttribute="bottom" id="NOJ-ga-Epw"/>
                 <constraint firstItem="k2k-VX-DIG" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="TpY-t0-XXR"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="U2J-WF-pcf" secondAttribute="trailing" id="UcS-h2-E0Z"/>
+                <constraint firstItem="nK8-aP-YaK" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Vzn-0l-vXP"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="k2k-VX-DIG" secondAttribute="trailing" constant="16" id="jKk-KK-qLP"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="124.55357142857142"/>

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -101,12 +101,17 @@ extension UIButton {
 
     /// Applies the Link Button Style: Clear BG / Brand Text Color
     ///
-    func applyLinkButtonStyle() {
+    func applyLinkButtonStyle(enableMultipleLines: Bool = false) {
         backgroundColor = .clear
         contentEdgeInsets = Style.defaultEdgeInsets
         tintColor = .accent
         titleLabel?.applyBodyStyle()
         titleLabel?.textAlignment = .natural
+
+        if enableMultipleLines {
+            self.enableMultipleLines()
+        }
+
         setTitleColor(.accent, for: .normal)
         setTitleColor(.accentDark, for: .highlighted)
     }


### PR DESCRIPTION
Refs #4478, #3963 
Depended by #4492, #4493

## Summary
Based on this [code review](https://github.com/woocommerce/woocommerce-ios/pull/4493#pullrequestreview-697643887) in #4493, there were problems with large text sizes. This PR provides accessibility support for large text. In a gist:

- The content view is nested in a scroll view, so the contents are vertically scrollable when using large text sizes.
- The link button does not have multi-line support by default, causing the UIButton to not respect the adjusted intrinsic content size. This PR addresses that.
- Since the action buttons are vertically stacked _and_ the secondary button title is rather long, I've applied a maximum font size for the buttons to allow for readable space for the content. Note that **this is only applied in iPhone interface idioms**.
- The `class` to `AnyObject` change in `RoleErrorOutput` is to get rid of an Xcode warning.

## 👀 Screenshots

• | Portrait | Landscape
--|--|--
iPhone, normal size | ![4478_a11y_reg_iphone_portrait](https://user-images.githubusercontent.com/1299411/125661237-1fd8054c-7c22-4999-b45d-5a1496ab803f.png) | ![4478_a11y_reg_iphone_landscape](https://user-images.githubusercontent.com/1299411/125661235-ac1061b0-6018-41cd-9f5e-2693c885ae42.png)
iPhone, large size | ![4478_a11y_xl_iphone_portrait](https://user-images.githubusercontent.com/1299411/125661244-df792030-b1e3-4562-abbd-d7ce7cd81f06.png) | ![4478_a11y_xl_iphone_landscape](https://user-images.githubusercontent.com/1299411/125661241-0c4d190e-3b5b-49c2-b73d-20fb2d8af1fd.png)
iPad, normal size | ![4478_a11y_reg_ipad_portrait](https://user-images.githubusercontent.com/1299411/125661230-c8032d66-d3ee-42db-81b7-47f938dc2ba6.png) | ![4478_a11y_reg_ipad_landscape](https://user-images.githubusercontent.com/1299411/125661226-0aad6e19-5100-415c-bf58-3c8d202b6ae9.png)
iPad, large size | ![4478_a11y_ipad_portrait](https://user-images.githubusercontent.com/1299411/125661218-582d755b-2ab7-4d49-9b3e-4d37e45eb1a2.png) | ![4478_a11y_ipad_landscape](https://user-images.githubusercontent.com/1299411/125661200-22c4cd7a-160a-42bf-9eaa-867b4f8b3a61.png)

Note: for dark mode looks, please refer to #4478.

## To Test
Currently, there's no path present to reach the new role error page. For the sake of just testing the layout, you'd have to intercept with the navigation flow temporarily. Modify `AppCoordinator` like so:

```swift
// AppCoordinator.swift:L38
guard let self = self else { return }

// add these lines to always show the role error page.
let viewModel = RoleErrorViewModel(displayName: "John Doe", roles: ["editor"])
let viewController = RoleErrorViewController(viewModel: viewModel)
let navigationController = WooNavigationController(rootViewController: viewController)
self.setWindowRootViewControllerAndAnimateIfNeeded(navigationController)
self.isLoggedIn = isLoggedIn
return
```
When running the app again, you should see the role error page pop up first thing.

## Author Checklist
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
