### PR TITLE
[Mobile Payments] Hide Shipping label button on orders eligible for In Person Payments

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -51,6 +51,13 @@ final class OrderDetailsDataSource: NSObject {
             hasCardPresentEligiblePaymentGatewayAccount()
     }
 
+    /// Whether the button to create shipping labels should be visible.
+    ///
+    private var shouldShowShippingLabelCreation: Bool {
+        return isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty &&
+            !isEligibleForCardPresentPayment
+    }
+
     func cardPresentPaymentGatewayAccounts() -> [PaymentGatewayAccount] {
         resultsControllers.paymentGatewayAccounts.filter { $0.isCardPresentEligible }
     }
@@ -868,19 +875,19 @@ extension OrderDetailsDataSource {
 
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
-            if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
+            if shouldShowShippingLabelCreation {
                 rows.append(.shippingLabelCreateButton)
             }
 
             if isProcessingPayment {
-                if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
+                if shouldShowShippingLabelCreation {
                     rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                     rows.append(.shippingLabelCreationInfo(showsSeparator: false))
                 } else {
                     rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
                 }
             } else if isRefundedStatus == false {
-                if isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty {
+                if shouldShowShippingLabelCreation {
                     rows.append(.shippingLabelCreationInfo(showsSeparator: true))
                 }
             }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -53,7 +53,7 @@ final class OrderDetailsDataSource: NSObject {
 
     /// Whether the button to create shipping labels should be visible.
     ///
-    private var shouldShowShippingLabelCreation: Bool {
+    var shouldShowShippingLabelCreation: Bool {
         return isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty &&
             !isEligibleForCardPresentPayment
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -228,7 +228,7 @@ private extension OrderDetailsViewController {
 //
 private extension OrderDetailsViewController {
     func updateTopBannerView() {
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: viewModel.dataSource.shouldShowShippingLabelCreation,
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: viewModel.dataSource.shouldShowShippingLabelCreation,
                                                      shippingLabels: viewModel.dataSource.shippingLabels)
         let isExpanded = topBannerView?.isExpanded ?? false
         factory.createTopBannerIfNeeded(isExpanded: isExpanded,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -228,7 +228,7 @@ private extension OrderDetailsViewController {
 //
 private extension OrderDetailsViewController {
     func updateTopBannerView() {
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: viewModel.dataSource.isEligibleForShippingLabelCreation,
+        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: viewModel.dataSource.shouldShowShippingLabelCreation,
                                                      shippingLabels: viewModel.dataSource.shippingLabels)
         let isExpanded = topBannerView?.isExpanded ?? false
         factory.createTopBannerIfNeeded(isExpanded: isExpanded,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactory.swift
@@ -4,16 +4,16 @@ import Yosemite
 /// The top banner has two actions: "give feedback" and "dismiss".
 /// This class is not meant to be retained since it uses strong `self` in action handling, so that it has the same life cycle as the top banner.
 final class ShippingLabelsTopBannerFactory {
-    private var isEligibleForShippingLabelCreation: Bool
+    private var shouldShowShippingLabelCreation: Bool
     private let shippingLabels: [ShippingLabel]
     private let stores: StoresManager
     private let analytics: Analytics
 
-    init(isEligibleForShippingLabelCreation: Bool,
+    init(shouldShowShippingLabelCreation: Bool,
          shippingLabels: [ShippingLabel],
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
-        self.isEligibleForShippingLabelCreation = isEligibleForShippingLabelCreation
+        self.shouldShowShippingLabelCreation = shouldShowShippingLabelCreation
         self.shippingLabels = shippingLabels
         self.stores = stores
         self.analytics = analytics
@@ -49,7 +49,7 @@ final class ShippingLabelsTopBannerFactory {
 
 private extension ShippingLabelsTopBannerFactory {
     func determineIfTopBannerShouldBeShown(onCompletion: @escaping (_ shouldShow: Bool) -> Void) {
-        guard isEligibleForShippingLabelCreation && shippingLabels.nonRefunded.isEmpty else {
+        guard shouldShowShippingLabelCreation && shippingLabels.nonRefunded.isEmpty else {
             onCompletion(false)
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -329,11 +329,14 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_create_shipping_label_button_is_not_visible_for_cash_on_delivery_order() throws {
         // Given
-        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100", paymentMethodID: "cod")
+        storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
-        dataSource.isEligibleForShippingLabelCreation = false
+        dataSource.isEligibleForShippingLabelCreation = true
 
         // When
+        dataSource.configureResultsControllers { }
         dataSource.reloadSections()
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -327,6 +327,20 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(createShippingLabelRow)
     }
 
+    func test_create_shipping_label_button_is_not_visible_for_cash_on_delivery_order() throws {
+        // Given
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.isEligibleForShippingLabelCreation = false
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let productSection = try section(withTitle: Title.products, from: dataSource)
+        let createShippingLabelRow = row(row: .shippingLabelCreateButton, in: productSection)
+        XCTAssertNil(createShippingLabelRow)
+    }
 }
 
 // MARK: - Test Data

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/ShippingLabelsTopBannerFactoryTests.swift
@@ -5,7 +5,7 @@ import Yosemite
 final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
     func test_creating_top_banner_with_empty_shipping_labels_and_not_eligible_for_creation_returns_nil() throws {
         // Given
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: false, shippingLabels: [])
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: false, shippingLabels: [])
 
         // When
         let topBannerView = waitFor { promise in
@@ -23,7 +23,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         // Given
         let refundedShippingLabel = MockShippingLabel.emptyLabel().copy(refund: .init(dateRequested: Date(), status: .pending))
         let stores = createStores(feedbackVisibilityResult: .success(true))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [refundedShippingLabel], stores: stores)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [refundedShippingLabel], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -40,7 +40,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
     func test_creating_top_banner_with_empty_shipping_labels_and_eligible_for_creation_returns_banner() throws {
         // Given)
         let stores = createStores(feedbackVisibilityResult: .success(true))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [], stores: stores)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -58,7 +58,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
         let stores = createStores(feedbackVisibilityResult: .success(false))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [shippingLabel], stores: stores)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [shippingLabel], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -76,7 +76,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel().copy(refund: nil)
         let stores = createStores(feedbackVisibilityResult: .failure(SampleError.first))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [shippingLabel], stores: stores)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [shippingLabel], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -93,7 +93,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
     func test_top_banner_has_two_actions() throws {
         // Given
         let stores = createStores(feedbackVisibilityResult: .success(true))
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [], stores: stores)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [], stores: stores)
 
         // When
         let topBannerView = waitFor { promise in
@@ -116,7 +116,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         let stores = createStores(feedbackVisibilityResult: .success(true))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true,
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true,
                                                      shippingLabels: [],
                                                      stores: stores, analytics: analytics)
 
@@ -163,7 +163,7 @@ final class ShippingLabelsTopBannerFactoryTests: XCTestCase {
         }
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let factory = ShippingLabelsTopBannerFactory(isEligibleForShippingLabelCreation: true, shippingLabels: [], stores: stores, analytics: analytics)
+        let factory = ShippingLabelsTopBannerFactory(shouldShowShippingLabelCreation: true, shippingLabels: [], stores: stores, analytics: analytics)
 
         // When
         var isDismissButtonPressed = false


### PR DESCRIPTION
Closes #4101 

Hide the Create Shipping Label button on cash on delivery orders.

For cash on delivery orders:

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/128087379-205f621e-257f-43cb-b839-d31dd8b62cc3.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/128087381-1fd13ca9-4b18-4ede-b0b6-58f61f8bba19.png" width="350"/> |

A couple more "afters":

* order paid by credit card:
<img src="https://user-images.githubusercontent.com/2722505/128087547-37ec6622-594b-4641-902d-df4837dfffd3.png" width="350"/>

* order paid by bank transfer:
<img src="https://user-images.githubusercontent.com/2722505/128087655-74447ed4-5b2a-4ac8-80c4-4e9aca963c6a.png" width="350"/> 

## Changes
* Encapsulate the logic that decides if the "Create Shipping Label" button is visible in a private var, add logic to the previous check (order eligibility and shipping labels not refunded empty) to validate tat the order is not eligible for In-Person Payments
* Add a test for this use case.

## How to test
* Create an order eligible for shipping labels, but not eligible for In-Person Payments. Check that the "Create Shipping label" button is visible
* Create an order eligible for shipping labels and eligible for In-Person Payments. Check that the "Create Shipping label" button is not visible, while the "Collect Payment" button is visible.

Requesting review from @allendav (as the one logging the issue) and/or @pmusolino and/or @rachelmcr  (as the persons more knowledgeable of shipping labels)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
