### PR TITLE
Add primary and secondary button styles for SwiftUI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -30,22 +30,46 @@ private struct PrimaryButton: View {
 
     var body: some View {
         BaseButton(configuration: configuration)
-            .foregroundColor(Color(isEnabled ? .primaryButtonTitle : .buttonDisabledTitle))
+            .foregroundColor(Color(foregroundColor))
             .background(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
-                    .fill(Color(isEnabled
-                                        ? configuration.isPressed ? .primaryButtonDownBackground : .primaryButtonBackground
-                                        : .buttonDisabledBackground))
+                    .fill(Color(backgroundColor))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
                     .strokeBorder(
-                        Color(isEnabled
-                                    ? configuration.isPressed ? .primaryButtonDownBorder : .primaryButtonBorder
-                                    : .buttonDisabledBorder),
+                        Color(borderColor),
                         lineWidth: Style.defaultBorderWidth
                     )
             )
+    }
+
+    var foregroundColor: UIColor {
+        isEnabled ? .primaryButtonTitle : .buttonDisabledTitle
+    }
+
+    var backgroundColor: UIColor {
+        if isEnabled {
+            if configuration.isPressed {
+                return .primaryButtonDownBackground
+            } else {
+                return .primaryButtonBackground
+            }
+        } else {
+            return .buttonDisabledBackground
+        }
+    }
+
+    var borderColor: UIColor {
+        if isEnabled {
+            if configuration.isPressed {
+                return .primaryButtonDownBorder
+            } else {
+                return .primaryButtonBorder
+            }
+        } else {
+            return .buttonDisabledBorder
+        }
     }
 }
 
@@ -56,22 +80,46 @@ private struct SecondaryButton: View {
 
     var body: some View {
         BaseButton(configuration: configuration)
-            .foregroundColor(Color(isEnabled ? .secondaryButtonTitle : .buttonDisabledTitle))
+            .foregroundColor(Color(foregroundColor))
             .background(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
-                    .fill(Color(isEnabled
-                                        ? configuration.isPressed ? .secondaryButtonDownBackground : .secondaryButtonBackground
-                                        : .buttonDisabledBackground))
+                    .fill(Color(backgroundColor))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
                     .strokeBorder(
-                        Color(isEnabled
-                                    ? configuration.isPressed ? .secondaryButtonDownBorder : .secondaryButtonBorder
-                                    : .buttonDisabledBorder),
+                        Color(borderColor),
                         lineWidth: Style.defaultBorderWidth
                     )
             )
+    }
+
+    var foregroundColor: UIColor {
+        isEnabled ? .secondaryButtonTitle : .buttonDisabledTitle
+    }
+
+    var backgroundColor: UIColor {
+        if isEnabled {
+            if configuration.isPressed {
+                return .secondaryButtonDownBackground
+            } else {
+                return .secondaryButtonBackground
+            }
+        } else {
+            return .buttonDisabledBackground
+        }
+    }
+
+    var borderColor: UIColor {
+        if isEnabled {
+            if configuration.isPressed {
+                return .secondaryButtonDownBorder
+            } else {
+                return .secondaryButtonBorder
+            }
+        } else {
+            return .buttonDisabledBorder
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        PrimaryButton(configuration: configuration)
+    }
+}
+
+struct SecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        SecondaryButton(configuration: configuration)
+    }
+}
+
+private struct BaseButton: View {
+    let configuration: ButtonStyleConfiguration
+
+    var body: some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .font(.headline)
+            .padding(Style.defaultEdgeInsets)
+    }
+}
+
+private struct PrimaryButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
+    let configuration: ButtonStyleConfiguration
+
+    var body: some View {
+        BaseButton(configuration: configuration)
+            .foregroundColor(Color(isEnabled ? .primaryButtonTitle : .buttonDisabledTitle))
+            .background(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .fill(Color(isEnabled
+                                        ? configuration.isPressed ? .primaryButtonDownBackground : .primaryButtonBackground
+                                        : .buttonDisabledBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .strokeBorder(
+                        Color(isEnabled
+                                    ? configuration.isPressed ? .primaryButtonDownBorder : .primaryButtonBorder
+                                    : .buttonDisabledBorder),
+                        lineWidth: Style.defaultBorderWidth
+                    )
+            )
+    }
+}
+
+private struct SecondaryButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
+    let configuration: ButtonStyleConfiguration
+
+    var body: some View {
+        BaseButton(configuration: configuration)
+            .foregroundColor(Color(isEnabled ? .secondaryButtonTitle : .buttonDisabledTitle))
+            .background(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .fill(Color(isEnabled
+                                        ? configuration.isPressed ? .secondaryButtonDownBackground : .secondaryButtonBackground
+                                        : .buttonDisabledBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
+                    .strokeBorder(
+                        Color(isEnabled
+                                    ? configuration.isPressed ? .secondaryButtonDownBorder : .secondaryButtonBorder
+                                    : .buttonDisabledBorder),
+                        lineWidth: Style.defaultBorderWidth
+                    )
+            )
+    }
+}
+
+private enum Style {
+    static let defaultCornerRadius = CGFloat(8.0)
+    static let defaultBorderWidth = CGFloat(1.0)
+    static let defaultEdgeInsets = EdgeInsets(top: 12, leading: 22, bottom: 12, trailing: 22)
+}
+
+struct PrimaryButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            Button("Primary button") {}
+                .buttonStyle(PrimaryButtonStyle())
+
+            Button("Primary button (disabled)") {}
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(true)
+
+            Button("Secondary button") {}
+                .buttonStyle(SecondaryButtonStyle())
+
+            Button("Secondary button (disabled)") {}
+                .buttonStyle(SecondaryButtonStyle())
+                .disabled(true)
+        }
+        .padding()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1235,6 +1235,7 @@
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
 		E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */; };
+		E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
 		E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D4E84326776A6A00256B83 /* HeadlineTableViewCell.swift */; };
@@ -2572,6 +2573,7 @@
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
 		E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequiredTests.swift; sourceTree = "<group>"; };
+		E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingStack.swift; sourceTree = "<group>"; };
 		E1D4E84226776A6A00256B83 /* HeadlineTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeadlineTableViewCell.xib; sourceTree = "<group>"; };
@@ -4138,6 +4140,7 @@
 				45DB6D962632CF9300E83C1A /* ActivityIndicator.swift */,
 				45A8DA3F2664E40B00308FBE /* EmptyState.swift */,
 				E10DFC792673595A0083AFF2 /* ShareSheet.swift */,
+				E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -6716,6 +6719,7 @@
 				456931842653E9F2009ED69D /* ShippingLabelCarrierRow.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
+				E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,


### PR DESCRIPTION
The upcoming UI for Payments Onboarding (see #4611) will use SwiftUI for its screens. Currently we don't have a way to apply our primary/secondary button styles to SwiftUI buttons, so I'm adding those in this PR, since they're not specific to onboarding.

The styles have been copied from `UIButton+Helpers.swift`, and adapted to SwiftUI. An example of usage can be seen in the SwiftUI preview code:

```swift
Button("Primary button") {}
    .buttonStyle(PrimaryButtonStyle())

Button("Secondary button") {}
    .buttonStyle(SecondaryButtonStyle())
```

![button-styles](https://user-images.githubusercontent.com/8739/128343502-3fceb99a-25aa-4fc3-9aee-2cae55c20a3d.png)

## To test

These aren't used anywhere in the app yet, but it can be tested through the SwiftUI preview

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
