### PR TITLE
Added 'Product saved' confirmation message when a product is updated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Order Detail: now we do not offer the "email note to customer" option if no email is available. [https://github.com/woocommerce/woocommerce-ios/pull/4680]
 - [internal] Upgraded Zendesk SDK to version 5.3.0 [https://github.com/woocommerce/woocommerce-ios/pull/4699]
+- [*] Fix: Added 'Product saved' confirmation message when a product is updated [https://github.com/woocommerce/woocommerce-ios/pull/4709]
 
 7.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -121,7 +121,6 @@ private enum Localization {
         // Product saved or updated
         static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
                                                                            comment: "Title of the alert when a user is saving a product")
-        
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -41,7 +41,7 @@ extension ProductFormViewController {
             noticePresenter.presentingViewController = self
             return noticePresenter
         }()
-        contextNoticePresenter.enqueue(notice: .init(title: Localization.Alert.productSavedConfirmationTitle))
+        contextNoticePresenter.enqueue(notice: .init(title: Localization.Alert.presentProductConfirmationSaveAlert))
     }
     /// Product Confirmation Delete alert
     ///
@@ -112,14 +112,14 @@ private extension ProductFormViewController {
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
         inProgressViewController.modalPresentationStyle = .overCurrentContext
 
-        navigationController?.present(inProgressViewController, animated: true, completion: presentProductConfirmationSaveAlert)
+        navigationController?.present(inProgressViewController, animated: true, completion: nil)
     }
 }
 
 private enum Localization {
     enum Alert {
         // Product saved or updated
-        static let productSavedConfirmationTitle = NSLocalizedString("Product saved",
+        static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
         comment: "Title of the alert when a user is saving a product")
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -120,7 +120,8 @@ private enum Localization {
     enum Alert {
         // Product saved or updated
         static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
-        comment: "Title of the alert when a user is saving a product")
+                                                                           comment: "Title of the alert when a user is saving a product")
+        
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -33,7 +33,18 @@ extension ProductFormViewController {
         alertController.addAction(confirm)
         present(alertController, animated: true)
     }
-
+    
+    /// Product Confirmation Save alert
+    ///
+    func presentProductConfirmationSaveAlert() {
+        let contextNoticePresenter: NoticePresenter = {
+            let noticePresenter = DefaultNoticePresenter()
+            noticePresenter.presentingViewController = self
+            return noticePresenter
+        }()
+        contextNoticePresenter.enqueue(notice: .init(title: Localization.Alert.productSavedConfirmationTitle))
+    }
+    
     /// Product Confirmation Delete alert
     ///
     func presentProductConfirmationDeleteAlert(completion: @escaping (_ isConfirmed: Bool) -> ()) {
@@ -103,12 +114,16 @@ private extension ProductFormViewController {
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
         inProgressViewController.modalPresentationStyle = .overCurrentContext
 
-        navigationController?.present(inProgressViewController, animated: true, completion: nil)
+        navigationController?.present(inProgressViewController, animated: true, completion: presentProductConfirmationSaveAlert)
     }
 }
 
 private enum Localization {
     enum Alert {
+        // Product saved or updated
+        static let productSavedConfirmationTitle = NSLocalizedString("Product saved",
+        comment: "Title of the alert when a user is saving a product")
+        
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -33,7 +33,6 @@ extension ProductFormViewController {
         alertController.addAction(confirm)
         present(alertController, animated: true)
     }
-    
     /// Product Confirmation Save alert
     ///
     func presentProductConfirmationSaveAlert() {
@@ -44,7 +43,6 @@ extension ProductFormViewController {
         }()
         contextNoticePresenter.enqueue(notice: .init(title: Localization.Alert.productSavedConfirmationTitle))
     }
-    
     /// Product Confirmation Delete alert
     ///
     func presentProductConfirmationDeleteAlert(completion: @escaping (_ isConfirmed: Bool) -> ()) {
@@ -123,7 +121,6 @@ private enum Localization {
         // Product saved or updated
         static let productSavedConfirmationTitle = NSLocalizedString("Product saved",
         comment: "Title of the alert when a user is saving a product")
-        
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -607,7 +607,6 @@ private extension ProductFormViewController {
         let messageType = viewModel.saveMessageType(for: productStatus)
         showSavingProgress(messageType)
         saveImagesAndProductRemotely(status: status)
-        presentProductConfirmationSaveAlert()
     }
 
     func saveImagesAndProductRemotely(status: ProductStatus?) {
@@ -660,8 +659,9 @@ private extension ProductFormViewController {
                     self?.displayError(error: error)
                 }
             case .success:
-                // Dismisses the in-progress UI.
+                // Dismisses the in-progress UI, then presents the confirmation alert.
                 self?.navigationController?.dismiss(animated: true, completion: nil)
+                self?.presentProductConfirmationSaveAlert()
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -606,8 +606,8 @@ private extension ProductFormViewController {
         let productStatus = status ?? product.status
         let messageType = viewModel.saveMessageType(for: productStatus)
         showSavingProgress(messageType)
-
         saveImagesAndProductRemotely(status: status)
+        presentProductConfirmationSaveAlert()
     }
 
     func saveImagesAndProductRemotely(status: ProductStatus?) {


### PR DESCRIPTION
Fixes #4545 

# Description
This PR adds a confirmation message after a product has been successfully saved or updated.

# Changes
I have added a new helper function to  the `ProductFormViewController` extension. This gets called after a product is saved and updated, triggering a "snackbar-style" confirmation message with the text "Product Saved" at the bottom of the screen.

Portrait:

![fix-4545-alert](https://user-images.githubusercontent.com/3812076/127767370-cbc1491c-e84e-432f-9466-1f2ebd8d7a58.gif)

Landscape:

<img width="707" alt="Screenshot 2021-08-02 at 12 21 45" src="https://user-images.githubusercontent.com/3812076/127808130-25acb194-00f0-41c6-b37a-d8f9c52ced07.png">


The notice will appear in the following cases:
* A new product is created, and saved as a `published`, `draft`, or `pending review`.
* An existing product is updated.

The notice will not appear in the following cases:
* A product is deleted.

# Testing steps
1 - Go to Products > Tap on any existing product, or create a new one.
2 - Make any change.
3 - Tap `Save`.
4 - An alert "Snackbar-type" confirmation message saying “Product saved” should appear in the bottom and disappear after 5 seconds ( or upon tapping anywhere on screen ).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
