### PR TITLE
Errors: Banner message for error loading data on My Store dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 7.3
 -----
 - [*] Order Detail: now we do not offer the "email note to customer" option if no email is available. [https://github.com/woocommerce/woocommerce-ios/pull/4680]
+- [*] My Store: If there are errors loading the My Store screen, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4704]
 
 7.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -53,7 +53,7 @@ final class DashboardViewController: UIViewController {
 
     /// A stack view for views displayed between the navigation bar and content (e.g. store name subtitle, top banner)
     ///
-    private lazy var stackView: UIStackView = {
+    private lazy var headerStackView: UIStackView = {
         let view = UIStackView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .listForeground
@@ -79,6 +79,8 @@ final class DashboardViewController: UIViewController {
                                               })
     }()
 
+    /// A spacer view to add a margin below the top banner (between the banner and dashboard UI)
+    ///
     private lazy var spacerView: UIView = {
         let view = UIView()
         view.heightAnchor.constraint(equalToConstant: Constants.bannerBottomMargin).isActive = true
@@ -149,12 +151,12 @@ private extension DashboardViewController {
         }
         storeNameLabel.text = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
         innerStackView.addArrangedSubview(storeNameLabel)
-        stackView.addArrangedSubview(innerStackView)
-        containerView.addSubview(stackView)
+        headerStackView.addArrangedSubview(innerStackView)
+        containerView.addSubview(headerStackView)
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            headerStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            headerStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            headerStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
         ])
     }
 
@@ -164,7 +166,7 @@ private extension DashboardViewController {
         }
         contentView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor),
+            contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor),
             contentView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
