### PR TITLE
[Order Fulfillment] Update constraints of Review Order footer view to safe areas

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 
 7.2
 -----
-- [*] Updated success notice message for Order Fulfillment [https://github.com/woocommerce/woocommerce-ios/pull/4589]
+- [*] Order Fulfillment: Updated success notice message [https://github.com/woocommerce/woocommerce-ios/pull/4589]
+- [*] Order Fulfillment: Fixed issue footer view getting clipped of by iPhone notch [https://github.com/woocommerce/woocommerce-ios/pull/4631]
 - [*] Shipping Labels: Updated address validation to make sure a name is entered for each address. [https://github.com/woocommerce/woocommerce-ios/pull/4601]
 
 7.1

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -109,9 +109,9 @@ private extension ReviewOrderViewController {
         containerView.addSubview(emailLabel)
 
         NSLayoutConstraint.activate([
-            emailLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            emailLabel.leadingAnchor.constraint(equalTo: containerView.safeLeadingAnchor, constant: 16),
             emailLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 24),
-            containerView.trailingAnchor.constraint(equalTo: emailLabel.trailingAnchor, constant: 16)
+            containerView.safeTrailingAnchor.constraint(equalTo: emailLabel.trailingAnchor, constant: 16)
         ])
 
         let actionButton = UIButton(frame: .zero)
@@ -123,9 +123,9 @@ private extension ReviewOrderViewController {
 
         NSLayoutConstraint.activate([
             actionButton.topAnchor.constraint(equalTo: emailLabel.bottomAnchor, constant: 16),
-            actionButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            actionButton.leadingAnchor.constraint(equalTo: containerView.safeLeadingAnchor, constant: 16),
             containerView.safeBottomAnchor.constraint(equalTo: actionButton.bottomAnchor, constant: 24),
-            containerView.trailingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 16)
+            containerView.safeTrailingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 16)
         ])
 
         return containerView


### PR DESCRIPTION
Closes #4608 

# Description
This PR aims to make sure that the footer view in Review Order screen stays within safe areas and not clipped by iPhone notch.

# Changes
- Updated leading and trailing constraints of email label to safe areas
- Updated leading and trailing constraints of action button to safe areas

# Screenshot
<img width="805" alt="Screen Shot 2021-07-16 at 11 08 47" src="https://user-images.githubusercontent.com/5533851/125890343-623ccab2-9f83-47b5-9a63-c0fcf3288a0e.png">


# Testing
1. Go to Orders tab
2. Select an order with Processing status
3. Tap Mark Order Complete
4. On Review Order screen, switch to landscape mode
5. Scroll down to bottom and notice that the email text and action button are not clipped by iPhone notch.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
