### PR TITLE
[CPP Onboarding] Add learn more link to InPersonPaymentsUnavailableView

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct InPersonPaymentsLearnMore: View {
+    @State var presentedURL: URL? = nil
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 20) {
+            Image(uiImage: .infoOutlineImage)
+                .accentColor(Color(.lightGray))
+                .frame(width: 20, height: 20)
+            AttributedText(Localization.learnMore)
+                .accentColor(Color(.textLink))
+                .customOpenURL(binding: $presentedURL)
+        }
+        .safariSheet(url: $presentedURL)
+    }
+}
+
+private enum Localization {
+    static let unavailable = NSLocalizedString(
+        "In-Person Payments is currently unavailable",
+        comment: "Title for the error screen when In-Person Payments is unavailable"
+    )
+
+    static let acceptCash = NSLocalizedString(
+        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
+        comment: "Generic error message when In-Person Payments is unavailable"
+    )
+
+    static var learnMore: NSAttributedString {
+        let learnMoreText = NSLocalizedString(
+            "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
+            comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
+        )
+
+        let learnMoreAttributes: [NSAttributedString.Key: Any] = [
+            .font: StyleManager.footerLabelFont,
+            .foregroundColor: UIColor.textSubtle
+        ]
+
+        let learnMoreAttrText = NSMutableAttributedString()
+        learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
+        let range = NSRange(location: 0, length: learnMoreAttrText.length)
+        learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
+
+        return learnMoreAttrText
+    }
+}
+
+struct InPersonPaymentsLearnMore_Previews: PreviewProvider {
+    static var previews: some View {
+        InPersonPaymentsLearnMore()
+            .padding()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -1,19 +1,37 @@
 import SwiftUI
 
 struct InPersonPaymentsUnavailableView: View {
+    @State var presentedURL: URL? = nil
+
     var body: some View {
-        VStack(alignment: .center, spacing: 42) {
-            Text(Localization.unavailable)
-                .font(.headline)
-                .multilineTextAlignment(.center)
-            Image(uiImage: .paymentErrorImage)
-                .resizable()
-                .scaledToFit()
-                .frame(height: 180.0)
-            Text(Localization.acceptCash)
-                .font(.callout)
-                .multilineTextAlignment(.center)
+        VStack {
+            Spacer()
+
+            VStack(alignment: .center, spacing: 42) {
+                Text(Localization.unavailable)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                Image(uiImage: .paymentErrorImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 180.0)
+                Text(Localization.acceptCash)
+                    .font(.callout)
+                    .multilineTextAlignment(.center)
+            }
+
+            Spacer()
+
+            HStack(alignment: .center, spacing: 20) {
+                Image(uiImage: .infoOutlineImage)
+                    .accentColor(Color(.lightGray))
+                    .frame(width: 20, height: 20)
+                AttributedText(Localization.learnMore)
+                    .accentColor(Color(.textLink))
+                    .customOpenURL(binding: $presentedURL)
+            }
         }
+        .safariSheet(url: $presentedURL)
         .padding(24.0)
     }
 }
@@ -28,6 +46,25 @@ private enum Localization {
         "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
         comment: "Generic error message when In-Person Payments is unavailable"
     )
+
+    static var learnMore: NSAttributedString {
+        let learnMoreText = NSLocalizedString(
+            "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
+            comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
+        )
+
+        let learnMoreAttributes: [NSAttributedString.Key: Any] = [
+            .font: StyleManager.footerLabelFont,
+            .foregroundColor: UIColor.textSubtle
+        ]
+
+        let learnMoreAttrText = NSMutableAttributedString()
+        learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
+        let range = NSRange(location: 0, length: learnMoreAttrText.length)
+        learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
+
+        return learnMoreAttrText
+    }
 }
 
 struct InPersonPaymentsUnavailableView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct InPersonPaymentsUnavailableView: View {
-    @State var presentedURL: URL? = nil
-
     var body: some View {
         VStack {
             Spacer()
@@ -22,16 +20,8 @@ struct InPersonPaymentsUnavailableView: View {
 
             Spacer()
 
-            HStack(alignment: .center, spacing: 20) {
-                Image(uiImage: .infoOutlineImage)
-                    .accentColor(Color(.lightGray))
-                    .frame(width: 20, height: 20)
-                AttributedText(Localization.learnMore)
-                    .accentColor(Color(.textLink))
-                    .customOpenURL(binding: $presentedURL)
-            }
+            InPersonPaymentsLearnMore()
         }
-        .safariSheet(url: $presentedURL)
         .padding(24.0)
     }
 }
@@ -46,25 +36,6 @@ private enum Localization {
         "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
         comment: "Generic error message when In-Person Payments is unavailable"
     )
-
-    static var learnMore: NSAttributedString {
-        let learnMoreText = NSLocalizedString(
-            "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
-            comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
-        )
-
-        let learnMoreAttributes: [NSAttributedString.Key: Any] = [
-            .font: StyleManager.footerLabelFont,
-            .foregroundColor: UIColor.textSubtle
-        ]
-
-        let learnMoreAttrText = NSMutableAttributedString()
-        learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
-        let range = NSRange(location: 0, length: learnMoreAttrText.length)
-        learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
-
-        return learnMoreAttrText
-    }
 }
 
 struct InPersonPaymentsUnavailableView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+/*
+ This class was based on the [AttributedText](https://github.com/gonzalezreal/AttributedText) library
+ by [Guille Gonzalez](https://github.com/gonzalezreal). It has then been adapted to fit our requirements.
+
+ Copyright (c) 2020 Guille Gonzalez
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+struct AttributedText: View {
+    @StateObject private var textViewStore = TextViewStore()
+
+    let attributedText: NSAttributedString
+
+    init(_ attributedText: NSAttributedString) {
+        self.attributedText = attributedText
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            TextViewWrapper(
+                attributedText: attributedText,
+                maxLayoutWidth: geometry.maxWidth,
+                textViewStore: textViewStore
+            )
+        }
+        .frame(
+            idealWidth: textViewStore.intrinsicContentSize?.width,
+            idealHeight: textViewStore.intrinsicContentSize?.height
+        )
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private extension GeometryProxy {
+    var maxWidth: CGFloat {
+        size.width - safeAreaInsets.leading - safeAreaInsets.trailing
+    }
+}
+
+final class TextViewStore: ObservableObject {
+    @Published var intrinsicContentSize: CGSize?
+
+    func didUpdateTextView(_ textView: TextViewWrapper.View) {
+        intrinsicContentSize = textView.intrinsicContentSize
+    }
+}
+
+struct TextViewWrapper: UIViewRepresentable {
+    final class View: UITextView {
+        var maxLayoutWidth: CGFloat = 0 {
+            didSet {
+                guard maxLayoutWidth != oldValue else { return }
+                invalidateIntrinsicContentSize()
+            }
+        }
+
+        override var intrinsicContentSize: CGSize {
+            guard maxLayoutWidth > 0 else {
+                return super.intrinsicContentSize
+            }
+
+            return sizeThatFits(
+                CGSize(width: maxLayoutWidth, height: .greatestFiniteMagnitude)
+            )
+        }
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var openURL: ((URL) -> Void)?
+
+        func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction _: UITextItemInteraction) -> Bool {
+            openURL?(URL)
+            return false
+        }
+    }
+
+    let attributedText: NSAttributedString
+    let maxLayoutWidth: CGFloat
+    let textViewStore: TextViewStore
+
+    func makeUIView(context: Context) -> View {
+        let uiView = View()
+
+        uiView.backgroundColor = .clear
+        uiView.textContainerInset = .zero
+        uiView.isEditable = false
+        uiView.isScrollEnabled = false
+        uiView.textContainer.lineFragmentPadding = 0
+        uiView.delegate = context.coordinator
+
+        return uiView
+    }
+
+    func updateUIView(_ uiView: View, context: Context) {
+        uiView.attributedText = attributedText
+        uiView.maxLayoutWidth = maxLayoutWidth
+
+        uiView.textContainer.maximumNumberOfLines = context.environment.lineLimit ?? 0
+
+        context.coordinator.openURL = context.environment.customOpenURL ?? context.environment.openURL.callAsFunction(_:)
+
+        textViewStore.didUpdateTextView(uiView)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+}
+
+struct CustomOpenURL: EnvironmentKey {
+    static let defaultValue: ((URL) -> Void)? = nil
+}
+
+public extension EnvironmentValues {
+    var customOpenURL: ((URL) -> Void)? {
+        get { self[CustomOpenURL.self] }
+        set { self[CustomOpenURL.self] = newValue }
+    }
+}
+
+extension View {
+    func customOpenURL(action: @escaping (URL) -> Void) -> some View {
+        environment(\.customOpenURL, action)
+    }
+
+    func customOpenURL(binding: Binding<URL?>) -> some View {
+        customOpenURL { url in
+            binding.wrappedValue = url
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SafariSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SafariSheet.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+import SafariServices
+import UIKit
+
+struct SafariSheetView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // nothing to do here
+    }
+}
+
+extension View {
+    /// Presents a sheet with a browser when a binding to a Boolean value that you provide is true
+    ///
+    func safariSheet(isPresented: Binding<Bool>, url: URL) -> some View {
+        sheet(isPresented: isPresented) {
+            SafariSheetView(url: url)
+        }
+    }
+
+    /// Presents a sheet with a browser when a binding to an optional URL that you provide has a value
+    ///
+    /// When the sheet is dismissed, the binding's value will be set to nil.
+    ///
+    func safariSheet(url: Binding<URL?>) -> some View {
+        sheet(isPresented: url.notNil()) {
+            if let url = url.wrappedValue {
+                SafariSheetView(url: url)
+            }
+        }
+    }
+}
+
+private extension Binding {
+    /// Returns a new binding that has a Boolean value indicating whether the underlying optional has a value
+    ///
+    /// Note that setting a true value will do nothing since we can't infer a value if there isn't a previous one,
+    /// but setting a false value will set the underlying value to nil.
+    ///
+    /// Because of that, this is a private helper to make the sheet presentation logic more concise and readable,
+    /// but it wasn't a good candidate for a more general public operator.
+    func notNil<V>() -> Binding<Bool> where Value == V? {
+        Binding<Bool>(
+            get: { self.wrappedValue != nil },
+            set: { self.wrappedValue = $0 ? self.wrappedValue : nil }
+        )
+    }
+}

--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -44,6 +44,7 @@
             <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>
             <li><a href="https://github.com/onevcat/Kingfisher">Kingfisher</a> by <a href="https://github.com/onevcat">Wei Wang</a></li>
             <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
+            <li><a href="https://github.com/gonzalezreal/AttributedText">AttributedText</a> by <a href="https://github.com/gonzalezreal">Guille Gonzalez</a></li>
         </ul>
 
         <h4>The following libraries are licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">The Apache License, Version 2.0</a>:</h4>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1231,6 +1231,8 @@
 		E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */; };
 		E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */; };
 		E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */; };
