### PR TITLE
New Tracks event `shipping_label_order_is_eligible`

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -212,6 +212,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Shipping Labels Creation Events
     //
+    case shippingLabelOrderIsEligible = "shipping_label_order_is_eligible"
     case shippingLabelPurchaseFlow = "shipping_label_purchase_flow"
     case shippingLabelOrderFulfillSucceeded = "shipping_label_order_fulfill_succeeded"
     case shippingLabelOrderFulfillFailed = "shipping_label_order_fulfill_failed"

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -448,6 +448,10 @@ extension OrderDetailsViewModel {
                                                                   canCreateCustomsForm: isCustomsFormEnabled,
                                                                   canCreatePackage: isPackageCreationEnabled) { [weak self] isEligible in
             self?.dataSource.isEligibleForShippingLabelCreation = isEligible
+            if isEligible, let orderStatus = self?.orderStatus?.status.rawValue {
+                ServiceLocator.analytics.track(.shippingLabelOrderIsEligible,
+                                               withProperties: ["order_status": orderStatus])
+            }
             onCompletion?()
         }
         stores.dispatch(action)


### PR DESCRIPTION
Fixes #4690 

Added a new Tracks event `shipping_label_order_is_eligible` that will be sent when the current order is eligible for shipping label creation.

## Testing
1. Open an order that is eligible for shipping label creation.
2. Check if inside the console you are able to see the event `shipping_label_order_is_eligible` with the `order_status` property.



Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
