### PR TITLE
Show extension metadata in order item details

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */; };
 		268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FA24C87384007EBF1D /* leaderboards-products.json */; };
 		268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */; };
+		268EC45C26C169F600716F5C /* order-with-faulty-attributes.json in Resources */ = {isa = PBXBuildFile; fileRef = 268EC45B26C169F600716F5C /* order-with-faulty-attributes.json */; };
 		26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */; };
 		26B2F74324C545D50065CCC8 /* Leaderboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74224C545D50065CCC8 /* Leaderboard.swift */; };
 		26B2F74524C5573F0065CCC8 /* LeaderboardListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */; };
@@ -663,6 +664,7 @@
 		2685C101263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupRemoteTests.swift; sourceTree = "<group>"; };
 		268B68FA24C87384007EBF1D /* leaderboards-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-products.json"; sourceTree = "<group>"; };
 		268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "leaderboards-year-alt.json"; sourceTree = "<group>"; };
+		268EC45B26C169F600716F5C /* order-with-faulty-attributes.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-faulty-attributes.json"; sourceTree = "<group>"; };
 		26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardsRemote.swift; sourceTree = "<group>"; };
 		26B2F74224C545D50065CCC8 /* Leaderboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Leaderboard.swift; sourceTree = "<group>"; };
 		26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardListMapper.swift; sourceTree = "<group>"; };
@@ -1594,6 +1596,7 @@
 				02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */,
 				02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */,
 				CE19CB10222486A500E8AF7A /* order-statuses.json */,
+				268EC45B26C169F600716F5C /* order-with-faulty-attributes.json */,
 				0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */,
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
@@ -2205,6 +2208,7 @@
 				451274A625276C82009911FF /* product-variation.json in Resources */,
 				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
+				268EC45C26C169F600716F5C /* order-with-faulty-attributes.json in Resources */,
 				45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */,
 				3158FE8426129F3A00E566B9 /* wcpay-account-unknown-status.json in Resources */,
 				31054720262E2F9D00C5C02B /* wcpay-payment-intent-processing.json in Resources */,

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -22,7 +22,7 @@ public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakea
         let metaID = try container.decode(Int64.self, forKey: .metaID)
         let name = try container.decode(String.self, forKey: .name)
 
-        /// Some extensions sent the `value` field with non-string format.
+        /// Some extensions send the `value` field with non-string format.
         /// We don't support those, but we also don't want the whole decoding to fail.
         let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
 

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -21,7 +21,10 @@ public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakea
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let metaID = try container.decode(Int64.self, forKey: .metaID)
         let name = try container.decode(String.self, forKey: .name)
-        let value = try container.decode(String.self, forKey: .value)
+
+        /// Some extensions sent the `value` field with non-string format.
+        /// We don't support those, but we also don't want the whole decoding to fail.
+        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
 
         // initialize the struct
         self.init(metaID: metaID, name: name, value: value)

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -338,6 +338,7 @@ private extension OrderMapperTests {
     }
 
     /// Returns the OrderMapper output upon receiving `order-with-faulty-attributes`
+    /// Where the `value` to `_measurement_data` is not a `string` but a `JSON object`
     ///
     func mapLoadOrderWithFaultyAttributesResponse() -> Order? {
         return mapOrder(from: "order-with-faulty-attributes")

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -278,6 +278,18 @@ final class OrderMapperTests: XCTestCase {
         XCTAssertEqual(fee.taxes, [])
         XCTAssertEqual(fee.attributes, [])
     }
+
+    func test_order_line_item_attributes_handle_unexpected_formatted_attributes() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithFaultyAttributesResponse())
+
+        // When
+        let attributes = try XCTUnwrap(order.items.first?.attributes)
+
+        // Then
+        let expectedAttributes = [OrderItemAttribute(metaID: 3665, name: "Required Weight (kg)", value: "2.3")]
+        assertEqual(attributes, expectedAttributes)
+    }
 }
 
 
