### PR TITLE
Shipping Labels: Handle decimal quantities in package details

### DIFF
--- a/WooCommerce/Classes/Extensions/Decimal+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Decimal+Helpers.swift
@@ -2,20 +2,20 @@ import Foundation
 
 extension Decimal {
 
-    /// Returns the int value of a decimal. We ensure we round down our Decimal before converting it to an Int, using NSDecimalRound.
+    /// Returns the int value of a decimal. We ensure we round up our Decimal before converting it to an Int, using NSDecimalRound.
     ///
     var intValue: Int {
         NSDecimalNumber(decimal: whole).intValue
     }
 
-    private func rounded(_ roundingMode: NSDecimalNumber.RoundingMode = .down, scale: Int = 0) -> Self {
+    private func rounded(_ roundingMode: NSDecimalNumber.RoundingMode = .up, scale: Int = 0) -> Self {
         var result = Self()
         var number = self
         NSDecimalRound(&result, &number, scale, roundingMode)
         return result
     }
 
-    private var whole: Self { rounded( self < 0 ? .up : .down) }
+    private var whole: Self { rounded( self < 0 ? .down : .up) }
 
     private var fraction: Self { self - whole }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -135,14 +135,18 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
                 product = products.first { $0.productID == item.productID }
             }
             if product?.virtual == false || productVariation?.virtual == false {
+                var tempItemQuantity = Double(truncating: item.quantity as NSDecimalNumber)
 
-                /// We do not consider fractional quantities because the backend will return always int values for the quantity.
-                /// We are also showing items only when the quantity is > 1, because in that case we are not considering it a valid value.
-                ///
                 for _ in 0..<item.quantity.intValue {
                     let attributes = item.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) }
+                    var weight = Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
+                    if tempItemQuantity < 1 {
+                        weight *= tempItemQuantity
+                    } else {
+                        tempItemQuantity -= 1
+                    }
                     let unit: String = weightUnit ?? ""
-                    let subtitle = Localization.subtitle(weight: isVariation ? productVariation?.weight : product?.weight,
+                    let subtitle = Localization.subtitle(weight: weight.description,
                                                          weightUnit: unit,
                                                          attributes: attributes)
                     itemsToFulfill.append(ItemToFulfillRow(title: item.name, subtitle: subtitle))
@@ -174,9 +178,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
                 product = products.first { $0.productID == item.productID }
             }
             if product?.virtual == false || productVariation?.virtual == false {
-                for _ in 0..<item.quantity.intValue {
-                    tempTotalWeight += Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
-                }
+                let itemWeight = Double(productVariation?.weight ?? product?.weight ?? "0") ?? 0
+                tempTotalWeight += itemWeight * Double(truncating: item.quantity as NSDecimalNumber)
             }
         }
 

