### PR TITLE
Shipping Labels: Validate that address name field is not empty

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -498,6 +498,14 @@ extension ShippingLabelFormViewModel {
 
         let addressToBeVerified = ShippingLabelAddressVerification(address: address, type: type)
 
+        // Validate name field locally before validating the address remotely.
+        // The name field cannot be empty when creating a shipping label, but this is not part of the remote validation.
+        // See: https://github.com/Automattic/woocommerce-services/issues/2457
+        if address.name.isEmpty {
+            let missingNameError = ShippingLabelAddressValidationError(addressError: nil, generalError: "Name is required")
+            onCompletion?(.validationError(missingNameError), nil)
+        }
+
         updateValidatingAddressState(true, type: type)
 
         let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -278,6 +278,24 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(updatedRows?[2].displayMode, .editable)
     }
 
+    func test_validateAddress_returns_validation_error_when_missing_name() {
+        // Given
+        let expectedValidationError = ShippingLabelAddressValidationError(addressError: nil, generalError: "Name is required")
+        let originAddress = Address.fake()
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: originAddress,
+                                                                    destinationAddress: nil)
+
+        // When
+        shippingLabelFormViewModel.validateAddress(type: .origin) { validationState, validationSuccess in
+            guard case let .validationError(error) = validationState else {
+                XCTFail("Validation error was not returned")
+                return
+            }
+            XCTAssertEqual(error, expectedValidationError)
+        }
+    }
+
     func test_handlePaymentMethodValueChanges_returns_updated_data_and_state_with_no_selected_payment_method() {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),


### PR DESCRIPTION
## Description

This PR adds local validation to check that the shipping address name field is not empty when creating shipping labels. If it is empty, it opens the Edit Address screen to prompt the user to enter a name.

This was [fixed on `develop`](https://github.com/woocommerce/woocommerce-ios/pull/4601) and the fix is being introduced to `release/7.1` based on beta testing feedback. (Internal ref: p5T066-2uU-p2#comment-9242)

FYI @jkmassel since this is targeting the 7.1 release.

## Changes

* Adds a check for `address.name.isEmpty` before doing the remote address validation in `ShippingLabelFormViewModel`.
* Adds a unit test.

Before|After
-|-
![validate-name-before](https://user-images.githubusercontent.com/8658164/125477810-3d78cc42-614e-4abc-88d4-b0eb6c773dbf.gif)|![validate-name-after](https://user-images.githubusercontent.com/8658164/125477822-de7332ac-6ec0-49cd-8c0c-698b0ce40c66.gif)

## Testing

1. Make sure your `First name` and `Last name` are empty in your [WordPress.com account settings](https://wordpress.com/me).
2. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
3. Launch the app.
4. If you are already logged in, log out and log in again (to make sure you don't have old account settings stored in the app).
5. Open an order detail that is eligible for the shipping label.
6. Tap the button "Create Shipping Label".
7. In the `Ship from` section, tap the "Continue" button.
8. Confirm that the Edit Address screen opens (with the "Name missing" validation error prompting you to enter a name).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.