### PR TITLE
Shipping Labels: Navigate from creation form to customs form list

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1058,6 +1058,7 @@ extension ShippingLabelCustomsForm {
     ///
     public static func fake() -> ShippingLabelCustomsForm {
         .init(
+            packageID: .fake(),
             contentsType: .fake(),
             contentExplanation: .fake(),
             restrictionType: .fake(),

--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelPackageSelected.swift
@@ -47,38 +47,7 @@ public struct ShippingLabelPackageSelected: Equatable, GeneratedFakeable {
 }
 
 // MARK: Codable
-extension ShippingLabelPackageSelected: Codable {
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        let boxID = try container.decode(String.self, forKey: .boxID)
-        let length = try container.decode(Double.self, forKey: .length)
-        let width = try container.decode(Double.self, forKey: .width)
-        let height = try container.decode(Double.self, forKey: .height)
-        let weight = try container.decode(Double.self, forKey: .weight)
-        let isLetter = try container.decode(Bool.self, forKey: .isLetter)
-
-        let customsForm: ShippingLabelCustomsForm? = try? {
-            let contentsType = try container.decode(ShippingLabelCustomsForm.ContentsType.self, forKey: .contentsType)
-            let contentsExplanation = (try? container.decode(String.self, forKey: .contentsExplanation)) ?? ""
-            let restrictionType = try container.decode(ShippingLabelCustomsForm.RestrictionType.self, forKey: .restrictionType)
-            let restrictionComments = (try? container.decode(String.self, forKey: .restrictionComments)) ?? ""
-            let nonDeliveryOption = try container.decode(ShippingLabelCustomsForm.NonDeliveryOption.self, forKey: .nonDeliveryOption)
-            let itn = (try? container.decode(String.self, forKey: .itn)) ?? ""
-            let items = try container.decode([ShippingLabelCustomsForm.Item].self, forKey: .items)
-
-            return ShippingLabelCustomsForm(contentsType: contentsType,
-                                            contentExplanation: contentsExplanation,
-                                            restrictionType: restrictionType,
-                                            restrictionComments: restrictionComments,
-                                            nonDeliveryOption: nonDeliveryOption,
-                                            itn: itn,
-                                            items: items)
-        }()
-
-        self.init(boxID: boxID, length: length, width: width, height: height, weight: weight, isLetter: isLetter, customsForm: customsForm)
-    }
+extension ShippingLabelPackageSelected: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -4,6 +4,13 @@ import Codegen
 /// Represents customs info for a shipping label package
 ///
 public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
+    /// ID of the associated package.
+    ///
+    /// This is for identifying the package when inputing customs form only,
+    /// no need for encoding and sending to remote.
+    ///
+    public let packageID: String
+
     /// Type of contents to declare with customs.
     public let contentsType: ContentsType
 
@@ -25,13 +32,17 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
     /// Items in the package to declare.
     public let items: [Item]
 
-    public init(contentsType: ShippingLabelCustomsForm.ContentsType,
+    /// Memberwise initializer
+    ///
+    public init(packageID: String,
+                contentsType: ShippingLabelCustomsForm.ContentsType,
                 contentExplanation: String,
                 restrictionType: ShippingLabelCustomsForm.RestrictionType,
                 restrictionComments: String,
                 nonDeliveryOption: ShippingLabelCustomsForm.NonDeliveryOption,
                 itn: String,
                 items: [ShippingLabelCustomsForm.Item]) {
+        self.packageID = packageID
         self.contentsType = contentsType
         self.contentExplanation = contentExplanation
         self.restrictionType = restrictionType
@@ -39,6 +50,22 @@ public struct ShippingLabelCustomsForm: Equatable, GeneratedFakeable {
         self.nonDeliveryOption = nonDeliveryOption
         self.itn = itn
         self.items = items
+    }
+
+    /// Convenient intializer
+    ///
+    public init(packageID: String, productIDs: [Int64]) {
+        let items = productIDs.map { id in
+            Item(description: "", quantity: 1, value: 0, weight: 0, hsTariffNumber: "", originCountry: "", productID: id)
+        }
+        self.init(packageID: packageID,
+                  contentsType: .merchandise,
+                  contentExplanation: "",
+                  restrictionType: .none,
+                  restrictionComments: "",
+                  nonDeliveryOption: .return,
+                  itn: "",
+                  items: items)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import Yosemite
+
+struct ShippingLabelCustomsFormInput: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct ShippingLabelCustomsFormInput_Previews: PreviewProvider {
+    static var previews: some View {
+        ShippingLabelCustomsFormInput()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import Yosemite
+
+struct ShippingLabelCustomsFormList: View {
+    @ObservedObject private var viewModel: ShippingLabelCustomsFormViewModel
+    private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
+
+    init(viewModel: ShippingLabelCustomsFormViewModel,
+         onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
+        self.viewModel = viewModel
+        self.onCompletion = onCompletion
+    }
+
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct ShippingLabelCustomsFormList_Previews: PreviewProvider {
+    static let sampleViewModel: ShippingLabelCustomsFormViewModel = {
+        let sampleOrder = ShippingLabelPackageDetailsViewModel.sampleOrder()
+        let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", productIDs: sampleOrder.items.map { $0.productID })
+        return ShippingLabelCustomsFormViewModel(order: sampleOrder, customsForms: [sampleForm])
+    }()
+
+    static var previews: some View {
+        ShippingLabelCustomsFormList(viewModel: sampleViewModel) { _ in }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import Yosemite
 
 struct ShippingLabelCustomsFormList: View {
-    @ObservedObject private var viewModel: ShippingLabelCustomsFormViewModel
+    @ObservedObject private var viewModel: ShippingLabelCustomsFormListViewModel
     private let onCompletion: ([ShippingLabelCustomsForm]) -> Void
 
-    init(viewModel: ShippingLabelCustomsFormViewModel,
+    init(viewModel: ShippingLabelCustomsFormListViewModel,
          onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
         self.viewModel = viewModel
         self.onCompletion = onCompletion
@@ -17,10 +17,10 @@ struct ShippingLabelCustomsFormList: View {
 }
 
 struct ShippingLabelCustomsFormList_Previews: PreviewProvider {
-    static let sampleViewModel: ShippingLabelCustomsFormViewModel = {
+    static let sampleViewModel: ShippingLabelCustomsFormListViewModel = {
         let sampleOrder = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", productIDs: sampleOrder.items.map { $0.productID })
-        return ShippingLabelCustomsFormViewModel(order: sampleOrder, customsForms: [sampleForm])
+        return ShippingLabelCustomsFormListViewModel(order: sampleOrder, customsForms: [sampleForm])
     }()
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -2,9 +2,9 @@ import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 
-/// View model for ShippingLabelsCustomsFormInput
+/// View model for ShippingLabelsCustomsFormList
 ///
-final class ShippingLabelCustomsFormViewModel: ObservableObject {
+final class ShippingLabelCustomsFormListViewModel: ObservableObject {
 
     /// Associated order of the shipping label.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View model for ShippingLabelsCustomsFormInput
+///
+final class ShippingLabelCustomsFormViewModel: ObservableObject {
+
+    /// Associated order of the shipping label.
+    ///
+    private let order: Order
+
+    /// Input customs forms of the shipping label if added initially.
+    ///
+    private let customsForms: [ShippingLabelCustomsForm]
+
+    /// Stores to sync data of products and variations.
+    ///
+    private let stores: StoresManager
+
+    /// Storage to fetch products and variations.
+    ///
+    private let storageManager: StorageManagerType
+
+    init(order: Order,
+         customsForms: [ShippingLabelCustomsForm],
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.order = order
+        self.customsForms = customsForms
+        self.stores = stores
+        self.storageManager = storageManager
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -282,7 +282,7 @@ private extension ShippingLabelFormViewController {
                        body: Localization.customsCellSubtitle,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
-            self.displayCustomsFormListVC(customsForms: self.viewModel.defaultCustomsForms)
+            self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -161,6 +161,8 @@ extension ShippingLabelFormViewController: UITableViewDelegate {
         case Row(type: .packageDetails, dataState: .validated, displayMode: .editable):
             displayPackageDetailsVC(selectedPackageID: viewModel.selectedPackageID,
                                     totalPackageWeight: viewModel.totalPackageWeight)
+        case Row(type: .customs, dataState: .validated, displayMode: .editable):
+            displayCustomsFormListVC(customsForms: viewModel.customsForms)
         case Row(type: .shippingCarrierAndRates, dataState: .validated, displayMode: .editable):
             displayCarriersAndRatesVC(selectedRate: viewModel.selectedRate,
                                       selectedSignatureRate: viewModel.selectedSignatureRate,
@@ -278,8 +280,9 @@ private extension ShippingLabelFormViewController {
                        icon: .globeImage,
                        title: Localization.customsCellTitle,
                        body: Localization.customsCellSubtitle,
-                       buttonTitle: Localization.continueButtonInCells) {
-            // TODO: show customs form creation view
+                       buttonTitle: Localization.continueButtonInCells) { [weak self] in
+            guard let self = self else { return }
+            self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
         }
     }
 
@@ -416,6 +419,15 @@ private extension ShippingLabelFormViewController {
         }
 
         let hostingVC = UIHostingController(rootView: packageDetails)
+        navigationController?.show(hostingVC, sender: nil)
+    }
+
+    func displayCustomsFormListVC(customsForms: [ShippingLabelCustomsForm]) {
+        let vm = ShippingLabelCustomsFormListViewModel(order: viewModel.order, customsForms: viewModel.customsForms)
+        let formList = ShippingLabelCustomsFormList(viewModel: vm) { [weak self] forms in
+            self?.viewModel.handleCustomsFormsValueChanges(customsForms: forms)
+        }
+        let hostingVC = UIHostingController(rootView: formList)
         navigationController?.show(hostingVC, sender: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -282,7 +282,7 @@ private extension ShippingLabelFormViewController {
                        body: Localization.customsCellSubtitle,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
-            self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
+            self.displayCustomsFormListVC(customsForms: self.viewModel.defaultCustomsForms)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -216,6 +216,18 @@ final class ShippingLabelFormViewModel {
         }
         updateRowState(type: .packageDetails, dataState: .validated, displayMode: .editable)
 
+        // We reset the selected customs forms & carrier & rates because if the package change
+        // these change accordingly.
+        handleCustomsFormsValueChanges(customsForms: [])
+        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+    }
+
+    func handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm]) {
+        self.customsForms = customsForms
+        guard customsForms.isNotEmpty else {
+            return updateRowState(type: .customs, dataState: .pending, displayMode: .editable)
+        }
+        updateRowState(type: .customs, dataState: .validated, displayMode: .editable)
         // We reset the carrier and rates selected because if the package change
         // the carrier and rate change accordingly
         handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -40,22 +40,15 @@ final class ShippingLabelFormViewModel {
     /// Packages
     ///
     private(set) var packagesResponse: ShippingLabelPackagesResponse?
-    private(set) var selectedPackageID: String?
+    private(set) var selectedPackageID: String? {
+        didSet {
+            setDefaultCustomsFormsIfNeeded()
+        }
+    }
 
     /// Customs forms
     ///
     private (set) var customsForms: [ShippingLabelCustomsForm] = []
-
-    /// Temporary solution for creating default customs forms.
-    /// When multi-package support is available, we should create separate form for each package ID.
-    ///
-    var defaultCustomsForms: [ShippingLabelCustomsForm] {
-        guard let packageID = selectedPackageID else {
-            return []
-        }
-        let productIDs = order.items.map { $0.productOrVariationID }
-        return [ShippingLabelCustomsForm(packageID: packageID, productIDs: productIDs)]
-    }
 
     /// Carrier and Rates
     ///
@@ -611,6 +604,17 @@ private extension ShippingLabelFormViewModel {
         }
 
         return nil
+    }
+
+    /// Temporary solution for creating default customs forms.
+    /// When multi-package support is available, we should create separate form for each package ID.
+    ///
+    private func setDefaultCustomsFormsIfNeeded() {
+        guard customsFormRequired, let packageID = selectedPackageID else {
+            return customsForms = []
+        }
+        let productIDs = order.items.map { $0.productOrVariationID }
+        customsForms = [ShippingLabelCustomsForm(packageID: packageID, productIDs: productIDs)]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -46,6 +46,17 @@ final class ShippingLabelFormViewModel {
     ///
     private (set) var customsForms: [ShippingLabelCustomsForm] = []
 
+    /// Temporary solution for creating default customs forms.
+    /// When multi-package support is available, we should create separate form for each package ID.
+    ///
+    var defaultCustomsForms: [ShippingLabelCustomsForm] {
+        guard let packageID = selectedPackageID else {
+            return []
+        }
+        let productIDs = order.items.map { $0.productOrVariationID }
+        return [ShippingLabelCustomsForm(packageID: packageID, productIDs: productIDs)]
+    }
+
     /// Carrier and Rates
     ///
     private(set) var selectedRate: ShippingLabelCarrierRate?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -42,6 +42,10 @@ final class ShippingLabelFormViewModel {
     private(set) var packagesResponse: ShippingLabelPackagesResponse?
     private(set) var selectedPackageID: String?
 
+    /// Customs forms
+    ///
+    private (set) var customsForms: [ShippingLabelCustomsForm] = []
+
     /// Carrier and Rates
     ///
     private(set) var selectedRate: ShippingLabelCarrierRate?
@@ -55,26 +59,28 @@ final class ShippingLabelFormViewModel {
         let weight = Double(totalPackageWeight ?? "0") ?? .zero
 
         if let customPackage = packagesResponse.customPackages.first(where: { $0.title == selectedPackageID }) {
-            // TODO: set customs forms
-            return ShippingLabelPackageSelected(boxID: customPackage.title,
+            let boxID = customPackage.title
+            let customsForm = customsForms.first(where: { $0.packageID == boxID })
+            return ShippingLabelPackageSelected(boxID: boxID,
                                                 length: customPackage.getLength(),
                                                 width: customPackage.getWidth(),
                                                 height: customPackage.getHeight(),
                                                 weight: weight,
                                                 isLetter: customPackage.isLetter,
-                                                customsForm: nil)
+                                                customsForm: customsForm)
         }
 
         for option in packagesResponse.predefinedOptions {
             if let predefinedPackage = option.predefinedPackages.first(where: { $0.id == selectedPackageID }) {
-                // TODO: set customs forms
-                return ShippingLabelPackageSelected(boxID: predefinedPackage.id,
+                let boxID = predefinedPackage.id
+                let customsForm = customsForms.first(where: { $0.packageID == boxID })
+                return ShippingLabelPackageSelected(boxID: boxID,
                                                     length: predefinedPackage.getLength(),
                                                     width: predefinedPackage.getWidth(),
                                                     height: predefinedPackage.getHeight(),
                                                     weight: weight,
                                                     isLetter: predefinedPackage.isLetter,
-                                                    customsForm: nil)
+                                                    customsForm: customsForm)
             }
         }
 
@@ -692,8 +698,10 @@ extension ShippingLabelFormViewModel {
         }
 
         let productIDs = order.items.map { $0.productOrVariationID }
-        // TODO: get customs form for the selected package and send to the model
-        let package = ShippingLabelPackagePurchase(package: selectedPackage, rate: selectedRate, productIDs: productIDs, customsForm: nil)
+        let package = ShippingLabelPackagePurchase(package: selectedPackage,
+                                                   rate: selectedRate,
+                                                   productIDs: productIDs,
+                                                   customsForm: selectedPackage.customsForm)
         let startTime = Date()
         let action = ShippingLabelAction.purchaseShippingLabel(siteID: siteID,
                                                                orderID: order.orderID,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1221,6 +1221,8 @@
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
+		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */; };
+		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
@@ -2561,6 +2563,8 @@
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
+		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormViewModel.swift; sourceTree = "<group>"; };
+		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
@@ -3930,6 +3934,7 @@
 				4515C88A25D6BD520099C8E3 /* Shipping Address Validation */,
 				456C7EE825EE71C10016CBC6 /* Shipping Address Suggested Address */,
 				451A995B260E2E0A0059D135 /* Package Details */,
+				DEC2961D26BD15D3005A056B /* Customs */,
 				4569317A2653E7F9009ED69D /* Carriers and Rates */,
 				CC4A4E91265523DB00B75DCD /* Payment Methods */,
 				456396B325C8266D001F1A26 /* Cells */,
@@ -5985,6 +5990,15 @@
 			path = Plugins;
 			sourceTree = "<group>";
 		};
+		DEC2961D26BD15D3005A056B /* Customs */ = {
+			isa = PBXGroup;
+			children = (
+				DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */,
+				DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */,
+			);
+			path = Customs;
+			sourceTree = "<group>";
+		};
 		DEFD6E5F264990DD00E51E0D /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -7292,6 +7306,7 @@
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
+				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
@@ -7336,6 +7351,7 @@
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
+				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				3143AEBD269618DF00BACA7A /* CardReaderSettingsKnownViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1221,7 +1221,7 @@
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
-		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */; };
+		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
 		DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2564,7 +2564,7 @@
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
-		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormViewModel.swift; sourceTree = "<group>"; };
+		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
 		DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5995,7 +5995,7 @@
 		DEC2961D26BD15D3005A056B /* Customs */ = {
 			isa = PBXGroup;
 			children = (
-				DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */,
+				DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */,
 				DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */,
 				DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */,
 			);
@@ -7310,7 +7310,7 @@
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
-				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift in Sources */,
+				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1222,7 +1222,8 @@
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */; };
-		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */; };
+		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
+		DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
@@ -2564,7 +2565,8 @@
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormViewModel.swift; sourceTree = "<group>"; };
-		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
+		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
+		DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInput.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
@@ -5994,7 +5996,8 @@
 			isa = PBXGroup;
 			children = (
 				DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormViewModel.swift */,
-				DEC2962026BD1627005A056B /* ShippingLabelCustomsFormInput.swift */,
+				DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */,
+				DEC2962226BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift */,
 			);
 			path = Customs;
 			sourceTree = "<group>";
@@ -7000,6 +7003,7 @@
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,
 				0259D5FF2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift in Sources */,
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
+				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,
@@ -7351,7 +7355,7 @@
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
-				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
+				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				3143AEBD269618DF00BACA7A /* CardReaderSettingsKnownViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -244,6 +244,34 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(carrierRow?.displayMode, .disabled)
     }
 
+    func test_handleCustomsFormsValueChanges_resets_carrier_and_rates_selection() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil)
+
+        shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
+                                                                   validated: true)
+        shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
+        shippingLabelFormViewModel.handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm.fake()])
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
+                                                                     selectedSignatureRate: nil,
+                                                                     selectedAdultSignatureRate: nil,
+                                                                     editable: true)
+        XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
+
+        // When
+        shippingLabelFormViewModel.handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm.fake()])
+
+        // Then
+        XCTAssertNil(shippingLabelFormViewModel.selectedRate)
+
+        let rows = shippingLabelFormViewModel.state.sections.first?.rows
+        let carrierRow = rows?.first { $0.type == .shippingCarrierAndRates }
+        XCTAssertEqual(carrierRow?.dataState, .pending)
+        XCTAssertEqual(carrierRow?.displayMode, .disabled)
+    }
+
     func test_handleCarrierAndRatesValueChanges_returns_updated_data() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -870,7 +870,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(updatedRows?[2].displayMode, .disabled)
     }
 
-    func test_defaultCustomsForms_returns_correctly_with_a_selectedPackageID() {
+    func test_customsForms_returns_correctly_when_updating_selectedPackageID() {
         // Given
         let expectedProductID: Int64 = 123
         let expectedPackageID = "Food Package"
@@ -879,14 +879,18 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let viewModel = ShippingLabelFormViewModel(order: order, originAddress: nil, destinationAddress: nil)
 
         // When
+        viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
+        viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
         viewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: "55")
 
         // Then
-        let defaultForms = viewModel.defaultCustomsForms
-        XCTAssertEqual(defaultForms.count, 1)
-        XCTAssertEqual(defaultForms.first?.packageID, expectedPackageID)
-        XCTAssertEqual(defaultForms.first?.items.count, 1)
-        XCTAssertEqual(defaultForms.first?.items.first?.productID, expectedProductID)
+        DispatchQueue.main.async {
+            let defaultForms = viewModel.customsForms
+            XCTAssertEqual(defaultForms.count, 1)
+            XCTAssertEqual(defaultForms.first?.packageID, expectedPackageID)
+            XCTAssertEqual(defaultForms.first?.items.count, 1)
+            XCTAssertEqual(defaultForms.first?.items.first?.productID, expectedProductID)
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -85,6 +85,7 @@ public typealias ShippingLabelAddressValidationError = Networking.ShippingLabelA
 public typealias ShippingLabelCustomPackage = Networking.ShippingLabelCustomPackage
 public typealias ShippingLabelPackagePurchase = Networking.ShippingLabelPackagePurchase
 public typealias ShippingLabelPackageSelected = Networking.ShippingLabelPackageSelected
+public typealias ShippingLabelCustomsForm = Networking.ShippingLabelCustomsForm
 public typealias ShippingLabelPredefinedOption = Networking.ShippingLabelPredefinedOption
 public typealias ShippingLabelPredefinedPackage = Networking.ShippingLabelPredefinedPackage
 public typealias ShippingLabelPaperSize = Networking.ShippingLabelPaperSize


### PR DESCRIPTION
Part of #4687 

# Description
This PR aims to handle navigation between Shipping Label form and customs form list. This navigation is handled when tapping "Done" button on the customs cell added in #4723, or tapping on that cell when customs forms are input and validated. The UI for the customs form list is still a placeholder and will be implemented in the next PR.

# Changes
- Added new view and view model for customs form list. This is called a list since I want to prepare for multi-package support, and the view model should accept a list of customs forms instead of just one.
- Added a placeholder view for customs form input, which is also empty for now. The customs form list should include of several input views for each package associated with the shipping label.
- Added new property `packageID` to associate a customs form model with a package. This is for use in development only and not to encode and send to remote.
- Updated `ShippingLabelCustomsForm` model with a convenient intializer to accept package ID and product ID list as input. This is helpful for creating default customs forms for each package with associating order items.
- Updated `ShippingLabelFormViewModel` to setup default customs forms based on currently selected package ID. These forms will be used as initial input for the customs form list.
- Added new property `customsForms` and updated how customs forms are set to selected package and purchase package.
- Updated handling changes of data for shipping label form rows, to make sure that both customs and carrier cells are reset when updating package details. Carrier cells should also be updated when updating customs forms.
- Implement navigation between the shipping label form and customs form list. When initially configuring customs form, the default form list is used as input; otherwise the configured form list will be used.

# Testing
1. Create an order on your test store that's eligible for international shipping (different countries for origin and destination addresses; or shipping between US and US military states).
2. Navigate to Orders tab, select the new order.
3. Select Create Shipping Label, skip through ship from and to and package details.
4. Tap on Continue button on Customs row, you should be navigated to a new screen with placeholder text "Hello World". The content of this view will be implemented in the next PR.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
