### PR TITLE
Shipping Labels: Refactor package details view model with Combine

### DIFF
--- a/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
@@ -4,8 +4,7 @@ extension Publishers {
     /// When upstream publisher emits an event, this will combine it with
     /// latest event of the other publisher into a tuple to send downstream.
     ///
-    public struct WithLatestFrom<Upstream: Publisher, Other: Publisher>:
-        Publisher where Upstream.Failure == Other.Failure {
+    public struct WithLatestFrom<Upstream: Publisher, Other: Publisher>: Publisher where Upstream.Failure == Other.Failure {
         // MARK: - Types
         public typealias Output = (Upstream.Output, Other.Output)
         public typealias Failure = Upstream.Failure

--- a/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
@@ -1,0 +1,96 @@
+import Combine
+
+extension Publishers {
+    public struct WithLatestFrom<Upstream: Publisher, Other: Publisher>:
+        Publisher where Upstream.Failure == Other.Failure
+    {
+        // MARK: - Types
+        public typealias Output = (Upstream.Output, Other.Output)
+        public typealias Failure = Upstream.Failure
+
+        // MARK: - Properties
+        private let upstream: Upstream
+        private let other: Other
+
+        // MARK: - Initialization
+        init(upstream: Upstream, other: Other) {
+            self.upstream = upstream
+            self.other = other
+        }
+
+        // MARK: - Publisher Lifecycle
+        public func receive<S: Subscriber>(subscriber: S)
+            where S.Failure == Failure, S.Input == Output
+        {
+            let merged = mergedStream(upstream, other)
+            let result = resultStream(from: merged)
+            result.subscribe(subscriber)
+        }
+    }
+}
+
+// MARK: - Helpers
+private extension Publishers.WithLatestFrom {
+    // MARK: - Types
+    enum MergedElement {
+        case upstream1(Upstream.Output)
+        case upstream2(Other.Output)
+    }
+
+    typealias ScanResult =
+        (value1: Upstream.Output?,
+         value2: Other.Output?, shouldEmit: Bool)
+
+    // MARK: - Pipelines
+    func mergedStream(_ upstream1: Upstream, _ upstream2: Other)
+        -> AnyPublisher<MergedElement, Failure>
+    {
+        let mergedElementUpstream1 = upstream1
+            .map { MergedElement.upstream1($0) }
+        let mergedElementUpstream2 = upstream2
+            .map { MergedElement.upstream2($0) }
+        return mergedElementUpstream1
+            .merge(with: mergedElementUpstream2)
+            .eraseToAnyPublisher()
+    }
+
+    func resultStream(
+        from mergedStream: AnyPublisher<MergedElement, Failure>
+    ) -> AnyPublisher<Output, Failure>
+    {
+        mergedStream
+            .scan(nil) {
+                (prevResult: ScanResult?,
+                mergedElement: MergedElement) -> ScanResult? in
+
+                var newValue1: Upstream.Output?
+                var newValue2: Other.Output?
+                let shouldEmit: Bool
+
+                switch mergedElement {
+                case .upstream1(let v):
+                    newValue1 = v
+                    shouldEmit = prevResult?.value2 != nil
+                case .upstream2(let v):
+                    newValue2 = v
+                    shouldEmit = false
+                }
+
+                return ScanResult(value1: newValue1 ?? prevResult?.value1,
+                                  value2: newValue2 ?? prevResult?.value2,
+                                  shouldEmit: shouldEmit)
+        }
+        .compactMap { $0 }
+        .filter { $0.shouldEmit }
+        .map { Output($0.value1!, $0.value2!) }
+        .eraseToAnyPublisher()
+    }
+}
+
+extension Publisher {
+    func withLatestFrom<Other: Publisher>(_ other: Other)
+        -> Publishers.WithLatestFrom<Self, Other>
+    {
+        return .init(upstream: self, other: other)
+    }
+}

--- a/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+WithLatestFrom.swift
@@ -4,6 +4,9 @@ extension Publishers {
     /// When upstream publisher emits an event, this will combine it with
     /// latest event of the other publisher into a tuple to send downstream.
     ///
+    /// Origin of implementation: https://medium.com/@sergebouts/combine-withlatestfrom-operator-8c529e809fd3.
+    /// RxMarbles for withLatestFrom: https://rxmarbles.com/#withLatestFrom.
+    ///
     public struct WithLatestFrom<Upstream: Publisher, Other: Publisher>: Publisher where Upstream.Failure == Other.Failure {
         // MARK: - Types
         public typealias Output = (Upstream.Output, Other.Output)
@@ -42,6 +45,8 @@ private extension Publishers.WithLatestFrom {
          value2: Other.Output?, shouldEmit: Bool)
 
     // MARK: - Pipelines
+    /// Create a Merge for the two publishers
+    ///
     func mergedStream(_ upstream1: Upstream, _ upstream2: Other)
         -> AnyPublisher<MergedElement, Failure> {
         let mergedElementUpstream1 = upstream1
@@ -53,6 +58,9 @@ private extension Publishers.WithLatestFrom {
             .eraseToAnyPublisher()
     }
 
+    /// Scan the merge of two streams and emit the combined values of them
+    /// only when the first stream emits new event and second stream has emitted at least one event.
+    ///
     func resultStream(
         from mergedStream: AnyPublisher<MergedElement, Failure>
     ) -> AnyPublisher<Output, Failure> {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -61,12 +61,7 @@ struct ShippingLabelPackageDetails: View {
                                              placeholder: "0",
                                              text: $viewModel.totalWeight,
                                              symbol: viewModel.weightUnit,
-                                             keyboardType: .decimalPad,
-                                             onEditingChanged: { _ in
-                                                // We don't have a Return button to track committed changes to this field,
-                                                // so if the user starts editing the field we assume it was edited.
-                                                viewModel.isPackageWeightEdited = true
-                                             })
+                                             keyboardType: .decimalPad)
                             .padding(.horizontal, insets: geometry.safeAreaInsets)
 
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -95,8 +95,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.packagesResponse = packagesResponse
         self.selectedPackageID = selectedPackageID
 
-        setDefaultPackage()
         configureResultsControllers()
+        setDefaultPackage()
         syncProducts()
         syncProductVariations()
         configureItemRows()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -200,6 +200,8 @@ private extension ShippingLabelPackageDetailsViewModel {
     /// Calculate total weight based on the weight of the selected package if it's a custom package;
     /// And the products and products variation inside the order items, only if they are not virtual products.
     ///
+    /// Note: Only custom package is needed for input because only custom packages have weight to be included in the total weight.
+    ///
     func calculateTotalWeight(products: [Product], productVariations: [ProductVariation], customPackage: ShippingLabelCustomPackage?) -> Double {
         var tempTotalWeight: Double = 0
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -121,25 +121,23 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// Observe changes in selected custom package, products and variations to update total package weight.
     ///
     private func configureTotalWeights() {
-        $selectedCustomPackage.combineLatest($products, $productVariations) { (customPackage, products, variations) in
-            (customPackage, products, variations)
-        }
-        .filter { [weak self] _ in self?.isPackageWeightEdited == false }
-        .map { [weak self] (customPackage, products, variations) -> Double in
-            self?.calculateTotalWeight(products: products, productVariations: variations, customPackage: customPackage) ?? 0
-        }
-        .map { [weak self] in
-            let calculatedWeight = String($0)
-            // Set the total weight as the initial value if it was input manually; otherwise use the calculated weight.
-            if let initialTotalWeight = self?.initialTotalWeight,
-               calculatedWeight != initialTotalWeight {
-                self?.initialTotalWeight = nil
-                self?.isPackageWeightEdited = true
-                return initialTotalWeight
+        $selectedCustomPackage.combineLatest($products, $productVariations)
+            .filter { [weak self] _ in self?.isPackageWeightEdited == false }
+            .map { [weak self] (customPackage, products, variations) -> Double in
+                self?.calculateTotalWeight(products: products, productVariations: variations, customPackage: customPackage) ?? 0
             }
-            return calculatedWeight
-        }
-        .assign(to: &$totalWeight)
+            .map { [weak self] in
+                let calculatedWeight = String($0)
+                // Set the total weight as the initial value if it was input manually; otherwise use the calculated weight.
+                if let initialTotalWeight = self?.initialTotalWeight,
+                   calculatedWeight != initialTotalWeight {
+                    self?.initialTotalWeight = nil
+                    self?.isPackageWeightEdited = true
+                    return initialTotalWeight
+                }
+                return calculatedWeight
+            }
+            .assign(to: &$totalWeight)
     }
 
     private func configureResultsControllers() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -131,11 +131,14 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         productVariations = resultsControllers?.productVariations ?? []
         setTotalWeight()
     }
+}
 
+// MARK: - Helper methods
+private extension ShippingLabelPackageDetailsViewModel {
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,
-    /// we will generate 3 different items), and we will remove virtual products. 
+    /// we will generate 3 different items), and we will remove virtual products.
     ///
-    private func generateItemsRows(products: [Product], productVariations: [ProductVariation]) -> [ItemToFulfillRow] {
+    func generateItemsRows(products: [Product], productVariations: [ProductVariation]) -> [ItemToFulfillRow] {
         var itemsToFulfill: [ItemToFulfillRow] = []
         for item in orderItems {
             let isVariation = item.variationID > 0
@@ -175,7 +178,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     /// - Parameter initialWeight: An initial value used to set the total package weight if it was input manually.
     ///
-    private func setTotalWeight(using initialWeight: String? = nil) {
+    func setTotalWeight(using initialWeight: String? = nil) {
         guard !isPackageWeightEdited else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -108,7 +108,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     private func configureItemRows() {
         $products.combineLatest($productVariations) { [weak self] (products, variations) in
             guard let self = self else { return [] }
-            return self.generateItemsRows(from: products, variations: variations)
+            return self.generateItemsRows(products: products, productVariations: variations)
         }
         .assign(to: &$itemsRows)
     }
@@ -135,7 +135,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,
     /// we will generate 3 different items), and we will remove virtual products. 
     ///
-    private func generateItemsRows(from products: [Product], variations: [ProductVariation]) -> [ItemToFulfillRow] {
+    private func generateItemsRows(products: [Product], productVariations: [ProductVariation]) -> [ItemToFulfillRow] {
         var itemsToFulfill: [ItemToFulfillRow] = []
         for item in orderItems {
             let isVariation = item.variationID > 0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -119,7 +119,11 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     private func configureTotalWeights(initialTotalWeight: String?) {
         if let initialTotalWeight = initialTotalWeight {
-            totalWeight = initialTotalWeight
+            let calculatedWeight = calculateTotalWeight(products: products, productVariations: productVariations, customPackage: selectedCustomPackage)
+            if initialTotalWeight != String(calculatedWeight) {
+                isPackageWeightEdited = true
+                return totalWeight = initialTotalWeight
+            }
         }
 
         let calculatedWeight = $selectedCustomPackage.combineLatest($products, $productVariations)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -118,7 +118,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         .assign(to: &$itemsRows)
     }
 
-    /// Observe changes in selected package ID, products and variations to update total package weight.
+    /// Observe changes in selected custom package, products and variations to update total package weight.
     ///
     private func configureTotalWeights() {
         $selectedCustomPackage.combineLatest($products, $productVariations) { (customPackage, products, variations) in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1218,6 +1218,7 @@
 		DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */; };
 		DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
+		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2552,6 +2553,7 @@
 		DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+InsetPaddings.swift"; sourceTree = "<group>"; };
 		DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+Woo.swift"; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
+		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5420,6 +5422,7 @@
 				023D877825EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift */,
 				DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */,
 				DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */,
+				DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7110,6 +7113,7 @@
 				5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */,
 				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
+				DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */,
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
 				D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */,
 				45A8DA402664E40B00308FBE /* EmptyState.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1219,6 +1219,7 @@
 		DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
+		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2554,6 +2555,7 @@
 		DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+Woo.swift"; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
+		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -4941,6 +4943,7 @@
 				02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */,
 				025C00CB2551524300FAC222 /* BarcodeScannerFrameScalerTests.swift */,
 				D88100D2257DD060008DE6F2 /* WordPressComSiteInfoWooTests.swift */,
+				DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7539,6 +7542,7 @@
 				02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */,
 				D802547826551DB8001B2CC1 /* CardPresentModalRemoveCardTests.swift in Sources */,
 				02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */,
+				DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */,
 				023EC2E024DA87460021DA91 /* ProductInventorySettingsViewModelTests.swift in Sources */,
 				AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */,
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/Publisher+WithLatestFromTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Publisher+WithLatestFromTests.swift
@@ -1,0 +1,55 @@
+import Combine
+import XCTest
+@testable import WooCommerce
+
+class Publisher_WithLatestFromTests: XCTestCase {
+
+    var cancellable: AnyCancellable?
+    @Published var firstStream = 0
+    @Published var secondStream = "🍕"
+    let resultStream = CurrentValueSubject<(Int, String), Never>((0, "🍕"))
+
+    override func tearDown() {
+        firstStream = 0
+        secondStream = "🍕"
+        resultStream.send((firstStream, secondStream))
+    }
+
+    func test_withLatestFrom_emits_new_event_when_first_stream_emits_new_event_and_ignores_subsequent_events_of_second_stream() {
+        // Given
+        cancellable = $firstStream.withLatestFrom($secondStream)
+            .sink { [weak self] first, second in
+                self?.resultStream.send((first, second))
+            }
+
+        XCTAssertEqual(resultStream.value.0, 0)
+        XCTAssertEqual(resultStream.value.1, "🍕")
+
+        // When
+        firstStream = 1
+        secondStream = "🥗"
+
+        // Then
+        XCTAssertEqual(resultStream.value.0, 1)
+        XCTAssertEqual(resultStream.value.1, "🍕")
+    }
+
+    func test_withLatestFrom_emits_latest_event_from_second_stream_when_first_stream_emits_new_event() {
+        // Given
+        cancellable = $firstStream.withLatestFrom($secondStream)
+            .sink { [weak self] first, second in
+                self?.resultStream.send((first, second))
+            }
+        firstStream = 1
+        secondStream = "🥗"
+        XCTAssertEqual(resultStream.value.0, 1)
+        XCTAssertEqual(resultStream.value.1, "🍕")
+
+        // When
+        firstStream = 2
+
+        // Then
+        XCTAssertEqual(resultStream.value.0, 2)
+        XCTAssertEqual(resultStream.value.1, "🥗")
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/Publisher+WithLatestFromTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Publisher+WithLatestFromTests.swift
@@ -4,52 +4,48 @@ import XCTest
 
 class Publisher_WithLatestFromTests: XCTestCase {
 
-    var cancellable: AnyCancellable?
     @Published var firstStream = 0
     @Published var secondStream = "🍕"
-    let resultStream = CurrentValueSubject<(Int, String), Never>((0, "🍕"))
+    @Published var resultStream = (0, "🍕")
 
     override func tearDown() {
         firstStream = 0
         secondStream = "🍕"
-        resultStream.send((firstStream, secondStream))
+        resultStream = (firstStream, secondStream)
     }
 
     func test_withLatestFrom_emits_new_event_when_first_stream_emits_new_event_and_ignores_subsequent_events_of_second_stream() {
         // Given
-        cancellable = $firstStream.withLatestFrom($secondStream)
-            .sink { [weak self] first, second in
-                self?.resultStream.send((first, second))
-            }
+        $firstStream.withLatestFrom($secondStream)
+            .assign(to: &$resultStream)
 
-        XCTAssertEqual(resultStream.value.0, 0)
-        XCTAssertEqual(resultStream.value.1, "🍕")
+        XCTAssertEqual(resultStream.0, 0)
+        XCTAssertEqual(resultStream.1, "🍕")
 
         // When
         firstStream = 1
         secondStream = "🥗"
 
         // Then
-        XCTAssertEqual(resultStream.value.0, 1)
-        XCTAssertEqual(resultStream.value.1, "🍕")
+        XCTAssertEqual(resultStream.0, 1)
+        XCTAssertEqual(resultStream.1, "🍕")
     }
 
     func test_withLatestFrom_emits_latest_event_from_second_stream_when_first_stream_emits_new_event() {
         // Given
-        cancellable = $firstStream.withLatestFrom($secondStream)
-            .sink { [weak self] first, second in
-                self?.resultStream.send((first, second))
-            }
+        $firstStream.withLatestFrom($secondStream)
+            .assign(to: &$resultStream)
+
         firstStream = 1
         secondStream = "🥗"
-        XCTAssertEqual(resultStream.value.0, 1)
-        XCTAssertEqual(resultStream.value.1, "🍕")
+        XCTAssertEqual(resultStream.0, 1)
+        XCTAssertEqual(resultStream.1, "🍕")
 
         // When
         firstStream = 2
 
         // Then
-        XCTAssertEqual(resultStream.value.0, 2)
-        XCTAssertEqual(resultStream.value.1, "🥗")
+        XCTAssertEqual(resultStream.0, 2)
+        XCTAssertEqual(resultStream.1, "🥗")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -192,23 +192,23 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedPackageName, "Small")
     }
 
-    func test_isPackageDetailsDoneButtonEnabled_returns_the_expected_value() {
+    func test_isPackageDetailsDoneButtonEnabled_returns_true_initially() {
         // Given
-        let order = MockOrders().empty().copy(siteID: sampleSiteID)
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
+                                                             selectedPackageID: "Box",
                                                              totalWeight: nil,
                                                              formatter: currencyFormatter,
-                                                             stores: stores,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
 
-        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
-
         // When
-        viewModel.totalWeight = "10"
         viewModel.selectedPackageID = "sample-package"
 
         // Then
@@ -217,25 +217,26 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
     func test_isPackageDetailsDoneButtonEnabled_returns_the_expected_value_when_the_totalWeight_is_not_valid() {
         // Given
-        let order = MockOrders().empty().copy(siteID: sampleSiteID)
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
+                                                             selectedPackageID: "Box",
                                                              totalWeight: nil,
                                                              formatter: currencyFormatter,
-                                                             stores: stores,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
 
-        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
-
         // When
-        viewModel.totalWeight = "0"
         viewModel.selectedPackageID = "sample-package"
 
         // Then
-        XCTAssertFalse(viewModel.isPackageDetailsDoneButtonEnabled())
+        XCTAssertTrue(viewModel.isPackageDetailsDoneButtonEnabled())
 
         // When
         viewModel.totalWeight = "0.0"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -416,7 +416,6 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         // When new weight is input manually
         viewModel.totalWeight = "500"
-        viewModel.isPackageWeightEdited = true
 
         // Then
         XCTAssertEqual(viewModel.totalWeight, "500")


### PR DESCRIPTION
Closes #4666 

# Description
Currently the view model of Package Details has duplicated calls to `setTotalWeight` and `setItemRows`. Since we're already using publishers, I figure this is a nice opportunity to make use of Combine. This PR aims to refactor these functions by observing changes in relevant variables and re-calculate data when appropriate.

# Changes
## Configuring item rows
- Updated `generateItemsRows` method to accept products and product variations as input instead of reading from class properties directly.  This is to make sure of the single source of truth for the method.
- Create new method `configureItemsRows` to observe changes in products and variations and get results from `generateItemsRows` to assign to `itemsRows` directly. This method is called directly from the initializer of the class.
- Remove duplicated calls to `generateItemsRows`.

## Configuring total weight
- Renamed `setTotalWeight` to `calculateTotalWeight`, and updated it to accept products, product variations and an optional custom package as input. The result weight will be calculated solely on these input.
- Added an optional variable `initialTotalWeight` as a new private property for the view model.
- Added a new method `configureTotalWeight` to observe changes in selected custom package, products and variations to calculate total weight accordingly. This observing is only handled when the package weight is not manually input, and there's also a check for initial total weight to update `isPackageWeightEdited` appropriately.
- Updated unit tests for `isPackageDetailsDoneButtonEnabled` to reflects the function correctly.

# Testing
Unit tests should still pass after the refactoring. When running the feature, everything should still work as expected:
1. Navigate to Orders tab.
2. Select an order with status Processing.
3. Select Create Shipping Label.
4. Configure package details: notice that order items are correct, and package weight is updated correctly when switching between packages.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
