### PR TITLE
[CPP Onboarding] Update title and message for generic error

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -13,7 +13,7 @@ struct InPersonPaymentsUnavailable: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 180.0)
-                Text(Localization.acceptCash)
+                Text(Localization.message)
                     .font(.callout)
                     .multilineTextAlignment(.center)
             }
@@ -28,12 +28,12 @@ struct InPersonPaymentsUnavailable: View {
 
 private enum Localization {
     static let unavailable = NSLocalizedString(
-        "In-Person Payments is currently unavailable",
+        "Unable to verify In-Person Payments for this store",
         comment: "Title for the error screen when In-Person Payments is unavailable"
     )
 
-    static let acceptCash = NSLocalizedString(
-        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
+    static let message = NSLocalizedString(
+        "We're sorry, we were unable to verify In-Person Payments for this store.",
         comment: "Generic error message when In-Person Payments is unavailable"
     )
 }


### PR DESCRIPTION
Part of #4611 

This updates the generic error to match what Android shows.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/129176676-e2b80212-59f4-43a0-9fbd-e1d42feb7572.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/129176678-48406d78-77b4-4300-bc8f-d3b85b2671e9.png" width="350"/> | 

## How to test
This will a generic error screen that shows for unknown errors, so I am not 100% sure how to trigger it, or how is the best way to trigger it.
What I did was:
1. In InPersonPaymentsViewController, remove the if/else in line 27 and always return `InPersonPaymentsUnavailable()`
2. Navigate to Settings > In-Person Payments > Manage card reader
3. Notice the error screen

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
