### PR TITLE
[CPP Onboarding] Implement country checks

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1314,7 +1314,7 @@ extension SiteSetting {
             siteID: .fake(),
             settingID: .fake(),
             label: .fake(),
-            description: .fake(),
+            settingDescription: .fake(),
             value: .fake(),
             settingGroupKey: .fake()
         )

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1057,6 +1057,33 @@ extension SitePlugin {
     }
 }
 
+extension SiteSetting {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        settingID: CopiableProp<String> = .copy,
+        label: CopiableProp<String> = .copy,
+        settingDescription: CopiableProp<String> = .copy,
+        value: CopiableProp<String> = .copy,
+        settingGroupKey: CopiableProp<String> = .copy
+    ) -> SiteSetting {
+        let siteID = siteID ?? self.siteID
+        let settingID = settingID ?? self.settingID
+        let label = label ?? self.label
+        let settingDescription = settingDescription ?? self.settingDescription
+        let value = value ?? self.value
+        let settingGroupKey = settingGroupKey ?? self.settingGroupKey
+
+        return SiteSetting(
+            siteID: siteID,
+            settingID: settingID,
+            label: label,
+            settingDescription: settingDescription,
+            value: value,
+            settingGroupKey: settingGroupKey
+        )
+    }
+}
+
 extension SystemPlugin {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/SiteSetting.swift
+++ b/Networking/Networking/Model/SiteSetting.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a specific setting entity for a specific site.
 ///
-public struct SiteSetting: Decodable, Equatable, GeneratedFakeable {
+public struct SiteSetting: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
     public let settingID: String
     public let label: String
@@ -13,11 +13,11 @@ public struct SiteSetting: Decodable, Equatable, GeneratedFakeable {
 
     /// OrderNote struct initializer.
     ///
-    public init(siteID: Int64, settingID: String, label: String, description: String, value: String, settingGroupKey: String) {
+    public init(siteID: Int64, settingID: String, label: String, settingDescription: String, value: String, settingGroupKey: String) {
         self.siteID = siteID
         self.settingID = settingID
         self.label = label
-        self.settingDescription = description
+        self.settingDescription = settingDescription
         self.value = value
         self.settingGroupKey = settingGroupKey
     }
@@ -47,7 +47,7 @@ public struct SiteSetting: Decodable, Equatable, GeneratedFakeable {
             DDLogWarn("⚠️ Could not successfully decode SiteSetting value for \(settingID)")
         }
 
-        self.init(siteID: siteID, settingID: settingID, label: label, description: settingDescription, value: value, settingGroupKey: settingGroupKey)
+        self.init(siteID: siteID, settingID: settingID, label: label, settingDescription: settingDescription, value: value, settingGroupKey: settingGroupKey)
     }
 }
 

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -1,21 +1,25 @@
 import Foundation
 import Yosemite
+import Storage
 
 /// Settings for the selected Site
 ///
 final class SelectedSiteSettings: NSObject {
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
 
     /// ResultsController: Whenever settings change, I will change. We both change. The world changes.
     ///
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
-        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteSetting.siteID, ascending: false)
         return ResultsController<StorageSiteSetting>(storageManager: storageManager, sortedBy: [descriptor])
     }()
 
-    public private(set) var siteSettings: [SiteSetting] = []
+    public private(set) var siteSettings: [Yosemite.SiteSetting] = []
 
-    override init() {
+    init(stores: StoresManager = ServiceLocator.stores, storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.stores = stores
+        self.storageManager = storageManager
         super.init()
         configureResultsController()
     }
@@ -43,7 +47,7 @@ extension SelectedSiteSettings {
     }
 
     private func refreshResultsPredicate() {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+        guard let siteID = stores.sessionManager.defaultStoreID else {
             DDLogError("Error: no siteID found when attempting to refresh CurrencySettings results predicate.")
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -1,5 +1,9 @@
 import Foundation
 import Storage
+import Yosemite
+
+typealias SitePlugin = Yosemite.SitePlugin
+typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
 
 public struct CardPresentPaymentsOnboardingUseCase {
     let storageManager: StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -60,6 +60,7 @@ struct CardPresentPaymentsOnboardingUseCase {
     public func checkOnboardingState() -> CardPresentPaymentOnboardingState {
         // Country checks
         guard let countryCode = storeCountryCode else {
+            DDLogError("[CardPresentPaymentsOnboarding] Couldn't determine country for store")
             return .genericError
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -1,5 +1,5 @@
-import Yosemite
 import Combine
+import Yosemite
 
 final class InPersonPaymentsViewModel: ObservableObject {
     @Published var state: CardPresentPaymentOnboardingState

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -7,11 +7,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
     /// Initializes the view model for a specific site
     ///
     init(siteID: Int64) {
-        let useCase = CardPresentPaymentsOnboardingUseCase(
-            siteID: siteID,
-            storageManager: ServiceLocator.storageManager,
-            dispatch: { action in ServiceLocator.stores.dispatch(action) }
-        )
+        let useCase = CardPresentPaymentsOnboardingUseCase()
         state = useCase.checkOnboardingState()
         useCase.synchronizeRequiredData { [weak self] in
             guard let self = self else {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1223,6 +1223,8 @@
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
+		E12AF69926BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */; };
+		E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */; };
 		E12FB786266E0CAE0039E9C2 /* ApllicationLogDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */; };
 		E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */; };
 		E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */; };
@@ -2556,6 +2558,8 @@
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
+		E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
+		E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCaseTests.swift; sourceTree = "<group>"; };
 		E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApllicationLogDetailView.swift; sourceTree = "<group>"; };
 		E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewController.swift; sourceTree = "<group>"; };
 		E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsUnavailableView.swift; sourceTree = "<group>"; };
@@ -5796,6 +5800,7 @@
 		D810F8F62639EDD900437C67 /* CardPresentPayments */ = {
 			isa = PBXGroup;
 			children = (
+				E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */,
 				D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */,
 			);
 			path = CardPresentPayments;
@@ -5985,6 +5990,7 @@
 		E138D4F2269ED99A006EA5C6 /* In-Person Payments */ = {
 			isa = PBXGroup;
 			children = (
+				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
@@ -7033,6 +7039,7 @@
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,
 				CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */,
 				02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */,
+				E12AF69926BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */,
 				45C11B7C2508E156006C2089 /* SelectedSiteSettings.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
@@ -7489,6 +7496,7 @@
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
+				E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -58,35 +58,35 @@ final class CurrencySettingsTests: XCTestCase {
         let wooCurrencyCode = SiteSetting(siteID: 1,
                                           settingID: "woocommerce_currency",
                                           label: "",
-                                          description: "",
+                                          settingDescription: "",
                                           value: "SHP",
                                           settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let wooCurrencyPosition = SiteSetting(siteID: 1,
                                               settingID: "woocommerce_currency_pos",
                                               label: "",
-                                              description: "",
+                                              settingDescription: "",
                                               value: "right",
                                               settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let thousandsSeparator = SiteSetting(siteID: 1,
                                              settingID: "woocommerce_price_thousand_sep",
                                              label: "",
-                                             description: "",
+                                             settingDescription: "",
                                              value: "X",
                                              settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let decimalSeparator = SiteSetting(siteID: 1,
                                            settingID: "woocommerce_price_decimal_sep",
                                            label: "",
-                                           description: "",
+                                           settingDescription: "",
                                            value: "Y",
                                            settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let numberOfDecimals = SiteSetting(siteID: 1,
                                            settingID: "woocommerce_price_num_decimals",
                                            label: "",
-                                           description: "",
+                                           settingDescription: "",
                                            value: "3",
                                            settingGroupKey: SiteSettingGroup.general.rawValue)
 
@@ -109,28 +109,28 @@ final class CurrencySettingsTests: XCTestCase {
         let wooCurrencyCode = SiteSetting(siteID: 1,
                                           settingID: "woocommerce_currency",
                                           label: "",
-                                          description: "",
+                                          settingDescription: "",
                                           value: "SHP",
                                           settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let wooCurrencyPosition = SiteSetting(siteID: 1,
                                               settingID: "woocommerce_currency_pos",
                                               label: "",
-                                              description: "",
+                                              settingDescription: "",
                                               value: "right",
                                               settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let thousandsSeparator = SiteSetting(siteID: 1,
                                              settingID: "woocommerce_price_thousand_sep",
                                              label: "",
-                                             description: "",
+                                             settingDescription: "",
                                              value: "X",
                                              settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let decimalSeparator = SiteSetting(siteID: 1,
                                            settingID: "woocommerce_price_decimal_sep",
                                            label: "",
-                                           description: "",
+                                           settingDescription: "",
                                            value: "Y",
                                            settingGroupKey: SiteSettingGroup.general.rawValue)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Fakes
-@testable import Yosemite
+@testable import WooCommerce
 
 class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     /// Mock Storage: InMemory

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -7,6 +7,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     ///
     private var storageManager: MockStorageManager!
 
+    /// Mock Stores
+    ///
+    private var stores: MockStoresManager!
+
     /// Dummy Site ID
     ///
     private let sampleSiteID: Int64 = 1234
@@ -14,10 +18,13 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         storageManager = MockStorageManager()
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.updateDefaultStore(storeID: sampleSiteID)
     }
 
     override func tearDownWithError() throws {
         storageManager = nil
+        stores = nil
         try super.tearDownWithError()
     }
 
@@ -31,7 +38,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSampleSitePlugin(readOnlySitePlugin: plugin)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.checkOnboardingState()
 
         // Then
@@ -55,7 +62,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.checkOnboardingState()
 
         // Then
@@ -79,7 +86,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
 
         // When
-        let useCase = CardPresentPaymentsOnboardingUseCase(siteID: sampleSiteID, storageManager: storageManager, dispatch: { _ in })
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
         let state = useCase.checkOnboardingState()
 
         // Then

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -328,8 +328,6 @@
 		DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */; };
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
 		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
-		E14C63A526B40D8300312224 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14C63A426B40D8300312224 /* CardPresentPaymentsOnboardingUseCase.swift */; };
-		E1BB4D6626B7EE3C006798F7 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BB4D6526B7EE3C006798F7 /* CardPresentPaymentsOnboardingUseCaseTests.swift */; };
 		FE28F6EE268440B1004465C7 /* UserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6ED268440B1004465C7 /* UserAction.swift */; };
 		FE28F6F026844231004465C7 /* UserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6EF26844231004465C7 /* UserStore.swift */; };
 		FE28F6F2268462A6004465C7 /* UserStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6F1268462A6004465C7 /* UserStoreTests.swift */; };
