### PR TITLE
Shipping Labels: Automatically accept normalized address with trivial normalization

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] My Store: If there are errors loading the My Store screen, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4704]
 - [internal] Upgraded Zendesk SDK to version 5.3.0 [https://github.com/woocommerce/woocommerce-ios/pull/4699]
 - [*] Fix: Added 'Product saved' confirmation message when a product is updated [https://github.com/woocommerce/woocommerce-ios/pull/4709]
+- [*] Shipping Labels: Updated address validation to automatically use trivially normalized address for origin and destination. [https://github.com/woocommerce/woocommerce-ios/pull/4719]
 
 7.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -210,7 +210,7 @@ private extension ShippingLabelFormViewController {
                 let shippingLabelAddress = self.viewModel.originAddress
                 switch validationState {
                 case .validated:
-                    self.viewModel.handleOriginAddressValueChanges(address: shippingLabelAddress,
+                    self.viewModel.handleOriginAddressValueChanges(address: response?.address,
                                                                    validated: true)
                 case .suggestedAddress:
                     self.displaySuggestedAddressVC(address: shippingLabelAddress, suggestedAddress: response?.address, type: .origin)
@@ -237,8 +237,8 @@ private extension ShippingLabelFormViewController {
                 let shippingLabelAddress = self.viewModel.destinationAddress
                 switch validationState {
                 case .validated:
-                    self.viewModel.handleDestinationAddressValueChanges(address: shippingLabelAddress,
-                                                                   validated: true)
+                    self.viewModel.handleDestinationAddressValueChanges(address: response?.address,
+                                                                        validated: true)
                 case .suggestedAddress:
                     self.displaySuggestedAddressVC(address: shippingLabelAddress, suggestedAddress: response?.address, type: .destination)
                 case .validationError(let validationError):


### PR DESCRIPTION
Fixes: #4664

## Description

When sending a shipping label address (origin or destination) to normalize to the server, if the response has the `is_trivial_normalization` property set to true, then the normalized address will be automatically accepted without user intervention. As its name indicates, that flag will be set when the changes made by the address normalization were trivial, such as adding the +4 portion to a ZIP code, or changing capitalization, or changing street to st for example.

Previously, when `is_trivial_normalization` was true, we accepted the address as validated and continued to use it without any changes. With this PR, we update the address on the shipping label to the normalized address without user intervention. You can see the 

## Changes

In `ShippingLabelFormViewController`, when we validate the origin/destination address and the address has the `.validated` state, instead of continuing to use `viewModel.originAddress` or `viewModel.destinationAddress` we update the address to `response?.address`. This is the normalized address returned in the `ShippingLabelAddressValidationSuccess` response.

Origin address needs validation | Origin address validated with trivial normalization
-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-08-03 at 17 18 38](https://user-images.githubusercontent.com/8658164/128050830-e3b27f97-3c58-4146-8a8d-a1a63b366bf2.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-03 at 17 19 01](https://user-images.githubusercontent.com/8658164/128050841-dcc44436-22e2-4779-a282-9676ca234832.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods and one or more custom packages (with a set package weight) set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Add an order to your store that is eligible for a shipping label, and make sure that either your store's address or the shipping address on the order is valid but requires trivial normalization. (For example, it doesn't include the +4 portion of the ZIP code, isn't fully capitalized, or uses "street" instead of "st".)
3. Launch the app.
4. Open the order detail for the order eligible for a shipping label.
5. Tap the button "Create Shipping Label".
6. Confirm "Ship From" and "Ship To".
7. Check that the address in "Ship From" and "Ship To" was automatically updated with the normalized address.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
