### PR TITLE
Hide bottom tab bar for card reader settings presenting view controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -177,7 +177,7 @@
         <!--Card Reader Settings Presenting View Controller-->
         <scene sceneID="NEs-n8-mBS">
             <objects>
-                <viewController storyboardIdentifier="CardReaderSettingsPresentingViewController" id="PIe-XS-6gZ" customClass="CardReaderSettingsPresentingViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CardReaderSettingsPresentingViewController" hidesBottomBarWhenPushed="YES" id="PIe-XS-6gZ" customClass="CardReaderSettingsPresentingViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EOU-z7-aBS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
Addresses "hide tab bar in card reader settings" from #3745 

To test:
- Enter settings > manage card readers
- Ensure the tab bar is hidden and the view occupies the space where the tab bar was
- Exit back to settings
- Ensure the tab bar reappears
- Repeat for both light and dark modes and ensure the view background color is used where the tab bar was

fyi @Garance91540 @adamzelinski 

![hide-tab-bar](https://user-images.githubusercontent.com/1595739/126376346-1a49557d-e69d-40ce-8a2d-798741dd535c.gif)

Note:
- This change also hides the tab bar if the reader is not already connected when collecting a payment for an order. An upcoming change will remove the CardReaderSettingsPresentingViewController from that flow, but for now you may also verify that the tab bar is restored when returning to collect payment flow after connecting a reader in that context

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