@@ -697,8 +695,6 @@
 		DEFD6D9426443CA100E51E0D /* SitePluginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStore.swift; sourceTree = "<group>"; };
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
-		E14C63A426B40D8300312224 /* CardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
-		E1BB4D6526B7EE3C006798F7 /* CardPresentPaymentsOnboardingUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCaseTests.swift; sourceTree = "<group>"; };
 		FE28F6ED268440B1004465C7 /* UserAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAction.swift; sourceTree = "<group>"; };
 		FE28F6EF26844231004465C7 /* UserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStore.swift; sourceTree = "<group>"; };
 		FE28F6F1268462A6004465C7 /* UserStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStoreTests.swift; sourceTree = "<group>"; };
@@ -1185,7 +1181,6 @@
 		B5BC736320D1A98500B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
-				E1C1125E26B40639005E52F6 /* Payments */,
 				5758EB2E24DC7777009ED8A6 /* AppSettings */,
 				5726456D250BD177005BBD7C /* Order */,
 				570B05CD246B6A2F00C186AE /* ProductReview */,
@@ -1231,7 +1226,6 @@
 		B5BC736620D1AA8F00B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
-				E1BB4D6426B7EE1C006798F7 /* Payments */,
 				5758EB3124DC961E009ED8A6 /* AppSettings */,
 				57264570250BE2CE005BBD7C /* Order */,
 				578CE7862475D6FA00492EBF /* ProductReview */,
