### PR TITLE
Shipping Labels: Add the button "Create new package" in the package selected screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -60,19 +60,22 @@ struct ShippingLabelPackageList: View {
                         presentation.wrappedValue.dismiss()
                     }, label: {
                         Text(Localization.doneButton)
-                }))
+                    }))
 
-                    Button(action: {
-                        // TODO-3909: Navigate to create custom package screen
-                    }) {
-                        HStack {
-                            Image(uiImage: .plusImage)
-                            Text(Localization.createPackageButton)
-                            Spacer()
-                        }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                    VStack(spacing: 0) {
+                        Divider()
+                        Button(action: {
+                            // TODO-3909: Navigate to create custom package screen
+                        }) {
+                            HStack {
+                                Image(uiImage: .plusImage)
+                                Text(Localization.createPackageButton)
+                                Spacer()
+                            }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                        }
+                        .buttonStyle(LinkButtonStyle())
+                        .background(Color(.listForeground))
                     }
-                    .buttonStyle(LinkButtonStyle())
-                    .background(Color(.listForeground))
                 }.edgesIgnoringSafeArea([.bottom])
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -63,20 +63,12 @@ struct ShippingLabelPackageList: View {
                     }))
 
                     if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages) {
-                        VStack(spacing: 0) {
-                            Divider()
-                            Button(action: {
-                                // TODO-3909: Navigate to create custom package screen
-                            }) {
-                                HStack {
-                                    Image(uiImage: .plusImage)
-                                    Text(Localization.createPackageButton)
-                                    Spacer()
-                                }
-                            }
-                            .buttonStyle(LinkButtonStyle())
-                            .background(Color(.listForeground))
-                        }.edgesIgnoringSafeArea([.bottom])
+                        BottomButtonView(style: LinkButtonStyle(),
+                                         title: Localization.createPackageButton,
+                                         image: .plusImage,
+                                         onButtonTapped: {
+                                            // TODO-3909: Navigate to create custom package screen
+                                         })
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -62,19 +62,21 @@ struct ShippingLabelPackageList: View {
                         Text(Localization.doneButton)
                     }))
 
-                    VStack(spacing: 0) {
-                        Divider()
-                        Button(action: {
-                            // TODO-3909: Navigate to create custom package screen
-                        }) {
-                            HStack {
-                                Image(uiImage: .plusImage)
-                                Text(Localization.createPackageButton)
-                                Spacer()
-                            }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                    if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages) {
+                        VStack(spacing: 0) {
+                            Divider()
+                            Button(action: {
+                                // TODO-3909: Navigate to create custom package screen
+                            }) {
+                                HStack {
+                                    Image(uiImage: .plusImage)
+                                    Text(Localization.createPackageButton)
+                                    Spacer()
+                                }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                            }
+                            .buttonStyle(LinkButtonStyle())
+                            .background(Color(.listForeground))
                         }
-                        .buttonStyle(LinkButtonStyle())
-                        .background(Color(.listForeground))
                     }
                 }.edgesIgnoringSafeArea([.bottom])
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -72,13 +72,13 @@ struct ShippingLabelPackageList: View {
                                     Image(uiImage: .plusImage)
                                     Text(Localization.createPackageButton)
                                     Spacer()
-                                }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                                }
                             }
                             .buttonStyle(LinkButtonStyle())
                             .background(Color(.listForeground))
-                        }
+                        }.edgesIgnoringSafeArea([.bottom])
                     }
