### PR TITLE
Shipping Labels: Create separate feature flags for M4

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,8 +9,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsM2M3:
             return true
-        case .shippingLabelsM4:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsInternational:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsAddPaymentMethods:

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,6 +11,14 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsM4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsInternational:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsAddPaymentMethods:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsAddCustomPackages:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .shippingLabelsMultiPackage:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sitePlugins:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentOnboarding:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -22,10 +22,6 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsM2M3
 
-    /// Shipping labels - Milestone 4
-    ///
-    case shippingLabelsM4
-
     /// Shipping labels - International Shipping
     ///
     case shippingLabelsInternational

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -26,6 +26,22 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsM4
 
+    /// Shipping labels - International Shipping
+    ///
+    case shippingLabelsInternational
+
+    /// Shipping labels - Add payment methods
+    ///
+    case shippingLabelsAddPaymentMethods
+
+    /// Shipping labels - Add custom packages
+    ///
+    case shippingLabelsAddCustomPackages
+
+    /// Shipping labels - Multi-package support
+    ///
+    case shippingLabelsMultiPackage
+
     /// Site Plugin list entry point on Settings screen
     ///
     case sitePlugins

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -439,12 +439,14 @@ extension OrderDetailsViewModel {
 
         // Check shipping label creation eligibility remotely, according to client features available in Shipping Labels Milestone 4
         // like creating Shipping Labels outside of United States
-        let isFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsM4)
+        let isCustomsFormEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsInternational)
+        let isPaymentMethodCreationEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddPaymentMethods)
+        let isPackageCreationEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages)
         let action = ShippingLabelAction.checkCreationEligibility(siteID: order.siteID,
                                                                   orderID: order.orderID,
-                                                                  canCreatePaymentMethod: isFeatureFlagEnabled,
-                                                                  canCreateCustomsForm: isFeatureFlagEnabled,
-                                                                  canCreatePackage: isFeatureFlagEnabled) { [weak self] isEligible in
+                                                                  canCreatePaymentMethod: isPaymentMethodCreationEnabled,
+                                                                  canCreateCustomsForm: isCustomsFormEnabled,
+                                                                  canCreatePackage: isPackageCreationEnabled) { [weak self] isEligible in
             self?.dataSource.isEligibleForShippingLabelCreation = isEligible
             onCompletion?()
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -2,20 +2,35 @@
 
 struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsM2M3On: Bool
-    private let isShippingLabelsM4On: Bool
+    private let isInternationalShippingLabelsOn: Bool
+    private let isShippingLabelsPaymentMethodCreationOn: Bool
+    private let isShippingLabelsPackageCreationOn: Bool
+    private let isShippingLabelsMultiPackageOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
-         isShippingLabelsM4On: Bool = false) {
+         isInternationalShippingLabelsOn: Bool = false,
+         isShippingLabelsPaymentMethodCreationOn: Bool = false,
+         isShippingLabelsPackageCreationOn: Bool = false,
+         isShippingLabelsMultiPackageOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
-        self.isShippingLabelsM4On = isShippingLabelsM4On
+        self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
+        self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
+        self.isShippingLabelsPackageCreationOn = isShippingLabelsPackageCreationOn
+        self.isShippingLabelsMultiPackageOn = isShippingLabelsMultiPackageOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
         case .shippingLabelsM2M3:
             return isShippingLabelsM2M3On
-        case .shippingLabelsM4:
-            return isShippingLabelsM4On
+        case .shippingLabelsInternational:
+            return isInternationalShippingLabelsOn
+        case .shippingLabelsAddPaymentMethods:
+            return isShippingLabelsPaymentMethodCreationOn
+        case .shippingLabelsAddCustomPackages:
+            return isShippingLabelsPackageCreationOn
+        case .shippingLabelsMultiPackage:
+            return isShippingLabelsMultiPackageOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -146,7 +146,9 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_international_and_addPaymentMethod_flags_are_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isInternationalShippingLabelsOn: true, isShippingLabelsPaymentMethodCreationOn: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true,
+                                                        isInternationalShippingLabelsOn: true,
+                                                        isShippingLabelsPaymentMethodCreationOn: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
@@ -174,9 +176,12 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(canCreatePackage)
     }
 
