### PR TITLE
Attempted to initialize an object with an unknown UUID: Remove unknown UUID

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7404,7 +7404,6 @@
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
-				3143AEBD269618DF00BACA7A /* CardReaderSettingsKnownViewController.swift in Sources */,
 				D8B4D5EE26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift in Sources */,
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,
 				2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */,


### PR DESCRIPTION
On running bundle exec pod install, the following warning appears:

```
Pod installation complete! There are 19 dependencies from the Podfile and 40 total pods installed.

[!] `<PBXSourcesBuildPhase UUID=`B56DB3C22049BFAA00D4AA8E`>` attempted to initialize an object with an unknown UUID. `3143AEBD269618DF00BACA7A` for attribute: `files`. This can be the result of a merge and the unknown UUID is being discarded.
```

Careful examination of the WooCommerce/WooCommerce.xcodeproj/project.pbxproj file shows one reference to this UUID:

```
3143AEBD269618DF00BACA7A /* CardReaderSettingsKnownViewController.swift in Sources */,
```

which was removed by this PR: https://github.com/woocommerce/woocommerce-ios/pull/4757/files

but was put back in by an unknown later commit / bad resolved conflict.

This PR removes that UUID.

To test:
- Ensure you can run `bundle exec pod install` without that warning
- Ensure you can build the app

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