-                }.edgesIgnoringSafeArea([.bottom])
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageList: View {
     var body: some View {
         GeometryReader { geometry in
             NavigationView {
-                ZStack(alignment: .bottom) {
+                VStack(spacing: 0) {
                     ScrollView {
                         LazyVStack(spacing: 0) {
                             /// Custom Packages

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -8,57 +8,72 @@ struct ShippingLabelPackageList: View {
     var body: some View {
         GeometryReader { geometry in
             NavigationView {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        /// Custom Packages
-                        ///
-                        if viewModel.showCustomPackagesHeader {
-                            ListHeaderView(text: Localization.customPackageHeader.uppercased(), alignment: .left)
-                                .padding(.horizontal, insets: geometry.safeAreaInsets)
-                        }
-                        ForEach(viewModel.customPackages, id: \.title) { package in
-                            let selected = package == viewModel.selectedCustomPackage
-                            SelectableItemRow(title: package.title, subtitle: package.dimensions + " \(viewModel.dimensionUnit)", selected: selected)
-                                .onTapGesture {
-                                    viewModel.didSelectPackage(package.title)
-                                    ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "packages_selected"])
-                                }
-                                .padding(.horizontal, insets: geometry.safeAreaInsets)
-                                .background(Color(.systemBackground))
-                            Divider().padding(.leading, Constants.dividerPadding)
-                        }
-
-                        /// Predefined Packages
-                        ///
-                        ForEach(viewModel.predefinedOptions, id: \.title) { option in
-
-                            ListHeaderView(text: option.title.uppercased(), alignment: .left)
-                                .padding(.horizontal, insets: geometry.safeAreaInsets)
-                            ForEach(option.predefinedPackages) { package in
-                                let selected = package == viewModel.selectedPredefinedPackage
-                                SelectableItemRow(title: package.title,
-                                                  subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
-                                                  selected: selected).onTapGesture {
-                                                    viewModel.didSelectPackage(package.id)
-                                                    ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "packages_selected"])
-                                                  }
+                ZStack(alignment: .bottom) {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            /// Custom Packages
+                            ///
+                            if viewModel.showCustomPackagesHeader {
+                                ListHeaderView(text: Localization.customPackageHeader.uppercased(), alignment: .left)
+                                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            }
+                            ForEach(viewModel.customPackages, id: \.title) { package in
+                                let selected = package == viewModel.selectedCustomPackage
+                                SelectableItemRow(title: package.title, subtitle: package.dimensions + " \(viewModel.dimensionUnit)", selected: selected)
+                                    .onTapGesture {
+                                        viewModel.didSelectPackage(package.title)
+                                        ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "packages_selected"])
+                                    }
                                     .padding(.horizontal, insets: geometry.safeAreaInsets)
                                     .background(Color(.systemBackground))
                                 Divider().padding(.leading, Constants.dividerPadding)
                             }
+
+                            /// Predefined Packages
+                            ///
+                            ForEach(viewModel.predefinedOptions, id: \.title) { option in
+
+                                ListHeaderView(text: option.title.uppercased(), alignment: .left)
+                                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                                ForEach(option.predefinedPackages) { package in
+                                    let selected = package == viewModel.selectedPredefinedPackage
+                                    SelectableItemRow(title: package.title,
+                                                      subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
+                                                      selected: selected).onTapGesture {
+                                                        viewModel.didSelectPackage(package.id)
+                                                        ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
+                                                                                       withProperties: ["state": "packages_selected"])
+                                                      }
+                                        .padding(.horizontal, insets: geometry.safeAreaInsets)
+                                        .background(Color(.systemBackground))
+                                    Divider().padding(.leading, Constants.dividerPadding)
+                                }
+                            }
                         }
                     }
-                }
-                .background(Color(.listBackground))
-                .ignoresSafeArea(.container, edges: .horizontal)
-                .navigationTitle(Localization.title)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(trailing: Button(action: {
-                    viewModel.confirmPackageSelection()
-                    presentation.wrappedValue.dismiss()
-                }, label: {
-                    Text(Localization.doneButton)
+                    .background(Color(.listBackground))
+                    .ignoresSafeArea(.container, edges: .horizontal)
+                    .navigationTitle(Localization.title)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationBarItems(trailing: Button(action: {
+                        viewModel.confirmPackageSelection()
+                        presentation.wrappedValue.dismiss()
+                    }, label: {
+                        Text(Localization.doneButton)
                 }))
+
+                    Button(action: {
+                        // TODO-3909: Navigate to create custom package screen
+                    }) {
+                        HStack {
+                            Image(uiImage: .plusImage)
+                            Text(Localization.createPackageButton)
+                            Spacer()
+                        }.padding(.bottom, geometry.safeAreaInsets.bottom)
+                    }
+                    .buttonStyle(LinkButtonStyle())
+                    .background(Color(.listForeground))
+                }.edgesIgnoringSafeArea([.bottom])
             }
         }
     }
@@ -70,6 +85,7 @@ private extension ShippingLabelPackageList {
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button under the Package Selected screen in Shipping Label flow")
         static let customPackageHeader = NSLocalizedString("CUSTOM PACKAGES",
                                                            comment: "Header for the Custom Packages section in Shipping Label Package listing")
+        static let createPackageButton = NSLocalizedString("Create new package", comment: "Button to create a new package in Shipping Label Package screen")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct BottomButtonView<Style>: View where Style: ButtonStyle {
+    let style: Style
+    let title: String
+    let image: UIImage?
+    let onButtonTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Button(action: { onButtonTapped() }) {
+                HStack {
+                    if let image = image {
+                        Image(uiImage: image)
+                    }
+                    Text(title)
+                    Spacer()
+                }
+            }
+            .buttonStyle(style)
+        }.edgesIgnoringSafeArea([.bottom])
+    }
+}
+
+struct BottomButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        BottomButtonView(style: LinkButtonStyle(),
+                         title: "Bottom Button",
+                         image: .plusImage,
+                         onButtonTapped: {})
+            .previewLayout(.sizeThatFits)
+
+        BottomButtonView(style: LinkButtonStyle(),
+                         title: "Bottom Button",
+                         image: .plusImage,
+                         onButtonTapped: {})
+            .previewLayout(.sizeThatFits)
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            .previewDisplayName("Large font")
+
+        BottomButtonView(style: LinkButtonStyle(),
+                         title: "Bottom Button",
+                         image: .plusImage,
+                         onButtonTapped: {})
+            .previewLayout(.sizeThatFits)
+            .environment(\.layoutDirection, .rightToLeft)
+            .previewDisplayName("Right to left")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
@@ -19,7 +19,7 @@ struct BottomButtonView<Style>: View where Style: ButtonStyle {
                 }
             }
             .buttonStyle(style)
-        }.edgesIgnoringSafeArea([.bottom])
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -12,13 +12,18 @@ struct SecondaryButtonStyle: ButtonStyle {
     }
 }
 