@@ -1490,22 +1484,6 @@
 				D8652E4726307A5000350F37 /* MockReceiptPrinterService.swift */,
 			);
 			path = CardPresentPayments;
-			sourceTree = "<group>";
-		};
-		E1BB4D6426B7EE1C006798F7 /* Payments */ = {
-			isa = PBXGroup;
-			children = (
-				E1BB4D6526B7EE3C006798F7 /* CardPresentPaymentsOnboardingUseCaseTests.swift */,
-			);
-			path = Payments;
-			sourceTree = "<group>";
-		};
-		E1C1125E26B40639005E52F6 /* Payments */ = {
-			isa = PBXGroup;
-			children = (
-				E14C63A426B40D8300312224 /* CardPresentPaymentsOnboardingUseCase.swift */,
-			);
-			path = Payments;
 			sourceTree = "<group>";
 		};
 		E35A5B190486BCE158B0320B /* Pods */ = {
@@ -1790,7 +1768,6 @@
 				D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */,
 				744A321B216D57D40051439B /* SiteVisitStats+ReadOnlyType.swift in Sources */,
 				02124DAE2431C11600980D74 /* Media+ProductImage.swift in Sources */,
-				E14C63A526B40D8300312224 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */,
 				DEFD6D9526443CA100E51E0D /* SitePluginStore.swift in Sources */,
 				26577517243D5E42003168A5 /* ProductCategoryUpdated.swift in Sources */,
 				261CF1F1255B389F0090D8D3 /* PaymentGatewayStore.swift in Sources */,
@@ -1940,7 +1917,6 @@
 				022F9319257F24730011CD94 /* MockShippingLabel.swift in Sources */,
 				02FF055623D984310058E6E7 /* MockFileManager.swift in Sources */,
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
-				E1BB4D6626B7EE3C006798F7 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
 				0248B36924590FC300A271A4 /* ProductStore+FilterProductsTests.swift in Sources */,
 				02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */,
 				02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
@@ -23,7 +23,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
         return SiteSetting(siteID: siteID,
                            settingID: settingID ?? "",
                            label: label ?? "",
-                           description: settingDescription ?? "",
+                           settingDescription: settingDescription ?? "",
                            value: value ?? "",
                            settingGroupKey: settingGroupKey ?? SiteSettingGroup.general.rawValue) // Default to general group
     }

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -140,4 +140,14 @@ extension MockStorageManager {
 
         return newPlugin
     }
