### PR TITLE
Shipping Labels: fixed total weight in Package Details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -174,7 +174,9 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
                 product = products.first { $0.productID == item.productID }
             }
             if product?.virtual == false || productVariation?.virtual == false {
-                tempTotalWeight += Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
+                for _ in 0..<item.quantity.intValue {
+                    tempTotalWeight += Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
+                }
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -273,7 +273,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // When
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123"))
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9"))
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1.44"))
         insert(ProductVariation.fake().copy(siteID: sampleSiteID,
                                             productID: 49,
                                             productVariationID: 49,
@@ -290,7 +290,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
 
         // Then
-        XCTAssertEqual(viewModel.totalWeight, "124.0")
+        XCTAssertEqual(viewModel.totalWeight, "125.88")
     }
 
     func test_totalWeight_returns_the_expected_value_when_already_set() {


### PR DESCRIPTION
Fixes #4643 

## Description
Previously, the total package weight in the Package Details screen under the Shipping Label Creation flow was the sum of the weight of the products, without considering the quantities. Now, the total weight is calculated based on items quantity.

FYI @jkmassel since this is targeting the 7.1 release.

## Testing
1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app.
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Confirm "Ship From" and "Ship To".
6. In the package details section, make sure that the "Total package weight" displayed is now correct, and it's the sum of the weight of the item shown on the screen.


| Before             |  After |
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/495617/126172605-f89b1f78-2310-4607-b171-2306b62ed9d4.png) | ![after](https://user-images.githubusercontent.com/495617/126172620-27e2d3fb-0ed3-46c7-8702-13f6b60692fa.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
