### PR TITLE
System plugins - Sync System plugins in DefaultStoreManager and Site plugins in PluginList

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -43,7 +43,7 @@ final class PluginListViewController: UIViewController {
         configureNavigation()
         configureTableView()
         configureGhostTableView()
-        configureViewModel()
+        syncPlugins(onCompletion: configureViewModel)
     }
 }
 
@@ -97,16 +97,27 @@ private extension PluginListViewController {
 // MARK: - Actions
 //
 private extension PluginListViewController {
+    
+    /// resyncPlugins is used when the view need to resynchronize data
+    ///
     @objc func resyncPlugins() {
+        syncPlugins(onCompletion: nil)
+    }
+
+    /// syncPlugins synchronizes all plugins and execute onCompletion when is finished
+    ///
+    @objc func syncPlugins(onCompletion: (() -> Void)?) {
         removeErrorStateView()
         startGhostAnimation()
-        viewModel.resyncPlugins { [weak self] result in
+        viewModel.syncPlugins { [weak self] result in
             guard let self = self else { return }
             self.refreshControl.endRefreshing()
             self.stopGhostAnimation()
             if result.isFailure {
                 self.displayErrorStateView()
             }
+            guard let onCompletion = onCompletion else { return }
+            onCompletion()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -17,7 +17,7 @@ final class PluginListViewController: UIViewController {
     ///
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(resyncPlugins), for: .valueChanged)
+        refreshControl.addTarget(self, action: #selector(syncPlugins), for: .valueChanged)
         return refreshControl
     }()
 
@@ -43,7 +43,7 @@ final class PluginListViewController: UIViewController {
         configureNavigation()
         configureTableView()
         configureGhostTableView()
-        syncPlugins(onCompletion: configureViewModel)
+        configureViewModel()
     }
 }
 
@@ -91,6 +91,8 @@ private extension PluginListViewController {
         viewModel.observePlugins { [weak self] in
             self?.tableView.reloadData()
         }
+
+        syncPlugins()
     }
 }
 
@@ -98,15 +100,9 @@ private extension PluginListViewController {
 //
 private extension PluginListViewController {
 
-    /// resyncPlugins is used when the view need to resynchronize data
+    /// syncPlugins synchronizes all plugins
     ///
-    @objc func resyncPlugins() {
-        syncPlugins(onCompletion: nil)
-    }
-
-    /// syncPlugins synchronizes all plugins and execute onCompletion when is finished
-    ///
-    @objc func syncPlugins(onCompletion: (() -> Void)?) {
+    @objc func syncPlugins() {
         removeErrorStateView()
         startGhostAnimation()
         viewModel.syncPlugins { [weak self] result in
@@ -116,8 +112,6 @@ private extension PluginListViewController {
             if result.isFailure {
                 self.displayErrorStateView()
             }
-            guard let onCompletion = onCompletion else { return }
-            onCompletion()
         }
     }
 }
@@ -189,7 +183,7 @@ private extension PluginListViewController {
             image: .pluginListError,
             details: details,
             buttonTitle: buttonTitle) { [weak self] button in
-            self?.resyncPlugins()
+            self?.syncPlugins()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewController.swift
@@ -97,7 +97,7 @@ private extension PluginListViewController {
 // MARK: - Actions
 //
 private extension PluginListViewController {
-    
+
     /// resyncPlugins is used when the view need to resynchronize data
     ///
     @objc func resyncPlugins() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -53,9 +53,9 @@ final class PluginListViewModel {
         resultsController.onDidChangeContent = onDataChanged
     }
 
-    /// Manually resync plugins.
+    /// Manually sync plugins.
     ///
-    func resyncPlugins(onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func syncPlugins(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let action = SitePluginAction.synchronizeSitePlugins(siteID: siteID, onCompletion: onCompletion)
         storesManager.dispatch(action)
     }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -58,6 +58,7 @@ class AuthenticatedState: StoresManagerState {
             SitePluginStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             SitePostStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             TaxClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             UserStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             CardPresentPaymentStore(dispatcher: dispatcher,

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -379,7 +379,7 @@ private extension DefaultStoresManager {
         }
         dispatch(action)
     }
-    
+
     /// Loads the Default Site into the current Session, if possible.
     ///
     func restoreSessionSiteIfPossible() {
@@ -395,7 +395,6 @@ private extension DefaultStoresManager {
         retrieveOrderStatus(with: siteID)
         synchronizePaymentGateways(siteID: siteID)
         synchronizeAddOnsGroups(siteID: siteID)
-        synchronizePlugins(siteID: siteID)
         synchronizeSystemPlugins(siteID: siteID)
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -369,6 +369,17 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
+    /// Synchronizes all system plugins for the store with specifie ID
+    ///
+    func synchronizeSystemPlugins(siteID: Int64) {
+        let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
+            if let error = result.failure {
+                DDLogError("⛔️ Failed to sync sytem plugins for siteID: \(siteID). Error: \(error)")
+            }
+        }
+        dispatch(action)
+    }
+    
     /// Loads the Default Site into the current Session, if possible.
     ///
     func restoreSessionSiteIfPossible() {
@@ -385,6 +396,7 @@ private extension DefaultStoresManager {
         synchronizePaymentGateways(siteID: siteID)
         synchronizeAddOnsGroups(siteID: siteID)
         synchronizePlugins(siteID: siteID)
+        synchronizeSystemPlugins(siteID: siteID)
     }
 
     /// Loads the specified siteID into the Session, if possible.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -358,17 +358,6 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
-    /// Synchronizes all plugins for the store with specified ID.
-    ///
-    func synchronizePlugins(siteID: Int64) {
-        let action = SitePluginAction.synchronizeSitePlugins(siteID: siteID) { result in
-            if let error = result.failure {
-                DDLogError("⛔️ Failed to sync plugins for siteID: \(siteID). Error: \(error)")
-            }
-        }
-        dispatch(action)
-    }
-
     /// Synchronizes all system plugins for the store with specifie ID
     ///
     func synchronizeSystemPlugins(siteID: Int64) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Plugins/SitePluginListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Plugins/SitePluginListViewModelTests.swift
@@ -224,7 +224,7 @@ class PluginListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.cellModelForRow(at: IndexPath(row: 0, section: 0)).name, plugin2.name)
     }
 
-    func test_resyncPlugins_dispatches_synchronizeSitePlugins_action_with_correct_siteID() {
+    func test_syncPlugins_dispatches_synchronizeSitePlugins_action_with_correct_siteID() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
         var triggeredSiteID: Int64?
@@ -237,13 +237,13 @@ class PluginListViewModelTests: XCTestCase {
         let viewModel = PluginListViewModel(siteID: sampleSiteID, storesManager: storesManager)
 
         // When
-        viewModel.resyncPlugins { _ in }
+        viewModel.syncPlugins { _ in }
 
         // Then
         XCTAssertEqual(triggeredSiteID, sampleSiteID)
     }
 
-    func test_resyncPlugins_returns_success_when_synchronizeSitePlugins_action_completes_successfully() {
+    func test_syncPlugins_returns_success_when_synchronizeSitePlugins_action_completes_successfully() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -256,7 +256,7 @@ class PluginListViewModelTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            viewModel.resyncPlugins { result in
+            viewModel.syncPlugins { result in
                 promise(result)
             }
         }
@@ -265,7 +265,7 @@ class PluginListViewModelTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
     }
 
-    func test_resyncPlugins_returns_error_when_synchronizeSitePlugins_action_fails() {
+    func test_syncPlugins_returns_error_when_synchronizeSitePlugins_action_fails() {
         // Given
         let storesManager = MockStoresManager(sessionManager: .testingInstance)
         storesManager.whenReceivingAction(ofType: SitePluginAction.self) { action in
@@ -278,7 +278,7 @@ class PluginListViewModelTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            viewModel.resyncPlugins { result in
+            viewModel.syncPlugins { result in
                 promise(result)
             }
         }


### PR DESCRIPTION
Closes #4606 
## Description
This PR aims to sync the new System Plugins in DefaultStoreManager and sync Site Plugins in PluginListViewController

## Changes
- Remove sync Site Plugins of DefaultStoreManager, it's not needed.
- Add sync System Plugins in DefaultStoreManager.
- Add sync Site Plugins in PluginList screen before `resultController` init.

## Testing
Test System plugins:
- Use "Launch Wormholy Debug" feature to see that `system_status` call is launched.

Test Site plugins:
- Go to the Plugins screen and check that the ghost table appears and the data is loaded.
- Add a new plugin to your store and scroll the Plugins screen, it should be updated with the new plugin added.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
