### PR TITLE
[Mobile Payments] Display reader connection modals on top of Order Details view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -23,23 +23,25 @@ final class CardReaderConnectionController {
         ///
         case searching
 
-        /// Ending search for card readers
-        ///
-        case endSearch
-
         /// Found a card reader
         ///
         case foundReader
 
-        /// Attempting to connect to a card reader
+        /// Attempting to connect to a card reader. The completion passed to `searchAndConnect`
+        /// will be called with a `success` `Bool` `True` result if successful, after which the view controller
+        /// passed to `searchAndConnect` will be dereferenced and the state set to `idle`
         ///
         case connectToReader
 
-        /// Connected successfully to a card reader
+        /// User cancelled search/connecting to a card reader. The completion passed to `searchAndConnect`
+        /// will be called with a `success` `Bool` `False` result. The view controller passed to `searchAndConnect` will be
+        /// dereferenced and the state set to `idle`
         ///
-        case connectedToReader
+        case cancel
 
-        /// A failure occurred during search or connection
+        /// A failure occurred. The completion passed to `searchAndConnect`
+        /// will be called with a `failure` result. The view controller passed to `searchAndConnect` will be
+        /// dereferenced and the state set to `idle`
         ///
         case failed(Error)
     }
@@ -49,7 +51,7 @@ final class CardReaderConnectionController {
             didSetState()
         }
     }
-    private var fromController: UIViewController
+    private var fromController: UIViewController?
     private var siteID: Int64
     private var knownCardReadersProvider: CardReaderSettingsKnownReadersProvider
 
