### PR TITLE
Edge-to-edge table views on Orders tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Order Fulfillment: Updated success notice message [https://github.com/woocommerce/woocommerce-ios/pull/4589]
 - [*] Order Fulfillment: Fixed issue footer view getting clipped of by iPhone notch [https://github.com/woocommerce/woocommerce-ios/pull/4631]
 - [*] Shipping Labels: Updated address validation to make sure a name is entered for each address. [https://github.com/woocommerce/woocommerce-ios/pull/4601]
+- [*] Orders and Order Details: Updated edge-to-edge table views for consistent look across the app. [https://github.com/woocommerce/woocommerce-ios/pull/4638]
 
 7.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -257,7 +257,7 @@ private extension OrderDetailsViewController {
         // top banner view can be Auto Layout based with dynamic height.
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)
-        headerContainer.pinSubviewToSafeArea(topBannerView, insets: Constants.headerContainerInsets)
+        headerContainer.pinSubviewToAllEdges(topBannerView, insets: Constants.headerContainerInsets)
         tableView.tableHeaderView = headerContainer
         tableView.updateHeaderHeight()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -224,7 +224,7 @@ private extension OrderListViewController {
 
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(tableView)
+        view.pinSubviewToAllEdges(tableView)
     }
 
     /// Setup: Ghostable TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,8 +33,8 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="UvB-Se-4t8" firstAttribute="top" secondItem="wvX-aq-v2S" secondAttribute="top" id="4Ub-DZ-ghw"/>
-                            <constraint firstItem="wvX-aq-v2S" firstAttribute="trailing" secondItem="UvB-Se-4t8" secondAttribute="trailing" id="5yv-ks-XxC"/>
-                            <constraint firstItem="UvB-Se-4t8" firstAttribute="leading" secondItem="wvX-aq-v2S" secondAttribute="leading" id="gCC-dv-e72"/>
+                            <constraint firstAttribute="trailing" secondItem="UvB-Se-4t8" secondAttribute="trailing" id="5yv-ks-XxC"/>
+                            <constraint firstItem="UvB-Se-4t8" firstAttribute="leading" secondItem="BSM-Pn-wcY" secondAttribute="leading" id="gCC-dv-e72"/>
                             <constraint firstItem="wvX-aq-v2S" firstAttribute="bottom" secondItem="UvB-Se-4t8" secondAttribute="bottom" id="r2l-mN-F5h"/>
                         </constraints>
                     </view>
@@ -83,9 +83,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -101,12 +101,11 @@ private extension OrdersRootViewController {
             view.pinSubviewToAllEdges(hiddenScrollView, insets: .zero)
         }
 
-        // A container view is added to respond to safe area insets from the view controller.
-        // This is needed when the child view controller's view has to use a frame-based layout
-        // (e.g. when the child view controller is a `ButtonBarPagerTabStripViewController` subclass).
+        // A container view is pinned to all edges of the view controller.
+        // to keep the consistent edge-to-edge look across app.
         view.addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(containerView)
+        view.pinSubviewToAllEdges(containerView)
     }
 
     func configureChildViewController() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -144,8 +144,8 @@ private extension OrdersTabbedViewController {
 
         NSLayoutConstraint.activate([
             border.topAnchor.constraint(equalTo: buttonBarView.bottomAnchor),
-            border.leadingAnchor.constraint(equalTo: buttonBarView.leadingAnchor),
-            border.trailingAnchor.constraint(equalTo: buttonBarView.trailingAnchor)
+            border.leadingAnchor.constraint(equalTo: superView.leadingAnchor),
+            border.trailingAnchor.constraint(equalTo: superView.trailingAnchor)
         ])
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,8 +41,8 @@
             <viewLayoutGuide key="safeArea" id="rGE-vr-B04"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="VD7-Yu-YwE" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="1oC-b9-sf9"/>
-                <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="VD7-Yu-YwE" secondAttribute="trailing" id="9vb-3t-PWE"/>
+                <constraint firstItem="VD7-Yu-YwE" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="1oC-b9-sf9"/>
+                <constraint firstAttribute="trailing" secondItem="VD7-Yu-YwE" secondAttribute="trailing" id="9vb-3t-PWE"/>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="top" secondItem="7lu-ed-U2a" secondAttribute="bottom" id="L4N-Ce-OKC"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="bottom" secondItem="VD7-Yu-YwE" secondAttribute="bottom" id="LZC-0z-fDh"/>
                 <constraint firstItem="7lu-ed-U2a" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="Rct-WJ-OQP"/>


### PR DESCRIPTION
Part of #3716 

# Description
This PR aims to keep consistent edge-to-edge look on table views of Orders tab. 

Note: This PR only covers Orders and Order Details screens - Shipping Labels screens will be handled in a separate PR.

# Changes
- Updated tab view on Orders screen to be edge-to-edge - the tab scroll view is pinned to its super view's leading and trailing edges.
- Both Root Orders controller and Order List table view were also updated to constrained to super view's edges.
- Order Details table view and header view were both pinned to their super view's edges as well.

# Screenshots
| Before | After |
| ------ | ------ |
| <img src="https://user-images.githubusercontent.com/5533851/126127056-c9191788-f70f-4a38-9304-8d36d5974aef.PNG" width=400 /><img src="https://user-images.githubusercontent.com/5533851/126127150-dd300bcd-9d19-4c3b-87dd-bbfce6249616.PNG" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/126129928-2a0a17a2-d7dc-4e36-b51d-5cbbb75e4859.png" width=400 /><img src="https://user-images.githubusercontent.com/5533851/126127213-eca5ba66-c27f-4cb4-99f7-20f40e4de667.png" width=400 /> |

# Testing
1. Navigate to Orders tab
2. Switch to landscape mode
3. Notice that there's no leading or trailing margins on the Orders table view or tab view.
4. Select an order to see details.
5. Notice that there's no leading or trailing margins on the details table view order header view.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
