### PR TITLE
Order Detail: "email note to customer" option is now hidden if no email is available

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.3
 -----
-
+- [*] Order Detail: now we do not offer the "email note to customer" option if no email is available.
 
 7.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.3
 -----
-- [*] Order Detail: now we do not offer the "email note to customer" option if no email is available.
+- [*] Order Detail: now we do not offer the "email note to customer" option if no email is available. [https://github.com/woocommerce/woocommerce-ios/pull/4680]
 
 7.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -105,10 +105,12 @@ private extension NewNoteViewController {
     private func loadSections() {
         let writeNoteSectionTitle = NSLocalizedString("WRITE NOTE", comment: "Add a note screen - Write Note section title")
         let writeNoteSection = Section(title: writeNoteSectionTitle, rows: [.writeNote])
-        var emailCustomerSection: Section? = nil
-        if viewModel.order.billingAddress?.hasEmailAddress == true {
-            emailCustomerSection = Section(title: nil, rows: [.emailCustomer])
-        }
+        let emailCustomerSection: Section? = {
+            if viewModel.order.billingAddress?.hasEmailAddress == true {
+                return Section(title: nil, rows: [.emailCustomer])
+            }
+            return nil
+        }()
 
         sections = [writeNoteSection, emailCustomerSection].compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -105,9 +105,12 @@ private extension NewNoteViewController {
     private func loadSections() {
         let writeNoteSectionTitle = NSLocalizedString("WRITE NOTE", comment: "Add a note screen - Write Note section title")
         let writeNoteSection = Section(title: writeNoteSectionTitle, rows: [.writeNote])
-        let emailCustomerSection = Section(title: nil, rows: [.emailCustomer])
+        var emailCustomerSection: Section? = nil
+        if viewModel.order.billingAddress?.hasEmailAddress == true {
+            emailCustomerSection = Section(title: nil, rows: [.emailCustomer])
+        }
 
-        sections = [writeNoteSection, emailCustomerSection]
+        sections = [writeNoteSection, emailCustomerSection].compactMap { $0 }
     }
 
     /// Cell Configuration


### PR DESCRIPTION
Fixes #3840 

## Description
if you try using the "Email note to customer" option if there is no email saved as part of the order details then the email will fail silently—we should not show the email toggle if there is no email on file to send the message to.

## Testing
1. Create an order that does not have an email included.
2. Open the order in the app.
3. Tap "Add a note".
4. Observe that the section "Email note to customer" option is hidden.
5. Try the same procedure with an order with email included. The section should be visible.


## Screenshots
| Order with Customer's email             |  Order without Customer's email |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 12 Pro - 2021-07-27 at 12 16 30](https://user-images.githubusercontent.com/495617/127158427-6024e073-6192-446f-b6d8-2a45eee5ca5b.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-27 at 12 24 54](https://user-images.githubusercontent.com/495617/127158435-d431d185-2bdc-4f66-84a9-4e1d5d67f25d.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
