### PR TITLE
[Tooling] Fix hotfix lanes

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,5 +1,5 @@
 ---
 BUNDLE_RETRY: "3"
 BUNDLE_PATH: "vendor/bundle"
-BUNDLE_JOBS: "3"
+BUNDLE_JOBS: "16"
 BUNDLE_WITHOUT: "screenshots"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -197,7 +197,7 @@ platform :ios do
   # bundle exec fastlane new_hotfix_release version:10.6.1
   # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
   #####################################################################################
-  desc 'Creates a new hotfix branch from the given tag'
+  desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do |options|
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
@@ -214,7 +214,7 @@ platform :ios do
   # Example:
   # bundle exec fastlane finalize_hotfix_release skip_confirm:true
   #####################################################################################
-  desc 'Creates a new hotfix branch from the given tag'
+  desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
     ios_finalize_prechecks(options)
     version = ios_get_app_version
@@ -236,24 +236,25 @@ platform :ios do
   #####################################################################################
   desc 'Trigger the final release build on CI'
   lane :finalize_release do |options|
+    UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
+
     ios_finalize_prechecks(options)
-    unless ios_current_branch_is_hotfix
-      UI.message('Checking app strings translation status...')
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/',
-        abort_on_violations: false
-      )
 
-      UI.message("Checking release notes strings translation status...")
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/release-notes/',
-        abort_on_violations: false
-      )
+    UI.message('Checking app strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/',
+      abort_on_violations: false
+    )
 
-      ios_update_metadata(options)
-      ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
-      ios_bump_version_beta
-    end
+    UI.message("Checking release notes strings translation status...")
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/release-notes/',
+      abort_on_violations: false
+    )
+
+    ios_update_metadata(options)
+    ios_lint_localizations(input_dir: 'WooCommerce/Resources', allow_retry: true)
+    ios_bump_version_beta
 
     # Wrap up
     version = ios_get_app_version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,10 +89,11 @@ platform :ios do
 
     ios_bump_version_release
     new_version = ios_get_app_version
-    extract_release_notes_for_version(version: new_version,
-                                      release_notes_file_path: 'RELEASE-NOTES.txt',
-                                      extracted_notes_file_path: File.join('WooCommerce',
-                                                                           'Resources', 'release_notes.txt'))
+    extract_release_notes_for_version(
+      version: new_version,
+      release_notes_file_path: 'RELEASE-NOTES.txt',
+      extracted_notes_file_path: File.join('WooCommerce', 'Resources', 'release_notes.txt')
+    )
     ios_update_release_notes(new_version: new_version)
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version,
                  report_path: File.join(File.expand_path('~'), "wcios_prs_list_#{old_version}_#{new_version}.txt"))
@@ -135,11 +136,11 @@ platform :ios do
   #####################################################################################
   desc 'Updates the AppStoreStrings.pot file with the latest data'
   lane :update_appstore_strings do |options|
-    prj_folder = Pathname.new(File.join(Dir.pwd, '..')).expand_path.to_s
-    source_metadata_folder = File.join(prj_folder, 'fastlane/appstoreres/metadata/source')
+    project_root = File.dirname(File.expand_path(__dir__))
+    source_metadata_folder = File.join(project_root, 'fastlane', 'appstoreres', 'metadata', 'source')
 
     files = {
-      whats_new: File.join(prj_folder, '/WooCommerce/Resources/release_notes.txt'),
+      whats_new: File.join(project_root, 'WooCommerce', 'Resources', 'release_notes.txt'),
       app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
       app_store_desc: File.join(source_metadata_folder, 'description.txt'),
       app_store_keywords: File.join(source_metadata_folder, 'keywords.txt'),
@@ -151,9 +152,11 @@ platform :ios do
       'app_store_screenshot-5' => File.join(source_metadata_folder, 'promo_screenshot_5.txt')
     }
 
-    ios_update_metadata_source(po_file_path: prj_folder + '/WooCommerce/Resources/AppStoreStrings.pot',
-                               source_files: files,
-                               release_version: options[:version])
+    ios_update_metadata_source(
+      po_file_path: File.join(project_root, 'WooCommerce', 'Resources', 'AppStoreStrings.pot'),
+      source_files: files,
+      release_version: options[:version]
+    )
   end
 
   #####################################################################################


### PR DESCRIPTION
Part of the paaHJt-1WQ-p2 project.

_Note: In the case of WCiOS, not much has been changed on the hotfix lanes as part of this PR (except the lane's description to make them more descriptive), but as part of this project, it's still worth going through the test scenario below to ensure that hotfix were already working as expected (and didn't break in the past but got unnoticed)_

## To test

 - Checkout this branch, run `bundle install`
 - Run `bundle exec fastlane new_hotfix_release version:7.0.1`
 - Verify that it cut a `release/7.0.1` branch from the `7.0` tag
 - Verify that it bumped the version in `Version.internal.xcconfig`, `Version.public.xcconfig` and `fastlane/Deliverfile` (*)
 - cherry-pick all the commits from this PR on top of the `release/7.0.1` branch. This is because we are gonna test the updated finalize lanes, and need to be on the hotfix release branch to test them. (You might get conflicts during the cherry-pick)
 - [Open the CircleCI page for WCiOS](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios) in advance, to be ready to cancel the release build
 - Run `bundle exec fastlane finalize_release`. You should get an error telling you that you should use `finalize_hotfix_release` for hotfix branches instead
 - Run `bundle exec fastlane finalize_hotfix_release` and verify that it triggered a release build, and that is is building it from the release/7.0.1 hotfix branch. Cancel the CI build immediately.
 - Delete the `release/7.0.1` branch (from both local and remote)

## A note on Deliverfile bump

@mokagio is working on removing the `Deliverfile` – see https://github.com/wordpress-mobile/release-toolkit/pull/287 – in our repos, to run `deliver` as part of a lane to which we'll explicitly pass the right parameters, including the version, hence the bump not needing to change the app version in `Deliverfile` anymore in the future.

This means that once @mokagio's work lands, the hotfix lanes will need to be amended again, to specify that the `Deliverfile` should not be updated as part of any version bump… including hotfix ones. This work will be done separately to the hotfix alignment work from this PR, to avoid postponing things too much and blocking the project.