### PR TITLE
[Mobile Payments] Update settings view controller to use new connection controller

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsUnknownViewModel.swift
@@ -2,25 +2,15 @@ import Foundation
 import Combine
 import Yosemite
 
-enum CardReaderSettingsUnknownViewModelDiscoveryState {
-    case notSearching
-    case searching
-    case failed(Error)
-    case foundReader
-    case connectingToReader
-    case restartingSearch
-}
-
 final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewModel {
-
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
 
     private var noConnectedReaders: CardReaderSettingsTriState = .isUnknown
     private var noKnownReaders: CardReaderSettingsTriState = .isUnknown
-    private let knownReadersProvider: CardReaderSettingsKnownReadersProvider?
-    private let siteID: Int64
+    private(set) var knownReadersProvider: CardReaderSettingsKnownReadersProvider?
+    private(set) var siteID: Int64
 
     private var subscriptions = Set<AnyCancellable>()
 
@@ -36,11 +26,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
     }
     private var foundReader: CardReader?
 
-    var discoveryState: CardReaderSettingsUnknownViewModelDiscoveryState = .notSearching {
-        didSet {
-            didUpdate?()
-        }
-    }
     var foundReaderID: String? {
         foundReader?.id
     }
@@ -89,94 +74,6 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         ServiceLocator.stores.dispatch(connectedAction)
     }
 
-    /// Dispatch a request to start reader discovery
-    ///
-    func startReaderDiscovery() {
-        discoveryState = .searching
-
-        ServiceLocator.analytics.track(.cardReaderDiscoveryTapped)
-        let action = CardPresentPaymentAction.startCardReaderDiscovery(
-            siteID: siteID,
-            onReaderDiscovered: { [weak self] cardReaders in
-                self?.didDiscoverReaders(cardReaders: cardReaders)
-            },
-            onError: { [weak self] error in
-                self?.discoveryState = .failed(error)
-                ServiceLocator.analytics.track(.cardReaderDiscoveryFailed, withError: error)
-            })
-
-        ServiceLocator.stores.dispatch(action)
-    }
-
-    /// Alert the user we have a found reader
-    ///
-    func didDiscoverReaders(cardReaders: [CardReader]) {
-        /// If we are already presenting a foundReader alert to the user, ignore the found reader
-        guard case .searching = discoveryState else {
-            return
-        }
-
-        /// The publisher for discovered readers can return an initial empty value. We'll want to ignore that.
-        guard cardReaders.count > 0 else {
-            return
-        }
-
-        ServiceLocator.analytics.track(.cardReaderDiscoveredReader)
-
-        /// This viewmodel and view supports single reader discovery only.
-        /// TODO: Add another viewmodel and view to handle multiple discovered readers.
-        guard let cardReader = cardReaders.first else {
-            return
-        }
-
-        foundReader = cardReader
-        discoveryState = .foundReader
-    }
-
-    /// Dispatch a request to cancel reader discovery
-    ///
-    func cancelReaderDiscovery() {
-        discoveryState = .notSearching
-        cancelReaderDiscovery(completion: nil)
-    }
-
-    /// Dispatch a request to connect to the found reader
-    ///
-    func connectToReader() {
-        guard let foundReader = foundReader else {
-            DDLogError("foundReader unexpectedly nil in connectToReader")
-            return
-        }
-
-        discoveryState = .connectingToReader
-
-        ServiceLocator.analytics.track(.cardReaderConnectionTapped)
-        let action = CardPresentPaymentAction.connect(reader: foundReader) { [weak self] result in
-            switch result {
-            case .success(let reader):
-                self?.knownReadersProvider?.rememberCardReader(cardReaderID: reader.id)
-                // If the reader does not have a battery, or the battery level is unknown, it will be nil
-                let properties = reader.batteryLevel
-                    .map { ["battery_level": $0] }
-                ServiceLocator.analytics.track(.cardReaderConnectionSuccess, withProperties: properties)
-            case .failure(let error):
-                ServiceLocator.analytics.track(.cardReaderConnectionFailed, withError: error)
-            }
-        }
-        ServiceLocator.stores.dispatch(action)
-    }
-
-    /// Discard the found reader and keep searching
-    /// As discussed in p91TBi-5fB-p2#comment-4849, for the first release,
-    /// we will restart the discovery process again
-    func continueSearch() {
-        foundReader = nil
-        discoveryState = .restartingSearch
-        cancelReaderDiscovery { [weak self] in
-            self?.startReaderDiscovery()
-        }
-    }
-
     /// Updates whether the view this viewModel is associated with should be shown or not
     /// Notifes the viewModel owner if a change occurs via didChangeShouldShow
     ///
@@ -198,16 +95,5 @@ final class CardReaderSettingsUnknownViewModel: CardReaderSettingsPresentedViewM
         if didChange {
             didChangeShouldShow?(shouldShow)
         }
-    }
-}
-
-
-private extension CardReaderSettingsUnknownViewModel {
-    func cancelReaderDiscovery(completion: (()-> Void)?) {
-        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { _ in
-            completion?()
-        }
-
-        ServiceLocator.stores.dispatch(action)
     }
 }


### PR DESCRIPTION
Partially addresses #4546

This PR updates the CardReaderSettingsUnknownViewModel and Controller to remove all the connection logic and modal handling and use the new controller added in #4721 instead

The next PR will complete the effort for #4546 by addressing the CardReaderSettingsKnownViewModel and Controller which also contains very similar logic

To test:
- Settings > Manage Card Readers
- Verify you can initiate a search, cancel search, connect and disconnect from a reader
- Ensure all unit tests pass

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