@@ -57,17 +59,17 @@ final class CardReaderConnectionController {
     private var knownReaderIDs: [String]
     private var subscriptions = Set<AnyCancellable>()
 
+    private var onCompletion: ((Result<Bool, Error>) -> Void)?
+
     private lazy var alerts: CardReaderSettingsAlerts = {
         CardReaderSettingsAlerts()
     }()
 
     init(
-        from: UIViewController,
         forSiteID: Int64,
         knownReadersProvider: CardReaderSettingsKnownReadersProvider
     ) {
         state = .idle
-        fromController = from
         siteID = forSiteID
         knownCardReadersProvider = knownReadersProvider
         knownReaderIDs = []
@@ -77,47 +79,70 @@ final class CardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func start() {
+    func searchAndConnect(from: UIViewController?, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        guard from != nil else {
+            return
+        }
+
+        self.fromController = from
+        self.onCompletion = onCompletion
         self.state = .initializing
-
-        /// Subscribe to the list of known readers
-        ///
-        knownCardReadersProvider.knownReaders.sink(receiveValue: { [weak self] readerIDs in
-            self?.knownReaderIDs = readerIDs
-            /// We are now ready to actually begin the search
-            self?.state = .beginSearch
-        }).store(in: &subscriptions)
-
     }
 }
 
 private extension CardReaderConnectionController {
     func didSetState() {
         switch state {
+        case .idle:
+            onIdle()
+        case .initializing:
+            onInitialization()
         case .beginSearch:
             onBeginSearch()
         case .searching:
             onSearching()
-        case .endSearch:
-            onEndSearch()
         case .foundReader:
             onFoundReader()
+        case .cancel:
+            onCancel()
         case .connectToReader:
             onConnectToReader()
         case .failed(let error):
             onFailed(error: error)
-        default:
-            dismissAnyModal()
         }
     }
 
-    /// Begin the search for a card reader
+    /// Initial state of the controller
+    ///
+    func onIdle() {
+    }
+
+    /// Begins a fetch for the list of known readers
+    /// Does NOT open any modal
+    /// Transitions state to `.beginSearch` after receiving the known readers list
+    ///
+    func onInitialization() {
+        knownCardReadersProvider.knownReaders.sink(receiveValue: { [weak self] readerIDs in
+            self?.knownReaderIDs = readerIDs
+            self?.state = .beginSearch
+        }).store(in: &subscriptions)
+    }
+
+    /// Begins the search for a card reader
+    /// Does NOT open any modal
+    /// Transitions state to `.searching`
+    /// Later, when a reader is found, state transitions to `.foundReader` if it is unknown,
+    /// or  to `.connectToReader` if it is known
     ///
     func onBeginSearch() {
         self.state = .searching
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,
             onReaderDiscovered: { [weak self] cardReaders in
+                guard let self = self else {
+                    return
+                }
+
                 /// Surprisingly, onReaderDiscovered may be called with an empty array
                 ///
                 guard cardReaders.count > 0 else {
@@ -128,65 +153,59 @@ private extension CardReaderConnectionController {
                 /// When we stop using proximity, we'll need more elaborate logic as we
                 /// won't be able to do that anymore
                 ///
-                self?.foundReader = cardReaders.first
+                self.foundReader = cardReaders.first
 
-                guard let foundReaderID = self?.foundReader?.id else {
+                guard let foundReaderID = self.foundReader?.id else {
                     DDLogWarn("onBeginSearch unexpectedly handled a nil found reader")
-                    self?.state = .endSearch
                     return
                 }
 
-                /// If we know this reader, automatically connect to it
-                ///
-                let knownReaderIDs = self?.knownReaderIDs ?? []
-                if knownReaderIDs.contains(foundReaderID) {
-                    self?.state = .connectToReader
-                } else {
-                    self?.state = .foundReader
-                }
+                let knownReaderIDs = self.knownReaderIDs
+                self.state = knownReaderIDs.contains(foundReaderID) ? .connectToReader : .foundReader
             },
             onError: { [weak self] error in
+                guard let self = self else {
+                    return
+                }
+
                 ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
-                self?.state = .failed(error)
+                self.state = .failed(error)
             })
 
         ServiceLocator.stores.dispatch(action)
     }
 
-    /// A search is in progress
+    /// Opens the scanning for reader modal
+    /// If the user cancels the modal will trigger a transition to `.endSearch`
     ///
     func onSearching() {
-        alerts.scanningForReader(from: fromController, cancel: {
-            self.state = .endSearch
+        guard let from = fromController else {
+            return
+        }
+
+        alerts.scanningForReader(from: from, cancel: {
+            self.state = .cancel
         })
     }
 
-    /// End the search for a card reader
-    ///
-    func onEndSearch() {
-        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() {_ in
-            self.state = .idle
-        }
-        ServiceLocator.stores.dispatch(action)
-    }
-
-    /// A reader has been found
+    /// A (unknown) reader has been found
+    /// Opens a confirmation modal for the user to accept the found reader (or keep searching)
     ///
     func onFoundReader() {
         guard foundReader != nil else {
-            DDLogWarn("onFoundReader unexpectedly called with no found reader")
-            self.state = .endSearch
             return
         }
 
         guard let name = foundReader?.id else {
-            DDLogWarn("Found reader unexpectedly had no id (name)")
-            self.state = .endSearch
+            return
+        }
+
+        guard let from = fromController else {
             return
         }
 
         alerts.foundReader(
-            from: fromController,
+            from: from,
             name: name,
             connect: {
                 self.state = .connectToReader
@@ -196,42 +215,78 @@ private extension CardReaderConnectionController {
             })
     }
 
-    /// Connect to a card reader
+    /// End the search for a card reader
+    ///
+    func onCancel() {
+        alerts.dismiss()
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
+            self?.returnSuccess(connected: false)
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    /// Connect to the card reader
     ///
     func onConnectToReader() {
         guard let reader = foundReader else {
-            DDLogWarn("No found reader to connect to")
-            self.state = .endSearch
+            return
+        }
+
+        guard let from = fromController else {
             return
         }
 
         let action = CardPresentPaymentAction.connect(reader: reader) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
             switch result {
             case .success(let reader):
-                self?.knownCardReadersProvider.rememberCardReader(cardReaderID: reader.id)
+                self.knownCardReadersProvider.rememberCardReader(cardReaderID: reader.id)
                 // If the reader does not have a battery, or the battery level is unknown, it will be nil
                 let properties = reader.batteryLevel
                     .map { ["battery_level": $0] }
                 ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)
-                self?.state = .connectedToReader
+                self.returnSuccess(connected: true)
             case .failure(let error):
                 ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
-                self?.state = .failed(error)
+                self.returnFailure(error: error)
             }
         }
         ServiceLocator.stores.dispatch(action)
-        alerts.connectingToReader(from: fromController)
+
+        alerts.connectingToReader(from: from)
     }
 
     /// An error has occurred
+    /// Presents the error in a modal
     ///
     private func onFailed(error: Error) {
-        alerts.scanningFailed(from: fromController, error: error) { [weak self] in
-            self?.state = .idle
+        guard let from = fromController else {
+            return
+        }
+
+        alerts.scanningFailed(from: from, error: error) { [weak self] in
+            self?.returnFailure(error: error)
         }
     }
 
-    private func dismissAnyModal() {
-        alerts.dismiss()
+    /// Calls the completion with a success result
+    ///
+    private func returnSuccess(connected: Bool) {
+        self.alerts.dismiss()
+        self.onCompletion?(.success(connected))
+        self.fromController = nil
+        self.state = .idle
+    }
+
+    /// Calls the completion with a failure result
+    ///
+    private func returnFailure(error: Error) {
+        self.alerts.dismiss()
+        self.onCompletion?(.failure(error))
+        self.fromController = nil
+        self.state = .idle
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -1,0 +1,132 @@
+import Foundation
+import UIKit
+import Yosemite
+
+final class CardReaderConnectionController {
+    enum ControllerState {
+        case idle
+        case searching
+        case stoppingSearch
+        case foundReader
+        case connectingToReader
+        case connectedToReader
+        case failed(Error)
+    }
+
+    private var controllerState: ControllerState {
+        didSet {
+            didSetControllerState()
+        }
+    }
+    private var fromController: UIViewController
+    private var siteID: Int64
+    private var foundReaders: [CardReader]
+
+    private lazy var alerts: CardReaderSettingsAlerts = {
+        CardReaderSettingsAlerts()
+    }()
+
+    // TODO - ignore store state changes while connectionState == .idle
+
+    init(from: UIViewController, forSiteID: Int64) {
+        controllerState = .idle
+        fromController = from
+        siteID = forSiteID
+        foundReaders = []
+    }
+
+    func start() {
+        // TODO check and see if we are connected and if so, set our state to .connectedToReader
+        // Or, if we are not connected, kick off the search by setting our state to .searching
+        controllerState = .searching
+    }
+}
+
+private extension CardReaderConnectionController {
+    func didSetControllerState() {
+        switch controllerState {
+        case .searching:
+            onSearching()
+        case .stoppingSearch:
+            onStoppingSearch()
+        case .foundReader:
+            onFoundReader()
+        case .connectingToReader:
+            onConnectingToReader()
+        case .failed(let error):
+            onFailed(error: error)
+        default:
+            dismissAnyModal()
+        }
+    }
+
+    func onSearching() {
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(
+            siteID: siteID,
+            onReaderDiscovered: { [weak self] cardReaders in
+                self?.foundReaders = cardReaders
+                self?.controllerState = .foundReader
+            },
+            onError: { [weak self] error in
+                ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
+                self?.controllerState = .failed(error)
+            })
+
+        ServiceLocator.stores.dispatch(action)
+
+        alerts.scanningForReader(from: fromController, cancel: {
+            self.controllerState = .idle // TODO - transition through stop searching first
+        })
+    }
+
+    private func onStoppingSearch() {
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() {_ in
+            self.controllerState = .idle
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    private func onFoundReader() {
+        let name = foundReaders[0].id // TODO guard count
+
+        alerts.foundReader(
+            from: fromController,
+            name: name,
+            connect: {
+                self.controllerState = .connectingToReader
+            },
+            continueSearch: {
+                self.controllerState = .searching
+            })
+    }
+
+    private func onConnectingToReader() {
+        // TODO guard count foundReader
+        let action = CardPresentPaymentAction.connect(reader: foundReaders[0]) { [weak self] result in
+            switch result {
+            case .success(let reader):
+                // TODO - reconnect this - self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.id)
+                // If the reader does not have a battery, or the battery level is unknown, it will be nil
+                let properties = reader.batteryLevel
+                    .map { ["battery_level": $0] }
+                ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)
+                self?.controllerState = .connectedToReader
+            case .failure(let error):
+                ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
+                self?.controllerState = .failed(error)
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
+        alerts.connectingToReader(from: fromController)
+    }
+
+    private func onFailed(error: Error) {
+        alerts.scanningFailed(from: fromController, error: error) { [weak self] in
+            self?.controllerState = .idle
+        }
+    }
+
+    private func dismissAnyModal() {
+        alerts.dismiss()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -192,10 +192,6 @@ private extension CardReaderConnectionController {
     /// Opens a confirmation modal for the user to accept the found reader (or keep searching)
     ///
     func onFoundReader() {
-        guard foundReader != nil else {
-            return
-        }
-
         guard let name = foundReader?.id else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -1,58 +1,109 @@
+import Combine
 import Foundation
 import UIKit
 import Yosemite
 
+/// Facilitates connecting to a card reader
+///
 final class CardReaderConnectionController {
-    enum ControllerState {
+    private enum ControllerState {
+        /// Initial state of the controller
+        ///
         case idle
+
+        /// Initializing (fetching the list of any known readers)
+        ///
+        case initializing
+
+        /// Begin search for card readers
+        ///
+        case beginSearch
+
+        /// Searching for a card reader
+        ///
         case searching
-        case stoppingSearch
+
+        /// Ending search for card readers
+        ///
+        case endSearch
+
+        /// Found a card reader
+        ///
         case foundReader
-        case connectingToReader
+
+        /// Attempting to connect to a card reader
+        ///
+        case connectToReader
+
+        /// Connected successfully to a card reader
+        ///
         case connectedToReader
+
+        /// A failure occurred during search or connection
+        ///
         case failed(Error)
     }
 
-    private var controllerState: ControllerState {
+    private var state: ControllerState {
         didSet {
-            didSetControllerState()
+            didSetState()
         }
     }
     private var fromController: UIViewController
     private var siteID: Int64
-    private var foundReaders: [CardReader]
+    private var knownCardReadersProvider: CardReaderSettingsKnownReadersProvider
+
+    private var foundReader: CardReader?
+    private var knownReaderIDs: [String]
+    private var subscriptions = Set<AnyCancellable>()
 
     private lazy var alerts: CardReaderSettingsAlerts = {
         CardReaderSettingsAlerts()
     }()
 
-    // TODO - ignore store state changes while connectionState == .idle
-
-    init(from: UIViewController, forSiteID: Int64) {
-        controllerState = .idle
+    init(
+        from: UIViewController,
+        forSiteID: Int64,
+        knownReadersProvider: CardReaderSettingsKnownReadersProvider
+    ) {
+        state = .idle
         fromController = from
         siteID = forSiteID
-        foundReaders = []
+        knownCardReadersProvider = knownReadersProvider
+        knownReaderIDs = []
+    }
+
+    deinit {
+        subscriptions.removeAll()
     }
 
     func start() {
-        // TODO check and see if we are connected and if so, set our state to .connectedToReader
-        // Or, if we are not connected, kick off the search by setting our state to .searching
-        controllerState = .searching
+        self.state = .initializing
+
+        /// Subscribe to the list of known readers
+        ///
+        knownCardReadersProvider.knownReaders.sink(receiveValue: { [weak self] readerIDs in
+            self?.knownReaderIDs = readerIDs
+            /// We are now ready to actually begin the search
+            self?.state = .beginSearch
+        }).store(in: &subscriptions)
+
     }
 }
 
 private extension CardReaderConnectionController {
-    func didSetControllerState() {
-        switch controllerState {
+    func didSetState() {
+        switch state {
+        case .beginSearch:
+            onBeginSearch()
         case .searching:
             onSearching()
-        case .stoppingSearch:
-            onStoppingSearch()
+        case .endSearch:
+            onEndSearch()
         case .foundReader:
             onFoundReader()
-        case .connectingToReader:
-            onConnectingToReader()
+        case .connectToReader:
+            onConnectToReader()
         case .failed(let error):
             onFailed(error: error)
         default:
@@ -60,69 +111,123 @@ private extension CardReaderConnectionController {
         }
     }
 
-    func onSearching() {
+    /// Begin the search for a card reader
+    ///
+    func onBeginSearch() {
+        self.state = .searching
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,
             onReaderDiscovered: { [weak self] cardReaders in
-                self?.foundReaders = cardReaders
-                self?.controllerState = .foundReader
+                /// Surprisingly, onReaderDiscovered may be called with an empty array
+                ///
+                guard cardReaders.count > 0 else {
+                    return
+                }
+
+                /// For now, we only work with the first card reader returned
+                /// When we stop using proximity, we'll need more elaborate logic as we
+                /// won't be able to do that anymore
+                ///
+                self?.foundReader = cardReaders.first
+
+                guard let foundReaderID = self?.foundReader?.id else {
+                    DDLogWarn("onBeginSearch unexpectedly handled a nil found reader")
+                    self?.state = .endSearch
+                    return
+                }
+
+                /// If we know this reader, automatically connect to it
+                ///
+                let knownReaderIDs = self?.knownReaderIDs ?? []
+                if knownReaderIDs.contains(foundReaderID) {
+                    self?.state = .connectToReader
+                } else {
+                    self?.state = .foundReader
+                }
             },
             onError: { [weak self] error in
                 ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
-                self?.controllerState = .failed(error)
+                self?.state = .failed(error)
             })
 
         ServiceLocator.stores.dispatch(action)
+    }
 
+    /// A search is in progress
+    ///
+    func onSearching() {
         alerts.scanningForReader(from: fromController, cancel: {
-            self.controllerState = .idle // TODO - transition through stop searching first
+            self.state = .endSearch
         })
     }
 
-    private func onStoppingSearch() {
+    /// End the search for a card reader
+    ///
+    func onEndSearch() {
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() {_ in
-            self.controllerState = .idle
+            self.state = .idle
         }
         ServiceLocator.stores.dispatch(action)
     }
 
-    private func onFoundReader() {
-        let name = foundReaders[0].id // TODO guard count
+    /// A reader has been found
+    ///
+    func onFoundReader() {
+        guard foundReader != nil else {
+            DDLogWarn("onFoundReader unexpectedly called with no found reader")
+            self.state = .endSearch
+            return
+        }
+
+        guard let name = foundReader?.id else {
+            DDLogWarn("Found reader unexpectedly had no id (name)")
+            self.state = .endSearch
+            return
+        }
 
         alerts.foundReader(
             from: fromController,
             name: name,
             connect: {
-                self.controllerState = .connectingToReader
+                self.state = .connectToReader
             },
             continueSearch: {
-                self.controllerState = .searching
+                self.state = .searching
             })
     }
 
-    private func onConnectingToReader() {
-        // TODO guard count foundReader
-        let action = CardPresentPaymentAction.connect(reader: foundReaders[0]) { [weak self] result in
+    /// Connect to a card reader
+    ///
+    func onConnectToReader() {
+        guard let reader = foundReader else {
+            DDLogWarn("No found reader to connect to")
+            self.state = .endSearch
+            return
+        }
+
+        let action = CardPresentPaymentAction.connect(reader: reader) { [weak self] result in
             switch result {
             case .success(let reader):
-                // TODO - reconnect this - self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.id)
+                self?.knownCardReadersProvider.rememberCardReader(cardReaderID: reader.id)
                 // If the reader does not have a battery, or the battery level is unknown, it will be nil
                 let properties = reader.batteryLevel
                     .map { ["battery_level": $0] }
                 ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)
-                self?.controllerState = .connectedToReader
+                self?.state = .connectedToReader
             case .failure(let error):
                 ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
-                self?.controllerState = .failed(error)
+                self?.state = .failed(error)
             }
         }
         ServiceLocator.stores.dispatch(action)
         alerts.connectingToReader(from: fromController)
     }
 
+    /// An error has occurred
+    ///
     private func onFailed(error: Error) {
         alerts.scanningFailed(from: fromController, error: error) { [weak self] in
-            self?.controllerState = .idle
+            self?.state = .idle
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -66,6 +66,17 @@ final class OrderDetailsViewController: UIViewController {
     ///
     private var cardReaderAvailableSubscription: Combine.Cancellable? = nil
 
+    /// Controller that facilitates connecting to card readers
+    private lazy var cardReaderConnectionController: CardReaderConnectionController = {
+        let knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
+        let connectionController = CardReaderConnectionController(
+            from: self,
+            forSiteID: viewModel.order.siteID,
+            knownReadersProvider: knownReadersProvider
+        )
+        return connectionController
+    }()
+
     // MARK: - View Lifecycle
 
     /// Create an instance of `Self` from its corresponding storyboard.
@@ -708,13 +719,7 @@ private extension OrderDetailsViewController {
     }
 
     private func connectToCardReader() {
-        let knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
-        let connectionController = CardReaderConnectionController(
-            from: self,
-            forSiteID: viewModel.order.siteID,
-            knownReadersProvider: knownReadersProvider
-        )
-        connectionController.start()
+        cardReaderConnectionController.start()
     }
 
     private func cancelObservingCardReader() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -708,15 +708,8 @@ private extension OrderDetailsViewController {
     }
 
     private func connectToCardReader() {
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
-            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
-        }
-
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
-        viewController.configure(viewModelsAndViews: viewModelsAndViews)
-        viewController.presentationController?.delegate = self
-
-        present(viewController, animated: true)
+        let connectionController = CardReaderConnectionController(from: self, forSiteID: viewModel.order.siteID)
+        connectionController.start()
     }
 
     private func cancelObservingCardReader() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -66,17 +66,6 @@ final class OrderDetailsViewController: UIViewController {
     ///
     private var cardReaderAvailableSubscription: Combine.Cancellable? = nil
 
-    /// Controller that facilitates connecting to card readers
-    private lazy var cardReaderConnectionController: CardReaderConnectionController = {
-        let knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
-        let connectionController = CardReaderConnectionController(
-            from: self,
-            forSiteID: viewModel.order.siteID,
-            knownReadersProvider: knownReadersProvider
-        )
-        return connectionController
-    }()
-
     // MARK: - View Lifecycle
 
     /// Create an instance of `Self` from its corresponding storyboard.
@@ -719,7 +708,15 @@ private extension OrderDetailsViewController {
     }
 
     private func connectToCardReader() {
-        cardReaderConnectionController.start()
+        let knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
+        let connectionController = CardReaderConnectionController(
+            forSiteID: viewModel.order.siteID,
+            knownReadersProvider: knownReadersProvider
+        )
+        connectionController.searchAndConnect(from: self) { _ in
+            /// No need for logic here. Once connected, the connected reader will publish
+            /// through the `cardReaderAvailableSubscription`
+        }
     }
 
     private func cancelObservingCardReader() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -708,7 +708,12 @@ private extension OrderDetailsViewController {
     }
 
     private func connectToCardReader() {
-        let connectionController = CardReaderConnectionController(from: self, forSiteID: viewModel.order.siteID)
+        let knownReadersProvider = CardReaderSettingsKnownReadersStoredList()
+        let connectionController = CardReaderConnectionController(
+            from: self,
+            forSiteID: viewModel.order.siteID,
+            knownReadersProvider: knownReadersProvider
+        )
         connectionController.start()
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */; };
 		31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */; };
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */; };
+		31E6F21F26B3577800227E6F /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */; };
 		31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */; };
 		31F21B02263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */; };
 		31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */; };
@@ -1808,6 +1809,7 @@
 		31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReader.swift; sourceTree = "<group>"; };
 		31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingToReader.swift; sourceTree = "<group>"; };
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsUnknownViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModel.swift; sourceTree = "<group>"; };
+		31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
 		31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPrioritizedViewModelsProvider.swift; sourceTree = "<group>"; };
 		31F21B01263C8E150035B50A /* CardReaderSettingsUnknownViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsUnknownViewModelTests.swift; sourceTree = "<group>"; };
 		31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsStoresManager.swift; sourceTree = "<group>"; };
@@ -5867,6 +5869,7 @@
 				D8815ADE26383EE700EDAD62 /* CardPresentPaymentsModalViewController.xib */,
 				D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */,
 				D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */,
+				31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7289,6 +7292,7 @@
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
+				31E6F21F26B3577800227E6F /* CardReaderConnectionController.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				0229ED00258767BC00C336F8 /* ShippingLabelPrintingStepContentView.swift in Sources */,


### PR DESCRIPTION
Ready for review

Partially addresses #4546 - avoids the "connect your card reader" and "disconnect" views from appearing when connecting a card reader in the context of order details

NOTE:
- Unit tests will be added in a subsequent PR
- At least one modal briefly flashes after connecting.  If I can't resolve that shortly, I'll open an issue for that as well.

To test:
- Create a test order with cash on delivery as the payment method
- Make sure the card reader is off and NOT known to the mobile device
- Navigate to the order and tap collect payment
- Ensure the Scanning for reader modal appears in front of the Order details
- Tap cancel
- Ensure you are returned to Order details
- Navigate to the order and tap collect payment
- Ensure the Scanning for reader modal appears in front of the Order details
- Power on the reader
- When prompted “Do you want to connect to reader XXX”, tap Connect to Reader
- Ensure you get the “Collect payment from XXX” modal next
- Tap cancel to abort the payment collection
- Tap collect payment again and ensure you get the “Collect payment from XXX” modal again immediately
- Tap cancel to abort the payment collection
- Power off the reader
- Tap collect payment
- Ensure the Scanning for reader modal appears in front of the Order details
- Power on the reader
- Ensure you are immediately sent to the get the “Collect payment from XXX” modal since the reader is now known

Screengrabs:

<img src="https://user-images.githubusercontent.com/1595739/128103520-d308e57a-6a08-40dc-b6da-c7fc506a2fe1.png" width=50% />
<img src="https://user-images.githubusercontent.com/1595739/128103522-8eacca73-426e-4841-8680-c352328373d8.png" width=50% />
<img src="https://user-images.githubusercontent.com/1595739/128103523-4b0c9ed7-035c-4cdb-b491-8a38713ab876.png" width=50% />


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
