### PR TITLE
Plugins: Fix Storage warnings

### DIFF
--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 54.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 54.xcdatamodel/contents
@@ -637,7 +637,7 @@
         <attribute name="name" attributeType="String"/>
         <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Country" inverseName="states" inverseEntity="Country"/>
     </entity>
-    <entity name="SystemPlugin" representedClassName="SystemPlugin" syncable="YES" codeGenerationType="class">
+    <entity name="SystemPlugin" representedClassName="SystemPlugin" syncable="YES">
         <attribute name="authorName" attributeType="String"/>
         <attribute name="authorUrl" attributeType="String"/>
         <attribute name="name" attributeType="String"/>


### PR DESCRIPTION
# Why

Apparently, https://github.com/woocommerce/woocommerce-ios/pull/4617 introduced some warnings to the `Storage` framework. Due to marking the `SitePlugin` entity as code-generatable.

<img width="849" alt="Screen Shot 2021-07-29 at 3 41 49 PM" src="https://user-images.githubusercontent.com/562080/127563338-986ced10-ca7f-4ea7-9647-2bd9b975dc1b.png">

This PR removes that, which removes the warnings.

# Testing

Compile this branch and see that no warnings are generated under the `Storage` framework.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
