### PR TITLE
Fix: updated the top banner in Order Detail screen informing the user of the shipping label creation

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -9,7 +9,7 @@ public enum FeedbackType: String, Codable {
     ///
     case productsVariations
 
-    /// identifier for the shipping labels m1 feedback survey
+    /// identifier for the shipping labels m3 feedback survey
     ///
-    case shippingLabelsRelease1
+    case shippingLabelsRelease3
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -60,8 +60,8 @@ extension WooAnalyticsEvent {
         case general
         /// Shown in products banner for Variations release.
         case productsVariations = "products_variations"
-        /// Shown in shipping labels banner for Milestone 1 features.
-        case shippingLabelsRelease1 = "shipping_labels_m1"
+        /// Shown in shipping labels banner for Milestone 3 features.
+        case shippingLabelsRelease3 = "shipping_labels_m3"
         /// Shown in beta feature banner for order add-ons.
         case addOnsI1 = "add-ons_i1"
     }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,12 +83,12 @@ extension WooConstants {
         ///
         case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
-        /// URL for the shipping labels M1 feedback survey
+        /// URL for the shipping labels M3 feedback survey
         ///
 #if DEBUG
-        case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-testing-feature-feedback-shipping-labels"
+        case shippingLabelsRelease3Feedback = "https://automattic.survey.fm/woo-app-testing-feature-feedback-shipping-labels"
 #else
-        case shippingLabelsRelease1Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
+        case shippingLabelsRelease3Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
 #endif
 
         /// URL for the order add-on i1 feedback survey

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -228,7 +228,8 @@ private extension OrderDetailsViewController {
 //
 private extension OrderDetailsViewController {
     func updateTopBannerView() {
-        let factory = ShippingLabelsTopBannerFactory(shippingLabels: viewModel.dataSource.shippingLabels)
+        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: viewModel.dataSource.isEligibleForShippingLabelCreation,
+                                                     shippingLabels: viewModel.dataSource.shippingLabels)
         let isExpanded = topBannerView?.isExpanded ?? false
         factory.createTopBannerIfNeeded(isExpanded: isExpanded,
                                         expandedStateChangeHandler: { [weak self] in
@@ -273,7 +274,7 @@ private extension OrderDetailsViewController {
     }
 
     func presentShippingLabelsFeedbackSurvey() {
-        let navigationController = SurveyCoordinatingController(survey: .shippingLabelsRelease1Feedback)
+        let navigationController = SurveyCoordinatingController(survey: .shippingLabelsRelease3Feedback)
         present(navigationController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
@@ -4,13 +4,16 @@ import Yosemite
 /// The top banner has two actions: "give feedback" and "dismiss".
 /// This class is not meant to be retained since it uses strong `self` in action handling, so that it has the same life cycle as the top banner.
 final class ShippingLabelsTopBannerFactory {
+    private var isEligibleForShippingLabelCreation: Bool
     private let shippingLabels: [ShippingLabel]
     private let stores: StoresManager
     private let analytics: Analytics
 
-    init(shippingLabels: [ShippingLabel],
+    init(isEligibleForShippingLabelCreation: Bool,
+         shippingLabels: [ShippingLabel],
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
+        self.isEligibleForShippingLabelCreation = isEligibleForShippingLabelCreation
         self.shippingLabels = shippingLabels
         self.stores = stores
         self.analytics = analytics
@@ -46,12 +49,12 @@ final class ShippingLabelsTopBannerFactory {
 
 private extension ShippingLabelsTopBannerFactory {
     func determineIfTopBannerShouldBeShown(onCompletion: @escaping (_ shouldShow: Bool) -> Void) {
-        guard shippingLabels.nonRefunded.isNotEmpty else {
+        guard isEligibleForShippingLabelCreation && shippingLabels.isEmpty else {
             onCompletion(false)
             return
         }
 
-        let action = AppSettingsAction.loadFeedbackVisibility(type: .shippingLabelsRelease1) { result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .shippingLabelsRelease3) { result in
             switch result {
             case .success(let visible):
                 onCompletion(visible)
@@ -70,12 +73,12 @@ private extension ShippingLabelsTopBannerFactory {
         let icon: UIImage = .megaphoneIcon
         let infoText = Localization.info
         let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
-            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease1, action: .gaveFeedback))
+            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease3, action: .gaveFeedback))
             onGiveFeedbackButtonPressed()
         }
         let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
-            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease1, action: .dismissed))
-            let action = AppSettingsAction.updateFeedbackStatus(type: .shippingLabelsRelease1, status: .dismissed) { result in
+            self.analytics.track(event: .featureFeedbackBanner(context: .shippingLabelsRelease3, action: .dismissed))
+            let action = AppSettingsAction.updateFeedbackStatus(type: .shippingLabelsRelease3, status: .dismissed) { result in
                 onDismissButtonPressed()
             }
             self.stores.dispatch(action)
@@ -97,13 +100,12 @@ private extension ShippingLabelsTopBannerFactory {
 private extension ShippingLabelsTopBannerFactory {
     enum Localization {
         static let title =
-            NSLocalizedString("Print shipping labels from your device!",
+            NSLocalizedString("Create shipping labels from your device!",
                               comment: "The title of the shipping labels top banner in order details")
         static let info =
             NSLocalizedString(
-                "We are working on making it easier for you to print shipping labels directly from your device! "
-                    + "For now, if you have created labels for an order in your store admin with WooCommerce Shipping, "
-                    + "you can print them in your Order details here.",
+                "You can now create shipping labels for all physical orders directly from your device with the free WooCommerce Shipping plugin. "
+                    + "Tap on Create shipping label to try our beta feature!",
                 comment: "The info of the shipping labels top banner in order details")
         static let giveFeedback =
             NSLocalizedString("Give feedback",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
@@ -105,7 +105,7 @@ private extension ShippingLabelsTopBannerFactory {
         static let info =
             NSLocalizedString(
                 "You can now create shipping labels for all physical orders directly from your device with the free WooCommerce Shipping plugin. "
-                    + "Tap on Create shipping label to try our beta feature!",
+                    + "Tap on Create Shipping Label to try our beta feature!",
                 comment: "The info of the shipping labels top banner in order details")
         static let giveFeedback =
             NSLocalizedString("Give feedback",

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -64,7 +64,7 @@ extension SurveyViewController {
     enum Source {
         case inAppFeedback
         case productsVariationsFeedback
-        case shippingLabelsRelease1Feedback
+        case shippingLabelsRelease3Feedback
         case addOnsI1
 
         fileprivate var url: URL {
@@ -80,11 +80,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .shippingLabelsRelease1Feedback:
-                return WooConstants.URLs.shippingLabelsRelease1Feedback
+            case .shippingLabelsRelease3Feedback:
+                return WooConstants.URLs.shippingLabelsRelease3Feedback
                     .asURL()
                     .tagPlatform("ios")
-                    .tagShippingLabelsMilestone("1")
+                    .tagShippingLabelsMilestone("3")
                     .tagAppVersion(Bundle.main.bundleVersion())
             case .addOnsI1:
                 return WooConstants.URLs.orderAddOnI1Feedback
@@ -98,7 +98,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsVariationsFeedback, .shippingLabelsRelease1Feedback, .addOnsI1:
+            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1:
                 return Localization.giveFeedback
             }
         }
@@ -110,8 +110,8 @@ extension SurveyViewController {
                 return .general
             case .productsVariationsFeedback:
                 return .productsVariations
-            case .shippingLabelsRelease1Feedback:
-                return .shippingLabelsRelease1
+            case .shippingLabelsRelease3Feedback:
+                return .shippingLabelsRelease3
             case .addOnsI1:
                 return .addOnsI1
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -39,7 +39,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_loads_the_correct_shipping_labels_release_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .shippingLabelsRelease1Feedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .shippingLabelsRelease3Feedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -47,10 +47,10 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.shippingLabelsRelease1Feedback
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.shippingLabelsRelease3Feedback
                         .asURL()
                         .tagPlatform("ios")
-                        .tagShippingLabelsMilestone("1")
+                        .tagShippingLabelsMilestone("3")
                         .tagAppVersion(Bundle.main.bundleVersion()))
     }
 

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -39,8 +39,8 @@ struct InAppFeedbackCardVisibilityUseCase {
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
         case .productsVariations:
             return shouldProductsFeedbackBeVisible()
-        case .shippingLabelsRelease1:
-            return shouldShippingLabelsRelease1FeedbackBeVisible()
+        case .shippingLabelsRelease3:
+            return shouldShippingLabelsRelease3FeedbackBeVisible()
         }
     }
 
@@ -72,9 +72,9 @@ struct InAppFeedbackCardVisibilityUseCase {
         return settings.feedbackStatus(of: feedbackType) == .pending
     }
 
-    /// Returns whether the shippingLabelsRelease1 feedback request should be displayed
+    /// Returns whether the shippingLabelsRelease3 feedback request should be displayed
     ///
-    private func shouldShippingLabelsRelease1FeedbackBeVisible() -> Bool {
+    private func shouldShippingLabelsRelease3FeedbackBeVisible() -> Bool {
         return settings.feedbackStatus(of: feedbackType) == .pending
     }
 


### PR DESCRIPTION
Fixes #4625 

## Description
Updated the top banner in Order Detail screen, informing the user of the Shipping Label Creation.
This PR will be merged in release 7.1, since we need to inform users about this new beta feature.

## Testing
#### Case 1
1. Open an order that is eligible for Shipping Label creation.
2. You should see the new top banner appearing with the new text.

#### Case 2
1. Open an order with existing shipping labels.
2. You shouldn't see the top banner.

## Screenshots
| Before (Order with existing Shipping Labels)            |  After (Order eligible for Shipping Label creation) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-07-15 at 11 15 27](https://user-images.githubusercontent.com/495617/125774091-867d3190-3cf2-41bf-81a9-8a9cf77b0d7f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-15 at 11 44 43](https://user-images.githubusercontent.com/495617/125774099-24c465ea-3114-4de3-b55d-6e40d72fa94e.png)




Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