+		E15FC74126BC1CED00CF83E6 /* AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74026BC1CED00CF83E6 /* AttributedText.swift */; };
+		E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
@@ -2568,6 +2570,8 @@
 		E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewController.swift; sourceTree = "<group>"; };
 		E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsUnavailableView.swift; sourceTree = "<group>"; };
 		E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewModel.swift; sourceTree = "<group>"; };
+		E15FC74026BC1CED00CF83E6 /* AttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedText.swift; sourceTree = "<group>"; };
+		E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariSheet.swift; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
@@ -4138,6 +4142,8 @@
 				45DB6D962632CF9300E83C1A /* ActivityIndicator.swift */,
 				45A8DA3F2664E40B00308FBE /* EmptyState.swift */,
 				E10DFC792673595A0083AFF2 /* ShareSheet.swift */,
+				E15FC74026BC1CED00CF83E6 /* AttributedText.swift */,
+				E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -6785,6 +6791,7 @@
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
+				E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */,
 				459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */,
 				02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */,
 				0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */,
@@ -6998,6 +7005,7 @@
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,
+				E15FC74126BC1CED00CF83E6 /* AttributedText.swift in Sources */,
 				D8815AFB26384A1F00EDAD62 /* CardPresentModalReaderIsReady.swift in Sources */,
 				31316F9C25CB20FD00D9F129 /* OrderStatusListViewModel.swift in Sources */,
 				B56DB3CA2049BFAA00D4AA8E /* AppDelegate.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1233,6 +1233,7 @@
 		E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */; };
 		E15FC74126BC1CED00CF83E6 /* AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74026BC1CED00CF83E6 /* AttributedText.swift */; };
 		E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */; };
