### PR TITLE
[Mobile Payments] [Customers] Fetch and pass customer when creating payment intent

### DIFF
--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -32,17 +32,24 @@ public struct PaymentIntentParameters {
     /// This can be useful for storing additional information about the object in a structured format.
     public let metadata: [AnyHashable: Any]?
 
+    /// A Stripe issued customer ID
+    /// See https://stripe.com/docs/api/customers
+    ///
+    public let customerID: String?
+
     public init(amount: Decimal,
                 currency: String,
                 receiptDescription: String? = nil,
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
-                metadata: [AnyHashable: Any]? = nil) {
+                metadata: [AnyHashable: Any]? = nil,
+                customerID: String? = nil) {
         self.amount = amount
         self.currency = currency
         self.receiptDescription = receiptDescription
         self.statementDescription = statementDescription
         self.receiptEmail = receiptEmail
         self.metadata = metadata
+        self.customerID = customerID
     }
 }

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -19,6 +19,7 @@ extension Hardware.PaymentIntentParameters {
         returnValue.stripeDescription = self.receiptDescription
         returnValue.statementDescriptor = self.statementDescription
         returnValue.receiptEmail = self.receiptEmail
+        returnValue.customer = self.customerID
         returnValue.metadata = self.metadata
 
         return returnValue

--- a/Hardware/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentParametersTests.swift
@@ -66,4 +66,13 @@ final class PaymentIntentParametersTests: XCTestCase {
 
         XCTAssertEqual(statementDescription, "A DESCRIPTION LONGER T")
     }
+
+    func test_customer_id_is_passed_to_stripe() {
+        let customerID = "customer_id"
+        let params = PaymentIntentParameters(amount: 100, currency: "usd", statementDescription: "A DESCRIPTION", customerID: customerID)
+
+        let stripeParameters = params.toStripe()
+
+        XCTAssertEqual(stripeParameters?.customer, customerID)
+    }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -27,7 +27,7 @@ final class PaymentCaptureOrchestrator {
             switch result {
             case .success(let customer):
                 customerID = customer.id
-            case .failure(_):
+            case .failure:
                 // It is not ideal but ok to proceed to payment intent creation without a customer ID
                 DDLogWarn("Warning: failed to fetch customer ID for an order")
             }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,5 +1,4 @@
 import Yosemite
-import Networking
 import PassKit
 
 /// Orchestrates the sequence of actions required to capture a payment:

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import Networking
 import PassKit
 
 /// Orchestrates the sequence of actions required to capture a payment:
@@ -20,39 +21,60 @@ final class PaymentCaptureOrchestrator {
                         onClearMessage: @escaping () -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
-        guard let parameters = paymentParameters(order: order, account: paymentsAccount) else {
-            DDLogError("Error: failed to create payment parameters for an order")
-            onCompletion(.failure(CardReaderServiceError.paymentCapture()))
-            return
+        /// First ask the backend to create/assign a Stripe customer for the order
+        ///
+        var customerID: String?
+        let customerAction = CardPresentPaymentAction.fetchOrderCustomer(siteID: order.siteID, orderID: order.orderID) { [self] result in
+            switch result {
+            case .success(let customer):
+                customerID = customer.id
+            case .failure(_):
+                // It is not ideal but ok to proceed to payment intent creation without a customer ID
+                DDLogWarn("Warning: failed to fetch customer ID for an order")
+            }
+
+            guard let parameters = paymentParameters(order: order, account: paymentsAccount, customerID: customerID) else {
+                DDLogError("Error: failed to create payment parameters for an order")
+                onCompletion(.failure(CardReaderServiceError.paymentCapture()))
+                return
+            }
+
+            /// Briefly suppress pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
+            /// reader begins to collect payment.
+            ///
+            suppressPassPresentation()
+
+            let paymentAction = CardPresentPaymentAction.collectPayment(
+                siteID: order.siteID,
+                orderID: order.orderID,
+                parameters: parameters,
+                onCardReaderMessage: { (event) in
+                    switch event {
+                    case .displayMessage (let message):
+                        onPresentMessage(message)
+                    case .waitingForInput (let message):
+                        onPresentMessage(message)
+                    case .cardRemoved:
+                        onClearMessage()
+                    default:
+                        break
+                    }
+                },
+                onCompletion: { [weak self] result in
+                    self?.allowPassPresentation()
+                    onProcessingMessage()
+                    self?.completePaymentIntentCapture(
+                        order: order,
+                        captureResult: result,
+                        onCompletion: onCompletion
+                    )
+                }
+            )
+
+            ServiceLocator.stores.dispatch(paymentAction)
         }
 
-        /// Briefly suppress pass (wallet) presentation so that the merchant doesn't attempt to pay for the buyer's order when the
-        /// reader begins to collect payment.
-        ///
-        suppressPassPresentation()
-
-        let action = CardPresentPaymentAction.collectPayment(siteID: order.siteID,
-                                                             orderID: order.orderID, parameters: parameters,
-                                                             onCardReaderMessage: { (event) in
-                                                                switch event {
-                                                                case .displayMessage (let message):
-                                                                    onPresentMessage(message)
-                                                                case .waitingForInput (let message):
-                                                                    onPresentMessage(message)
-                                                                case .cardRemoved:
-                                                                    onClearMessage()
-                                                                default:
-                                                                    break
-                                                                }
-                                                             }, onCompletion: { [weak self] result in
-                                                                self?.allowPassPresentation()
-                                                                onProcessingMessage()
-                                                                self?.completePaymentIntentCapture(order: order,
-                                                                                                 captureResult: result,
-                                                                                                 onCompletion: onCompletion)
-        })
-
-        ServiceLocator.stores.dispatch(action)
+        ServiceLocator.stores.dispatch(customerAction)
     }
 
     func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
@@ -184,7 +206,7 @@ private extension PaymentCaptureOrchestrator {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func paymentParameters(order: Order, account: PaymentGatewayAccount?) -> PaymentParameters? {
+    func paymentParameters(order: Order, account: PaymentGatewayAccount?, customerID: String?) -> PaymentParameters? {
         guard let orderTotal = currencyFormatter.convertToDecimal(from: order.total) else {
             DDLogError("Error: attempted to collect payment for an order without a valid total.")
             return nil
@@ -214,11 +236,12 @@ private extension PaymentCaptureOrchestrator {
         )
 
         return PaymentParameters(amount: orderTotal as Decimal,
-                                                  currency: order.currency,
-                                                  receiptDescription: receiptDescription(orderNumber: order.number),
-                                                  statementDescription: account?.statementDescriptor,
-                                                  receiptEmail: order.billingAddress?.email,
-                                                  metadata: metadata)
+                                 currency: order.currency,
+                                 receiptDescription: receiptDescription(orderNumber: order.number),
+                                 statementDescription: account?.statementDescriptor,
+                                 receiptEmail: order.billingAddress?.email,
+                                 metadata: metadata,
+                                 customerID: customerID)
     }
 
     func receiptDescription(orderNumber: String) -> String? {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -529,7 +529,6 @@ extension OrderDetailsViewModel {
                         onClearMessage: @escaping () -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {
-
         /// We don't have a concept of priority yet, so use the first paymentGatewayAccount for now
         /// since we can't yet have multiple accounts
         ///

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -26,6 +26,10 @@ public enum CardPresentPaymentAction: Action {
     ///
     case observeConnectedReaders(onCompletion: ([CardReader]) -> Void)
 
+    /// Get a Stripe Customer for an order.
+    ///
+    case fetchOrderCustomer(siteID: Int64, orderID: Int64, onCompletion: (Result<WCPayCustomer, Error>) -> Void)
+
     /// Collected payment for an order.
     ///
     case collectPayment(siteID: Int64,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -126,6 +126,7 @@ public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias WCPayAccount = Networking.WCPayAccount
 public typealias WCPayAccountStatusEnum = Networking.WCPayAccountStatusEnum
+public typealias WCPayCustomer = Networking.WCPayCustomer
 
 // MARK: - Exported Storage Symbols
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -49,6 +49,8 @@ public final class CardPresentPaymentStore: Store {
             disconnect(onCompletion: completion)
         case .observeConnectedReaders(let completion):
             observeConnectedReaders(onCompletion: completion)
+        case .fetchOrderCustomer(let siteID, let orderID, let completion):
+            fetchOrderCustomer(siteID: siteID, orderID: orderID, completion: completion)
         case .collectPayment(let siteID, let orderID, let parameters, let event, let completion):
             collectPayment(siteID: siteID,
                            orderID: orderID,
@@ -174,6 +176,10 @@ private extension CardPresentPaymentStore {
         } receiveValue: { intent in
             onCompletion(.success(intent))
         }
+    }
+
+    func fetchOrderCustomer(siteID: Int64, orderID: Int64, completion: @escaping (Result<WCPayCustomer, Error>) -> Void) {
+        remote.fetchOrderCustomer(for: siteID, orderID: orderID, completion: completion)
     }
 
     func cancelPayment(onCompletion: ((Result<Void, Error>) -> Void)?) {


### PR DESCRIPTION
Closes #4298 

Summary of changes:
- Builds on the remote added in #4765
- Adds an action to CardPresentPaymentAction, CardPresentPaymentStore for fetching a customer through that remote
- Adds customer ID to the payment intent parameters
- Updates `PaymentCaptureOrchestrator` to request the customer from the site for the order - also a bit of whitespace reformatting

To test:
- Create at least two COD orders as a registered user and one as a guest user
- Set a breakpoint in PaymentCaptureOrchestrator collectPayment after the completion switch for fetchOrderCustomer
- Collect payment for all three orders
- When the breakpoint hits, po parameters.customerID and then resume
- Ensure the two registered user orders are assigned the same Stripe customer ID. Ensure the guest order gets a different Stripe customer ID.
- Or, if you prefer, instead of breakpointing, you can view the payment intent details in the private dashboard, e.g.

<img width="1789" alt="pic" src="https://user-images.githubusercontent.com/1595739/129108033-0aef99be-a341-491b-9723-16a119a65608.png">

- Backwards compatibility is also important, since this customer-returning endpoint was only added to recently (plugin version 2.8.3) - repeat the test with a 2.7.x release, or edit the plugin to remove the endpoint, i.e.:

<img width="1014" alt="Screen Shot 2021-08-11 at 2 37 13 PM" src="https://user-images.githubusercontent.com/1595739/129108143-a831839a-b3ed-4ce1-8084-eb360f44ac73.png">

- Make sure you can still collect payment. When you look at the transaction in the dashboard, you should see "null" for the customer on the payment intent.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
