### PR TITLE
Remove unused and unnecessary code from `PrologueScreen`

### DIFF
--- a/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PrologueScreen.swift
@@ -7,15 +7,9 @@ private struct ElementStringIDs {
 }
 
 final class PrologueScreen: ScreenObject {
-    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons[ElementStringIDs.continueButton]
-    }
-    private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons[ElementStringIDs.siteAddressButton]
-    }
 
     private var continueButton: XCUIElement { expectedElement }
-    private var siteAddressButton: XCUIElement { siteAddressButtonGetter(app) }
+    private var siteAddressButton: XCUIElement { app.buttons[ElementStringIDs.siteAddressButton] }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(


### PR DESCRIPTION
Hat tip @jkmassel, see [here](https://github.com/woocommerce/woocommerce-ios/pull/4392#discussion_r686201816).

It's been a while since I wrote that code... My guess was that past me was experimenting with closures and runtime evaluation of the objects and didn't cleanup properly.

I think there might be a use case for defining getter closures within a `ScreenObject` subclass to expose them statically then reuse them in instance properties and method, but that's not the case in this particular case.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
