### PR TITLE
Shipping Labels: Show country picker for origin and destination address forms

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -275,8 +275,6 @@ extension ShippingLabelAddressFormViewController: UITableViewDelegate {
             show(listSelector, sender: self)
 
         case .country:
-            // The country is not editable in M2/M3 (because we support just US).
-            // It will be editable in M4 or M5.
             guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsInternational) else {
                 let notice = Notice(title: Localization.countryNotEditable, feedbackType: .warning)
                 ServiceLocator.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelCountryListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelCountryListSelectorCommand.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Yosemite
+
+final class ShippingLabelCountryListSelectorCommand: ListSelectorCommand {
+    typealias Model = Country
+    typealias Cell = BasicTableViewCell
+
+    /// Data to display
+    ///
+    let data: [Country]
+
+    /// Current selected country
+    ///
+    private(set) var selected: Country?
+
+    /// Navigation bar title
+    ///
+    let navigationBarTitle: String? = Localization.navigationBarTitle
+
+    init(countries: [Country], selected: Country?) {
+        self.data = countries
+        self.selected = selected
+    }
+
+    func handleSelectedChange(selected: Country, viewController: ViewController) {
+        self.selected = selected
+    }
+
+    func isSelected(model: Country) -> Bool {
+        model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: Country) {
+        cell.textLabel?.text = model.name
+    }
+}
+
+private extension ShippingLabelCountryListSelectorCommand {
+    enum Localization {
+        static var navigationBarTitle = NSLocalizedString("Choose a Country", comment: "Navigation title on the shipping label country selector screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -344,7 +344,7 @@ private extension ShippingLabelFormViewController {
             type: type,
             address: address,
             validationError: validationError,
-            countries: viewModel.countries,
+            countries: viewModel.filteredCountries(for: type),
             completion: { [weak self] (newShippingLabelAddress) in
                 guard let self = self else { return }
                 switch type {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -645,6 +645,9 @@ private extension ShippingLabelFormViewModel {
     }
 
     enum Constants {
+        /// This is hardcoded for now based on: https://git.io/JBuja.
+        /// It would be great if this can be fetched remotely.
+        ///
         static let acceptedUSPSCountries = [
             "US", // United States
             "PR", // Puerto Rico

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Provides view data for Create Shipping Label, and handles init/UI/navigation actions needed.
 ///
@@ -79,10 +80,8 @@ final class ShippingLabelFormViewModel {
 
     /// ResultsController: Loads Countries from the Storage Layer.
     ///
-    private let resultsController: ResultsController<StorageCountry> = {
-        let storageManager = ServiceLocator.storageManager
+    private lazy var resultsController: ResultsController<StorageCountry> = {
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
-
         return ResultsController(storageManager: storageManager, matching: nil, sortedBy: [descriptor])
     }()
 
@@ -91,6 +90,8 @@ final class ShippingLabelFormViewModel {
     }
 
     private let stores: StoresManager
+
+    private let storageManager: StorageManagerType
 
     /// Closure to notify the `ViewController` when the view model properties change.
     ///
@@ -107,7 +108,8 @@ final class ShippingLabelFormViewModel {
     init(order: Order,
          originAddress: Address?,
          destinationAddress: Address?,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
 
         self.siteID = order.siteID
         self.order = order
@@ -125,6 +127,7 @@ final class ShippingLabelFormViewModel {
 
         state.sections = ShippingLabelFormViewModel.generateInitialSections()
         self.stores = stores
+        self.storageManager = storageManager
 
         syncShippingLabelAccountSettings()
         syncPackageDetails()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -339,14 +339,14 @@ final class ShippingLabelFormViewModel {
     /// Filter country for picking based on ship type.
     ///
     /// For origin address, country list should show only US or any of its territories that have at least one USPS postal office.
-    /// For destination address, country list should show countries that the store sells to.
+    /// Destination address should allow picking from the complete country list.
     ///
     func filteredCountries(for type: ShipType) -> [Country] {
         switch type {
         case .origin:
             return countries.filter { Constants.acceptedUSPSCountries.contains($0.code) }
         case .destination:
-            return []
+            return countries
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -335,6 +335,20 @@ final class ShippingLabelFormViewModel {
 
         return price
     }
+
+    /// Filter country for picking based on ship type.
+    ///
+    /// For origin address, country list should show only US or any of its territories that have at least one USPS postal office.
+    /// For destination address, country list should show countries that the store sells to.
+    ///
+    func filteredCountries(for type: ShipType) -> [Country] {
+        switch type {
+        case .origin:
+            return countries.filter { Constants.acceptedUSPSCountries.contains($0.code) }
+        case .destination:
+            return []
+        }
+    }
 }
 
 // MARK: - State Machine
@@ -625,5 +639,19 @@ private extension ShippingLabelFormViewModel {
                               comment: "Selected credit card in Shipping Label form. %1$@ is a placeholder for the last four digits of the credit card.")
         static let orderSummaryHeader = NSLocalizedString("Shipping label order summary",
                                                           comment: "Header of the order summary section in the shipping label creation form")
+    }
+
+    enum Constants {
+        static let acceptedUSPSCountries = [
+            "US", // United States
+            "PR", // Puerto Rico
+            "VI", // Virgin Islands
+            "GU", // Guam
+            "AS", // American Samoa
+            "UM", // United States Minor Outlying Islands
+            "MH", // Marshall Islands
+            "FM", // Micronesia
+            "MP" // Northern Mariana Islands
+        ]
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1213,6 +1213,7 @@
 		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
+		DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */; };
 		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
 		DE4B3B2E269455D400EEF2D8 /* MockShipmentActionStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */; };
 		DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */; };
@@ -2547,6 +2548,7 @@
 		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
+		DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCountryListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShipmentActionStoresManager.swift; sourceTree = "<group>"; };
 		DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+InsetPaddings.swift"; sourceTree = "<group>"; };
@@ -3827,6 +3829,7 @@
 				4515C89725D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift */,
 				45C91CFD25E55A1200FD8812 /* ShippingLabelAddressTopBannerFactory.swift */,
 				45BBE5C6268CBB090017D8F8 /* ShippingLabelStateOfACountryListSelectorCommand.swift */,
+				DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */,
 			);
 			path = "Shipping Address Validation";
 			sourceTree = "<group>";
@@ -6799,6 +6802,7 @@
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
+				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -1,8 +1,25 @@
 import XCTest
 @testable import WooCommerce
 import Yosemite
+@testable import Storage
 
 final class ShippingLabelFormViewModelTests: XCTestCase {
+
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
 
     func test_conversion_from_Address_to_ShippingLabelAddress_returns_correct_data() {
 
@@ -371,23 +388,41 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
 
     func test_filteredCountries_returns_only_USPS_supported_countries_for_origin_address() {
         // Given
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+        let country1 = Country(code: "US", name: "United States", states: [])
+        let country2 = Country(code: "IT", name: "Italy", states: [])
+        insert(country1)
+        insert(country2)
+
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil, storageManager: storageManager)
 
         // When
         let filteredCountries = viewModel.filteredCountries(for: .origin)
 
         // Then
-        XCTAssertEqual(filteredCountries.count, 9)
+        XCTAssertEqual(filteredCountries.count, 1)
     }
 
     func test_filteredCountries_returns_complete_country_list_for_destination_address() {
         // Given
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+        let country1 = Country(code: "US", name: "United States", states: [])
+        let country2 = Country(code: "IT", name: "Italy", states: [])
+        insert(country1)
+        insert(country2)
+
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil, storageManager: storageManager)
 
         // When
         let filteredCountries = viewModel.filteredCountries(for: .destination)
 
         // Then
-        XCTAssertEqual(filteredCountries.count, viewModel.countries.count)
+        XCTAssertEqual(filteredCountries.count, 2)
+    }
+}
+
+// MARK: - Utils
+private extension ShippingLabelFormViewModelTests {
+    func insert(_ readOnlyCountry: Yosemite.Country) {
+        let country = storage.insertNewObject(ofType: StorageCountry.self)
+        country.update(with: readOnlyCountry)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -368,4 +368,26 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let paymentMethodBody = viewModel.getPaymentMethodBody()
         XCTAssertEqual(paymentMethodBody, "Credit card ending in 4242")
     }
+
+    func test_filteredCountries_returns_only_USPS_supported_countries_for_origin_address() {
+        // Given
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+
+        // When
+        let filteredCountries = viewModel.filteredCountries(for: .origin)
+
+        // Then
+        XCTAssertEqual(filteredCountries.count, 9)
+    }
+
+    func test_filteredCountries_returns_complete_country_list_for_destination_address() {
+        // Given
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+
+        // When
+        let filteredCountries = viewModel.filteredCountries(for: .destination)
+
+        // Then
+        XCTAssertEqual(filteredCountries.count, viewModel.countries.count)
+    }
 }


### PR DESCRIPTION
Closes #4684 
Also closes #4685

# Description
To support international shipping labels, we want to let user select countries in origin and destination forms. This PR adds that feature.

# Changes
- Updated `ShippingLabelAddressFormViewController` to navigate to a list selector view controller with its view model's country list. This is hidden under `.shippingLabelsInternational` feature flag.
- Updated `ShippingLabelFormViewModel` with a function to get a country list based on ship type (origin or destination). For origin address, the country list should only contains USPS [supported countries](https://github.com/Automattic/woocommerce-services/blob/dbeed610f336f8db7995743765dbcd0ff2e18474/client/extensions/woocommerce/woocommerce-services/state/shipping-label/constants.js#L1) and territories. For destination address, we're showing the complete list of countries.
- Updated `ShippingLabelFormViewController` to send appropriate country list based on ship type.
- Added unit tests for `filteredCountries`.

# Demo
![country-list](https://user-images.githubusercontent.com/5533851/127488783-7d76bde8-295a-43db-a299-b4f733ebacab.gif)

# Testing
1. Navigate to Orders tab and select an order with Processing status.
2. Select Create Shipping Label.
3. Select Ship From, notice that when tapping on Country there's no longer notice about supporting only US. A list of USPS supported countries and territories should show up. Current country if present in the list should be selected.
4. Proceed to Ship To, notice that when tapping on Country there's no longer notice about supporting only US. A full list of countries should show up to select from. Current country of the address should be selected.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
