### PR TITLE
Shipping Labels: Make it possible to manually input state for countries with no states

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -266,7 +266,7 @@ extension ShippingLabelAddressFormViewController: UITableViewDelegate {
         switch row {
         case .state:
             let states = viewModel.statesOfSelectedCountry
-            guard !states.isEmpty else {
+            guard states.isNotEmpty else {
                 return
             }
             let selectedState = states.first { $0.code == viewModel.address?.state }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -527,8 +527,10 @@ private extension ShippingLabelAddressFormViewController {
         static let postcodeFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
         static let stateField = NSLocalizedString("State", comment: "Text field state in Shipping Label Address Validation")
         static let stateFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
-        static let stateFieldPlaceholderOptional = NSLocalizedString("Optional",
-                                                                     comment: "Text field placeholder in Shipping Label Address Validation when specified country has no state")
+        static let stateFieldPlaceholderOptional = NSLocalizedString(
+            "Optional",
+            comment: "Text field placeholder in Shipping Label Address Validation when specified country has no state"
+        )
         static let countryField = NSLocalizedString("Country", comment: "Text field country in Shipping Label Address Validation")
         static let countryFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -440,9 +440,10 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func configureState(cell: TitleAndTextFieldTableViewCell, row: Row) {
+        let placeholder = viewModel.stateOfCountryRequired ? Localization.stateFieldPlaceholder : Localization.stateFieldPlaceholderOptional
         let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.stateField,
                                                                      text: viewModel.extendedStateName,
-                                                                     placeholder: Localization.stateFieldPlaceholder,
+                                                                     placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
                                                                      textFieldAlignment: .leading) { _ in
@@ -526,6 +527,8 @@ private extension ShippingLabelAddressFormViewController {
         static let postcodeFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
         static let stateField = NSLocalizedString("State", comment: "Text field state in Shipping Label Address Validation")
         static let stateFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
+        static let stateFieldPlaceholderOptional = NSLocalizedString("Optional",
+                                                                     comment: "Text field placeholder in Shipping Label Address Validation when specified country has no state")
         static let countryField = NSLocalizedString("Country", comment: "Text field country in Shipping Label Address Validation")
         static let countryFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -266,6 +266,9 @@ extension ShippingLabelAddressFormViewController: UITableViewDelegate {
         switch row {
         case .state:
             let states = viewModel.statesOfSelectedCountry
+            guard !states.isEmpty else {
+                return
+            }
             let selectedState = states.first { $0.code == viewModel.address?.state }
             let command = ShippingLabelStateOfACountryListSelectorCommand(states: states, selected: selectedState)
             let listSelector = ListSelectorViewController(command: command) { [weak self] state in
@@ -445,7 +448,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      textFieldAlignment: .leading) { _ in
         }
         cell.configure(viewModel: cellViewModel)
-        cell.enableTextField(false)
+        cell.enableTextField(viewModel.statesOfSelectedCountry.isEmpty)
     }
 
     func configureCountry(cell: TitleAndTextFieldTableViewCell, row: Row) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -53,7 +53,7 @@ final class ShippingLabelAddressFormViewModel {
     }
 
     var stateOfCountryRequired: Bool {
-        !statesOfSelectedCountry.isEmpty
+        statesOfSelectedCountry.isNotEmpty
     }
 
     var extendedCountryName: String? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -179,7 +179,9 @@ extension ShippingLabelAddressFormViewModel {
             if addressToBeValidated.postcode.isEmpty {
                 errors.append(.postcode)
             }
-            if addressToBeValidated.state.isEmpty {
+
+            let stateList = countries.first { $0.code == addressToBeValidated.country }?.states ?? []
+            if addressToBeValidated.state.isEmpty && !stateList.isEmpty {
                 errors.append(.state)
             }
             if addressToBeValidated.country.isEmpty {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -52,6 +52,10 @@ final class ShippingLabelAddressFormViewModel {
         countries.first { $0.code == address?.country }?.states.sorted { $0.name < $1.name } ?? []
     }
 
+    var stateOfCountryRequired: Bool {
+        !statesOfSelectedCountry.isEmpty
+    }
+
     var extendedCountryName: String? {
         return countries.first { $0.code == address?.country }?.name
     }
@@ -179,9 +183,7 @@ extension ShippingLabelAddressFormViewModel {
             if addressToBeValidated.postcode.isEmpty {
                 errors.append(.postcode)
             }
-
-            let stateList = countries.first { $0.code == addressToBeValidated.country }?.states ?? []
-            if addressToBeValidated.state.isEmpty && !stateList.isEmpty {
+            if addressToBeValidated.state.isEmpty && stateOfCountryRequired {
                 errors.append(.state)
             }
             if addressToBeValidated.country.isEmpty {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -53,7 +53,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
-    func test_sections_are_returned_correctly_if_an_address_validation_error_occurs() {
+    func test_sections_are_returned_correctly_if_an_address_validation_error_occurs_for_all_empty_rows() {
         // Given
         let shippingAddress = MockShippingLabelAddress.sampleAddress()
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -75,8 +75,90 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (result) in
+        viewModel.validateAddress(onlyLocally: false) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
+                                                                     .company,
+                                                                     .phone,
+                                                                     .address,
+                                                                     .fieldError(.address),
+                                                                     .address2,
+                                                                     .city,
+                                                                     .fieldError(.city),
+                                                                     .postcode,
+                                                                     .fieldError(.postcode),
+                                                                     .state,
+                                                                     .country,
+                                                                     .fieldError(.country)]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
+    func test_sections_are_returned_correctly_if_stateOfCountry_is_not_required() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(country: "VN")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                onCompletion(.failure(validationError))
+            default:
+                break
+            }
         }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          stores: stores,
+                                                          validationError: nil,
+                                                          countries: sampleCountries())
+        viewModel.validateAddress(onlyLocally: false) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
+                                                                     .company,
+                                                                     .phone,
+                                                                     .address,
+                                                                     .fieldError(.address),
+                                                                     .address2,
+                                                                     .city,
+                                                                     .fieldError(.city),
+                                                                     .postcode,
+                                                                     .fieldError(.postcode),
+                                                                     .state,
+                                                                     .country]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
+    func test_sections_are_returned_correctly_if_stateOfCountry_is_required() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(country: "US")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                onCompletion(.failure(validationError))
+            default:
+                break
+            }
+        }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          stores: stores,
+                                                          validationError: nil,
+                                                          countries: sampleCountries())
+        viewModel.validateAddress(onlyLocally: false) { _ in }
 
         // Then
         let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
@@ -92,8 +174,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                                      .fieldError(.postcode),
                                                                      .state,
                                                                      .fieldError(.state),
-                                                                     .country,
-                                                                     .fieldError(.country)]
+                                                                     .country]
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
@@ -297,6 +378,8 @@ private extension ShippingLabelAddressFormViewModelTests {
         let state6 = StateOfACountry(code: "RM", name: "Roma")
         let country2 = Country(code: "IT", name: "Italy", states: [state4, state5, state6])
 
-        return [country1, country2]
+        let country3 = Country(code: "VN", name: "Vietnam", states: [])
+
+        return [country1, country2, country3]
     }
 }


### PR DESCRIPTION
Closes #4525 

# Description
Currently on address validation form, tapping on State navigates to an empty list if no state is found for specified country. This PR fixes that by letting user enter state manually as needed.

# Changes
- Updated State cell to enable text field if no state for the specified country is found.
- Updated tap action of State cell to only navigate to state list if the list is not empty.

# Demo
![country-state](https://user-images.githubusercontent.com/5533851/127622265-c7d26a7c-3861-4442-8776-c44c1e570092.gif)

# Testing
1. Navigate to Orders tab, select an order with Processing status.
2. Select Create Shipping Label and skip to configure Ship To address.
3. Select Australia / US as country, then tap State and notice that you're navigated to state list to pick one.
4. Select Vietnam, then tap State and notice that you'll have to enter name of the state (or keep it empty).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
