### PR TITLE
Shipping Labels: Flip arrows for RTL languages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Fix an issue where some extension was not shown in order item details. [https://github.com/woocommerce/woocommerce-ios/pull/4753]
 - [*] Fix: The refund button within Order Details will be hidden if the refund is zero. [https://github.com/woocommerce/woocommerce-ios/pull/4789]
+- [*] Fix: Incorrect arrow direction for right-to-left languages on Shipping Label flow. [https://github.com/woocommerce/woocommerce-ios/pull/4796]
 
 7.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelFormStepTableViewCell.swift
@@ -71,7 +71,7 @@ private extension ShippingLabelFormStepTableViewCell {
         applyDefaultBackgroundStyle()
         iconView.tintColor = .neutral(.shade100)
         selectionStyle = .none
-        chevronView.image = .chevronImage
+        chevronView.image = .chevronImage.imageFlippedForRightToLeftLayoutDirection()
         chevronView.tintColor = .neutral(.shade100)
         chevronView.alpha = 0.3
         separator.backgroundColor = .systemColor(.separator)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -9,29 +9,30 @@ struct TitleAndValueRow: View {
     var action: () -> Void
 
     var body: some View {
-        HStack {
-            Text(title)
-                .bodyStyle()
-            Spacer()
-            Text(value)
-                .font(.body)
-                .foregroundColor(Color(.textSubtle))
-
-            if selectable {
-                Image(uiImage: .chevronImage)
-                    .frame(width: Constants.imageSize, height: Constants.imageSize)
-                    .foregroundColor(Color(UIColor.gray(.shade30)))
-            }
-        }
-        .contentShape(Rectangle())
-        .frame(height: Constants.height)
-        .padding([.leading, .trailing], Constants.padding)
-        .onTapGesture {
+        Button(action: {
             guard selectable else {
                 return
             }
             action()
-         }
+        }, label: {
+            HStack {
+                Text(title)
+                    .bodyStyle()
+                Spacer()
+                Text(value)
+                    .font(.body)
+                    .foregroundColor(Color(.textSubtle))
+
+                Image(uiImage: .chevronImage)
+                    .flipsForRightToLeftLayoutDirection(true)
+                    .renderedIf(selectable)
+                    .frame(width: Constants.imageSize, height: Constants.imageSize)
+                    .foregroundColor(Color(UIColor.gray(.shade30)))
+            }
+            .contentShape(Rectangle())
+        })
+        .frame(height: Constants.height)
+        .padding(.horizontal, Constants.padding)
     }
 }
 


### PR DESCRIPTION
Closes #4795 

# Description
This PR fixes incorrect arrow direction on selectable table view rows in Shipping Label flow.

# Changes
- Added `imageFlippedForRightToLeftLayoutDirection()` to flip the arrow on `ShippingLabelFormStepTableViewCell`.
- Updated `TitleAndValueRow` using Button instead of tap gesture.
- Updated `TitleAndValueRow` image with modifier `.flipsForRightToLeftLayoutDirection(true)` to flip the arrow for RTL languages.

# Screenshots
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/129188589-566efc48-7cf2-48eb-850d-d4460dff8f5f.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/129188703-664aa810-38d1-4310-b600-3a9434e355a4.png" width=400 /> |
| <img src="https://user-images.githubusercontent.com/5533851/129188623-13f187b8-1481-4211-b6c6-40e7b78a43ab.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/129188754-c5e543ca-0a8a-4624-b103-351355bebdc6.png" width=400 /> |
| <img src="https://user-images.githubusercontent.com/5533851/129188680-8704e862-2197-4717-a8d1-a403b29a21f3.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/129188790-b613f834-e96a-4b70-a4ce-6a15947c723b.png" width=400 /> |

# Testing
1. Make sure that your test store is eligible for Shipping Labels (has WCShip plugin installed)
2. In Order tab of the app, select an order with Processing status and eligible for creating shipping labels (containing at least 1 physical product).
3. Select Create Shipping Label.
4. With your device switched to a RTL language (e.g Arabic), notice that the arrow on the Shipping Label form points to the left.
5. Skip through Ship To and Ship From, notice that the arrow on Selected Package row of Package Details screen points to the left. Notice that this row still look good as design too (regression check for the view structure update).
6. Proceed to Customs (if your order is eligible for international shipping), notice that the arrow on Content Type row points to the left too.
7. Switch your device language back to a LTR language (e.g English), notice that the aforementioned arrows point to the right.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
