### PR TITLE
Edge-to-edge table views on Reviews tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Order Fulfillment: Updated success notice message [https://github.com/woocommerce/woocommerce-ios/pull/4589]
 - [*] Order Fulfillment: Fixed issue footer view getting clipped of by iPhone notch [https://github.com/woocommerce/woocommerce-ios/pull/4631]
 - [*] Shipping Labels: Updated address validation to make sure a name is entered for each address. [https://github.com/woocommerce/woocommerce-ios/pull/4601]
+- [*] Reviews and Review Details: Updated edge-to-edge table views for consistent look across the app. [https://github.com/woocommerce/woocommerce-ios/pull/4637]
 
 7.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,14 +27,14 @@
                     </connections>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
                 <constraint firstItem="N9g-Ec-Iu1" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9YG-3M-BWi"/>
-                <constraint firstItem="N9g-Ec-Iu1" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KfE-6Z-RFy"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N9g-Ec-Iu1" secondAttribute="trailing" id="SL0-kI-NEx"/>
+                <constraint firstItem="N9g-Ec-Iu1" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="KfE-6Z-RFy"/>
+                <constraint firstAttribute="trailing" secondItem="N9g-Ec-Iu1" secondAttribute="trailing" id="SL0-kI-NEx"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N9g-Ec-Iu1" secondAttribute="bottom" id="ndn-Up-PKr"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="138" y="110"/>
         </view>
     </objects>

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,8 +29,8 @@
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="i5V-XB-HZ3" secondAttribute="bottom" id="Exe-g8-l8x"/>
                 <constraint firstItem="i5V-XB-HZ3" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="L2p-AO-VA3"/>
-                <constraint firstItem="i5V-XB-HZ3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ZFu-2m-NQX"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="i5V-XB-HZ3" secondAttribute="trailing" id="oja-Bt-7RE"/>
+                <constraint firstItem="i5V-XB-HZ3" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ZFu-2m-NQX"/>
+                <constraint firstAttribute="trailing" secondItem="i5V-XB-HZ3" secondAttribute="trailing" id="oja-Bt-7RE"/>
             </constraints>
             <point key="canvasLocation" x="139" y="86"/>
         </view>


### PR DESCRIPTION
Part of #3716 

# Description
This PR aims to remove the leading and trailing margins of the table views on Reviews and Review Details screens.

# Changes
- Updated the table view on Reviews screen to constrain to its super view's leading and trailing.
- Updated the table view on Review Details screen to constrain to its super view's leading and trailing.

# Screenshots
| Before | After |
| ------ | ------ |
| <img src="https://user-images.githubusercontent.com/5533851/126118464-9ff77ca5-051d-4761-ac90-a0494847cf99.PNG" width=400 /><img src="https://user-images.githubusercontent.com/5533851/126118469-5fc0b710-b605-46c5-8f1f-3dbce4150575.PNG" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/126118595-2f22db3b-61a0-48a9-8283-d718ef578745.png" width=400 /> <img src="https://user-images.githubusercontent.com/5533851/126118600-939b181e-8dda-4dcf-b060-394cbe268d5d.png" width=400 /> |

# Testing
1. Navigate to Reviews tab
2. Switch to landscape mode
3. Notice that the table view is edge-to-edge, i.e no leading or trailing margins.
4. Select a review to see details
5. Notice that the details table view is edge-to-edge too.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