-    func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_international_addPaymentMethod_and_addCustomPackage_flags_are_enabled() throws {
+    func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_and_M4_flags_are_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isInternationalShippingLabelsOn: true, isShippingLabelsPaymentMethodCreationOn: true, isShippingLabelsPackageCreationOn: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true,
+                                                        isInternationalShippingLabelsOn: true,
+                                                        isShippingLabelsPaymentMethodCreationOn: true,
+                                                        isShippingLabelsPackageCreationOn: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -114,9 +114,69 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(canCreatePackage)
     }
 
-    func test_checkShippingLabelCreationEligibility_dispatches_eligibility_check_with_client_features_when_both_flags_are_enabled() throws {
+    func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_and_international_flags_are_enabled() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isShippingLabelsM4On: true)
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isInternationalShippingLabelsOn: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
+
+        // When
+        viewModel.checkShippingLabelCreationEligibility()
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? ShippingLabelAction)
+        guard case let ShippingLabelAction.checkCreationEligibility(siteID: siteID,
+                                                                    orderID: orderID,
+                                                                    canCreatePaymentMethod: canCreatePaymentMethod,
+                                                                    canCreateCustomsForm: canCreateCustomsForm,
+                                                                    canCreatePackage: canCreatePackage,
+                                                                    onCompletion: _) = action else {
+            XCTFail("Expected \(action) to be \(ShippingLabelAction.self)")
+            return
+        }
+
+        XCTAssertEqual(siteID, order.siteID)
+        XCTAssertEqual(orderID, order.orderID)
+        XCTAssertFalse(canCreatePaymentMethod)
+        XCTAssertTrue(canCreateCustomsForm)
+        XCTAssertFalse(canCreatePackage)
+    }
+
+    func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_international_and_addPaymentMethod_flags_are_enabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isInternationalShippingLabelsOn: true, isShippingLabelsPaymentMethodCreationOn: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
+
+        // When
+        viewModel.checkShippingLabelCreationEligibility()
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? ShippingLabelAction)
+        guard case let ShippingLabelAction.checkCreationEligibility(siteID: siteID,
+                                                                    orderID: orderID,
+                                                                    canCreatePaymentMethod: canCreatePaymentMethod,
+                                                                    canCreateCustomsForm: canCreateCustomsForm,
+                                                                    canCreatePackage: canCreatePackage,
+                                                                    onCompletion: _) = action else {
+            XCTFail("Expected \(action) to be \(ShippingLabelAction.self)")
+            return
+        }
+
+        XCTAssertEqual(siteID, order.siteID)
+        XCTAssertEqual(orderID, order.orderID)
+        XCTAssertTrue(canCreatePaymentMethod)
+        XCTAssertTrue(canCreateCustomsForm)
+        XCTAssertFalse(canCreatePackage)
+    }
+
+    func test_checkShippingLabelCreationEligibility_dispatches_correct_check_when_M2M3_international_addPaymentMethod_and_addCustomPackage_flags_are_enabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isShippingLabelsM2M3On: true, isInternationalShippingLabelsOn: true, isShippingLabelsPaymentMethodCreationOn: true, isShippingLabelsPackageCreationOn: true)
         ServiceLocator.setFeatureFlagService(featureFlagService)
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 


### PR DESCRIPTION
Closes #4595 

# Description
We have separate features for Shipping Labels M4: [International Shipping Labels](https://github.com/woocommerce/woocommerce-ios/issues/4596), [Add Payment Methods](https://github.com/woocommerce/woocommerce-ios/issues/4598), [Add Custom Packages](https://github.com/woocommerce/woocommerce-ios/issues/3909) and [Multi-package Support](https://github.com/woocommerce/woocommerce-ios/issues/4599), and we want to roll out features as soon as they're ready. This PR aims to create separate flag for each feature to make it possible to release M4 gradually.

# Changes
- Added new feature flags for the 4 features of M4
- Updated shipping labels eligibility check on Order Details view model to check with new flags
- Updated MockFeatureFlagService for Shipping Labels and related unit tests
- Removed old feature flag `.shippingLabelsM4`

# Testing
Unit tests have been updated for shipping labels eligibility check - these tests should pass. Also, shipping label creation should work as before when `.shippingLabelsM2M3` and either of the new flags are enabled:
1. Make sure your test store is eligible for Shipping Labels
2. Navigate to Orders tab
3. Select an order with status Processing.
4. On Order Details screen of that order, Create Shipping Label button should be present.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
