### PR TITLE
Shipping Labels: Require phone number for international shipping

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -415,8 +415,10 @@ private extension ShippingLabelAddressFormViewController {
             errorMessage = Localization.missingState
         case .country:
             errorMessage = Localization.missingCountry
-        case .phoneNumber:
+        case .missingPhoneNumber:
             errorMessage = Localization.missingPhoneNumber
+        case .invalidPhoneNumber:
+            errorMessage = Localization.invalidPhoneNumber
         }
 
         cell.textLabel?.text = errorMessage
@@ -562,8 +564,11 @@ private extension ShippingLabelAddressFormViewController {
         static let missingCountry = NSLocalizedString("Country missing",
                                                       comment: "Error showed in Shipping Label Address Validation for the country field")
         static let missingPhoneNumber = NSLocalizedString("A phone number is required because this shipment requires a customs form",
-                                                          comment: "Error showed in Shipping Label Origin Address Validation for the " +
+                                                          comment: "Error shown in Shipping Label Origin Address validation for " +
                                                           "phone number field for international shipment")
+        static let invalidPhoneNumber = NSLocalizedString("Custom forms require a 10-digit phone number",
+                                                          comment: "Error shown in Shipping Label Origin Address validation for " +
+                                                            "phone number when the it doesn't have expected length for international shipment.")
         static let appleMapsErrorNotice = NSLocalizedString("Error in finding the address in Apple Maps",
                                                             comment: "Error in finding the address in the Shipping Label Address Validation in Apple Maps")
         static let phoneNumberErrorNotice = NSLocalizedString("The phone number is not valid or you can't call the customer from this device.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -60,10 +60,16 @@ final class ShippingLabelAddressFormViewController: UIViewController {
     init(siteID: Int64,
          type: ShipType,
          address: ShippingLabelAddress?,
+         phoneNumberRequired: Bool = false,
          validationError: ShippingLabelAddressValidationError?,
          countries: [Country],
          completion: @escaping Completion ) {
-        viewModel = ShippingLabelAddressFormViewModel(siteID: siteID, type: type, address: address, validationError: validationError, countries: countries)
+        viewModel = ShippingLabelAddressFormViewModel(siteID: siteID,
+                                                      type: type,
+                                                      address: address,
+                                                      phoneNumberRequired: phoneNumberRequired,
+                                                      validationError: validationError,
+                                                      countries: countries)
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
         switch type {
@@ -357,9 +363,10 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func configurePhone(cell: TitleAndTextFieldTableViewCell, row: Row) {
+        let placeholder = viewModel.phoneNumberRequired ? Localization.phoneFieldPlaceholderRequired : Localization.phoneFieldPlaceholder
         let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.phoneField,
                                                                      text: viewModel.address?.phone,
-                                                                     placeholder: Localization.phoneFieldPlaceholder,
+                                                                     placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .phonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
@@ -408,10 +415,13 @@ private extension ShippingLabelAddressFormViewController {
             errorMessage = Localization.missingState
         case .country:
             errorMessage = Localization.missingCountry
+        case .phoneNumber:
+            errorMessage = Localization.missingPhoneNumber
         }
 
         cell.textLabel?.text = errorMessage
         cell.textLabel?.textColor = .error
+        cell.textLabel?.numberOfLines = 0
         cell.backgroundColor = .listBackground
     }
 
@@ -517,6 +527,9 @@ private extension ShippingLabelAddressFormViewController {
         static let companyFieldPlaceholder = NSLocalizedString("Optional", comment: "Text field placeholder in Shipping Label Address Validation")
         static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Shipping Label Address Validation")
         static let phoneFieldPlaceholder = NSLocalizedString("Optional", comment: "Text field placeholder in Shipping Label Address Validation")
+        static let phoneFieldPlaceholderRequired = NSLocalizedString("Required",
+                                                                     comment: "Text field placeholder in Shipping Label Address Validation " +
+                                                                     "when phone number is required")
         static let addressField = NSLocalizedString("Address", comment: "Text field address in Shipping Label Address Validation")
         static let addressFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
         static let address2Field = NSLocalizedString("Address 2", comment: "Text field address 2 in Shipping Label Address Validation")
@@ -548,6 +561,9 @@ private extension ShippingLabelAddressFormViewController {
                                                     comment: "Error showed in Shipping Label Address Validation for the state field")
         static let missingCountry = NSLocalizedString("Country missing",
                                                       comment: "Error showed in Shipping Label Address Validation for the country field")
+        static let missingPhoneNumber = NSLocalizedString("A phone number is required because this shipment requires a customs form",
+                                                          comment: "Error showed in Shipping Label Origin Address Validation for the " +
+                                                          "phone number field for international shipment")
         static let appleMapsErrorNotice = NSLocalizedString("Error in finding the address in Apple Maps",
                                                             comment: "Error in finding the address in the Shipping Label Address Validation in Apple Maps")
         static let phoneNumberErrorNotice = NSLocalizedString("The phone number is not valid or you can't call the customer from this device.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -370,7 +370,8 @@ private extension ShippingLabelAddressFormViewController {
                                                                      state: .normal,
                                                                      keyboardType: .phonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
-            self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
+            let phone = newText?.filter { $0.isNumber }
+            self?.viewModel.handleAddressValueChanges(row: row, newValue: phone)
         }
         cell.configure(viewModel: cellViewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -370,7 +370,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      state: .normal,
                                                                      keyboardType: .phonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
-            let phone = newText?.filter { $0.isNumber }
+            let phone = newText?.filter { "0"..."9" ~= $0 }
             self?.viewModel.handleAddressValueChanges(row: row, newValue: phone)
         }
         cell.configure(viewModel: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -20,7 +20,7 @@ final class ShippingLabelAddressFormViewModel {
     private(set) var address: ShippingLabelAddress?
     private(set) var addressValidationError: ShippingLabelAddressValidationError?
     private(set) var addressValidated: Validation = .none
-    private let phoneNumberRequired: Bool
+    private(set) var phoneNumberRequired: Bool
 
     private let stores: StoresManager
 
@@ -69,7 +69,7 @@ final class ShippingLabelAddressFormViewModel {
         siteID: Int64,
         type: ShipType,
         address: ShippingLabelAddress?,
-        phoneNumberRequired: Bool = false,
+        phoneNumberRequired: Bool,
         stores: StoresManager = ServiceLocator.stores,
         validationError: ShippingLabelAddressValidationError?,
         countries: [Country]
@@ -145,6 +145,11 @@ final class ShippingLabelAddressFormViewModel {
         if localErrors.contains(.country) {
             if let index = rows.firstIndex(where: { $0 == .country }) {
                 rows.insert(.fieldError(.country), at: rows.index(after: index))
+            }
+        }
+        if localErrors.contains(.phoneNumber) {
+            if let index = rows.firstIndex(where: { $0 == .phone }) {
+                rows.insert(.fieldError(.phoneNumber), at: rows.index(after: index))
             }
         }
         sections = [Section(rows: rows)]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -20,6 +20,7 @@ final class ShippingLabelAddressFormViewModel {
     private(set) var address: ShippingLabelAddress?
     private(set) var addressValidationError: ShippingLabelAddressValidationError?
     private(set) var addressValidated: Validation = .none
+    private let phoneNumberRequired: Bool
 
     private let stores: StoresManager
 
@@ -68,6 +69,7 @@ final class ShippingLabelAddressFormViewModel {
         siteID: Int64,
         type: ShipType,
         address: ShippingLabelAddress?,
+        phoneNumberRequired: Bool = false,
         stores: StoresManager = ServiceLocator.stores,
         validationError: ShippingLabelAddressValidationError?,
         countries: [Country]
@@ -75,6 +77,7 @@ final class ShippingLabelAddressFormViewModel {
         self.siteID = siteID
         self.type = type
         self.address = address
+        self.phoneNumberRequired = phoneNumberRequired
         self.stores = stores
         if let validationError = validationError {
             addressValidationError = validationError
@@ -165,6 +168,7 @@ extension ShippingLabelAddressFormViewModel {
         case postcode
         case state
         case country
+        case phoneNumber
     }
 
     private func validateAddressLocally() -> [ValidationError] {
@@ -188,6 +192,9 @@ extension ShippingLabelAddressFormViewModel {
             }
             if addressToBeValidated.country.isEmpty {
                 errors.append(.country)
+            }
+            if addressToBeValidated.phone.isEmpty && phoneNumberRequired {
+                errors.append(.phoneNumber)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -69,7 +69,7 @@ final class ShippingLabelAddressFormViewModel {
         siteID: Int64,
         type: ShipType,
         address: ShippingLabelAddress?,
-        phoneNumberRequired: Bool,
+        phoneNumberRequired: Bool = false,
         stores: StoresManager = ServiceLocator.stores,
         validationError: ShippingLabelAddressValidationError?,
         countries: [Country]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -339,10 +339,12 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
+        let phoneNumberRequired = type == .origin && viewModel.originAddressPhoneRequired
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,
             address: address,
+            phoneNumberRequired: phoneNumberRequired,
             validationError: validationError,
             countries: viewModel.filteredCountries(for: type),
             completion: { [weak self] (newShippingLabelAddress) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -339,7 +339,7 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
-        let phoneNumberRequired = type == .origin && viewModel.originAddressPhoneRequired
+        let phoneNumberRequired = type == .origin && viewModel.isInternationalShipping
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -339,7 +339,7 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
-        let phoneNumberRequired = type == .origin && viewModel.isInternationalShipping
+        let phoneNumberRequired = type == .origin && viewModel.customsFormRequired
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -89,9 +89,9 @@ final class ShippingLabelFormViewModel {
         resultsController.fetchedObjects
     }
 
-    /// Check for international shipping based on whether destination country is other than US.
+    /// Check for the need of customs form
     ///
-    var isInternationalShipping: Bool {
+    var customsFormRequired: Bool {
         guard let originAddress = originAddress,
               let destinationAddress = destinationAddress else {
             return false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -89,6 +89,16 @@ final class ShippingLabelFormViewModel {
         resultsController.fetchedObjects
     }
 
+    /// If whether destination country is other than US,
+    /// phone number for origin address is required.
+    ///
+    var originAddressPhoneRequired: Bool {
+        guard let destinationCountry = destinationAddress?.country else {
+            return false
+        }
+        return !Constants.destinationCountriesWithoutPhoneRequirement.contains(destinationCountry)
+    }
+
     private let stores: StoresManager
 
     private let storageManager: StorageManagerType
@@ -658,6 +668,10 @@ private extension ShippingLabelFormViewModel {
             "MH", // Marshall Islands
             "FM", // Micronesia
             "MP" // Northern Mariana Islands
+        ]
+
+        static let destinationCountriesWithoutPhoneRequirement = [
+            "US", // United States
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -89,10 +89,9 @@ final class ShippingLabelFormViewModel {
         resultsController.fetchedObjects
     }
 
-    /// If whether destination country is other than US,
-    /// phone number for origin address is required.
+    /// Check for international shipping based on whether destination country is other than US.
     ///
-    var originAddressPhoneRequired: Bool {
+    var isInternationalShipping: Bool {
         guard let destinationCountry = destinationAddress?.country else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -178,6 +178,92 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
+    func test_sections_are_returned_correctly_if_phone_is_required_and_empty() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(country: "VN")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                onCompletion(.failure(validationError))
+            default:
+                break
+            }
+        }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          phoneNumberRequired: true,
+                                                          stores: stores,
+                                                          validationError: nil,
+                                                          countries: [])
+        viewModel.validateAddress(onlyLocally: false) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
+                                                                     .company,
+                                                                     .phone,
+                                                                     .fieldError(.missingPhoneNumber),
+                                                                     .address,
+                                                                     .fieldError(.address),
+                                                                     .address2,
+                                                                     .city,
+                                                                     .fieldError(.city),
+                                                                     .postcode,
+                                                                     .fieldError(.postcode),
+                                                                     .state,
+                                                                     .country]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
+    func test_sections_are_returned_correctly_if_phone_is_required_and_invalid() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(phone: "0123", country: "VN")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                onCompletion(.failure(validationError))
+            default:
+                break
+            }
+        }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          phoneNumberRequired: true,
+                                                          stores: stores,
+                                                          validationError: nil,
+                                                          countries: [])
+        viewModel.validateAddress(onlyLocally: false) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
+                                                                     .company,
+                                                                     .phone,
+                                                                     .fieldError(.invalidPhoneNumber),
+                                                                     .address,
+                                                                     .fieldError(.address),
+                                                                     .address2,
+                                                                     .city,
+                                                                     .fieldError(.city),
+                                                                     .postcode,
+                                                                     .fieldError(.postcode),
+                                                                     .state,
+                                                                     .country]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
     func test_address_validation_returns_correct_values_if_succeeded() {
         // Given
         let shippingAddress = ShippingLabelAddress(company: "Automattic Inc.",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -418,9 +418,19 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(filteredCountries.count, 2)
     }
 
-    func test_isInternationalShipping_returns_false_for_destination_in_US() {
+    func test_customsFormRequired_returns_false_for_origin_and_destination_in_US() {
         // Given
-        let originAddress = Address.fake()
+        let originAddress = Address(firstName: "Skylar",
+                                    lastName: "Ferry",
+                                    company: "Automattic Inc.",
+                                    address1: "60 29th Street #343",
+                                    address2: nil,
+                                    city: "New York",
+                                    state: "NY",
+                                    postcode: "94121-2303",
+                                    country: "US",
+                                    phone: nil,
+                                    email: nil)
         let destinationAddress = Address(firstName: "Skylar",
                                          lastName: "Ferry",
                                          company: "Automattic Inc.",
@@ -437,12 +447,22 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
 
         // Then
-        XCTAssertFalse(viewModel.isInternationalShipping)
+        XCTAssertFalse(viewModel.customsFormRequired)
     }
 
-    func test_isInternationalShipping_returns_true_for_destination_outside_US() {
+    func test_customsFormRequired_returns_true_for_military_state_origin() {
         // Given
-        let originAddress = Address.fake()
+        let originAddress = Address(firstName: "Skylar",
+                                    lastName: "Ferry",
+                                    company: "Automattic Inc.",
+                                    address1: "60 29th Street #343",
+                                    address2: nil,
+                                    city: "Milatry City",
+                                    state: "AA",
+                                    postcode: "94121-2303",
+                                    country: "US",
+                                    phone: nil,
+                                    email: nil)
         let destinationAddress = Address(firstName: "Skylar",
                                          lastName: "Ferry",
                                          company: "Automattic Inc.",
@@ -459,7 +479,71 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
 
         // Then
-        XCTAssertTrue(viewModel.isInternationalShipping)
+        XCTAssertTrue(viewModel.customsFormRequired)
+    }
+
+    func test_customsFormRequired_returns_true_for_military_state_destination() {
+        // Given
+        let originAddress = Address(firstName: "Skylar",
+                                    lastName: "Ferry",
+                                    company: "Automattic Inc.",
+                                    address1: "60 Hang Bong",
+                                    address2: nil,
+                                    city: "Hanoi",
+                                    state: "",
+                                    postcode: "94121-2303",
+                                    country: "VN",
+                                    phone: nil,
+                                    email: nil)
+        let destinationAddress = Address(firstName: "Skylar",
+                                         lastName: "Ferry",
+                                         company: "Automattic Inc.",
+                                         address1: "60 29th Street #343",
+                                         address2: nil,
+                                         city: "Milatry City",
+                                         state: "AA",
+                                         postcode: "94121-2303",
+                                         country: "US",
+                                         phone: nil,
+                                         email: nil)
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.customsFormRequired)
+    }
+
+    func test_customsFormRequired_returns_true_for_destination_country_different_from_origin_country() {
+        // Given
+        let originAddress = Address(firstName: "Skylar",
+                                    lastName: "Ferry",
+                                    company: "Automattic Inc.",
+                                    address1: "60 29th Street #343",
+                                    address2: nil,
+                                    city: "San Francisco",
+                                    state: "CA",
+                                    postcode: "94121-2303",
+                                    country: "US",
+                                    phone: nil,
+                                    email: nil)
+        let destinationAddress = Address(firstName: "Skylar",
+                                         lastName: "Ferry",
+                                         company: "Automattic Inc.",
+                                         address1: "60 Hang Bong",
+                                         address2: nil,
+                                         city: "Hanoi",
+                                         state: "",
+                                         postcode: "94121-2303",
+                                         country: "VN",
+                                         phone: nil,
+                                         email: nil)
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.customsFormRequired)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -417,6 +417,50 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(filteredCountries.count, 2)
     }
+
+    func test_isInternationalShipping_returns_false_for_destination_in_US() {
+        // Given
+        let originAddress = Address.fake()
+        let destinationAddress = Address(firstName: "Skylar",
+                                         lastName: "Ferry",
+                                         company: "Automattic Inc.",
+                                         address1: "60 29th Street #343",
+                                         address2: nil,
+                                         city: "San Francisco",
+                                         state: "CA",
+                                         postcode: "94121-2303",
+                                         country: "US",
+                                         phone: nil,
+                                         email: nil)
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+
+        // Then
+        XCTAssertFalse(viewModel.isInternationalShipping)
+    }
+
+    func test_isInternationalShipping_returns_true_for_destination_outside_US() {
+        // Given
+        let originAddress = Address.fake()
+        let destinationAddress = Address(firstName: "Skylar",
+                                         lastName: "Ferry",
+                                         company: "Automattic Inc.",
+                                         address1: "60 Hang Bong",
+                                         address2: nil,
+                                         city: "Hanoi",
+                                         state: "",
+                                         postcode: "94121-2303",
+                                         country: "VN",
+                                         phone: nil,
+                                         email: nil)
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+
+        // Then
+        XCTAssertTrue(viewModel.isInternationalShipping)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Closes #4686 

# Description
The PR adds validation for phone number of origin address when international shipping is detected.

# Changes
- Updated `ShippingLabelAddressFormViewModel` with a check for `isInternationalShipping`. This is based on whether destination address is a country outside of the US (country code other than "US").
- Added new param `phoneNumberRequired` for the initializer of `ShippingLabelAddressFormViewController` and its view model.
- Replaced phone error validation case with 2 separate cases for missing and invalid phone number. Each case is handled with a different error message.
- Update local validation of `ShippingLabelAddressFormViewModel` to check whether phone number is required and invalid.
- Added unit tests for `isInternationalShipping` and validation of `ShippingLabelAddressFormViewModel`.

# Demo
![phone](https://user-images.githubusercontent.com/5533851/127851320-53fd6c3d-2dc1-4908-a00e-820b0b11151e.gif)

# Testing
1. Navigate to Orders tab and select an order with status Processing and destination address outside of the US.
2. Select Create Shipping Labels and configure origin address.
3. Notice that if phone number is empty, you cannot proceed and there's a validation error message about a phone number is required.
4. Notice that if you try to proceed with a phone number with length other than 10 (or 11 if it starts with "1" - area code of US), there's a validation error message for requirement of 10-digit phone number.
5. Head back to Orders tab and select an order with destination address in the US. Repeat the same step and notice that phone number is optional for origin address.

# Discussion
I noticed that the phone number length is not validated when shipping within the US (this behavior is confirmed on both the web app and Android app). I figure I should keep the same behavior for the iOS app because general phone validation in the address form will require checking for country code too which can become messy.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
