### PR TITLE
Shipping Labels: Enable Create Shipping Label button on orders with only refunded labels

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -868,19 +868,19 @@ extension OrderDetailsDataSource {
 
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
-            if isEligibleForShippingLabelCreation && shippingLabels.isEmpty {
+            if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
                 rows.append(.shippingLabelCreateButton)
             }
 
             if isProcessingPayment {
-                if isEligibleForShippingLabelCreation && shippingLabels.isEmpty {
+                if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
                     rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                     rows.append(.shippingLabelCreationInfo(showsSeparator: false))
                 } else {
                     rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
                 }
             } else if isRefundedStatus == false {
-                if isEligibleForShippingLabelCreation && shippingLabels.isEmpty {
+                if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
                     rows.append(.shippingLabelCreationInfo(showsSeparator: true))
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
@@ -49,7 +49,7 @@ final class ShippingLabelsTopBannerFactory {
 
 private extension ShippingLabelsTopBannerFactory {
     func determineIfTopBannerShouldBeShown(onCompletion: @escaping (_ shouldShow: Bool) -> Void) {
-        guard isEligibleForShippingLabelCreation && shippingLabels.isEmpty else {
+        guard isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty else {
             onCompletion(false)
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -277,7 +277,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
     func test_create_shipping_label_button_is_visible_for_eligible_order_with_only_refunded_labels() throws {
         // Given
         let order = makeOrder()
-        let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: .init(dateRequested: Date(), status: .pending))
+        let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: ShippingLabelRefund.fake())
         insert(shippingLabel: refundedShippingLabel)
 
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -259,6 +259,74 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
+    func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() throws {
+        // Given
+        let order = makeOrder()
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = true
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productSection = try section(withTitle: Title.products, from: dataSource)
+        let createShippingLabelRow = row(row: .shippingLabelCreateButton, in: productSection)
+        XCTAssertNotNil(createShippingLabelRow)
+    }
+
+    func test_create_shipping_label_button_is_visible_for_eligible_order_with_only_refunded_labels() throws {
+        // Given
+        let order = makeOrder()
+        let refundedShippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID, refund: .init(dateRequested: Date(), status: .pending))
+        insert(shippingLabel: refundedShippingLabel)
+
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = true
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productSection = try section(withTitle: Title.products, from: dataSource)
+        let createShippingLabelRow = row(row: .shippingLabelCreateButton, in: productSection)
+        XCTAssertNotNil(createShippingLabelRow)
+    }
+
+    func test_create_shipping_label_button_is_not_visible_for_eligible_order_with_labels() throws {
+        // Given
+        let order = makeOrder()
+        let shippingLabel = ShippingLabel.fake().copy(siteID: order.siteID, orderID: order.orderID)
+        insert(shippingLabel: shippingLabel)
+
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = true
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productSection = try section(withTitle: Title.products, from: dataSource)
+        let createShippingLabelRow = row(row: .shippingLabelCreateButton, in: productSection)
+        XCTAssertNil(createShippingLabelRow)
+    }
+
+    func test_create_shipping_label_button_is_not_visible_for_ineligible_order() throws {
+        // Given
+        let order = makeOrder()
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = false
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productSection = try section(withTitle: Title.products, from: dataSource)
+        let createShippingLabelRow = row(row: .shippingLabelCreateButton, in: productSection)
+        XCTAssertNil(createShippingLabelRow)
+    }
+
 }
 
 // MARK: - Test Data
@@ -322,6 +390,18 @@ private extension OrderDetailsDataSourceTests {
         let storageRefund = storage.insertNewObject(ofType: StorageRefund.self)
         storageRefund.update(with: refund)
         storageRefund.addToItems(storageOrderItemRefunds as NSSet)
+    }
+
+    /// Inserts the shipping label into storage
+    ///
+    func insert(shippingLabel: ShippingLabel) {
+        let storageShippingLabel = storage.insertNewObject(ofType: StorageShippingLabel.self)
+        storageShippingLabel.update(with: shippingLabel)
+        if let shippingLabelRefund = shippingLabel.refund {
+            let storageRefund = storage.insertNewObject(ofType: StorageShippingLabelRefund.self)
+            storageRefund.update(with: shippingLabelRefund)
+            storageShippingLabel.refund = storageRefund
+        }
     }
 
     /// Finds first section with a given title from the provided data source.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
@@ -19,10 +19,11 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         XCTAssertNil(topBannerView)
     }
 
-    func test_creating_top_banner_with_a_refunded_shipping_label_returns_nil() throws {
+    func test_creating_top_banner_with_a_refunded_shipping_label_and_eligible_for_creation_returns_banner() throws {
         // Given
         let refundedShippingLabel = MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [refundedShippingLabel])
+        let stores = createStores(feedbackVisibilityResult: .success(true))
+        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [refundedShippingLabel], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -33,7 +34,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         }
 
         // Then
-        XCTAssertNil(topBannerView)
+        XCTAssertNotNil(topBannerView)
     }
 
     func test_creating_top_banner_with_empty_shipping_labels_and_eligible_for_creation_returns_banner() throws {


### PR DESCRIPTION
Fixes: #4629

## Description

If an order has a refunded shipping label, it is still eligible for a new shipping label to be created. (This is the behavior seen in wp-admin.)

However, in the app, even though the remote eligibility endpoint says the order is eligible for shipping label creation, we didn't show the "Create Shipping Label" button. This PR fixes that behavior so the "Create Shipping Label" button is shown if an order only has refunded shipping labels; it also makes sure the shipping label banner is displayed on those orders.

FYI @jkmassel since this is targeting the 7.1 release.

## Changes

* Updates the checks for displaying the "Create Shipping Label" button and shipping label banner to check `shippingLabels.nonRefunded.isEmpty` instead of `shippingLabels.isEmpty`.
* Updates the shipping label banner unit test for orders with a refunded label.
* Adds unit tests for the "Create Shipping Label" button visibility.

Before|After
-|-
![Shipping Label before](https://user-images.githubusercontent.com/8658164/125797027-cea961b5-8e95-461c-80a6-698e179b98bc.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-15 at 16 33 16](https://user-images.githubusercontent.com/8658164/125929042-eefc04e5-dc93-46e7-959f-3596b1f6d2de.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Make sure you have an order with a refunded shipping label. (You can purchase a shipping label and then immediately refund it.)
3. Launch the app.
4. Open the order details for the order with a refunded shipping label.
5. Confirm the shipping label banner appears at the top of the order detail screen, and the "Create Shipping Label" button is visible.
6. Tap the "Create Shipping Label" button and confirm you can successfully purchase a shipping label for that order.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
