### PR TITLE
HF: Fix TopBannerView on SwiftUI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerWrapperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerWrapperView.swift
@@ -54,8 +54,8 @@ final class TopBannerWrapperView: UIView {
 
         bannerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(bannerView)
-        self.edgeInsets = edgeInsets
         self.bannerView = bannerView
+        self.edgeInsets = edgeInsets
         self.backgroundColor = bannerView.backgroundColor
     }
 


### PR DESCRIPTION
# Why

It was reported by @designsimply that the Top Banner in the Add-Ons view is broken on Release 7.2.
After some investigation, the issue is a regression introduced on https://github.com/woocommerce/woocommerce-ios/pull/4657.

As the UI bug causes such a bad first impression(even if the feature is experimental), we have decided to ship the fix in `7.2` and not in `7.3`.

@jkmassel would you be so kind to include this in the `7.2 Release` 🙏 

# How

The issue was that the `TopBannerView` was not being pinned to its parent because the pinning happens when the edge insets are set

```swift
   var edgeInsets: EdgeInsets = .zero {
        didSet {
            removeConstraints(constraints)
            bannerView?.pinSubviewToAllEdges(self, insets: contentInsets)
        }
    }
```

But the banner was being set after the insets are set, so `bannerView` was nill at that time.

Assigning the banner before assigning the insets fixes the issue.

# Screenshots

Before | After
<img width="386" alt="bad" src="https://user-images.githubusercontent.com/562080/128434137-5599fb7f-26d2-4123-8456-d4a69e3814c6.png"> | <img width="383" alt="good" src="https://user-images.githubusercontent.com/562080/128434141-9d6aca43-4a9d-4939-88c1-8f57cc93fc96.png">

# Testing Steps

- Enable add-ons experimental feature
- Navigate to an order with add-ons and tap the view add-ons button
- See that the banner has the correct layout.

PS @itsmeichigo could you check that this does not break any other change that you meant with the original PR, please?

 
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
