### PR TITLE
Link XCUITestHelpers Swift package to UI and screenshot tests targets

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,6 +36,15 @@
           "revision": "5b2e81191e77f66e6c6ca497f11a77fe48f7f0fc",
           "version": "1.0.0"
         }
+      },
+      {
+        "package": "XCUITestHelpers",
+        "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
+        "state": {
+          "branch": null,
+          "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
+          "version": "0.1.0"
+        }
       }
     ]
   },

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -494,6 +494,8 @@
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
+		3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81C26C3542600228BF2 /* XCUITestHelpers */; };
+		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
 		3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF22489267073AE008FFA87 /* ScreenObject */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
@@ -2670,6 +2672,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
+				3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2679,6 +2682,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
+				3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6216,6 +6220,7 @@
 			name = WooCommerceUITests;
 			packageProductDependencies = (
 				3FF2247226706AA3008FFA87 /* ScreenObject */,
+				3F1CA81C26C3542600228BF2 /* XCUITestHelpers */,
 			);
 			productName = WooCommerceUITests;
 			productReference = CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */;
@@ -6239,6 +6244,7 @@
 			packageProductDependencies = (
 				247CE89B2583402A00F9D9D1 /* Embassy */,
 				3FF22489267073AE008FFA87 /* ScreenObject */,
+				3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */,
 			);
 			productName = WooCommerceScreenshots;
 			productReference = F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */;
@@ -6324,6 +6330,7 @@
 				247CE89A2583402A00F9D9D1 /* XCRemoteSwiftPackageReference "Embassy" */,
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
+				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -8421,6 +8428,14 @@
 				minimumVersion = 4.1.2;
 			};
 		};
+		3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
@@ -8452,6 +8467,16 @@
 		263E38452641FF3400260D3B /* Codegen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Codegen;
+		};
+		3F1CA81C26C3542600228BF2 /* XCUITestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
+			productName = XCUITestHelpers;
+		};
+		3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
+			productName = XCUITestHelpers;
 		};
 		3FF2247226706AA3008FFA87 /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
@@ -1,5 +1,5 @@
-import Foundation
 import XCTest
+import XCUITestHelpers
 
 private struct ElementStringIDs {
     static let passwordTextField = "Password"
@@ -28,7 +28,7 @@ final class LoginPasswordScreen: BaseScreen {
     func tryProceed(password: String) -> LoginPasswordScreen {
         XCTAssert(passwordTextField.waitForHittability(timeout: 3))
 
-        passwordTextField.pasteText(text: password)
+        passwordTextField.paste(text: password)
 
         XCTAssert(loginButton.waitForExistence(timeout: 3))
         XCTAssert(loginButton.waitForHittability(timeout: 3))

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -35,18 +35,6 @@ extension XCUIElement {
         self.typeText(text)
     }
 
-    func pasteText(text: String) -> Void {
-        let previousPasteboardContents = UIPasteboard.general.string
-        UIPasteboard.general.string = text
-
-        self.press(forDuration: 1.2)
-        XCUIApplication().menuItems.firstMatch.tap()
-
-        if let string = previousPasteboardContents {
-            UIPasteboard.general.string = string
-        }
-    }
-
     var stringValue: String? {
         return self.value as? String
     }


### PR DESCRIPTION
To verify it's linked properly, I removed the custom `pasteText(_:)` method in favor of the one offered by the package.

I run the UI tests in CI and they passed 🎉 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.