### PR TITLE
Add-ons: Remove addOnsI1 feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,8 +11,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsM4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .addOnsI1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sitePlugins:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentKnownReader:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -26,10 +26,6 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsM4
 
-    /// Product AddOns first iteration
-    ///
-    case addOnsI1
-
     /// Site Plugin list entry point on Settings screen
     ///
     case sitePlugins


### PR DESCRIPTION

# Why

As the project comes to an end, it's time to remove the feature flag used during development.
Note: The flag wasn't being used anymore.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
