### PR TITLE
Shipping Labels: Include selected package weight in total package weight

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -46,12 +46,10 @@ struct ShippingLabelPackageDetails: View {
                                      text: $viewModel.totalWeight,
                                      symbol: viewModel.weightUnit,
                                      keyboardType: .decimalPad,
-                                     onEditingChanged: { isEditing in
-                                        // We don't have a Return button to commit the change
-                                        // so we can track when editing is ended to know if a change was made.
-                                        if !isEditing {
-                                            viewModel.isPackageWeightEdited = true
-                                        }
+                                     onEditingChanged: { _ in
+                                        // We don't have a Return button to track committed changes to this field,
+                                        // so if the user starts editing the field we assume it was edited.
+                                        viewModel.isPackageWeightEdited = true
                                      })
                 Divider()
 
@@ -69,19 +67,6 @@ struct ShippingLabelPackageDetails: View {
             Text(Localization.doneButton)
         })
         .disabled(!viewModel.isPackageDetailsDoneButtonEnabled()))
-        .onTapGesture {
-            hideKeyboard()
-        }
-    }
-}
-
-private extension View {
-    /// Hides the keyboard (needed as long as we supported iOS 14).
-    /// See: https://www.hackingwithswift.com/quick-start/swiftui/how-to-dismiss-the-keyboard-for-a-textfield
-    ///
-    func hideKeyboard() {
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
-                                    to: nil, from: nil, for: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -45,7 +45,14 @@ struct ShippingLabelPackageDetails: View {
                                      placeholder: "0",
                                      text: $viewModel.totalWeight,
                                      symbol: viewModel.weightUnit,
-                                     keyboardType: .decimalPad)
+                                     keyboardType: .decimalPad,
+                                     onEditingChanged: { isEditing in
+                                        // We don't have a Return button to commit the change
+                                        // so we can track when editing is ended to know if a change was made.
+                                        if !isEditing {
+                                            viewModel.isPackageWeightEdited = true
+                                        }
+                                     })
                 Divider()
 
                 ListHeaderView(text: Localization.footer, alignment: .left)
@@ -62,6 +69,19 @@ struct ShippingLabelPackageDetails: View {
             Text(Localization.doneButton)
         })
         .disabled(!viewModel.isPackageDetailsDoneButtonEnabled()))
+        .onTapGesture {
+            hideKeyboard()
+        }
+    }
+}
+
+private extension View {
+    /// Hides the keyboard (needed as long as we supported iOS 14).
+    /// See: https://www.hackingwithswift.com/quick-start/swiftui/how-to-dismiss-the-keyboard-for-a-textfield
+    ///
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                    to: nil, from: nil, for: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -120,6 +120,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         products = resultsControllers?.products ?? []
         productVariations = resultsControllers?.productVariations ?? []
         itemsRows = generateItemsRows()
+        setTotalWeight()
     }
 
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -66,6 +66,10 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     @Published private(set) var selectedPredefinedPackage: ShippingLabelPredefinedPackage?
     @Published var totalWeight: String
 
+    /// Whether the user has edited the total package weight. If true, we won't make any automatic changes to the total weight.
+    ///
+    @Published var isPackageWeightEdited: Bool = false
+
     /// Returns if the custom packages header should be shown in Package List
     ///
     var showCustomPackagesHeader: Bool {
@@ -90,6 +94,9 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.packagesResponse = packagesResponse
         self.selectedPackageID = selectedPackageID
         self.totalWeight = totalWeight ?? ""
+        if totalWeight != nil {
+            self.isPackageWeightEdited = true
+        }
         configureResultsControllers()
         syncProducts()
         syncProductVariations()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -64,7 +64,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     }
     @Published private(set) var selectedCustomPackage: ShippingLabelCustomPackage?
     @Published private(set) var selectedPredefinedPackage: ShippingLabelPredefinedPackage?
-    @Published var totalWeight: String
+    @Published var totalWeight: String = ""
 
     /// Whether the user has edited the total package weight. If true, we won't make any automatic changes to the total weight.
     ///
@@ -93,14 +93,11 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.weightUnit = weightUnit
         self.packagesResponse = packagesResponse
         self.selectedPackageID = selectedPackageID
-        self.totalWeight = totalWeight ?? ""
-        if totalWeight != nil {
-            self.isPackageWeightEdited = true
-        }
         configureResultsControllers()
         syncProducts()
         syncProductVariations()
         setDefaultPackage()
