### PR TITLE
Shipping Labels: Create new model for customs form

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1053,6 +1053,36 @@ extension ShippingLabelCustomPackage {
         )
     }
 }
+extension ShippingLabelCustomsForm {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomsForm {
+        .init(
+            contentsType: .fake(),
+            contentExplanation: .fake(),
+            restrictionType: .fake(),
+            restrictionComments: .fake(),
+            nonDeliveryOption: .fake(),
+            itn: .fake(),
+            items: .fake()
+        )
+    }
+}
+extension ShippingLabelCustomsForm.Item {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomsForm.Item {
+        .init(
+            description: .fake(),
+            quantity: .fake(),
+            value: .fake(),
+            weight: .fake(),
+            hsTariffNumber: .fake(),
+            originCountry: .fake(),
+            productID: .fake()
+        )
+    }
+}
 extension ShippingLabelPackagePurchase {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1060,7 +1090,8 @@ extension ShippingLabelPackagePurchase {
         .init(
             package: .fake(),
             rate: .fake(),
-            productIDs: .fake()
+            productIDs: .fake(),
+            customsForm: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1068,6 +1068,13 @@ extension ShippingLabelCustomsForm {
         )
     }
 }
+extension ShippingLabelCustomsForm.ContentsType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomsForm.ContentsType {
+        .merchandise
+    }
+}
 extension ShippingLabelCustomsForm.Item {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1081,6 +1088,20 @@ extension ShippingLabelCustomsForm.Item {
             originCountry: .fake(),
             productID: .fake()
         )
+    }
+}
+extension ShippingLabelCustomsForm.NonDeliveryOption {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomsForm.NonDeliveryOption {
+        .`return`
+    }
+}
+extension ShippingLabelCustomsForm.RestrictionType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ShippingLabelCustomsForm.RestrictionType {
+        .none
     }
 }
 extension ShippingLabelPackagePurchase {

--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1105,7 +1105,8 @@ extension ShippingLabelPackageSelected {
             width: .fake(),
             height: .fake(),
             weight: .fake(),
-            isLetter: .fake()
+            isLetter: .fake(),
+            customsForm: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */; };
 		D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */; };
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
+		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1076,6 +1077,7 @@
 		D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-daily.json"; sourceTree = "<group>"; };
 		D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-month.json"; sourceTree = "<group>"; };
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
+		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1174,6 +1176,7 @@
 				451A97D4260A069B0059D135 /* Custom package */,
 				451A97E3260B63030059D135 /* Predefined package */,
 				456930A5264EA4E2009ED69D /* Carriers and Rates */,
+				DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */,
 			);
 			path = Packages;
 			sourceTree = "<group>";
@@ -1446,7 +1449,7 @@
 				029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */,
 				D8EDFE1D25EE87F1003D2213 /* WCPayRemote.swift */,
 				FE28F6E5268429B6004465C7 /* UserRemote.swift */,
-        077F39D526A58E4500ABEADC /* SystemPluginsRemote.swift */,
+				077F39D526A58E4500ABEADC /* SystemPluginsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -2305,6 +2308,7 @@
 				456930A9264EB576009ED69D /* ShippingLabelCarriersAndRates.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
 				020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */,
+				DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */,
 				31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -13,32 +13,36 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
     public let height: Double
     public let weight: Double
     public let isLetter: Bool
+    public let customsForm: ShippingLabelCustomsForm?
 
