### PR TITLE
Remove unused Buddybuild prebuild script

### DIFF
--- a/WooCommerce/buddybuild_prebuild.sh
+++ b/WooCommerce/buddybuild_prebuild.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-echo "warning: Detected Prebuild Step"
-mkdir -p ~/.mobile-secrets/iOS/WCiOS/
-cp ${BUDDYBUILD_SECURE_FILES}/woo_app_credentials.json ~/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json
-echo "warning: Copied files over"
-


### PR DESCRIPTION
I noticed this while working on the secrets. 

I'm not sure when we stopped using Buddybuild, but it certainly unused at the moment. On top of that, Apple shut it down, so, even if we wanted to keep this "just in case, for the future" there would be no point.

I also checked with `git grep buddy` and found no match.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
