### PR TITLE
Upgrade WordPressShared 1.15.0 -> 1.16.1

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.4)
     - WordPressShared (~> 1.15-beta)
     - wpxmlrpc (~> 0.9)
-  - WordPressShared (1.15.0):
+  - WordPressShared (1.16.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.12.1)
@@ -117,7 +117,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressShared
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -145,6 +144,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - Wormholy
     - WPMediaPicker
@@ -186,7 +186,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 4ccd7f41bae37247883922ad92a14f18cc759bf3
   WordPressKit: bd2386909067b48b5525569cefac206bc4234eb5
-  WordPressShared: e1915cf3b4ac33f41c47610693b9ca30c0cdab45
+  WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
   WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2


### PR DESCRIPTION
## Description

WordPressShared is one of dependencies holding us back from native Apple Silicon compatibility.
Apple Silicon compatibility for the lib landed in version 1.16.0 - https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/285

This PR upgrades it from 1.15.0 to 1.16.1 (latest version).

Changelog:
- https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/290
- https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/285
- https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/291
- https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/294

## Test

Since only functional change is related to fonts scaling - check:
1. In normal font size (no adjustment)
2. In largest possible accessibility font size

And make sure all labels look good.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