--- a/WooCommerce/WooCommerceTests/Extensions/DecimalWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DecimalWooTests.swift
@@ -11,18 +11,18 @@ final class DecimalWooTests: XCTestCase {
 
         // Positive numbers
         XCTAssertEqual(Decimal(string: "1234.0")?.intValue, 1234)
-        XCTAssertEqual(Decimal(string: "100.123456789123")?.intValue, 100)
+        XCTAssertEqual(Decimal(string: "100.123456789123")?.intValue, 101)
         XCTAssertEqual(Decimal(string: "200")?.intValue, 200)
         XCTAssertEqual(Decimal(string: "2")?.intValue, 2)
         XCTAssertEqual(Decimal(string: "0")?.intValue, 0)
-        XCTAssertEqual(Decimal(string: "0.2323921301")?.intValue, 0)
+        XCTAssertEqual(Decimal(string: "0.2323921301")?.intValue, 1)
 
         // Negative numbers
         XCTAssertEqual(Decimal(string: "-1234.0")?.intValue, -1234)
-        XCTAssertEqual(Decimal(string: "-100.123456789123")?.intValue, -100)
+        XCTAssertEqual(Decimal(string: "-100.123456789123")?.intValue, -101)
         XCTAssertEqual(Decimal(string: "-200")?.intValue, -200)
         XCTAssertEqual(Decimal(string: "-2")?.intValue, -2)
         XCTAssertEqual(Decimal(string: "-0")?.intValue, 0)
-        XCTAssertEqual(Decimal(string: "-0.2323921301")?.intValue, 0)
+        XCTAssertEqual(Decimal(string: "-0.2323921301")?.intValue, -1)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -259,7 +259,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
     func test_totalWeight_returns_the_expected_value() {
         // Given
         let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5),
                      MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
                      MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
                      MockOrderItem.sampleItem(name: "Jeans",
@@ -271,7 +271,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9"))
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1.44"))
         insert(ProductVariation.fake().copy(siteID: sampleSiteID,
@@ -290,7 +290,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
 
         // Then
-        XCTAssertEqual(viewModel.totalWeight, "125.88")
+        XCTAssertEqual(viewModel.totalWeight, "62.88")
     }
 
     func test_totalWeight_returns_the_expected_value_when_already_set() {


### PR DESCRIPTION
Fixes: #4640

## Description

When an order has decimal quantities, we should round up the quantity to the nearest bigger integer. If an order has 0.5 as quantity, the list of products in the package should show 1 product, and if it's 3.5, it should show 4, which is done by rounding the quantity to the nearest bigger integer.

This PR updates our Decimal `intValue` to round up by default. As far as I can see, we only use this when handling order item quantities, so it shouldn't affect other parts of the app.

This also affects the order item weight and total package weight, so this PR updates those weight calculations to provide an accurate weight for non-integer item quantities. For example, if an order has 0.5 as the quantity for an item that weighs 100g, the list of products in the package shows 1 product that weighs 50g, and the total package weight is 50g.

FYI @jkmassel since this is targeting the 7.1 release.

## Changes

* Updates `Decimal+Helpers` to default to rounding up instead of down for positive numbers (and down instead of up for negative numbers).
* Updates `ShippingLabelPackageDetailsViewModel`:
   * For each item in the order, the item weight is displayed as the product weight unless the quantity is less than 1. In that case, the weight is calculated by multiplying the product weight by the quantity to get an accurate weight. (I used `tempItemQuantity` to keep track of the quantity for calculating the weight for each item in the order, in particular in cases where there is a decimal quantity greater than 1, e.g. 2.5 items in the order. I'm very open to feedback about other ways to do this, if you have ideas.)
   * For the total package weight, the item weight is multiplied by the actual item quantity (not rounded) for an accurate package weight.

/|Order details|Package details - Before|Package details - After
-|-|-|-
Order with 0.5 item quantity|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 12 25 29](https://user-images.githubusercontent.com/8658164/126320266-2bb2efac-c806-4090-8884-cdec83e332ca.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 13 02 00](https://user-images.githubusercontent.com/8658164/126320377-d4fe8e3a-2f1f-4b6a-969e-c8bc6ba5247d.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 12 25 40](https://user-images.githubusercontent.com/8658164/126320618-688c6202-6322-4ef6-90d5-eae2f8c4e1f8.png)
Order with 2.5 item quantity|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 12 17 50](https://user-images.githubusercontent.com/8658164/126320633-b8fb8696-03f1-4fef-ac13-5becb123f390.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 13 01 38](https://user-images.githubusercontent.com/8658164/126320645-2eaae08d-aa9c-4d13-9d11-00c260e84ecc.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-20 at 12 18 00](https://user-images.githubusercontent.com/8658164/126320657-33401cec-7fc4-461b-b37a-868dd05400de.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app.
3. Open an order detail that is eligible for the shipping label and has a decimal item quantity in the order.
4. Tap the button "Create Shipping Label".
5. Confirm "Ship From" and "Ship To".
6. In the package details section, under "Items to fulfill" make sure the number of items is rounded up and the weight is accurate for the actual item quantity. (So an order with 0.5 as the item quantity shows 1 item and the weight is half the item weight.)
7. Under "Package details," make sure that the "Total package weight" displayed is now correct considering the decimal item quantity, and it's the sum of the weight of the item shown on the screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
