### PR TITLE
[CPP Onboarding] Add initial unit tests for onboarding state calculation

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -471,6 +471,25 @@ extension PaymentGateway {
         )
     }
 }
+extension PaymentGatewayAccount {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> PaymentGatewayAccount {
+        .init(
+            siteID: .fake(),
+            gatewayID: .fake(),
+            status: .fake(),
+            hasPendingRequirements: .fake(),
+            hasOverdueRequirements: .fake(),
+            currentDeadline: .fake(),
+            statementDescriptor: .fake(),
+            defaultCurrency: .fake(),
+            supportedCurrencies: .fake(),
+            country: .fake(),
+            isCardPresentEligible: .fake()
+        )
+    }
+}
 extension Post {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -232,6 +232,48 @@ extension OrderItemRefund {
     }
 }
 
+extension PaymentGatewayAccount {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        gatewayID: CopiableProp<String> = .copy,
+        status: CopiableProp<String> = .copy,
+        hasPendingRequirements: CopiableProp<Bool> = .copy,
+        hasOverdueRequirements: CopiableProp<Bool> = .copy,
+        currentDeadline: NullableCopiableProp<Date> = .copy,
+        statementDescriptor: CopiableProp<String> = .copy,
+        defaultCurrency: CopiableProp<String> = .copy,
+        supportedCurrencies: CopiableProp<[String]> = .copy,
+        country: CopiableProp<String> = .copy,
+        isCardPresentEligible: CopiableProp<Bool> = .copy
+    ) -> PaymentGatewayAccount {
+        let siteID = siteID ?? self.siteID
+        let gatewayID = gatewayID ?? self.gatewayID
+        let status = status ?? self.status
+        let hasPendingRequirements = hasPendingRequirements ?? self.hasPendingRequirements
+        let hasOverdueRequirements = hasOverdueRequirements ?? self.hasOverdueRequirements
+        let currentDeadline = currentDeadline ?? self.currentDeadline
+        let statementDescriptor = statementDescriptor ?? self.statementDescriptor
+        let defaultCurrency = defaultCurrency ?? self.defaultCurrency
+        let supportedCurrencies = supportedCurrencies ?? self.supportedCurrencies
+        let country = country ?? self.country
+        let isCardPresentEligible = isCardPresentEligible ?? self.isCardPresentEligible
+
+        return PaymentGatewayAccount(
+            siteID: siteID,
+            gatewayID: gatewayID,
+            status: status,
+            hasPendingRequirements: hasPendingRequirements,
+            hasOverdueRequirements: hasOverdueRequirements,
+            currentDeadline: currentDeadline,
+            statementDescriptor: statementDescriptor,
+            defaultCurrency: defaultCurrency,
+            supportedCurrencies: supportedCurrencies,
+            country: country,
+            isCardPresentEligible: isCardPresentEligible
+        )
+    }
+}
+
 extension Product {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/PaymentGatewayAccount.swift
+++ b/Networking/Networking/Model/PaymentGatewayAccount.swift
@@ -1,8 +1,9 @@
 import Foundation
+import Codegen
 
 /// Represents a Payment Gateway Account.
 ///
-public struct PaymentGatewayAccount {
+public struct PaymentGatewayAccount: GeneratedCopiable, GeneratedFakeable {
 
     /// Site identifier.
     ///

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -30,6 +30,16 @@ extension MockStorageManager {
         return newAccountSettings
     }
 
+    /// Inserts a new (Sample) Payment Gateway Account into the specified context.
+    ///
+    @discardableResult
+    func insertSamplePaymentGatewayAccount(readOnlyAccount: PaymentGatewayAccount) -> StoragePaymentGatewayAccount {
+        let newAccount = viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
+        newAccount.update(with: readOnlyAccount)
+
+        return newAccount
+    }
+
     /// Inserts a new (Sample) Product into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Fakes
 @testable import Yosemite
 @testable import Networking
 @testable import Storage
@@ -237,10 +238,51 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
     // MARK: - CardPresentPaymentAction.checkOnboardingState
     func test_onboarding_returns_generic_error_by_default() {
+        // Given
+
+        // When
+        let state = checkOnboardingState()
+
+        // Then
         // This is not the desired final state, but we will use a generic error for any case
         // that is not implemented yet
-        let state = checkOnboardingState()
         XCTAssertEqual(state, .genericError)
+    }
+
+    func test_onboarding_returns_generic_error_when_account_is_not_eligible() {
+        // Given
+        let paymentGatewayAccount = PaymentGatewayAccount
+            .fake()
+            .copy(
+                siteID: sampleSiteID,
+                isCardPresentEligible: false
+            )
+        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+
+        // When
+        let state = checkOnboardingState()
+
+        // Then
+        // This is not the desired final state, but we will use a generic error for any case
+        // that is not implemented yet
+        XCTAssertEqual(state, .genericError)
+    }
+
+    func test_onboarding_returns_complete_when_account_is_setup_successfully() {
+        // Given
+        let paymentGatewayAccount = PaymentGatewayAccount
+            .fake()
+            .copy(
+                siteID: sampleSiteID,
+                isCardPresentEligible: true
+            )
+        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+
+        // When
+        let state = checkOnboardingState()
+
+        // Then
+        XCTAssertEqual(state, .completed)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -234,4 +234,35 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         XCTAssertTrue(mockCardReaderService.didHitDisconnect)
     }
+
+    // MARK: - CardPresentPaymentAction.checkOnboardingState
+    func test_onboarding_returns_generic_error_by_default() {
+        // This is not the desired final state, but we will use a generic error for any case
+        // that is not implemented yet
+        let state = checkOnboardingState()
+        XCTAssertEqual(state, .genericError)
+    }
+}
+
+private extension CardPresentPaymentStoreTests {
+    /// Returns the current onboarding state
+    ///
+    /// This is a helper method to avoid repeating boilerplate in all the different test cases, so the actual tested logic is more apparent.
+    ///
+    func checkOnboardingState() -> CardPresentPaymentOnboardingState {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+        let expectation = self.expectation(description: "Check onboarding state")
+
+        var returnedState: CardPresentPaymentOnboardingState? = nil
+        let action = CardPresentPaymentAction.checkOnboardingState(siteID: sampleSiteID) { state in
+            returnedState = state
+            expectation.fulfill()
+        }
+        cardPresentStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        return returnedState!
+    }
 }


### PR DESCRIPTION
Fixes #4630 

So far there's not a lot of logic to test, as we are only checking if everything is set up correctly, and showing a generic error otherwise (see #4613).

This PR sets up some initial tests, and adds the necessary helpers to mock payment accounts, so it's easier to add more tests as we implement more of the functionality

## To test

Make sure unit tests pass

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