-    public init(boxID: String, length: Double, width: Double, height: Double, weight: Double, isLetter: Bool) {
+    public init(boxID: String, length: Double, width: Double, height: Double, weight: Double, isLetter: Bool, customsForm: ShippingLabelCustomsForm?) {
         self.boxID = boxID
         self.length = length
         self.width = width
         self.height = height
         self.weight = weight
         self.isLetter = isLetter
+        self.customsForm = customsForm
     }
 
-    public init(customPackage: ShippingLabelCustomPackage, totalWeight: Double) {
+    public init(customPackage: ShippingLabelCustomPackage, totalWeight: Double, customsForm: ShippingLabelCustomsForm?) {
         self.boxID = customPackage.title
         self.length = customPackage.getLength()
         self.width = customPackage.getWidth()
         self.height = customPackage.getHeight()
         self.weight = totalWeight
         self.isLetter = customPackage.isLetter
+        self.customsForm = customsForm
     }
 
-    public init(predefinedPackage: ShippingLabelPredefinedPackage, totalWeight: Double) {
+    public init(predefinedPackage: ShippingLabelPredefinedPackage, totalWeight: Double, customsForm: ShippingLabelCustomsForm?) {
         self.boxID = predefinedPackage.id
         self.length = predefinedPackage.getLength()
         self.width = predefinedPackage.getWidth()
         self.height = predefinedPackage.getHeight()
         self.weight = totalWeight
         self.isLetter = predefinedPackage.isLetter
+        self.customsForm = customsForm
     }
 }
 
@@ -55,7 +59,25 @@ extension ShippingLabelPackageSelected: Codable {
         let weight = try container.decode(Double.self, forKey: .weight)
         let isLetter = try container.decode(Bool.self, forKey: .isLetter)
 
-        self.init(boxID: boxID, length: length, width: width, height: height, weight: weight, isLetter: isLetter)
+        let customsForm: ShippingLabelCustomsForm? = try? {
+            let contentsType = try container.decode(ShippingLabelCustomsForm.ContentsType.self, forKey: .contentsType)
+            let contentsExplanation = (try? container.decode(String.self, forKey: .contentsExplanation)) ?? ""
+            let restrictionType = try container.decode(ShippingLabelCustomsForm.RestrictionType.self, forKey: .restrictionType)
+            let restrictionComments = (try? container.decode(String.self, forKey: .restrictionComments)) ?? ""
+            let nonDeliveryOption = try container.decode(ShippingLabelCustomsForm.NonDeliveryOption.self, forKey: .nonDeliveryOption)
+            let itn = (try? container.decode(String.self, forKey: .itn)) ?? ""
+            let items = try container.decode([ShippingLabelCustomsForm.Item].self, forKey: .items)
+
+            return ShippingLabelCustomsForm(contentsType: contentsType,
+                                            contentExplanation: contentsExplanation,
+                                            restrictionType: restrictionType,
+                                            restrictionComments: restrictionComments,
+                                            nonDeliveryOption: nonDeliveryOption,
+                                            itn: itn,
+                                            items: items)
+        }()
+
+        self.init(boxID: boxID, length: length, width: width, height: height, weight: weight, isLetter: isLetter, customsForm: customsForm)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -68,6 +90,15 @@ extension ShippingLabelPackageSelected: Codable {
         try container.encode(height, forKey: .height)
         try container.encode(weight, forKey: .weight)
         try container.encode(isLetter, forKey: .isLetter)
+        if let form = customsForm {
+            try container.encode(form.contentsType.rawValue, forKey: .contentsType)
+            try container.encode(form.contentExplanation, forKey: .contentsExplanation)
+            try container.encode(form.restrictionType.rawValue, forKey: .restrictionType)
+            try container.encode(form.restrictionComments, forKey: .restrictionComments)
+            try container.encode(form.nonDeliveryOption.rawValue, forKey: .nonDeliveryOption)
+            try container.encode(form.itn, forKey: .itn)
+            try container.encode(form.items, forKey: .items)
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -78,5 +109,12 @@ extension ShippingLabelPackageSelected: Codable {
         case height
         case weight
         case isLetter = "is_letter"
+        case contentsType = "contents_type"
+        case contentsExplanation = "contents_explanation"
+        case restrictionType = "restriction_type"
+        case restrictionComments = "restriction_comments"
+        case nonDeliveryOption = "non_delivery_option"
+        case itn
+        case items
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Codegen
+
+/// Represents customs info for a shipping label package
+///
+public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
+    /// Type of contents to declare with customs.
+    public let contentsType: ContentsType
+
+    /// Explanation for contents if of type other, empty otherwise.
+    public let contentExplanation: String
+
+    /// Restriction type of contents.
+    public let restrictionType: RestrictionType
+
+    /// Details about restriction if of type other, empty otherwise.
+    public let restrictionComments: String
+
+    /// Option if delivery fails.
+    public let nonDeliveryOption: NonDeliveryOption
+
+    /// Internal Transaction Number (optional).
+    public let itn: String?
+
+    /// Items in the package to declare.
+    public let items: [Item]
+}
+
+// MARK: - Subtypes
+//
+public extension ShippingLabelCustomsForm {
+    /// Types of contents to declare with customs.
+    ///
+    enum ContentsType: String {
+        case merchandise
+        case documents
+        case gift
+        case sample
+        case other
+    }
+
+    /// Types of restriction of contents to declare with customs.
+    ///
+    enum RestrictionType: String {
+        case none
+        case quarantine
+        case sanitaryOrPhytosanitaryInspection = "sanitary_phytosanitary_inspection"
+        case other
+    }
+
+    /// Options if delivery fails.
+    ///
+    enum NonDeliveryOption: String {
+        case `return`
+        case abandon
+    }
+
+    /// Information about a item to declare with customs.
+    ///
+    struct Item: Encodable, Equatable, GeneratedFakeable {
+        /// Description of item.
+        public let description: String
+
+        /// Quantity of item
+        public let quantity: Int
+
+        /// Price of item per unit.
+        public let value: Double
+
+        /// Weight of item per unit.
+        public let weight: Double
+
+        /// HS tariff number, empty if N/A.
+        public let hsTariffNumber: String
+
+        /// Origin country code of item.
+        public let originCountry: String
+
+        /// Product ID of item.
+        public let productID: Int64
+    }
+}
+
+// MARK: - Codable
+//
+private extension ShippingLabelCustomsForm.Item {
+    enum CodingKeys: String, CodingKey {
+        case description
+        case quantity
+        case value
+        case weight
+        case hsTariffNumber = "hs_tariff_number"
+        case originCountry = "origin_country"
+        case productID = "product_id"
+    }
+}

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -131,6 +131,12 @@ extension ShippingLabelCustomsForm.Item {
         let originCountry = try container.decode(String.self, forKey: .originCountry)
         let productID = try container.decode(Int64.self, forKey: .productID)
 
-        self.init(description: description, quantity: quantity, value: value, weight: weight, hsTariffNumber: hsTariffNumber, originCountry: originCountry, productID: productID)
+        self.init(description: description,
+                  quantity: quantity,
+                  value: value,
+                  weight: weight,
+                  hsTariffNumber: hsTariffNumber,
+                  originCountry: originCountry,
+                  productID: productID)
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -24,6 +24,22 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
 
     /// Items in the package to declare.
     public let items: [Item]
+
+    public init(contentsType: ShippingLabelCustomsForm.ContentsType,
+                contentExplanation: String,
+                restrictionType: ShippingLabelCustomsForm.RestrictionType,
+                restrictionComments: String,
+                nonDeliveryOption: ShippingLabelCustomsForm.NonDeliveryOption,
+                itn: String?,
+                items: [ShippingLabelCustomsForm.Item]) {
+        self.contentsType = contentsType
+        self.contentExplanation = contentExplanation
+        self.restrictionType = restrictionType
+        self.restrictionComments = restrictionComments
+        self.nonDeliveryOption = nonDeliveryOption
+        self.itn = itn
+        self.items = items
+    }
 }
 
 // MARK: - Subtypes
@@ -78,6 +94,16 @@ public extension ShippingLabelCustomsForm {
 
         /// Product ID of item.
         public let productID: Int64
+
+        public init(description: String, quantity: Int, value: Double, weight: Double, hsTariffNumber: String, originCountry: String, productID: Int64) {
+            self.description = description
+            self.quantity = quantity
+            self.value = value
+            self.weight = weight
+            self.hsTariffNumber = hsTariffNumber
+            self.originCountry = originCountry
+            self.productID = productID
+        }
     }
 }
 

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -47,7 +47,7 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
 public extension ShippingLabelCustomsForm {
     /// Types of contents to declare with customs.
     ///
-    enum ContentsType: String, Codable {
+    enum ContentsType: String, Codable, GeneratedFakeable {
         case merchandise
         case documents
         case gift
@@ -57,7 +57,7 @@ public extension ShippingLabelCustomsForm {
 
     /// Types of restriction of contents to declare with customs.
     ///
-    enum RestrictionType: String, Codable {
+    enum RestrictionType: String, Codable, GeneratedFakeable {
         case none
         case quarantine
         case sanitaryOrPhytosanitaryInspection = "sanitary_phytosanitary_inspection"
@@ -66,7 +66,7 @@ public extension ShippingLabelCustomsForm {
 
     /// Options if delivery fails.
     ///
-    enum NonDeliveryOption: String, Codable {
+    enum NonDeliveryOption: String, Codable, GeneratedFakeable {
         case `return`
         case abandon
     }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -19,8 +19,8 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
     /// Option if delivery fails.
     public let nonDeliveryOption: NonDeliveryOption
 
-    /// Internal Transaction Number (optional).
-    public let itn: String?
+    /// Internal Transaction Number, empty if not applicable.
+    public let itn: String
 
     /// Items in the package to declare.
     public let items: [Item]
@@ -30,7 +30,7 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
                 restrictionType: ShippingLabelCustomsForm.RestrictionType,
                 restrictionComments: String,
                 nonDeliveryOption: ShippingLabelCustomsForm.NonDeliveryOption,
-                itn: String?,
+                itn: String,
                 items: [ShippingLabelCustomsForm.Item]) {
         self.contentsType = contentsType
         self.contentExplanation = contentExplanation
@@ -47,7 +47,7 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
 public extension ShippingLabelCustomsForm {
     /// Types of contents to declare with customs.
     ///
-    enum ContentsType: String {
+    enum ContentsType: String, Codable {
         case merchandise
         case documents
         case gift
@@ -57,7 +57,7 @@ public extension ShippingLabelCustomsForm {
 
     /// Types of restriction of contents to declare with customs.
     ///
-    enum RestrictionType: String {
+    enum RestrictionType: String, Codable {
         case none
         case quarantine
         case sanitaryOrPhytosanitaryInspection = "sanitary_phytosanitary_inspection"
@@ -66,14 +66,14 @@ public extension ShippingLabelCustomsForm {
 
     /// Options if delivery fails.
     ///
-    enum NonDeliveryOption: String {
+    enum NonDeliveryOption: String, Codable {
         case `return`
         case abandon
     }
 
     /// Information about a item to declare with customs.
     ///
-    struct Item: Encodable, Equatable, GeneratedFakeable {
+    struct Item: Codable, Equatable, GeneratedFakeable {
         /// Description of item.
         public let description: String
 
@@ -109,8 +109,8 @@ public extension ShippingLabelCustomsForm {
 
 // MARK: - Codable
 //
-private extension ShippingLabelCustomsForm.Item {
-    enum CodingKeys: String, CodingKey {
+extension ShippingLabelCustomsForm.Item {
+    private enum CodingKeys: String, CodingKey {
         case description
         case quantity
         case value
@@ -118,5 +118,19 @@ private extension ShippingLabelCustomsForm.Item {
         case hsTariffNumber = "hs_tariff_number"
         case originCountry = "origin_country"
         case productID = "product_id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let description = try container.decode(String.self, forKey: .description)
+        let quantity = try container.decode(Int.self, forKey: .quantity)
+        let value = try container.decode(Double.self, forKey: .value)
+        let weight = try container.decode(Double.self, forKey: .weight)
+        let hsTariffNumber = (try? container.decode(String.self, forKey: .hsTariffNumber)) ?? ""
+        let originCountry = try container.decode(String.self, forKey: .originCountry)
+        let productID = try container.decode(Int64.self, forKey: .productID)
+
+        self.init(description: description, quantity: quantity, value: value, weight: weight, hsTariffNumber: hsTariffNumber, originCountry: originCountry, productID: productID)
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagePurchase.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagePurchase.swift
@@ -14,10 +14,14 @@ public struct ShippingLabelPackagePurchase: Equatable, GeneratedFakeable {
     /// IDs for the products to be shipped
     public let productIDs: [Int64]
 
-    public init(package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64]) {
+    /// Customs forms if applicable
+    public let customsForm: ShippingLabelCustomsForm?
+
+    public init(package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64], customsForm: ShippingLabelCustomsForm?) {
         self.package = package
         self.rate = rate
         self.productIDs = productIDs
+        self.customsForm = customsForm
     }
 }
 
@@ -40,6 +44,15 @@ extension ShippingLabelPackagePurchase: Encodable {
         try container.encode(rate.carrierID, forKey: .carrierID)
         try container.encode(rate.title, forKey: .serviceName)
         try container.encode(productIDs, forKey: .products)
+        if let form = customsForm {
+            try container.encode(form.contentsType.rawValue, forKey: .contentsType)
+            try container.encode(form.contentExplanation, forKey: .contentsExplanation)
+            try container.encode(form.restrictionType.rawValue, forKey: .restrictionType)
+            try container.encode(form.restrictionComments, forKey: .restrictionComments)
+            try container.encode(form.nonDeliveryOption.rawValue, forKey: .nonDeliveryOption)
+            try container.encode(form.itn, forKey: .itn)
+            try container.encode(form.items, forKey: .items)
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -56,5 +69,12 @@ extension ShippingLabelPackagePurchase: Encodable {
         case carrierID = "carrier_id"
         case serviceName = "service_name"
         case products
+        case contentsType = "contents_type"
+        case contentsExplanation = "contents_explanation"
+        case restrictionType = "restriction_type"
+        case restrictionComments = "restriction_comments"
+        case nonDeliveryOption = "non_delivery_option"
+        case itn
+        case items
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -682,7 +682,8 @@ extension ShippingLabelFormViewModel {
         }
 
         let productIDs = order.items.map { $0.productOrVariationID }
-        let package = ShippingLabelPackagePurchase(package: selectedPackage, rate: selectedRate, productIDs: productIDs)
+        // TODO: get customs form for the selected package and send to the model
+        let package = ShippingLabelPackagePurchase(package: selectedPackage, rate: selectedRate, productIDs: productIDs, customsForm: nil)
         let startTime = Date()
         let action = ShippingLabelAction.purchaseShippingLabel(siteID: siteID,
                                                                orderID: order.orderID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -55,22 +55,26 @@ final class ShippingLabelFormViewModel {
         let weight = Double(totalPackageWeight ?? "0") ?? .zero
 
         if let customPackage = packagesResponse.customPackages.first(where: { $0.title == selectedPackageID }) {
+            // TODO: set customs forms
             return ShippingLabelPackageSelected(boxID: customPackage.title,
                                                 length: customPackage.getLength(),
                                                 width: customPackage.getWidth(),
                                                 height: customPackage.getHeight(),
                                                 weight: weight,
-                                                isLetter: customPackage.isLetter)
+                                                isLetter: customPackage.isLetter,
+                                                customsForm: nil)
         }
 
         for option in packagesResponse.predefinedOptions {
             if let predefinedPackage = option.predefinedPackages.first(where: { $0.id == selectedPackageID }) {
+                // TODO: set customs forms
                 return ShippingLabelPackageSelected(boxID: predefinedPackage.id,
                                                     length: predefinedPackage.getLength(),
                                                     width: predefinedPackage.getWidth(),
                                                     height: predefinedPackage.getHeight(),
                                                     weight: weight,
-                                                    isLetter: predefinedPackage.isLetter)
+                                                    isLetter: predefinedPackage.isLetter,
+                                                    customsForm: nil)
             }
         }
 


### PR DESCRIPTION
Part of #4687

# Description
This PR creates new model `ShippingLabelCustomsForm` to contain information for a customs form of a package. Other models `ShippingLabelPackagePurchase` and `ShippingLabelPackageSelected` were also updated to contain customs form information.

# Changes
- Added new model `ShippingLabelCustomsForm` along with subtypes for its properties.
- Updated `ShippingLabelPackagePurchase` with new optional property for customs form. This property will be used to encode information about customs form to send in purchase request of the package.
- Updated `ShippingLabelPackageSelected` with new optional property for customs form. This property will be used to encode information about customs form to load carrier and rates available for the package.
- Generated fakes for the new models and update existing ones.

# Testing
This PR created new models only so there's nothing to test yet.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
