### PR TITLE
Hide refund button if order is not eligible for refund

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 7.4
 -----
 - [*] Fix an issue where some extension was not shown in order item details. [https://github.com/woocommerce/woocommerce-ios/pull/4753]
+- [*] Fix: The refund button within Order Details will be hidden if the refund is zero. [https://github.com/woocommerce/woocommerce-ios/pull/4789]
 
 7.3
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -33,9 +33,6 @@ final class OrderDetailsDataSource: NSObject {
     private var isRefundedStatus: Bool {
         return order.status == OrderStatusEnum.refunded
     }
-    /// Is this order eligible for a refund?
-    ///
-    var isEligibleForRefund: Bool = true
 
     /// Is the shipment tracking plugin available?
     ///
@@ -975,12 +972,8 @@ extension OrderDetailsDataSource {
             if shouldShowReceipts {
                 rows.append(.seeReceipt)
             }
-
-            if let orderTotal = Double(self.order.total) {
-                if orderTotal <= 0.0 {
-                    isEligibleForRefund = false
-                }
-            }
+            let orderTotal = Double(self.order.total) ?? 0
+            let isEligibleForRefund = orderTotal > 0
             if !isRefundedStatus && !isEligibleForCardPresentPayment && isEligibleForRefund {
                 rows.append(.issueRefundButton)
             }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -35,7 +35,7 @@ final class OrderDetailsDataSource: NSObject {
     }
     /// Is this order eligible for a refund?
     ///
-    var isEligibleForRefund : Bool = true
+    var isEligibleForRefund: Bool = true
 
     /// Is the shipment tracking plugin available?
     ///

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -972,7 +972,7 @@ extension OrderDetailsDataSource {
             if shouldShowReceipts {
                 rows.append(.seeReceipt)
             }
-            let orderTotal = Double(self.order.total) ?? 0
+            let orderTotal = Double(order.total) ?? 0
             let isEligibleForRefund = orderTotal > 0
             if !isRefundedStatus && !isEligibleForCardPresentPayment && isEligibleForRefund {
                 rows.append(.issueRefundButton)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -33,6 +33,9 @@ final class OrderDetailsDataSource: NSObject {
     private var isRefundedStatus: Bool {
         return order.status == OrderStatusEnum.refunded
     }
+    /// Is this order eligible for a refund?
+    ///
+    var isEligibleForRefund : Bool = true
 
     /// Is the shipment tracking plugin available?
     ///
@@ -973,7 +976,12 @@ extension OrderDetailsDataSource {
                 rows.append(.seeReceipt)
             }
 
-            if !isRefundedStatus && !isEligibleForCardPresentPayment {
+            if let orderTotal = Double(self.order.total) {
+                if orderTotal <= 0.0 {
+                    isEligibleForRefund = false
+                }
+            }
+            if !isRefundedStatus && !isEligibleForCardPresentPayment && isEligibleForRefund {
                 rows.append(.issueRefundButton)
             }
 


### PR DESCRIPTION
Fixes #3845 

## Description

This PR removes the `Issue Refund` button from the Order Details screen if there's actually no refund to be done. This also fits with how the Android version works.

## Changes

I have added an additional `isEligibleForRefund` check to the Order Details data source. This checks if the current `order.total` is positive. If the `order.total` is positive then the check will pass as there's something to be refunded, and we can load the cell for the refund button on this view.

Why use `order.total` for this check? This contains what a customer has effectively paid and sets the maximum that can be refunded, with coupons, shipping, fees, and taxes taken into consideration.

| Hide button: Order details when refund is `0` |  Show button: Order details when refund is `>0` | Hide button: Order details when refund is `0` because negative prices | Show button: Order details when partial refund | 
|---------------------|---|-----------------|----------------|
| <img width="338" alt="refund is 0, no button" src="https://user-images.githubusercontent.com/3812076/129125553-ec0fd4b3-20ae-48e3-9bbf-b2b816bf08c1.png"> | <img width="339" alt="refund is positive, button" src="https://user-images.githubusercontent.com/3812076/129125936-7857e505-fd95-4ac2-9bda-3d39ab3410eb.png"> | <img width="339" alt="refund is negative, no button" src="https://user-images.githubusercontent.com/3812076/129125983-cedfcebd-f61a-459f-8201-cf38f0d9c980.png">| <img width="357" alt="partial refund, shows button" src="https://user-images.githubusercontent.com/3812076/129146730-6d6f3ab6-67f8-49a9-be96-ce1b519aeff8.png"> |

**Edge Case: Refunding payment gateway fees:**

At the moment I left the option to see the Refund Button if there's fees in the order, so when we have the case `order.total = 0 && order.fees > 0` it will show the refund button, this is in consonance with how works in core: The button appears but is only possible to refund these fees directly through the payment gateway:

<img width="1029" alt="refund only fees" src="https://user-images.githubusercontent.com/3812076/129153503-d601f176-81d5-4950-9c5d-87a78cda9534.png">

I believe we have 2 options here:

- Option 1) Show the refund button when there's remaining fees, once the user taps on it we can edit the view to show "You need to manually issue the refund directly through your payment gateway" message.
- Option 2) Hide the button, I'm not personally on board with this option as there's actually something that could still be refunded, just not through the app.


## Work in progress
- [x] Is `order.total` updated after a partial refund?
- [x] Payment processor fees are added after the total. Should these be refundable as well? How does it work in WooCommerce core?

## Testing steps
1 - Create an order where the price of the product(s) is equal to zero. One way to do this would be to add a sale price of zero for a product.
2 - Open the order in the app.
3 - Attempt to issue a refund for the order. The button is not there.
4 - Now try the same with an order where the price of the product is positive. 
5 - Attempt to issue a refund for the order. The button will appear.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