+struct LinkButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        LinkButton(configuration: configuration)
+    }
+}
+
 private struct BaseButton: View {
     let configuration: ButtonStyleConfiguration
 
     var body: some View {
         configuration.label
             .frame(maxWidth: .infinity)
-            .font(.headline)
             .padding(Style.defaultEdgeInsets)
     }
 }
@@ -31,6 +36,7 @@ private struct PrimaryButton: View {
     var body: some View {
         BaseButton(configuration: configuration)
             .foregroundColor(Color(foregroundColor))
+            .font(.headline)
             .background(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
                     .fill(Color(backgroundColor))
@@ -81,6 +87,7 @@ private struct SecondaryButton: View {
     var body: some View {
         BaseButton(configuration: configuration)
             .foregroundColor(Color(foregroundColor))
+            .font(.headline)
             .background(
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
                     .fill(Color(backgroundColor))
@@ -123,6 +130,20 @@ private struct SecondaryButton: View {
     }
 }
 
+private struct LinkButton: View {
+    let configuration: ButtonStyleConfiguration
+
+    var body: some View {
+        BaseButton(configuration: configuration)
+            .foregroundColor(Color(foregroundColor))
+            .background(Color(.clear))
+    }
+
+    var foregroundColor: UIColor {
+        configuration.isPressed ? .accentDark : .accent
+    }
+}
+
 private enum Style {
     static let defaultCornerRadius = CGFloat(8.0)
     static let defaultBorderWidth = CGFloat(1.0)
@@ -145,6 +166,9 @@ struct PrimaryButton_Previews: PreviewProvider {
             Button("Secondary button (disabled)") {}
                 .buttonStyle(SecondaryButtonStyle())
                 .disabled(true)
+
+            Button("Link button") {}
+                .buttonStyle(LinkButtonStyle())
         }
         .padding()
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -930,6 +930,7 @@
 		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
 		CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */; };
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
+		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
@@ -2290,6 +2291,7 @@
 		CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
@@ -4160,6 +4162,7 @@
 				E15FC74026BC1CED00CF83E6 /* AttributedText.swift */,
 				E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */,
 				E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */,
+				CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7003,6 +7006,7 @@
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
+				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,


### PR DESCRIPTION
Resolves: #4742

## Description

Adds the button "Create new package" when creating a new shipping label, at the bottom of the Package Selected screen.

This button will allow users to create a new package to use with their shipping label (to be implemented in a future PR; for now the button doesn't do anything).

## Changes

* Adds a LinkButtonStyle to the SwiftUI `ButtonStyles`. This is the style used for the "Create new package" button.
* Adds a new reusable SwiftUI component `BottomButtonView`, which acts like our reusable UIKit `BottomButtonContainerView` (a view that can be used to add a button with the specified styles to the bottom of a SwiftUI view).
* Adds the "Create new package" button to the bottom of the Package Selected screen (`ShippingLabelPackageList`), by adding a new `VStack` that includes the existing `ScrollView` and a new `BottomButtonView`. This button is only displayed when the `shippingLabelsAddCustomPackages` feature flag is enabled.

Before|After (light)|After (dark)|After (short list)
-|-|-|-
![Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 17 22 11](https://user-images.githubusercontent.com/8658164/128740069-92461662-c330-4a8f-8c53-861733e8cafb.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 16 37 44](https://user-images.githubusercontent.com/8658164/128740079-e3df8768-90d4-4904-a648-322bf7c83d3d.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 16 37 28](https://user-images.githubusercontent.com/8658164/128740085-691f9cd4-5039-4bb6-9e5f-fea2787ae857.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-09 at 15 53 02](https://user-images.githubusercontent.com/8658164/128740092-f57f9ed1-45b5-4388-bd64-37563a6b8e38.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more payment methods and one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, confirm the “Create new package” button appears at the bottom of the screen.

You can also test with the `shippingLabelsAddCustomPackages` feature flag disabled (in production mode or by manually disabling that flag) to confirm the screen looks the same as before when the button is not on screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
