### PR TITLE
[Mobile Payments] Add card reader ID to payment intent

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -383,7 +383,7 @@ private extension StripeCardReaderService {
             return nil
         }
 
-        return connectedReaders[0].id
+        return connectedReaders.first?.id
     }
 
     func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<StripeTerminal.PaymentIntent, Error> {


### PR DESCRIPTION
Closes #4621 

Changes:
- Adds the connected card reader ID to the payment intent metadata
- This data will be used by our backend to correctly assess the number of readers actually used in a given month
- For simplicity's sake, and to have the insertion of the data as close to the consumer of the data, I elected to implement this wholly in StripeCardReaderService by appending the reader_ID to the metadata passed in instead of a more complex solution that would require modifications to have PaymentCaptureOrchestrator pass the reader ID into PaymentIntent initMetadata

To test:
- Complete a charge and then open it in our dashboard. Confirm the expected reader ID is present in the metadata, i.e.:

<img width="1221" alt="readerid" src="https://user-images.githubusercontent.com/1595739/127390607-7cf650c2-f795-4490-ac7b-fab7cd8e019e.png">

See also:
- https://github.com/woocommerce/woocommerce-android/pull/4470
- fyi @kidinov 

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
