### PR TITLE
[CPP Onboarding] Implement onboarding plugin checks

### DIFF
--- a/Networking/Networking/Model/SitePluginStatusEnum.swift
+++ b/Networking/Networking/Model/SitePluginStatusEnum.swift
@@ -39,6 +39,15 @@ extension SitePluginStatusEnum: RawRepresentable {
         case .unknown:       return Keys.unknown
         }
     }
+
+    /// Returns true if the plugin is active, either individually or network-wide
+    ///
+    public var isActive: Bool {
+        switch self {
+        case .active, .networkActive:   return true
+        case .inactive, .unknown:       return false
+        }
+    }
 }
 
 /// Enum containing all possible plugin status keys

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -136,13 +136,11 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isWCPayVersionSupported(plugin: SitePlugin) -> Bool {
-        // TODO: not implemented yet
-        return true
+        plugin.version.compare(Constants.supportedWCPayVersion, options: .numeric) != .orderedAscending
     }
 
     func isWCPayActivated(plugin: SitePlugin) -> Bool {
-        // TODO: not implemented yet
-        return true
+        plugin.status.isActive
     }
 
     func getWCPayAccount() -> PaymentGatewayAccount? {
@@ -194,5 +192,6 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
 private enum Constants {
     static let pluginName = "WooCommerce Payments"
+    static let supportedWCPayVersion = "2.5"
     static let supportedCountryCodes = ["US"]
 }


### PR DESCRIPTION
Part of #4611 

This PR adds all the onboarding checks related to plugins:
- Is WooCommerce Payments installed?
- Is WooCommerce Payments active?
- Is the WooCommerce Payments version recent enough (2.5+)?

## To test

I've tested on some actual stores that Jirka set up with every possible state. For this one, it might still be easy enough to test, but otherwise I'd say it might be OK to rely on unit tests for now, and do more thorough testing once all the checks are implemented.

If you want to test this, you'll need a store with a US address (only the country is checked, so the address might be fake). There is no UI to show this states so, to see any changes, you'll need to inspect the `viewModel.state` in `InPersonPaymentsView`. You can set a breakpoint, log to the console, or apply [this patch](https://gist.github.com/koke/c896431264a5284903aac84a0f9cfae5) so that the generic error screen includes the state.

Then go to Settings > In-Person payments, and you should see different states depending on the state of WCPay plugin installation on the store:

Before installing plugin | Installed but not active | Installed an old (<2.5) version | Installed and active
-|-|-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 10 37 52](https://user-images.githubusercontent.com/8739/128321048-e74add0d-bf37-4a02-9ee5-61183b7805b6.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 10 38 09](https://user-images.githubusercontent.com/8739/128321052-a11e28b7-dee4-4489-b929-268d945947bc.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 10 38 30](https://user-images.githubusercontent.com/8739/128321056-acaf3b7a-63ef-4091-98f5-2f51efa087b6.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 10 38 53](https://user-images.githubusercontent.com/8739/128321059-eb86599a-694a-40d4-bbda-5b31c19e1215.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
