### PR TITLE
Update WordPressAuthenticator and WordPressKit to latest betas

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,13 +38,13 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.41.0'
+  pod 'WordPressAuthenticator', '~> 1.42.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressKit', '~> 4.37.0'
+  pod 'WordPressKit', '~> 4.40.0-beta'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
 
   pod 'WordPressShared', '~> 1.15'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -51,7 +51,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.41.0):
+  - WordPressAuthenticator (1.42.0-beta.1):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -63,7 +63,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.37.0):
+  - WordPressKit (4.40.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -104,8 +104,8 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 1.4.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.41.0)
-  - WordPressKit (~> 4.37.0)
+  - WordPressAuthenticator (~> 1.42.0-beta)
+  - WordPressKit (~> 4.40.0-beta)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.1)
   - Wormholy (~> 1.6.4)
@@ -183,8 +183,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 65367984d9d7a83c3c11039a9762277e81dfd2ba
-  WordPressKit: bd2386909067b48b5525569cefac206bc4234eb5
+  WordPressAuthenticator: 9ead34013649fe7322ec996e2c8f40ca0dabee07
+  WordPressKit: 24ab754bca8bb8f2ee56147f8824af4f3f6f3602
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
@@ -199,6 +199,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: bec58b7449379a1c36fd383578402dc581e5c69a
+PODFILE CHECKSUM: 6ef2613127907d8a3d2836d5e04d8776732f0a3a
 
 COCOAPODS: 1.10.2

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -6181,7 +6181,6 @@
 				B56DB3C42049BFAA00D4AA8E /* Resources */,
 				B5650B1020A4CD7F009702D0 /* Embed Frameworks */,
 				B7A94351C1ADC31EA528B895 /* [CP] Embed Pods Frameworks */,
-				59DF5B32D7C07692EC8B4C59 /* [CP] Copy Pods Resources */,
 				095040D72655531C001D08FA /* Check for nested frameworks */,
 			);
 			buildRules = (
@@ -6624,23 +6623,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
 			shellScript = "$SRCROOT/../Scripts/build-phases/swiftlint.sh\n";
-		};
-		59DF5B32D7C07692EC8B4C59 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		91990E72B3E1D58AC13D7628 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Description

This PR updates `WordPressAuthenticator` and `WordPressKit` to latest betas.
`WordPressAuthenticator` update is bringing Apple Silicon support, only 1 PR diff from previous version:
- https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/612

`WordPressKit` update is just general version bump, here is the diff from previous version:
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/416
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/419
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/424
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/427
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/428
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/429
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/430

## Test

Install Pods, build and run the app. Do a quick smoke test, log out and back in.

Note for M1 users: if you want to test on arm64 simulator - hack only `StripeTerminal` dependency (like described in p91TBi-5tl-p2). It's not needed for device build or Rosetta mode.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