+		E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */; };
 		E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */; };
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
@@ -2572,6 +2573,7 @@
 		E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewModel.swift; sourceTree = "<group>"; };
 		E15FC74026BC1CED00CF83E6 /* AttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedText.swift; sourceTree = "<group>"; };
 		E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariSheet.swift; sourceTree = "<group>"; };
+		E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLearnMore.swift; sourceTree = "<group>"; };
 		E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmail.swift; sourceTree = "<group>"; };
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
@@ -6006,6 +6008,7 @@
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
+				E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -7116,6 +7119,7 @@
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
 				D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */,
 				45A8DA402664E40B00308FBE /* EmptyState.swift in Sources */,
+				E15FC74526BC213500CF83E6 /* InPersonPaymentsLearnMore.swift in Sources */,
 				D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */,
 				CE21B3DD20FF9BC200A259D5 /* ProductListViewController.swift in Sources */,
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,


### PR DESCRIPTION
Part of #4611 

This PR adds the "Learn more" link at the bottom of `InPersonPaymentsUnavailableView`. This is mostly an opportunity to  bring in `AttributedText` and `SafariSheet` from #4626 in a standalone PR so we can use it in all the future onboarding views.

The [AttributedText](https://github.com/gonzalezreal/AttributedText) file is a fork of a library necessary so we can customize how links are opened, instead of the default behavior of leaving the app to open in Safari (See paNNhX-fz-p2 for some extra discussion).

`SafariSheet` wraps a `SFSafariViewController` into a more typical SwiftUI sheet API. The method that uses a `Binding<URL?>` argument ended up a bit weird because I turn it into a `Binding<Bool>` to indicate whether the sheet should be presented. Technically, this allows an odd case where the binding could go from `false` to `true` but that couldn't translate into a URL to feed back to the view, so it does nothing. However, the `sheet` implementation will only ever set that from `true` to `false` on dismiss, and we only ever make it true when setting a URL so it's not a real problem. Still, the API is a bit uncomfortable to look at, but it's the best I got considering the URL to be presented is somewhat dynamic (it's not really, but it comes from an attributed string).

## To test

1. Go to Settings > In-Person Payments on a store that isn't ready to take payments so you can see the error screen.
2. Tap on the learn more link and make sure the Safari sheet is presented

Error screen | After tapping on Learn more
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 15 35 27](https://user-images.githubusercontent.com/8739/128360723-8dadb177-93f4-4122-9912-4713d6d0e04f.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-05 at 15 35 31](https://user-images.githubusercontent.com/8739/128360734-d8e70842-1496-407e-8a54-b9a1af4a0ea4.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
