### PR TITLE
[CPP Onboarding] Ordering card readers

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -83,7 +83,7 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
-        // TODO
+        WebviewHelper.launch(Constants.woocommercePurchaseCardReaderURL, with: self)
     }
 
     func manageCardReaderWasPressed() {
@@ -148,6 +148,10 @@ private enum Row: CaseIterable {
     var reuseIdentifier: String {
         return type.reuseIdentifier
     }
+}
+
+private enum Constants {
+    static let woocommercePurchaseCardReaderURL = URL(string: "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader")!
 }
 
 // MARK: - SwiftUI compatibility

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -1,0 +1,165 @@
+import UIKit
+import SwiftUI
+
+final class InPersonPaymentsMenuViewController: UITableViewController {
+    private var rows = [Row]()
+
+    init() {
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureRows()
+        configureTableView()
+        registerTableViewCells()
+    }
+}
+
+// MARK: - View configuration
+//
+private extension InPersonPaymentsMenuViewController {
+
+    func configureRows() {
+        rows = [
+            .orderCardReader,
+            .manageCardReader
+        ]
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.registerNib(for: row.type)
+        }
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as BasicTableViewCell where row == .orderCardReader:
+            configureOrderCardReader(cell: cell)
+        case let cell as BasicTableViewCell where row == .manageCardReader:
+            configureManageCardReader(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    func configureOrderCardReader(cell: UITableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Order card reader", comment: "Navigates to Card Reader ordering screen")
+    }
+
+    func configureManageCardReader(cell: UITableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Manage card reader", comment: "Navigates to Card Reader management screen")
+    }
+}
+
+// MARK: - Convenience methods
+//
+private extension InPersonPaymentsMenuViewController {
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        rows[indexPath.row]
+    }
+}
+
+// MARK: - Actions
+//
+extension InPersonPaymentsMenuViewController {
+    func orderCardReaderWasPressed() {
+        // TODO
+    }
+
+    func manageCardReaderWasPressed() {
+        ServiceLocator.analytics.track(.settingsCardReadersTapped)
+        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
+            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
+        }
+
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
+        viewController.configure(viewModelsAndViews: viewModelsAndViews)
+        show(viewController, sender: self)
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension InPersonPaymentsMenuViewController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+//
+extension InPersonPaymentsMenuViewController {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        // listed in the order they are displayed
+        switch rowAtIndexPath(indexPath) {
+        case .orderCardReader:
+            orderCardReaderWasPressed()
+        case .manageCardReader:
+            manageCardReaderWasPressed()
+        }
+    }
+}
+
+private enum Row: CaseIterable {
+    case orderCardReader
+    case manageCardReader
+    var type: UITableViewCell.Type {
+        switch self {
+        case .orderCardReader:
+            return BasicTableViewCell.self
+        case .manageCardReader:
+            return BasicTableViewCell.self
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
+    }
+}
+
+// MARK: - SwiftUI compatibility
+//
+
+/// SwiftUI wrapper for CardReaderSettingsPresentingViewController
+///
+struct InPersonPaymentsMenu: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> some UIViewController {
+        InPersonPaymentsMenuViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -47,7 +47,7 @@ struct InPersonPaymentsView: View {
                 case .stripeAccountRejected:
                     InPersonPaymentsStripeRejected()
                 case .completed:
-                    CardReaderSettingsPresentingView()
+                    InPersonPaymentsMenu()
                 default:
                     InPersonPaymentsUnavailable()
                 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1252,6 +1252,7 @@
 		E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */; };
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
 		E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */; };
+		E1906E9A26C4126300CA6819 /* InPersonPaymentsMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */; };
 		E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
@@ -2607,6 +2608,7 @@
 		E16715CC2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessWithoutEmailTests.swift; sourceTree = "<group>"; };
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
 		E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequiredTests.swift; sourceTree = "<group>"; };
+		E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewController.swift; sourceTree = "<group>"; };
 		E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingStack.swift; sourceTree = "<group>"; };
@@ -6069,6 +6071,7 @@
 				E107FCDD26C1295600BAF51B /* Onboarding Errors */,
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
+				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
 				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
@@ -7110,6 +7113,7 @@
 				0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */,
 				452FE6522565849B00EB54A0 /* LinkedProductsViewModel.swift in Sources */,
 				45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */,
+				E1906E9A26C4126300CA6819 /* InPersonPaymentsMenuViewController.swift in Sources */,
 				0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */,
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				45CE2D322625AA9A00E3CA00 /* ShippingLabelPackageList.swift in Sources */,


### PR DESCRIPTION
Part of #4611 

This adds a new menu when WCPay is set up correctly to show the option to either order or manage a card reader, instead of showing the card reader settings directly.

## Why UIKit?

There is an unresolved SwiftUI issue (see #3995) that will show an extra tab bar item when `NavigationLink` is used within a `UITabBarController`. Since we don't have a solution yet, and the card reader settings are still implemented in UIKit, one solution was to implement this new menu as a UITableView.

This is fine, and we use this approach for many other views in the app, but it's still painful that, without that bug, the implementation would have been so much simpler 😭 

```swift
struct InPersonPaymentsMenu: View {
    var body: some View {
        List {
            NavigationLink("Order card reader", destination: OrderCardReader())
            NavigationLink("Manage card reader", destination: CardReaderSettings())
        }
    }
}
```

## To Test

Use a store that was WCPay completely set up and is eligible for In-person payments

1. Go to Settings > In-Person Payments
2. See the new menu
3. Tapping on Order card reader should open a web browser. This is yet to be implemented in the backend, so the URL returns a 404 for now
4. Tapping on Manage card reader should push the card reader settings

In-Person Payments | Order card reader | Manage card reader
-|-|-
![Screen Shot 2021-08-11 at 16 54 23](https://user-images.githubusercontent.com/8739/129052540-67037fd4-f641-4cf6-a6d5-46347296290e.png)|![Screen Shot 2021-08-11 at 16 54 30](https://user-images.githubusercontent.com/8739/129052550-99e092fb-f87d-46b7-aaef-4a7b1245e493.png)|![Screen Shot 2021-08-11 at 16 55 08](https://user-images.githubusercontent.com/8739/129052563-62a647a2-159f-43ce-87bd-d37f189fae90.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