+
+    /// Inserts a new (Sample) Setting into the specified context.
+    ///
+    @discardableResult
+    func insertSampleSiteSetting(readOnlySiteSetting: SiteSetting) -> StorageSiteSetting {
+        let newSetting = viewStorage.insertNewObject(ofType: StorageSiteSetting.self)
+        newSetting.update(with: readOnlySiteSetting)
+
+        return newSetting
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -566,7 +566,8 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_currency",
                            label: "Currency",
-                           settingDescription: "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+                           settingDescription: "This controls what currency prices are listed at in the catalog"
+                            + " and which currency gateways will take payments in.",
                            value: "USD",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
     }

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -566,7 +566,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_currency",
                            label: "Currency",
-                           description: "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+                           settingDescription: "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
                            value: "USD",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
     }
@@ -575,7 +575,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_currency",
                            label: "Currency!",
-                           description: "This controls what currency prices are listed!",
+                           settingDescription: "This controls what currency prices are listed!",
                            value: "GBP",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
     }
@@ -584,7 +584,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_price_thousand_sep",
                            label: "Thousand separator",
-                           description: "This sets the thousand separator of displayed prices.",
+                           settingDescription: "This sets the thousand separator of displayed prices.",
                            value: ",",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
     }
@@ -593,7 +593,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_price_thousand_sep",
                            label: "Thousand separator!!",
-                           description: "This sets the thousand separator!!",
+                           settingDescription: "This sets the thousand separator!!",
                            value: "~",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
     }
@@ -604,7 +604,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_dimension_unit",
                            label: "Dimensions unit",
-                           description: "This controls what unit you will define lengths in.",
+                           settingDescription: "This controls what unit you will define lengths in.",
                            value: "m",
                            settingGroupKey: SiteSettingGroup.product.rawValue)
     }
@@ -613,7 +613,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_dimension_unit",
                            label: "Dimension Fruit",
-                           description: "This controls what fruit you will define lengths in.",
+                           settingDescription: "This controls what fruit you will define lengths in.",
                            value: "Kumquat",
                            settingGroupKey: SiteSettingGroup.product.rawValue)
     }
@@ -622,7 +622,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_weight_unit",
                            label: "Weight unit",
-                           description: "This controls what unit you will define weights in.",
+                           settingDescription: "This controls what unit you will define weights in.",
                            value: "kg",
                            settingGroupKey: SiteSettingGroup.product.rawValue)
     }
@@ -631,7 +631,7 @@ private extension SettingStoreTests {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_weight_unit",
                            label: "Animal unit",
-                           description: "This controls what animal you will define weights in.",
+                           settingDescription: "This controls what animal you will define weights in.",
                            value: "elephants",
                            settingGroupKey: SiteSettingGroup.product.rawValue)
     }


### PR DESCRIPTION
Part of #4611 

This PR checks the store address and returns a `wcpayUnsupportedVersion` state if the country is not supported (we currently only support the US). 

The implementation is relatively simple but I had to move around and refactor quite a few things. Before this PR, I had added `CardPresentPaymentsOnboardingUseCase` to Yosemite instead of WooCommerce, but now I realized it would make things a lot easier if we can access the existing logic for figuring out a site address via `SiteAddress` and `SelectedSiteSettings`, so I moved the existing code to `WooCommerce`.

Because the existing code relies more heavily on `ServiceLocator`, I changed the API so it doesn't take a `siteID` anymore, and takes it from the session instead. I also had to update `SelectedSiteSettings` to make it more testable.

Finally, I made `SiteSettings` copiable, but there was a mismatch where one of the initializer arguments didn't match the property name, so the generated `copy()` had a syntax error. This was an easy find and replace, but it makes the PR a bit noisier.

Because of all these things, I feel this PR is getting large enough, so I'll handle the error screen in a separate PR.

## To test

Unit tests should pass

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
