### PR TITLE
[CPP Onboarding] Implement onboarding payment account checks

### DIFF
--- a/Networking/Networking/Model/WCPayAccountStatusEnum.swift
+++ b/Networking/Networking/Model/WCPayAccountStatusEnum.swift
@@ -18,6 +18,11 @@ public enum WCPayAccountStatusEnum: Decodable, Hashable, GeneratedFakeable {
     /// review by Stripe and the merchant will probably not be able to collect card present payments.
     case restricted
 
+    /// This state occurs when there is required business information missing from the account but the
+    /// currentDeadline hasn't passed yet (aka there are no overdueRequirements). The merchant will probably be able
+    /// to collect card present payments.
+    case restrictedSoon
+
     /// This state occurs when our payment processor rejects the merchant account due to suspected fraudulent
     /// activity. The merchant will NOT be able to collect card present payments.
     case rejectedFraud
@@ -56,6 +61,8 @@ extension WCPayAccountStatusEnum: RawRepresentable {
             self = .complete
         case Keys.restricted:
             self = .restricted
+        case Keys.restrictedSoon:
+            self = .restrictedSoon
         case Keys.rejectedFraud:
             self = .rejectedFraud
         case Keys.rejectedTermsOfService:
@@ -77,6 +84,7 @@ extension WCPayAccountStatusEnum: RawRepresentable {
         switch self {
         case .complete:               return Keys.complete
         case .restricted:             return Keys.restricted
+        case .restrictedSoon:         return Keys.restrictedSoon
         case .rejectedFraud:          return Keys.rejectedFraud
         case .rejectedTermsOfService: return Keys.rejectedTermsOfService
         case .rejectedListed:         return Keys.rejectedListed
@@ -94,6 +102,8 @@ private enum Keys {
     static let complete               = "complete"
     /// The WCPay account is restricted - it is under review or has pending or overdue requirements.
     static let restricted             = "restricted"
+    /// The WCPay account has required information missing but it's not restricted yet.
+    static let restrictedSoon         = "restricted_soon"
     /// The WCPay account has been rejected due to fradulent activity.
     static let rejectedFraud          = "rejected.fraud"
     /// The WCPay account has been rejected due to violating the terms of service.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -92,11 +92,11 @@ struct CardPresentPaymentsOnboardingUseCase {
         guard !isStripeAccountUnderReview(account: account) else {
             return .stripeAccountUnderReview
         }
-        guard !isStripeAccountPendingRequirements(account: account) else {
-            return .stripeAccountPendingRequirement
-        }
         guard !isStripeAccountOverdueRequirements(account: account) else {
             return .stripeAccountOverdueRequirement
+        }
+        guard !isStripeAccountPendingRequirements(account: account) else {
+            return .stripeAccountPendingRequirement
         }
         guard !isStripeAccountRejected(account: account) else {
             return .stripeAccountRejected

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -154,8 +154,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isWCPaySetupCompleted(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return true
+        account.wcpayStatus != .noAccount
     }
 
     func isWCPayInTestModeWithLiveStripeAccount(account: PaymentGatewayAccount) -> Bool {
@@ -164,30 +163,37 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isStripeAccountUnderReview(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.wcpayStatus == .restricted
+            && !account.hasPendingRequirements
+            && !account.hasOverdueRequirements
     }
 
     func isStripeAccountPendingRequirements(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.wcpayStatus == .restricted
+            && account.hasPendingRequirements
+            || account.wcpayStatus == .restrictedSoon
     }
 
     func isStripeAccountOverdueRequirements(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.wcpayStatus == .restricted && account.hasOverdueRequirements
     }
 
     func isStripeAccountRejected(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.wcpayStatus == .rejectedFraud
+            || account.wcpayStatus == .rejectedListed
+            || account.wcpayStatus == .rejectedTermsOfService
+            || account.wcpayStatus == .rejectedOther
     }
 
     func isInUndefinedState(account: PaymentGatewayAccount) -> Bool {
-        // TODO: not implemented yet
-        return false
+        account.wcpayStatus != .complete
     }
+}
 
+private extension PaymentGatewayAccount {
+    var wcpayStatus: WCPayAccountStatusEnum {
+        .init(rawValue: status)
+    }
 }
 
 private enum Constants {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -99,14 +99,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupPlugin(status: .networkActive, version: .supportedExact)
-
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: sampleSiteID,
-                isCardPresentEligible: true
-            )
-        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+        setupPaymentGatewayAccount(isCardPresentEligible: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -120,14 +113,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupPlugin(status: .networkActive, version: .supported)
-
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: sampleSiteID,
-                isCardPresentEligible: true
-            )
-        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+        setupPaymentGatewayAccount(isCardPresentEligible: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -141,14 +127,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupPlugin(status: .networkActive, version: .supported)
-
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: sampleSiteID,
-                isCardPresentEligible: true
-            )
-        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+        setupPaymentGatewayAccount(isCardPresentEligible: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -177,14 +156,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupPlugin(status: .active, version: .supported)
-
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: sampleSiteID,
-                isCardPresentEligible: false
-            )
-        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+        setupPaymentGatewayAccount(isCardPresentEligible: false)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -198,14 +170,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .us)
         setupPlugin(status: .active, version: .supported)
-
-        let paymentGatewayAccount = PaymentGatewayAccount
-            .fake()
-            .copy(
-                siteID: sampleSiteID,
-                isCardPresentEligible: true
-            )
-        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
+        setupPaymentGatewayAccount(isCardPresentEligible: true)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
@@ -254,5 +219,18 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
         case supported = "2.6.1"
         case supportedExact = "2.5"
         case unsupported = "2.4.2"
+    }
+}
+
+// MARK: - Account helpers
+private extension CardPresentPaymentsOnboardingUseCaseTests {
+    func setupPaymentGatewayAccount(isCardPresentEligible: Bool) {
+        let paymentGatewayAccount = PaymentGatewayAccount
+            .fake()
+            .copy(
+                siteID: sampleSiteID,
+                isCardPresentEligible: isCardPresentEligible
+            )
+        storageManager.insertSamplePaymentGatewayAccount(readOnlyAccount: paymentGatewayAccount)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -222,6 +222,20 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .stripeAccountOverdueRequirement)
     }
 
+    func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_and_pending_requirements() {
+        // Given
+        setupCountry(country: .us)
+        setupPlugin(status: .active, version: .supported)
+        setupPaymentGatewayAccount(status: .restricted, hasPendingRequirements: true, hasOverdueRequirements: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.checkOnboardingState()
+
+        // Then
+        XCTAssertEqual(state, .stripeAccountOverdueRequirement)
+    }
+
     func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements() {
         // Given
         setupCountry(country: .us)


### PR DESCRIPTION
Part of #4611 
Fixes #4707

This PR adds the final set of onboarding checks related to the WCPay account:
- There is an account set up
- (Temporarily) It is eligible for In-Person payments
- Setup is complete
- The account is not under review
- The account doesn't have pending/overdue requirements
- The account hasn't been rejected

All these states come from the backend, but we want to show different error screens with different actions for each state. 

Note that this is heavily inspired on the existing android implementation:
- [CardReaderOnboardingChecker](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt)
- [CardReaderOnboardingCheckerTest](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt)

## To test

I've tested on some actual stores that Jirka set up with some of the possible states. I'd say it might be OK to rely on unit tests for now as it will be time consuming to test every possibility now. We can do more thorough testing once all the feature implementation is complete. I'm not sure if we'll be able to manually test every case anyway (e.g. the account was rejected for fraud).

If you want to test this, you'll need a store with a US address (only the country is checked, so the address might be fake). There is no UI to show this states so, to see any changes, you'll need to inspect the viewModel.state in InPersonPaymentsView. You can set a breakpoint, log to the console, or apply this patch so that the generic error screen includes the state.

Then go to Settings > In-Person payments, and you should see different states depending on the state of WCPay setup:

Account with overdue requirements | Account with pending requirements | Account rejected
-|-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 11 08 18](https://user-images.githubusercontent.com/8739/128325385-70acc502-37b5-4b2d-8796-cd407b254665.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 11 08 30](https://user-images.githubusercontent.com/8739/128325392-8eda9578-5f80-4163-a3ed-1d994f23178f.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 11 08 56](https://user-images.githubusercontent.com/8739/128325395-e99c1ce2-f8f6-4559-8b95-245ec8c4c2ae.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