+        setTotalWeight(using: totalWeight)
     }
 
     private func configureResultsControllers() {
@@ -166,7 +163,9 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// Set the total weight based on the weight of the selected package and
     /// the products and products variation inside the order items, only if they are not virtual products.
     ///
-    private func setTotalWeight() {
+    /// - Parameter initialWeight: An initial value used to set the total package weight if it was input manually.
+    ///
+    private func setTotalWeight(using initialWeight: String? = nil) {
         guard !isPackageWeightEdited else {
             return
         }
@@ -197,7 +196,13 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
             tempTotalWeight += selectedPackage.boxWeight
         }
 
-        totalWeight = String(tempTotalWeight)
+        // Set the total weight as the initial value if it was input manually; otherwise use the calculated weight.
+        if let initialWeight = initialWeight, initialWeight != String(tempTotalWeight) {
+            isPackageWeightEdited = true
+            totalWeight = initialWeight
+        } else {
+            totalWeight = String(tempTotalWeight)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -68,7 +68,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     /// Whether the user has edited the total package weight. If true, we won't make any automatic changes to the total weight.
     ///
-    @Published var isPackageWeightEdited: Bool = false
+    var isPackageWeightEdited: Bool = false
 
     /// Returns if the custom packages header should be shown in Package List
     ///
@@ -111,10 +111,12 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
             guard let self = self else { return }
             self.products = products
             self.itemsRows = self.generateItemsRows()
+            self.setTotalWeight()
         }, onProductVariationsReload: { [weak self] (productVariations) in
             guard let self = self else { return }
             self.productVariations = productVariations
             self.itemsRows = self.generateItemsRows()
+            self.setTotalWeight()
         })
 
         products = resultsControllers?.products ?? []

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -8,6 +8,7 @@ struct TitleAndTextFieldRow: View {
     @Binding var text: String
     let symbol: String?
     let keyboardType: UIKeyboardType
+    var onEditingChanged: ((Bool) -> Void)? = nil
 
     var body: some View {
         HStack {
@@ -16,7 +17,7 @@ struct TitleAndTextFieldRow: View {
                 .lineLimit(1)
                 .fixedSize()
             Spacer()
-            TextField(placeholder, text: $text)
+            TextField(placeholder, text: $text, onEditingChanged: onEditingChanged ?? { _ in })
                 .multilineTextAlignment(.trailing)
                 .font(.body)
                 .keyboardType(keyboardType)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -282,7 +282,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
+                                                             selectedPackageID: "Box",
                                                              totalWeight: nil,
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
@@ -290,7 +290,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
 
         // Then
-        XCTAssertEqual(viewModel.totalWeight, "62.88")
+        XCTAssertEqual(viewModel.totalWeight, "72.88")
     }
 
     func test_totalWeight_returns_the_expected_value_when_already_set() {
@@ -335,6 +335,34 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         }
 
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    func test_totalWeight_updates_when_selected_package_changes() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
+
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: nil,
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "120.0")
+
+        // When
+        viewModel.didSelectPackage("Box")
+        viewModel.confirmPackageSelection()
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "130.0")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -364,6 +364,69 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.totalWeight, "130.0")
     }
+
+    func test_totalWeight_does_not_update_when_initial_weight_is_arbitrary_value() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
+
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: "500",
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "500")
+
+        // When new package with additional weight is selected
+        viewModel.didSelectPackage("Box")
+        viewModel.confirmPackageSelection()
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "500")
+    }
+
+    func test_totalWeight_does_not_update_after_new_weight_is_input_manually() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
+
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
+                                                             packagesResponse: mockPackageResponse(),
+                                                             selectedPackageID: nil,
+                                                             totalWeight: nil,
+                                                             formatter: currencyFormatter,
+                                                             storageManager: storageManager,
+                                                             weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "120.0")
+
+        // When new weight is input manually
+        viewModel.totalWeight = "500"
+        viewModel.isPackageWeightEdited = true
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "500")
+
+        // When new package with additional weight is selected
+        viewModel.didSelectPackage("Box")
+        viewModel.confirmPackageSelection()
+
+        // Then
+        XCTAssertEqual(viewModel.totalWeight, "500")
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Fixes: #4648

## Description

When creating a shipping label, the Package Details screen has an editable field for the `total package weight`. The total package weight should include the weight of all the order items _and_ the weight of the selected package. We weren't including the selected package weight, so this PR adds that to the total package weight.

The total package weight is calculated when you first open the Package Details screen and any time the selected package is changed. (Note that only custom packages have a set weight, so if you choose a predefined package the total weight will be the total weight of the order items.) However, if that total weight is edited manually or saved, we _stop_ automatically updating the weight, even if the selected package changes. (This is consistent with web behavior and avoids overwriting the weight if the user has set it themselves.)

FYI @jkmassel since this is targeting the 7.1 release.

## Changes

* Adds an optional `onEditingChanged` closure to `TitleAndTextFieldRow`, so we can track when the text field has been edited. (I used `onEditingChanged` and not `onCommit` because we're using this with a decimal keyboard, which doesn't include a Return key, so we can't track committed changes to the text field.)
* In `ShippingLabelPackageDetailsViewModel`:
   * Adds `isPackageWeightEdited` to track when the package weight has been edited or saved.
   * In `setTotalWeight()`, check for `isPackageWeightEdited` instead of `totalWeight.isEmpty` before setting the total package weight, and add the selected package weight to the total. This makes it possible to update the total weight after it is set initially (e.g. to update it when the selected package changes) but still prevents the total weight from changing if the weight has been updated manually.
   * Set the total weight when a selected package is confirmed (in `confirmPackageSelection()`) to make sure the total weight is updated when the selected package changes.
* In `ShippingLabelPackageDetails`, sets `isPackageWeightEdited` to `true` (to track that the weight has been manually edited) if the text field is edited.
* Updates unit tests.

<img src="https://user-images.githubusercontent.com/8658164/126371344-45a18875-c106-4cb0-acc9-0b7508fb3041.gif" width="300px">


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods and one or more custom packages (with a set package weight) set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app.
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label".
5. Confirm "Ship From" and "Ship To".
6. In the package details section, confirm that the "Total package weight" include both the weight of the order items and the weight of the selected package (if any package is selected).
7. Select a custom package and confirm the "Total package weight" is updated with the custom package's weight.
8. Edit the "Total package weight" and confirm that it doesn't change automatically after that, even if you select a new package, unless you tap the "Back" button to exit without saving your changes.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