@@ -218,16 +220,16 @@ private extension DashboardViewController {
         guard let dashboardUI = dashboardUI else {
             return
         }
-        stackView.addArrangedSubview(topBannerView)
-        stackView.addArrangedSubview(spacerView)
+        headerStackView.addArrangedSubview(topBannerView)
+        headerStackView.addArrangedSubview(spacerView)
         if !shouldShowStoreNameAsSubtitle {
-            containerView.addSubview(stackView)
+            containerView.addSubview(headerStackView)
             dashboardUI.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-                stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                dashboardUI.view.topAnchor.constraint(equalTo: stackView.bottomAnchor),
+                headerStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                headerStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                headerStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                dashboardUI.view.topAnchor.constraint(equalTo: headerStackView.bottomAnchor),
                 dashboardUI.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 dashboardUI.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
                 dashboardUI.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
@@ -253,8 +255,8 @@ extension DashboardViewController: DashboardUIScrollDelegate {
         guard shouldShowStoreNameAsSubtitle else {
             return
         }
-        storeNameLabel.isHidden = offset > stackView.frame.height
-        if offset < -stackView.frame.height {
+        storeNameLabel.isHidden = offset > headerStackView.frame.height
+        if offset < -headerStackView.frame.height {
             UIView.transition(with: storeNameLabel, duration: Constants.animationDuration,
                               options: .showHideTransitionViews,
                               animations: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -297,7 +297,7 @@ private extension DashboardViewController {
             self?.hideTopBannerView()
             self?.pullToRefresh()
         }
-        updatedDashboardUI.displaySyncingErrorNotice = { [weak self] in
+        updatedDashboardUI.displaySyncingError = { [weak self] in
             self?.showTopBannerView()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Gridicons
 import WordPressUI
 import Yosemite
+import SafariServices.SFSafariViewController
 
 
 // MARK: - DashboardViewController
@@ -52,6 +53,21 @@ final class DashboardViewController: UIViewController {
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
     private let hiddenScrollView = UIScrollView()
+
+    /// Top banner that shows an error if there is a problem loading data
+    ///
+    private lazy var topBannerView = {
+        ErrorTopBannerFactory.createTopBanner(isExpanded: false,
+                                              expandedStateChangeHandler: {},
+                                              onTroubleshootButtonPressed: { [weak self] in
+                                                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+                                                self?.present(safariViewController, animated: true, completion: nil)
+                                              },
+                                              onContactSupportButtonPressed: { [weak self] in
+                                                guard let self = self else { return }
+                                                ZendeskManager.shared.showNewRequestIfPossible(from: self, with: nil)
+                                              })
+    }()
 
     // MARK: View Lifecycle
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -48,7 +48,7 @@ final class DashboardViewController: UIViewController {
     ///
     private lazy var innerStackView: UIStackView = {
         let view = UIStackView()
-        view.layoutMargins = UIEdgeInsets(top: 0, left: navigationController?.navigationBar.directionalLayoutMargins.leading ?? 0, bottom: 0, right: 0)
+        view.layoutMargins = UIEdgeInsets(top: 0, left: Constants.leadingMargin, bottom: 0, right: 0)
         view.isLayoutMarginsRelativeArrangement = true
         return view
     }()
@@ -148,8 +148,8 @@ private extension DashboardViewController {
         containerView.addSubview(stackView)
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: containerView.layoutMarginsGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: containerView.layoutMarginsGuide.trailingAnchor)
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
         ])
     }
 
@@ -347,5 +347,6 @@ private extension DashboardViewController {
     enum Constants {
         static let animationDuration = 0.2
         static let bannerBottomMargin = CGFloat(8)
+        static let leadingMargin = CGFloat(16)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -46,7 +46,7 @@ final class DashboardViewController: UIViewController {
     ///
     private lazy var innerStackView: UIStackView = {
         let view = UIStackView()
-        view.layoutMargins = UIEdgeInsets(top: 0, left: Constants.leadingMargin, bottom: 0, right: 0)
+        view.layoutMargins = UIEdgeInsets(top: 0, left: Constants.horizontalMargin, bottom: 0, right: Constants.horizontalMargin)
         view.isLayoutMarginsRelativeArrangement = true
         return view
     }()
@@ -352,6 +352,6 @@ private extension DashboardViewController {
     enum Constants {
         static let animationDuration = 0.2
         static let bannerBottomMargin = CGFloat(8)
-        static let leadingMargin = CGFloat(16)
+        static let horizontalMargin = CGFloat(16)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -31,9 +31,7 @@ final class DashboardViewController: UIViewController {
     // MARK: Subviews
 
     private lazy var containerView: UIView = {
-        let container = UIView(frame: .zero)
-        container.backgroundColor = .listBackground
-        return container
+        return UIView(frame: .zero)
     }()
 
     private lazy var storeNameLabel: UILabel = {
@@ -44,7 +42,7 @@ final class DashboardViewController: UIViewController {
         return label
     }()
 
-    /// A stack view to hold `storeNameLabel`
+    /// A stack view to display `storeNameLabel` with additional margins
     ///
     private lazy var innerStackView: UIStackView = {
         let view = UIStackView()
@@ -53,7 +51,7 @@ final class DashboardViewController: UIViewController {
         return view
     }()
 
-    /// A stack view to hold `storeNameLabel` and `topBannerView`, as needed
+    /// A stack view for views displayed between the navigation bar and content (e.g. store name subtitle, top banner)
     ///
     private lazy var stackView: UIStackView = {
         let view = UIStackView()
@@ -81,10 +79,11 @@ final class DashboardViewController: UIViewController {
                                               })
     }()
 
-    /// Top anchor constraint for Dashboard UI. Can be updated e.g. to change the margin between the stack view and dashboard UI.
-    ///
-    private lazy var dashboardUITopAnchor: NSLayoutConstraint = {
-        dashboardUI!.view.topAnchor.constraint(equalTo: stackView.bottomAnchor)
+    private lazy var spacerView: UIView = {
+        let view = UIView()
+        view.heightAnchor.constraint(equalToConstant: Constants.bannerBottomMargin).isActive = true
+        view.backgroundColor = .listBackground
+        return view
     }()
 
     // MARK: View Lifecycle
@@ -165,7 +164,7 @@ private extension DashboardViewController {
         }
         contentView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            dashboardUITopAnchor,
+            contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor),
             contentView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
@@ -220,6 +219,7 @@ private extension DashboardViewController {
             return
         }
         stackView.addArrangedSubview(topBannerView)
+        stackView.addArrangedSubview(spacerView)
         if !shouldShowStoreNameAsSubtitle {
             containerView.addSubview(stackView)
             dashboardUI.view.translatesAutoresizingMaskIntoConstraints = false
@@ -227,20 +227,19 @@ private extension DashboardViewController {
                 stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
                 stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                dashboardUITopAnchor,
+                dashboardUI.view.topAnchor.constraint(equalTo: stackView.bottomAnchor),
                 dashboardUI.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 dashboardUI.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
                 dashboardUI.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ])
         }
-        dashboardUITopAnchor.constant = Constants.bannerBottomMargin
     }
 
     /// Hide the error banner
     ///
     func hideTopBannerView() {
         topBannerView.removeFromSuperview()
-        dashboardUITopAnchor.constant = CGFloat(0)
+        spacerView.removeFromSuperview()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -322,17 +322,6 @@ private extension DashboardViewController {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
         reloadDashboardUIStatsVersion(forced: true)
     }
-
-    func displaySyncingErrorNotice() {
-        let title = NSLocalizedString("My store", comment: "My Store Notice Title for loading error")
-        let message = NSLocalizedString("Unable to load content", comment: "Load Action Failed")
-        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
-        let notice = Notice(title: title, message: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
-            self?.reloadData(forced: true)
-        }
-
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
-    }
 }
 
 // MARK: - Private Helpers

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -229,7 +229,7 @@ private extension DashboardViewController {
                 contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ])
         }
-        contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 8).isActive = true
+        contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.bannerBottomMargin).isActive = true
     }
 
     /// Hide the error banner
@@ -346,5 +346,6 @@ private extension DashboardViewController {
 
     enum Constants {
         static let animationDuration = 0.2
+        static let bannerBottomMargin = CGFloat(8)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -81,6 +81,12 @@ final class DashboardViewController: UIViewController {
                                               })
     }()
 
+    /// Top anchor constraint for Dashboard UI. Can be updated e.g. to change the margin between the stack view and dashboard UI.
+    ///
+    private lazy var dashboardUITopAnchor: NSLayoutConstraint = {
+        dashboardUI!.view.topAnchor.constraint(equalTo: stackView.bottomAnchor)
+    }()
+
     // MARK: View Lifecycle
 
     init(siteID: Int64) {
@@ -158,11 +164,8 @@ private extension DashboardViewController {
             return
         }
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        // Set the top anchor constraint as non-required so additional space can be added when the top banner is displayed
-        let topAnchorConstraint = contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor)
-        topAnchorConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
-            topAnchorConstraint,
+            dashboardUITopAnchor,
             contentView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
@@ -213,30 +216,31 @@ private extension DashboardViewController {
     /// Display the error banner at the top of the dashboard content (below the site title)
     ///
     func showTopBannerView() {
-        guard let dashboardUI = dashboardUI, let contentView = dashboardUI.view else {
+        guard let dashboardUI = dashboardUI else {
             return
         }
         stackView.addArrangedSubview(topBannerView)
         if !shouldShowStoreNameAsSubtitle {
             containerView.addSubview(stackView)
-            contentView.translatesAutoresizingMaskIntoConstraints = false
+            dashboardUI.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
                 stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                contentView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-                contentView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                contentView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+                dashboardUITopAnchor,
+                dashboardUI.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                dashboardUI.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                dashboardUI.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ])
         }
-        contentView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.bannerBottomMargin).isActive = true
+        dashboardUITopAnchor.constant = Constants.bannerBottomMargin
     }
 
     /// Hide the error banner
     ///
     func hideTopBannerView() {
-        dashboardUI?.view.topAnchor.constraint(equalTo: stackView.bottomAnchor).isActive = true
         topBannerView.removeFromSuperview()
+        dashboardUITopAnchor.constant = CGFloat(0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -131,7 +131,7 @@ private extension DashboardViewController {
 
     func configureNavigation() {
         configureTitle()
-        configureSubtitle()
+        configureHeaderStackView()
         configureNavigationItem()
     }
 
@@ -145,13 +145,9 @@ private extension DashboardViewController {
         navigationItem.title = titleName
     }
 
-    func configureSubtitle() {
-        guard shouldShowStoreNameAsSubtitle else {
-            return
-        }
-        storeNameLabel.text = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
-        innerStackView.addArrangedSubview(storeNameLabel)
-        headerStackView.addArrangedSubview(innerStackView)
+    func configureHeaderStackView() {
+        configureSubtitle()
+        configureErrorBanner()
         containerView.addSubview(headerStackView)
         NSLayoutConstraint.activate([
             headerStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
@@ -160,10 +156,23 @@ private extension DashboardViewController {
         ])
     }
 
-    func addViewBellowSubtitle(contentView: UIView) {
+    func configureSubtitle() {
         guard shouldShowStoreNameAsSubtitle else {
             return
         }
+        storeNameLabel.text = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
+        innerStackView.addArrangedSubview(storeNameLabel)
+        headerStackView.addArrangedSubview(innerStackView)
+    }
+
+    func configureErrorBanner() {
+        headerStackView.addArrangedSubviews([topBannerView, spacerView])
+        // Don't show the error banner subviews until they are needed
+        topBannerView.isHidden = true
+        spacerView.isHidden = true
+    }
+
+    func addViewBelowHeaderStackView(contentView: UIView) {
         contentView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor),
@@ -217,31 +226,15 @@ private extension DashboardViewController {
     /// Display the error banner at the top of the dashboard content (below the site title)
     ///
     func showTopBannerView() {
-        guard let dashboardUI = dashboardUI else {
-            return
-        }
-        headerStackView.addArrangedSubview(topBannerView)
-        headerStackView.addArrangedSubview(spacerView)
-        if !shouldShowStoreNameAsSubtitle {
-            containerView.addSubview(headerStackView)
-            dashboardUI.view.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                headerStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                headerStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-                headerStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                dashboardUI.view.topAnchor.constraint(equalTo: headerStackView.bottomAnchor),
-                dashboardUI.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-                dashboardUI.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                dashboardUI.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
-            ])
-        }
+        topBannerView.isHidden = false
+        spacerView.isHidden = false
     }
 
     /// Hide the error banner
     ///
     func hideTopBannerView() {
-        topBannerView.removeFromSuperview()
-        spacerView.removeFromSuperview()
+        topBannerView.isHidden = true
+        spacerView.isHidden = true
     }
 }
 
@@ -295,7 +288,7 @@ private extension DashboardViewController {
         addChild(updatedDashboardUI)
         containerView.addSubview(contentView)
         updatedDashboardUI.didMove(toParent: self)
-        addViewBellowSubtitle(contentView: contentView)
+        addViewBelowHeaderStackView(contentView: contentView)
 
         updatedDashboardUI.onPullToRefresh = { [weak self] in
             self?.pullToRefresh()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -274,6 +274,9 @@ private extension DashboardViewController {
             reloadData(forced: forced)
         }
 
+        // Optimistically hide the error banner any time the dashboard UI updates (not just pull to refresh)
+        hideTopBannerView()
+
         // No need to continue replacing the dashboard UI child view controller if the updated dashboard UI is the same as the currently displayed one.
         guard dashboardUI !== updatedDashboardUI else {
             return
@@ -293,7 +296,6 @@ private extension DashboardViewController {
         addViewBellowSubtitle(contentView: contentView)
 
         updatedDashboardUI.onPullToRefresh = { [weak self] in
-            self?.hideTopBannerView()
             self?.pullToRefresh()
         }
         updatedDashboardUI.displaySyncingError = { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -9,7 +9,7 @@ protocol DashboardUI: UIViewController {
     var scrollDelegate: DashboardUIScrollDelegate? { get set }
 
     /// Called when the Dashboard should display syncing error
-    var displaySyncingErrorNotice: () -> Void { get set }
+    var displaySyncingError: () -> Void { get set }
 
     /// Called when the user pulls to refresh
     var onPullToRefresh: () -> Void { get set }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -45,7 +45,7 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
 // Everything is empty as this deprecated stats screen is static
 extension DeprecatedDashboardStatsViewController: DashboardUI {
 
-    var displaySyncingErrorNotice: () -> Void {
+    var displaySyncingError: () -> Void {
         get {
             return {}
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -11,7 +11,7 @@ final class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripView
 
     // MARK: - DashboardUI protocol
 
-    var displaySyncingErrorNotice: () -> Void = {}
+    var displaySyncingError: () -> Void = {}
 
     var onPullToRefresh: () -> Void = {}
 
@@ -412,7 +412,7 @@ private extension StoreStatsAndTopPerformersViewController {
         case .statsModuleDisabled, .noPermission:
             showSiteVisitors(false)
         default:
-            displaySyncingErrorNotice()
+            displaySyncingError()
         }
     }
 
@@ -421,7 +421,7 @@ private extension StoreStatsAndTopPerformersViewController {
         case let siteVisitStatsStoreError as SiteVisitStatsStoreError:
             handleSiteVisitStatsStoreError(error: siteVisitStatsStoreError)
         default:
-            displaySyncingErrorNotice()
+            displaySyncingError()
         }
     }
 }


### PR DESCRIPTION
Resolves: #4382

## Description

To improve our error states, we are introducing a top banner that can be used whenever there is a problem loading data. The banner is collapsed by default and on select, users can read our troubleshooting tips or contact support directly.

This PR sets up the banner and adds it to the top of the My Store screen. (This banner replaces the "Unable to load content" notice we displayed before.)

## Changes

* Adds the error banner to `DashboardViewController`. A quick overview of the changes there:
   * Currently we display the store name in a stack view at the top of the screen, as long as `shouldShowStoreNameAsSubtitle` is `true`. The store name is now embedded inside another stack view, to retain its leading margin. (That margin is now defined with a constant equivalent to the margins it had before.)
   * If `shouldShowStoreNameAsSubtitle` is `false`, the stack view is added when the banner is displayed, with all necessary constraints. (Those constraints are otherwise set when the subtitle is configured and the dashboard UI is added below it).
* The error banner is displayed when there is a syncing error, and hidden when the screen refreshes.

My Store - no errors | My Store - error banner collapsed | My Store - error banner expanded
-|-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-07-30 at 13 14 40](https://user-images.githubusercontent.com/8658164/127675617-8a24f76e-86af-405b-8adc-ef395697235c.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-30 at 13 14 49](https://user-images.githubusercontent.com/8658164/127675635-0d682ff9-3278-4675-9727-10eb464c8a86.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-07-30 at 13 14 51](https://user-images.githubusercontent.com/8658164/127675642-01366d0f-695a-4909-81ee-00b6357665d5.png)


## Testing

1. Build and run the app.
2. Disconnect your internet connection. (This is so you will trigger a sync error; you can also disrupt your store's Jetpack connection for a more realistic scenario.)
3. Pull to refresh the My Store screen.
4. Notice the error banner appears at the top of the screen, below your store name, and remains on screen when you scroll.
5. Reconnect to the internet.
6. Expand the banner and confirm the "Troubleshoot" button opens a troubleshooting doc, and "Contact support" opens a new support ticket in the app.
7. Pull to refresh or navigate to another tab and back to refresh the My Store screen. Notice the error banner disappears on refresh.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
