### PR TITLE
[CPP Onboarding] Set padding for generic error to 24 pixels

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -14,7 +14,7 @@ struct InPersonPaymentsUnavailableView: View {
                 .font(.callout)
                 .multilineTextAlignment(.center)
         }
-        .padding()
+        .padding(24.0)
     }
 }
 


### PR DESCRIPTION
Part of #4611 
As noted in https://github.com/woocommerce/woocommerce-ios/pull/4613#issuecomment-880204405, we should use 24px of horizontal padding instead of the default SwiftUI padding.

## To test

Go to Settings > In-Person Payments on a store without payments set up

Before|After
-|-
![before](https://user-images.githubusercontent.com/8739/125756195-e2e51e13-8af2-455a-b292-0f9f3400ff96.png)|![after](https://user-images.githubusercontent.com/8739/125756201-4b6150ca-3678-490d-b36d-b96126ac7997.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