@@ -323,6 +335,12 @@ private extension OrderMapperTests {
     ///
     func mapLoadOrderWithLineItemAttributesResponse() -> Order? {
         return mapOrder(from: "order-with-line-item-attributes")
+    }
+
+    /// Returns the OrderMapper output upon receiving `order-with-faulty-attributes`
+    ///
+    func mapLoadOrderWithFaultyAttributesResponse() -> Order? {
+        return mapOrder(from: "order-with-faulty-attributes")
     }
 
     /// Returns the OrderMapper output upon receiving `order-with-line-item-attributes-before-API-support`

--- a/Networking/NetworkingTests/Responses/order-with-faulty-attributes.json
+++ b/Networking/NetworkingTests/Responses/order-with-faulty-attributes.json
@@ -1,0 +1,104 @@
+{
+  "data" : {
+    "billing" : {
+      "phone" : "",
+      "city" : "",
+      "country" : "",
+      "address_1" : "",
+      "last_name" : "",
+      "company" : "",
+      "postcode" : "",
+      "email" : "",
+      "address_2" : "",
+      "state" : "",
+      "first_name" : ""
+    },
+    "status" : "processing",
+    "total" : "378.23",
+    "shipping" : {
+      "city" : "",
+      "country" : "",
+      "address_1" : "",
+      "last_name" : "",
+      "company" : "",
+      "postcode" : "",
+      "address_2" : "",
+      "state" : "",
+      "first_name" : ""
+    },
+    "refunds" : [],
+    "currency" : "USD",
+    "parent_id" : 0,
+    "line_items" : [
+      {
+        "id" : 473,
+        "quantity" : 2,
+        "tax_class" : "",
+        "subtotal_tax" : "30.21",
+        "meta_data" : [
+          {
+            "display_value" : "2.3",
+            "id" : 3665,
+            "key" : "Required Weight (kg)",
+            "value" : "2.3",
+            "display_key" : "Required Weight (kg)"
+          },
+          {
+            "display_value" : {
+              "_measurement_needed" : 2.2999999999999998,
+              "_measurement_needed_unit" : "kg",
+              "weight" : {
+                "value" : "2.3",
+                "unit" : "kg"
+              }
+            },
+            "id" : 3666,
+            "key" : "_measurement_data",
+            "value" : {
+              "_measurement_needed" : 2.2999999999999998,
+              "_measurement_needed_unit" : "kg",
+              "weight" : {
+                "value" : "2.3",
+                "unit" : "kg"
+              }
+            },
+            "display_key" : "_measurement_data"
+          }
+        ],
+        "parent_name" : null,
+        "total" : "340.40",
+        "total_tax" : "30.21",
+        "sku" : "",
+        "subtotal" : "340.40",
+        "price" : 170.19999999999999,
+        "product_id" : 80,
+        "taxes" : [
+          {
+            "id" : 1,
+            "total" : "30.21",
+            "subtotal" : "30.21"
+          }
+        ],
+        "variation_id" : 0,
+        "name" : "Boldenona"
+      }
+    ],
+    "shipping_total" : "0.00",
+    "customer_id" : 1,
+    "date_paid_gmt" : null,
+    "total_tax" : "30.83",
+    "payment_method" : "cod",
+    "fee_lines" : [],
+    "id" : 656,
+    "shipping_tax" : "0.62",
+    "number" : "656",
+    "payment_method_title" : "Cash on delivery",
+    "discount_total" : "0.00",
+    "customer_note" : "",
+    "shipping_lines" : [],
+    "date_created_gmt" : "2021-08-04T19:28:01",
+    "date_modified_gmt" : "2021-08-04T19:28:01",
+    "coupon_lines" : [],
+    "discount_tax" : "0.00"
+  }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+7.4
+-----
+- [*] Fix an issue where some extension was not shown in order item details. [https://github.com/woocommerce/woocommerce-ios/pull/4753]
+
 7.3
 -----
 - [*] Order Detail: now we do not offer the "email note to customer" option if no email is available. [https://github.com/woocommerce/woocommerce-ios/pull/4680]


### PR DESCRIPTION
fix #4708

# Why

It was reported(4182704-zd-woothemes) that merchants were able to see some order metadata in Android but not in iOS.

After some investigation, this happens because some extensions(like [Measurement Price Calculator](https://woocommerce.com/products/measurement-price-calculator/)) adds some extra metadata that does not have the format we expect, hence making the whole metadata/attributes decoding to fail.

# How

This PR solves the problem by making the `value` field from `OrderItemAttribute` to be decoded safely when an unexpected format is found.

# Screenshots 

Core | Before | After
--- | --- | ---
<img width="375" alt="core" src="https://user-images.githubusercontent.com/562080/128727336-ea699c1d-ea2f-46a0-96b6-6cb909bfab9e.png"> | <img width="376" alt="bad" src="https://user-images.githubusercontent.com/562080/128727340-6cdec4e9-6b01-4268-9319-cafbab4fac4a.png"> | <img width="378" alt="good" src="https://user-images.githubusercontent.com/562080/128727347-0b1910b3-9e61-4c28-9099-dbd1cfde4186.png">

# Testing Steps

Follow testings steps on https://github.com/woocommerce/woocommerce-ios/issues/4708


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
