### PR TITLE
Move JSON credentials secret outside of the repository

### DIFF
--- a/.configure
+++ b/.configure
@@ -10,7 +10,7 @@
     },
     {
       "file": "iOS/WCiOS/woo_app_credentials.json",
-      "destination": ".configure-files/woo_app_credentials.json",
+      "destination": "~/.configure/woocommerce-ios/secrets/woo_app_credentials.json",
       "encrypt": true
     },
     {

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -euo pipefail
 
 DERIVED_PATH=${SOURCE_ROOT}/DerivedSources
 SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -16,6 +16,8 @@ PLIST_TEMPLATE_PATH=${SOURCE_ROOT}/Credentials/Templates/InfoPlist-Template.h
 BASH_INPUT_PATH=${SOURCE_ROOT}/Credentials/bash_secrets.tpl
 BASH_OUTPUT_PATH=${DERIVED_PATH}/bash_secrets
 
+SECRETS_PATH="${SRCROOT}/../.configure-files/woo_app_credentials.json"
+
 ## Validate Secrets!
 ##
 if [ ! -f $SECRETS_PATH ]; then

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -16,7 +16,7 @@ PLIST_TEMPLATE_PATH=${SOURCE_ROOT}/Credentials/Templates/InfoPlist-Template.h
 BASH_INPUT_PATH=${SOURCE_ROOT}/Credentials/bash_secrets.tpl
 BASH_OUTPUT_PATH=${DERIVED_PATH}/bash_secrets
 
-SECRETS_PATH="${SRCROOT}/../.configure-files/woo_app_credentials.json"
+SECRETS_PATH="${HOME}/.configure/woocommerce-ios/secrets/woo_app_credentials.json"
 
 ## Validate Secrets!
 ##

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -20,6 +20,8 @@ BASH_OUTPUT_PATH=${DERIVED_PATH}/bash_secrets
 ##
 if [ ! -f $SECRETS_PATH ]; then
 
+    echo "warning: Could not find secrets at $SECRETS_PATH. This is likely due to the secrets folder being missing. Falling back to templated secrets. If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
+
     echo ">> Using Templated Secrets"
 
     ## Generate the Derived Folder. If needed

--- a/Scripts/build-phases/generate-credentials.xcfilelist
+++ b/Scripts/build-phases/generate-credentials.xcfilelist
@@ -1,0 +1,9 @@
+# Input files for the script generating the app's credentials.
+# The script is currently run via a build phase in the GenerateCredentials
+# aggregate target.
+$(SRCROOT)/Credentials/replace_secrets.rb
+$(SRCROOT)/Credentials/ApiCredentials.tpl
+$(SRCROOT)/Credentials/InfoPlist.tpl
+$(SRCROOT)/Credentials/Templates/APICredentials-Template.swift
+$(SRCROOT)/Credentials/Templates/InfoPlist-Template.h
+$(SRCROOT)/../.configure-files/woo_app_credentials.json

--- a/Scripts/build-phases/generate-credentials.xcfilelist
+++ b/Scripts/build-phases/generate-credentials.xcfilelist
@@ -6,4 +6,7 @@ $(SRCROOT)/Credentials/ApiCredentials.tpl
 $(SRCROOT)/Credentials/InfoPlist.tpl
 $(SRCROOT)/Credentials/Templates/APICredentials-Template.swift
 $(SRCROOT)/Credentials/Templates/InfoPlist-Template.h
-$(SRCROOT)/../.configure-files/woo_app_credentials.json
+$(HOME)/.configure/woocommerce-ios/secrets/woo_app_credentials.json
+# Add the script itself as an input, so the build system will know to run it
+# if it changes
+$(SRCROOT)/../Scripts/build-phases/generate-credentials.sh

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7859,7 +7859,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.automattic.alpha.woocommerce";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -8066,7 +8065,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Development";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -8094,7 +8092,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.automattic.woocommerce";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7895,7 +7895,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = "Release-Alpha";
@@ -7906,7 +7905,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -7917,7 +7915,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = "$(SRCROOT)/../.configure-files/woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -6592,13 +6592,10 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputFileListPaths = (
+				"$(SRCROOT)/../Scripts/build-phases/generate-credentials.xcfilelist",
+			);
 			inputPaths = (
-				"$(SRCROOT)/Credentials/replace_secrets.rb",
-				"$(SRCROOT)/Credentials/ApiCredentials.tpl",
-				"$(SRCROOT)/Credentials/InfoPlist.tpl",
-				"$(SRCROOT)/../.configure-files/woo_app_credentials.json",
-				"$(SRCROOT)/Credentials/Templates/APICredentials-Template.swift",
-				"$(SRCROOT)/Credentials/Templates/InfoPlist-Template.h",
 			);
 			outputPaths = (
 				"$(SRCROOT)/DerivedSources/ApiCredentials.swift",


### PR DESCRIPTION
Move the remaining secret, `woo_app_credentials.json`, outside of the repository. The work was straightforward because everything was already mostly centralized. Thank you very much 🙇‍♂️ .

## How to test

1. Checkout this branch
1. Build the app, you should see a warning saying about the missing secret

<img width="1786" alt="Screen Shot 2021-08-04 at 9 33 46 pm" src="https://user-images.githubusercontent.com/1218433/128179040-06cd9bf0-b10c-4a94-aff6-f18e068ffad9.png">

1. Run `bundle exec fastlane run configure_apply`
1. Run `ls ~/.configure/woocommerce-ios/secrets/` to ensure `woo_app_credentials.json` is there
1. Build, the warning should be gone. Compare `ApiCredentials.swift` with `woo_app_credentials.json` to make sure they have the same values.

---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
