### PR TITLE
[CPP Onboarding] Synchronize required data when loading CPP Onboarding screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -36,7 +36,7 @@ private enum Localization {
 struct InPersonPaymentsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(initialState: .genericError))
+            InPersonPaymentsView(viewModel: InPersonPaymentsViewModel(fixedState: .genericError))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -4,7 +4,27 @@ import Combine
 final class InPersonPaymentsViewModel: ObservableObject {
     @Published var state: CardPresentPaymentOnboardingState
 
-    init(initialState: CardPresentPaymentOnboardingState) {
-        state = initialState
+    /// Initializes the view model for a specific site
+    ///
+    init(siteID: Int64) {
+        let useCase = CardPresentPaymentsOnboardingUseCase(
+            siteID: siteID,
+            storageManager: ServiceLocator.storageManager,
+            dispatch: { action in ServiceLocator.stores.dispatch(action) }
+        )
+        state = useCase.checkOnboardingState()
+        useCase.synchronizeRequiredData { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.state = useCase.checkOnboardingState()
+        }
+    }
+
+    /// Initializes the view model with a fixed state that never changes.
+    /// This is useful for SwiftUI previews or testing, but shouldn't be used in production
+    ///
+    init(fixedState: CardPresentPaymentOnboardingState) {
+        state = fixedState
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -541,12 +541,9 @@ private extension SettingsViewController {
         guard let siteID = self.siteID else {
             return
         }
-        let action = CardPresentPaymentAction.checkOnboardingState(siteID: siteID) { [weak self] state in
-            let viewModel = InPersonPaymentsViewModel(initialState: state)
-            let viewController = InPersonPaymentsViewController(viewModel: viewModel)
-            self?.show(viewController, sender: self)
-        }
-        ServiceLocator.stores.dispatch(action)
+        let viewModel = InPersonPaymentsViewModel(siteID: siteID)
+        let viewController = InPersonPaymentsViewController(viewModel: viewModel)
+        show(viewController, sender: self)
     }
 
     func privacyWasPressed() {

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -4,10 +4,6 @@
 import Combine
 
 public enum CardPresentPaymentAction: Action {
-    /// Checks the onboarding state for a site.
-    ///
-    case checkOnboardingState(siteID: Int64, onCompletion: (CardPresentPaymentOnboardingState) -> Void)
-
     /// Start the Card Reader discovery process.
     ///
     case startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: ([CardReader]) -> Void, onError: (Error) -> Void)

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -39,8 +39,6 @@ public final class CardPresentPaymentStore: Store {
         }
 
         switch action {
-        case .checkOnboardingState(let siteID, let onCompletion):
-            checkOnboardingState(siteID: siteID, onCompletion: onCompletion)
         case .startCardReaderDiscovery(let siteID, let onReaderDiscovered, let onError):
             startCardReaderDiscovery(siteID: siteID, onReaderDiscovered: onReaderDiscovered, onError: onError)
         case .cancelCardReaderDiscovery(let completion):
@@ -75,12 +73,6 @@ public final class CardPresentPaymentStore: Store {
 // MARK: - Services
 //
 private extension CardPresentPaymentStore {
-    func checkOnboardingState(siteID: Int64, onCompletion: (CardPresentPaymentOnboardingState) -> Void) {
-        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, siteID: siteID)
-        let state = useCase.checkOnboardingState()
-        onCompletion(state)
-    }
-
     func startCardReaderDiscovery(siteID: Int64, onReaderDiscovered: @escaping (_ readers: [CardReader]) -> Void, onError: @escaping (Error) -> Void) {
         do {
             try cardReaderService.start(WCPayTokenProvider(siteID: siteID, remote: self.remote))

--- a/Yosemite/YosemiteTests/Stores/Payments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Payments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -31,7 +31,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSampleSitePlugin(readOnlySitePlugin: plugin)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, siteID: sampleSiteID)
+        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
         let state = useCase.checkOnboardingState()
 
         // Then
@@ -55,7 +55,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, siteID: sampleSiteID)
+        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
         let state = useCase.checkOnboardingState()
 
         // Then
@@ -79,7 +79,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, siteID: sampleSiteID)
+        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
         let state = useCase.checkOnboardingState()
 
         // Then


### PR DESCRIPTION
Part of #4611

While working on #4702 I realized that, if we need to check data about plugins and settings, we need to ensure that the information is relatively fresh. Specially in the case of plugins, it doesn't seem like they are synced anywhere other than the plugins list, so if the user hasn't visited that, the app won't know about the installed plugins.

This PR ensures that all the required data is refreshed when In-Person Payments is loaded, and that the UI updates if the underlying data has changed.

## To test

I didn't fully test this in real world conditions because this is still mostly a skeleton for the future and most of the implementation is mocked. What I tested was:

1. Have a store correctly set up for payments.
2. In `InPersonPaymentsViewModel.init(siteID:)`, I replaced `state = useCase.checkOnboardingState()` with `state = .genericError`. This makes the screen show a generic error when you first visit.
3. Go to Settings > In-Person Payments. The screen should show the generic error we just forced.
4. After a moment, when the data is loaded from the API, the screen should change to the "Connect to Reader" screen.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
