### PR TITLE
System plugins - Fix  OrderDetailsDataSource tests adding `.some(nil)` to datePaid property

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -67,7 +67,7 @@ extension Order {
         let customerNote = customerNote ?? self.customerNote
         let dateCreated = dateCreated ?? self.dateCreated
         let dateModified = dateModified ?? self.dateModified
-        let datePaid = datePaid ?? nil
+        let datePaid = datePaid ?? self.datePaid
         let discountTotal = discountTotal ?? self.discountTotal
         let discountTax = discountTax ?? self.discountTax
         let shippingTotal = shippingTotal ?? self.shippingTotal
@@ -682,36 +682,6 @@ extension ProductVariation {
     }
 }
 
-extension ShipmentTracking {
-    public func copy(
-        siteID: CopiableProp<Int64> = .copy,
-        orderID: CopiableProp<Int64> = .copy,
-        trackingID: CopiableProp<String> = .copy,
-        trackingNumber: CopiableProp<String> = .copy,
-        trackingProvider: NullableCopiableProp<String> = .copy,
-        trackingURL: NullableCopiableProp<String> = .copy,
-        dateShipped: NullableCopiableProp<Date> = .copy
-    ) -> ShipmentTracking {
-        let siteID = siteID ?? self.siteID
-        let orderID = orderID ?? self.orderID
-        let trackingID = trackingID ?? self.trackingID
-        let trackingNumber = trackingNumber ?? self.trackingNumber
-        let trackingProvider = trackingProvider ?? self.trackingProvider
-        let trackingURL = trackingURL ?? self.trackingURL
-        let dateShipped = dateShipped ?? self.dateShipped
-
-        return ShipmentTracking(
-            siteID: siteID,
-            orderID: orderID,
-            trackingID: trackingID,
-            trackingNumber: trackingNumber,
-            trackingProvider: trackingProvider,
-            trackingURL: trackingURL,
-            dateShipped: dateShipped
-        )
-    }
-}
-
 extension Refund {
     public func copy(
         refundID: CopiableProp<Int64> = .copy,
@@ -750,6 +720,36 @@ extension Refund {
             createAutomated: createAutomated,
             items: items,
             shippingLines: shippingLines
+        )
+    }
+}
+
+extension ShipmentTracking {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        orderID: CopiableProp<Int64> = .copy,
+        trackingID: CopiableProp<String> = .copy,
+        trackingNumber: CopiableProp<String> = .copy,
+        trackingProvider: NullableCopiableProp<String> = .copy,
+        trackingURL: NullableCopiableProp<String> = .copy,
+        dateShipped: NullableCopiableProp<Date> = .copy
+    ) -> ShipmentTracking {
+        let siteID = siteID ?? self.siteID
+        let orderID = orderID ?? self.orderID
+        let trackingID = trackingID ?? self.trackingID
+        let trackingNumber = trackingNumber ?? self.trackingNumber
+        let trackingProvider = trackingProvider ?? self.trackingProvider
+        let trackingURL = trackingURL ?? self.trackingURL
+        let dateShipped = dateShipped ?? self.dateShipped
+
+        return ShipmentTracking(
+            siteID: siteID,
+            orderID: orderID,
+            trackingID: trackingID,
+            trackingNumber: trackingNumber,
+            trackingProvider: trackingProvider,
+            trackingURL: trackingURL,
+            dateShipped: dateShipped
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -133,7 +133,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: nil, paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 
@@ -221,7 +221,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: nil, total: "1", paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "1", paymentMethodID: "cod")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 


### PR DESCRIPTION
## Why
After executing `rake generate` we detected a small change in Order copiable model. 
<img width="479" alt="Captura de pantalla 2021-07-16 a las 17 27 12" src="https://user-images.githubusercontent.com/11411847/125971805-626a6a64-c646-4607-a052-e7a4e71bb934.png">

This change makes to fail some unit tests:
```
test_collect_payment_button_is_visible_and_primary_style_if_order_is_eligible_for_cash_on_delivery()

test_collect_payment_button_is_visible_if_order_is_eligible_for_cash_on_delivery_and_total_amount_is_greater_than_zero()
```
 
## How
Changing the way to put a nil `datePaid` value, fix these unit tests:
`let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")`

## Test
Execute unit tests.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
