### PR TITLE
Update MediaType to use modern UTType API

### DIFF
--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -2,6 +2,7 @@ import Foundation
 import MobileCoreServices
 import AVFoundation
 import Photos
+import UniformTypeIdentifiers
 
 /// Exports a media item of `PHAsset` type to be uploadable.
 ///
@@ -108,8 +109,7 @@ private extension MediaAssetExporter {
         }
 
         guard allowableFileExtensions.isEmpty == false,
-            let extensionType = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue() as String?
-            else {
+              let extensionType = UTType(uti)?.preferredFilenameExtension else {
                 return nil
         }
         guard allowableFileExtensions.contains(extensionType) else {

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -2,7 +2,6 @@ import Foundation
 import MobileCoreServices
 import AVFoundation
 import Photos
-import UniformTypeIdentifiers
 
 /// Exports a media item of `PHAsset` type to be uploadable.
 ///
@@ -109,10 +108,10 @@ private extension MediaAssetExporter {
         }
 
         guard allowableFileExtensions.isEmpty == false,
-              let extensionType = UTType(uti)?.preferredFilenameExtension else {
+              let fileExtensionForType = URL.fileExtensionForUTType(uti) else {
                 return nil
         }
-        guard allowableFileExtensions.contains(extensionType) else {
+        guard allowableFileExtensions.contains(fileExtensionForType) else {
             return kUTTypeJPEG as String
         }
         return uti

--- a/Yosemite/Yosemite/Tools/Media/MediaType.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaType.swift
@@ -1,4 +1,4 @@
-import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Types of media.
 ///
@@ -10,24 +10,22 @@ public enum MediaType {
     case other
 
     init(fileExtension: String) {
-        let unmanagedFileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension as CFString, nil)
-        guard let fileUTI = unmanagedFileUTI?.takeRetainedValue() else {
+        guard let typeIdentifier = UTType(filenameExtension: fileExtension) else {
             self = .other
             return
         }
-        self.init(fileUTI: fileUTI)
+        self.init(dataType: typeIdentifier)
     }
 
     init(mimeType: String) {
-        let unmanagedFileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType as CFString, nil)
-        guard let fileUTI = unmanagedFileUTI?.takeRetainedValue() else {
+        guard let typeIdentifier = UTType(mimeType: mimeType) else {
             self = .other
             return
         }
-        self.init(fileUTI: fileUTI)
+        self.init(dataType: typeIdentifier)
     }
 
-    private init(fileUTI: CFString) {
+    private init(dataType: UTType) {
         // Prior to iOS 14.4, video/webm and audio/webm were not natively supported and would
         // have resulted as `self = .other` in the code below. iOS 14.4 added support for them,
         // interpreting both as video types, but we don't want the app to allow users to upload
@@ -36,22 +34,18 @@ public enum MediaType {
         // The UT type identifier for both video/webm and audio/webm is "org.webmproject.webm"
         //
         // See https://github.com/woocommerce/woocommerce-ios/pull/4459/files#r656194065
-        guard "\(fileUTI)" != "org.webmproject.webm" else {
+        guard dataType != UTType("org.webmproject.webm") else {
             self = .other
             return
         }
 
-        if UTTypeConformsTo(fileUTI, kUTTypeImage) {
+        if dataType.conforms(to: UTType.image) {
             self = .image
-        } else if UTTypeConformsTo(fileUTI, kUTTypeVideo) {
+        } else if dataType.conforms(to: UTType.movie) {
             self = .video
-        } else if UTTypeConformsTo(fileUTI, kUTTypeMovie) {
-            self = .video
-        } else if UTTypeConformsTo(fileUTI, kUTTypeMPEG4) {
-            self = .video
-        } else if UTTypeConformsTo(fileUTI, kUTTypePresentation) {
+        } else if dataType.conforms(to: UTType.presentation) {
             self = .powerpoint
-        } else if UTTypeConformsTo(fileUTI, kUTTypeAudio) {
+        } else if dataType.conforms(to: UTType.audio) {
             self = .audio
         } else {
             self = .other

--- a/Yosemite/Yosemite/Tools/Media/URL+Media.swift
+++ b/Yosemite/Yosemite/Tools/Media/URL+Media.swift
@@ -1,13 +1,13 @@
-import MobileCoreServices
+import UniformTypeIdentifiers
 
 extension URL {
     var mimeTypeForPathExtension: String {
         guard
-            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
-            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() else {
+            let typeIdentifier = UTType(filenameExtension: pathExtension),
+            let mimeType = typeIdentifier.preferredMIMEType else {
                 return "application/octet-stream"
         }
-        return contentType as String
+        return mimeType
     }
 
     /// The expected file extension string for a given UTType identifier string.
@@ -16,7 +16,6 @@ extension URL {
     /// - returns: The expected file extension or nil if unknown.
     ///
     static func fileExtensionForUTType(_ type: String) -> String? {
-        let fileExtension = UTTypeCopyPreferredTagWithClass(type as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue()
-        return fileExtension as String?
+        return UTType(type)?.preferredFilenameExtension
     }
 }


### PR DESCRIPTION
## Description

Initially I stumbled upon `MediaType` because it was failing for me in all tests. I thought it's because of old API + M1 + Rosetta and decided to update it since our deployment target is already iOS 14 (required for `UniformTypeIdentifiers` module).

In the end, tests on new API failed as well 😅
I found Rosetta layer to be the issue - since old and new types API returns `nil` for some reason. On native ARM Xcode and Intel it works well in both cases.

I'm pushing the change since it's an improvement anyway, removing all CF bridging from codebase (`takeRetainedValue`).

## Further improvements

We can replace all usage of `kUTType..`  strings (from `MobileCoreServices`) with [UTType](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype) definitions (from `UniformTypeIdentifiers`, iOS 14+), but the immediate benefit is unclear.

## Tests

All changes already well covered by unit tests, but please upload couple of different media files to smoke test data flow.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
