### PR TITLE
Drop unnecessary Comparable conformance

### DIFF
--- a/Networking/Networking/Model/Account.swift
+++ b/Networking/Networking/Model/Account.swift
@@ -50,14 +50,3 @@ private extension Account {
         case gravatarUrl    = "avatar_URL"
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension Account: Comparable {
-    public static func < (lhs: Account, rhs: Account) -> Bool {
-        return lhs.userID < rhs.userID ||
-            (lhs.userID == rhs.userID && lhs.username < rhs.username) ||
-            (lhs.userID == rhs.userID && lhs.username == rhs.username && lhs.displayName < rhs.displayName)
-    }
-}

--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -90,15 +90,3 @@ private extension Address {
         case email      = "email"
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension Address: Comparable {
-    public static func < (lhs: Address, rhs: Address) -> Bool {
-        return lhs.city < rhs.city ||
-        (lhs.city == rhs.city && lhs.state < rhs.state) ||
-        (lhs.city == rhs.city && lhs.state == rhs.state && lhs.postcode < rhs.postcode) ||
-        (lhs.city == rhs.city && lhs.state == rhs.state && lhs.postcode == rhs.postcode && lhs.lastName < rhs.lastName)
-    }
-}

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -217,9 +217,9 @@ private extension Order {
 }
 
 
-// MARK: - Comparable Conformance
+// MARK: - Equatable Conformance
 //
-extension Order: Comparable {
+extension Order: Equatable {
     // custom implementation to ignore order for shippingLines, coupons, refunds, items
     public static func == (lhs: Order, rhs: Order) -> Bool {
         return lhs.siteID == rhs.siteID &&
@@ -249,12 +249,6 @@ extension Order: Comparable {
             lhs.refunds.sorted() == rhs.refunds.sorted() &&
             lhs.items.count == rhs.items.count &&
             lhs.items.sorted() == rhs.items.sorted()
-    }
-
-    public static func < (lhs: Order, rhs: Order) -> Bool {
-        return lhs.orderID < rhs.orderID ||
-            (lhs.orderID == rhs.orderID && lhs.dateCreated < rhs.dateCreated) ||
-            (lhs.orderID == rhs.orderID && lhs.dateCreated == rhs.dateCreated && lhs.dateModified < rhs.dateModified)
     }
 }
 

--- a/Networking/Networking/Model/OrderItemTax.swift
+++ b/Networking/Networking/Model/OrderItemTax.swift
@@ -60,14 +60,3 @@ private extension OrderItemTax {
         case total
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension OrderItemTax: Comparable {
-    public static func < (lhs: OrderItemTax, rhs: OrderItemTax) -> Bool {
-        return lhs.taxID < rhs.taxID ||
-            (lhs.taxID == rhs.taxID && lhs.subtotal < rhs.subtotal) ||
-            (lhs.taxID == rhs.taxID && lhs.subtotal == rhs.subtotal && lhs.total < rhs.total)
-    }
-}

--- a/Networking/Networking/Model/OrderNote.swift
+++ b/Networking/Networking/Model/OrderNote.swift
@@ -47,14 +47,3 @@ private extension OrderNote {
         case author         = "author"
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension OrderNote: Comparable {
-    public static func < (lhs: OrderNote, rhs: OrderNote) -> Bool {
-        return lhs.noteID < rhs.noteID ||
-            (lhs.noteID == rhs.noteID && lhs.dateCreated < rhs.dateCreated) ||
-            (lhs.noteID == rhs.noteID && lhs.dateCreated == rhs.dateCreated && lhs.note < rhs.note)
-    }
-}

--- a/Networking/Networking/Model/Post.swift
+++ b/Networking/Networking/Model/Post.swift
@@ -46,13 +46,3 @@ private extension Post {
         case password       = "password"
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension Post: Comparable {
-    public static func < (lhs: Post, rhs: Post) -> Bool {
-        return lhs.siteID < rhs.siteID
-    }
-
-}

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -640,56 +640,6 @@ private extension Product {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension Product: Comparable {
-    public static func < (lhs: Product, rhs: Product) -> Bool {
-        /// Note: stockQuantity can be `null` in the API,
-        /// which is why we are unable to sort by it here.
-        ///
-        return lhs.siteID < rhs.siteID ||
-            (lhs.siteID == rhs.siteID && lhs.productID < rhs.productID) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name < rhs.name) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug < rhs.slug) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated < rhs.dateCreated) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.productTypeKey < rhs.productTypeKey) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.productTypeKey == rhs.productTypeKey &&
-                lhs.statusKey < rhs.statusKey) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.productTypeKey == rhs.productTypeKey &&
-                lhs.statusKey == rhs.statusKey &&
-                lhs.stockStatusKey < rhs.stockStatusKey) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.productTypeKey == rhs.productTypeKey &&
-                lhs.statusKey == rhs.statusKey &&
-                lhs.stockStatusKey == rhs.stockStatusKey &&
-                lhs.averageRating < rhs.averageRating) ||
-            (lhs.siteID == rhs.siteID && lhs.productID == rhs.productID &&
-                lhs.name == rhs.name && lhs.slug == rhs.slug &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.productTypeKey == rhs.productTypeKey &&
-                lhs.statusKey == rhs.statusKey &&
-                lhs.stockStatusKey == rhs.stockStatusKey &&
-                lhs.averageRating == rhs.averageRating &&
-                lhs.ratingCount < rhs.ratingCount)
-    }
-}
-
-
 // MARK: - Constants!
 //
 private extension Product {

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductAttribute entity.
 ///
-public struct ProductAttribute: Codable, GeneratedFakeable, GeneratedCopiable {
+public struct ProductAttribute: Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
     public let attributeID: Int64
     public let name: String

--- a/Networking/Networking/Model/Product/ProductCategory.swift
+++ b/Networking/Networking/Model/Product/ProductCategory.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductCategory entity.
 ///
-public struct ProductCategory: Codable, GeneratedFakeable {
+public struct ProductCategory: Codable, Equatable, GeneratedFakeable {
     public let categoryID: Int64
     public let siteID: Int64
     public let parentID: Int64

--- a/Networking/Networking/Model/Product/ProductDefaultAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductDefaultAttribute.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductDefaultAttribute entity.
 ///
-public struct ProductDefaultAttribute: Decodable, GeneratedFakeable {
+public struct ProductDefaultAttribute: Decodable, Equatable, GeneratedFakeable {
     public let attributeID: Int64
     public let name: String?
     public let option: String?

--- a/Networking/Networking/Model/Product/ProductDimensions.swift
+++ b/Networking/Networking/Model/Product/ProductDimensions.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Dimensions Entity.
 ///
-public struct ProductDimensions: Codable, GeneratedFakeable {
+public struct ProductDimensions: Codable, Equatable, GeneratedFakeable {
     public let length: String
     public let width: String
     public let height: String
@@ -27,15 +27,5 @@ private extension ProductDimensions {
         case length
         case width
         case height
-    }
-}
-
-// MARK: - Comparable Conformance
-//
-extension ProductDimensions: Comparable {
-    public static func < (lhs: ProductDimensions, rhs: ProductDimensions) -> Bool {
-        return lhs.length < rhs.length ||
-            (lhs.length == rhs.length && lhs.width < rhs.width) ||
-            (lhs.length == rhs.length && lhs.width == rhs.width && lhs.height < rhs.height)
     }
 }

--- a/Networking/Networking/Model/Product/ProductDownload.swift
+++ b/Networking/Networking/Model/Product/ProductDownload.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductDownload entity.
 ///
-public struct ProductDownload: Codable, GeneratedFakeable {
+public struct ProductDownload: Codable, Equatable, GeneratedFakeable {
     public let downloadID: String
     public let name: String?
     public let fileURL: String?
@@ -49,14 +49,5 @@ private extension ProductDownload {
         case downloadID = "id"
         case name       = "name"
         case fileURL    = "file"
-    }
-}
-
-
-// MARK: - Comparable Conformance
-//
-extension ProductDownload: Comparable {
-    public static func < (lhs: ProductDownload, rhs: ProductDownload) -> Bool {
-        return lhs.downloadID < rhs.downloadID
     }
 }

--- a/Networking/Networking/Model/Product/ProductImage.swift
+++ b/Networking/Networking/Model/Product/ProductImage.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductImage entity.
 ///
-public struct ProductImage: Codable, GeneratedCopiable, GeneratedFakeable {
+public struct ProductImage: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
     public let imageID: Int64
     public let dateCreated: Date    // gmt
     public let dateModified: Date?  // gmt
@@ -59,16 +59,5 @@ private extension ProductImage {
         case src            = "src"
         case name           = "name"
         case alt            = "alt"
-    }
-}
-
-
-// MARK: - Comparable Conformance
-//
-extension ProductImage: Comparable {
-    public static func < (lhs: ProductImage, rhs: ProductImage) -> Bool {
-        return lhs.imageID < rhs.imageID ||
-            (lhs.imageID == rhs.imageID && lhs.dateCreated < rhs.dateCreated) ||
-            (lhs.imageID == rhs.imageID && lhs.dateCreated == rhs.dateCreated && lhs.src < rhs.src)
     }
 }

--- a/Networking/Networking/Model/Product/ProductTag.swift
+++ b/Networking/Networking/Model/Product/ProductTag.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a ProductTag entity.
 ///
-public struct ProductTag: Codable, GeneratedFakeable {
+public struct ProductTag: Codable, Equatable, GeneratedFakeable {
     public let siteID: Int64
     public let tagID: Int64
     public let name: String

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -141,17 +141,6 @@ private extension OrderItemRefund {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension OrderItemRefund: Comparable {
-    public static func < (lhs: OrderItemRefund, rhs: OrderItemRefund) -> Bool {
-        return lhs.itemID < rhs.itemID ||
-            (lhs.itemID == rhs.itemID && lhs.productID < rhs.productID) ||
-            (lhs.itemID == rhs.itemID && lhs.productID == rhs.productID && lhs.name < rhs.name)
-    }
-}
-
-
 // MARK: - Hashable Conformance
 //
 extension OrderItemRefund: Hashable {

--- a/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
@@ -59,14 +59,3 @@ private extension OrderItemTaxRefund {
         case total
     }
 }
-
-
-// MARK: - Comparable Conformance
-//
-extension OrderItemTaxRefund: Comparable {
-    public static func < (lhs: OrderItemTaxRefund, rhs: OrderItemTaxRefund) -> Bool {
-        return lhs.taxID < rhs.taxID ||
-            (lhs.taxID == rhs.taxID && lhs.subtotal < rhs.subtotal) ||
-            (lhs.taxID == rhs.taxID && lhs.subtotal == rhs.subtotal && lhs.total < rhs.total)
-    }
-}

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -137,9 +137,9 @@ private extension Refund {
 }
 
 
-// MARK: - Comparable Conformance
+// MARK: - Equatable Conformance
 //
-extension Refund: Comparable {
+extension Refund: Equatable {
     // custom implementation to ignore `createAutomated` and order for items
     public static func == (lhs: Refund, rhs: Refund) -> Bool {
         return lhs.refundID == rhs.refundID &&
@@ -150,26 +150,9 @@ extension Refund: Comparable {
             lhs.reason == rhs.reason &&
             lhs.refundedByUserID == rhs.refundedByUserID &&
             lhs.isAutomated == rhs.isAutomated &&
-            lhs.items.sorted() == rhs.items.sorted() &&
+            lhs.items.count == rhs.items.count &&
+            Set(lhs.items) == Set(rhs.items) &&
             lhs.shippingLines?.sorted() == rhs.shippingLines?.sorted()
-    }
-
-    public static func < (lhs: Refund, rhs: Refund) -> Bool {
-        return lhs.orderID == rhs.orderID ||
-            (lhs.orderID == rhs.orderID && lhs.refundID < rhs.refundID) ||
-            (lhs.orderID == rhs.orderID && lhs.refundID == rhs.refundID &&
-                lhs.dateCreated < rhs.dateCreated) ||
-            (lhs.orderID == rhs.orderID && lhs.refundID == rhs.refundID &&
-                lhs.dateCreated == rhs.dateCreated  &&
-                lhs.amount < rhs.amount) ||
-            (lhs.orderID == rhs.orderID && lhs.refundID == rhs.refundID &&
-                lhs.dateCreated == rhs.dateCreated  &&
-                lhs.amount == rhs.amount &&
-                rhs.items.count < rhs.items.count) ||
-            (lhs.orderID == rhs.orderID && lhs.refundID == rhs.refundID &&
-                lhs.dateCreated == rhs.dateCreated &&
-                lhs.amount == rhs.amount &&
-                rhs.items.count == rhs.items.count)
     }
 }
 

--- a/Networking/Networking/Model/ShipmentTracking.swift
+++ b/Networking/Networking/Model/ShipmentTracking.swift
@@ -111,11 +111,4 @@ extension ShipmentTracking: Comparable {
             (lhs.siteID == rhs.siteID && lhs.orderID == rhs.orderID && lhs.trackingID < rhs.trackingID) ||
             (lhs.siteID == rhs.siteID && lhs.orderID == rhs.orderID && lhs.trackingID == rhs.trackingID && lhs.trackingNumber < rhs.trackingNumber)
     }
-
-    public static func > (lhs: ShipmentTracking, rhs: ShipmentTracking) -> Bool {
-        return lhs.siteID > rhs.siteID ||
-            (lhs.siteID == rhs.siteID && lhs.orderID > rhs.orderID) ||
-            (lhs.siteID == rhs.siteID && lhs.orderID == rhs.orderID && lhs.trackingID > rhs.trackingID) ||
-            (lhs.siteID == rhs.siteID && lhs.orderID == rhs.orderID && lhs.trackingID == rhs.trackingID && lhs.trackingNumber > rhs.trackingNumber)
-    }
 }

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -92,17 +92,6 @@ public struct Site: Decodable, Equatable, GeneratedFakeable {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension Site: Comparable {
-    public static func < (lhs: Site, rhs: Site) -> Bool {
-        return lhs.siteID < rhs.siteID ||
-            (lhs.siteID == rhs.siteID && lhs.name < rhs.name) ||
-            (lhs.siteID == rhs.siteID && lhs.name == rhs.name && lhs.description < rhs.description)
-    }
-}
-
-
 /// Defines all of the Site CodingKeys.
 ///
 private extension Site {

--- a/Networking/Networking/Model/SiteAPI.swift
+++ b/Networking/Networking/Model/SiteAPI.swift
@@ -49,19 +49,6 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension SiteAPI: Comparable {
-    public static func < (lhs: SiteAPI, rhs: SiteAPI) -> Bool {
-        return lhs.siteID < rhs.siteID
-    }
-
-    public static func > (lhs: SiteAPI, rhs: SiteAPI) -> Bool {
-        return lhs.siteID > rhs.siteID
-    }
-}
-
-
 /// Defines all of the SiteAPI CodingKeys.
 ///
 private extension SiteAPI {

--- a/Networking/Networking/Model/SitePlan.swift
+++ b/Networking/Networking/Model/SitePlan.swift
@@ -36,15 +36,6 @@ public struct SitePlan: Decodable, Equatable, GeneratedFakeable {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension SitePlan: Comparable {
-    public static func < (lhs: SitePlan, rhs: SitePlan) -> Bool {
-        return lhs.siteID < rhs.siteID
-    }
-}
-
-
 /// Defines all of the SitePlan CodingKeys.
 ///
 private extension SitePlan {

--- a/Networking/Networking/Model/SiteSetting.swift
+++ b/Networking/Networking/Model/SiteSetting.swift
@@ -72,11 +72,6 @@ extension SiteSetting: Comparable {
         return lhs.settingID < rhs.settingID ||
             (lhs.settingID == rhs.settingID && lhs.label < rhs.label)
     }
-
-    public static func > (lhs: SiteSetting, rhs: SiteSetting) -> Bool {
-        return lhs.settingID > rhs.settingID ||
-            (lhs.settingID == rhs.settingID && lhs.label > rhs.label)
-    }
 }
 
 

--- a/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
@@ -35,16 +35,6 @@ public struct OrderStatsV4Interval: Decodable, Equatable, GeneratedFakeable {
 }
 
 
-// MARK: - Conformance to Comparable
-//
-extension OrderStatsV4Interval: Comparable {
-    public static func < (lhs: OrderStatsV4Interval, rhs: OrderStatsV4Interval) -> Bool {
-        return lhs.interval < rhs.interval ||
-            (lhs.interval == rhs.interval && lhs.subtotals < rhs.subtotals)
-    }
-}
-
-
 // MARK: - Constants!
 //
 private extension OrderStatsV4Interval {

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -62,13 +62,6 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedFakeable {
     }
 }
 
-extension OrderStatsV4Totals: Comparable {
-    public static func < (lhs: OrderStatsV4Totals, rhs: OrderStatsV4Totals) -> Bool {
-        return lhs.grossRevenue < rhs.grossRevenue ||
-            (lhs.grossRevenue == rhs.grossRevenue && lhs.totalOrders < rhs.totalOrders)
-    }
-}
-
 
 // MARK: - Constants!
 //

--- a/Networking/Networking/Model/Stats/SiteVisitStats.swift
+++ b/Networking/Networking/Model/Stats/SiteVisitStats.swift
@@ -61,9 +61,9 @@ private extension SiteVisitStats {
 }
 
 
-// MARK: - Comparable Conformance
+// MARK: - Equatable Conformance
 //
-extension SiteVisitStats: Comparable {
+extension SiteVisitStats: Equatable {
     // custom implementation to ignore order for items
     public static func == (lhs: SiteVisitStats, rhs: SiteVisitStats) -> Bool {
         return lhs.siteID == rhs.siteID &&
@@ -71,10 +71,6 @@ extension SiteVisitStats: Comparable {
             lhs.granularity == rhs.granularity &&
             lhs.items?.count == rhs.items?.count &&
             lhs.items?.sorted() == rhs.items?.sorted()
-    }
-
-    public static func < (lhs: SiteVisitStats, rhs: SiteVisitStats) -> Bool {
-        return lhs.date < rhs.date
     }
 }
 

--- a/Networking/Networking/Model/Stats/SiteVisitStatsItem.swift
+++ b/Networking/Networking/Model/Stats/SiteVisitStatsItem.swift
@@ -23,9 +23,4 @@ extension SiteVisitStatsItem: Comparable {
         return lhs.period < rhs.period ||
             (lhs.period == rhs.period && lhs.visitors < rhs.visitors)
     }
-
-    public static func > (lhs: SiteVisitStatsItem, rhs: SiteVisitStatsItem) -> Bool {
-        return lhs.period > rhs.period ||
-            (lhs.period == rhs.period && lhs.visitors > rhs.visitors)
-    }
 }

--- a/Networking/Networking/Model/Stats/TopEarnerStats.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStats.swift
@@ -53,9 +53,9 @@ private extension TopEarnerStats {
 }
 
 
-// MARK: - Comparable Conformance
+// MARK: - Equatable Conformance
 //
-extension TopEarnerStats: Comparable {
+extension TopEarnerStats: Equatable {
     // custom implementation to ignore order for items
     public static func == (lhs: TopEarnerStats, rhs: TopEarnerStats) -> Bool {
         return lhs.siteID == rhs.siteID &&
@@ -64,11 +64,6 @@ extension TopEarnerStats: Comparable {
             lhs.limit == rhs.limit &&
             lhs.items?.count == rhs.items?.count &&
             lhs.items?.sorted() == rhs.items?.sorted()
-    }
-
-    public static func < (lhs: TopEarnerStats, rhs: TopEarnerStats) -> Bool {
-        return lhs.date < rhs.date ||
-            (lhs.date == rhs.date && lhs.limit < rhs.limit)
     }
 }
 

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -70,9 +70,4 @@ extension TopEarnerStatsItem: Comparable {
         return lhs.total < rhs.total ||
             (lhs.total == rhs.total && lhs.quantity < rhs.quantity)
     }
-
-    public static func > (lhs: TopEarnerStatsItem, rhs: TopEarnerStatsItem) -> Bool {
-        return lhs.total > rhs.total ||
-            (lhs.total == rhs.total && lhs.quantity > rhs.quantity)
-    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Aggregate Order Items/AggregateOrderItem.swift
@@ -49,16 +49,6 @@ struct AggregateOrderItem: Equatable, GeneratedCopiable {
 }
 
 
-// MARK: - Comparable Conformance
-//
-extension AggregateOrderItem: Comparable {
-    public static func < (lhs: AggregateOrderItem, rhs: AggregateOrderItem) -> Bool {
-        return lhs.productID < rhs.productID ||
-            (lhs.productID == rhs.productID && lhs.variationID < rhs.variationID)
-    }
-}
-
-
 // MARK: - Hashable Conformance
 //
 extension AggregateOrderItem: Hashable {

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -52,8 +52,6 @@ Mappers receive an instance of `Data` and return  the result of parsing that dat
 ## Model objects
 Model objects declared in `Networking` are immutable, and modelled as value types (structs) that typically implement `Decodable`.
 
-Model objects should implement `Comparable`.
-
 Model objects should conform to `GeneratedFakeable` and `GeneratedCopiable`. [Fakeable](fakeable.md) and [Copiable](copiable.md) methods should be generated automatically with `rake generate`.
 
 ## Unit tests


### PR DESCRIPTION
## Description

While working on https://github.com/woocommerce/woocommerce-ios/pull/4641 I've noticed that there are many unused `Comparable` implementations. This PR removes most of unused stuff.

Also there is a line in the docs that feels too strict to me and is removed in this PR too:
```
Model objects should implement `Comparable`.
```

Generally `Comparable` conformance in WC-iOS is used so we can ignore order for arrays of objects in tests. There is no real need for boilerplate in every model unless we want to sort it.

Related discussion ref: p91TBi-5Ea-p2

## Test

Check CI status.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.