### PR TITLE
SwiftUI: Add custom view modifier for adding a minimal back button to the navigation bar

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -103,6 +103,12 @@ extension UIImage {
         return UIImage.gridicon(.chevronRight)
     }
 
+    /// Chevron Pointing Left
+    ///
+    static var chevronLeftImage: UIImage {
+        return UIImage.gridicon(.chevronLeft)
+    }
+
     /// Chevron Pointing Down
     ///
     static var chevronDownImage: UIImage {

--- a/WooCommerce/Classes/View Modifiers/View+Toolbars.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Toolbars.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Custom view modifier for displaying a minimal back button in the navigation bar
+struct MinimalNavigationBarBackButton: ViewModifier {
+    @Environment(\.presentationMode) var presentation
+
+    func body(content: Content) -> some View {
+        content
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        presentation.wrappedValue.dismiss()
+                    } label: {
+                        Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    /// Displays a minimal back button in the navigation bar
+    func minimalNavigationBarBackButton() -> some View {
+        self.modifier(MinimalNavigationBarBackButton())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -22,7 +22,7 @@ struct ShippingLabelAddNewPackage: View {
                 Button {
                     presentation.wrappedValue.dismiss()
                 } label: {
-                    Image(uiImage: .chevronImage.withHorizontallyFlippedOrientation().imageFlippedForRightToLeftLayoutDirection())
+                    Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
                 }
 
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -16,17 +16,7 @@ struct ShippingLabelAddNewPackage: View {
         }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    presentation.wrappedValue.dismiss()
-                } label: {
-                    Image(uiImage: .chevronLeftImage.imageFlippedForRightToLeftLayoutDirection())
-                }
-
-            }
-        }
+        .minimalNavigationBarBackButton()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -933,6 +933,7 @@
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
 		CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */; };
 		CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */; };
+		CC254F3A26C54AD4005F3C82 /* View+Toolbars.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3926C54AD4005F3C82 /* View+Toolbars.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
@@ -2311,6 +2312,7 @@
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
 		CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModel.swift; sourceTree = "<group>"; };
 		CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageSelection.swift; sourceTree = "<group>"; };
+		CC254F3926C54AD4005F3C82 /* View+Toolbars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Toolbars.swift"; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
@@ -3651,6 +3653,7 @@
 				262A09802628A8F40033AD20 /* WooStyleModifiers.swift */,
 				26E0AE12263359F900A5EB3B /* View+Conditionals.swift */,
 				DE4B3B5526A68DD000EEF2D8 /* View+InsetPaddings.swift */,
+				CC254F3926C54AD4005F3C82 /* View+Toolbars.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -7117,6 +7120,7 @@
 				7421344A210A323C00C13890 /* WooAnalyticsStat.swift in Sources */,
 				02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */,
 				02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */,
+				CC254F3A26C54AD4005F3C82 /* View+Toolbars.swift in Sources */,
 				B5D6DC54214802740003E48A /* SyncCoordinator.swift in Sources */,
 				B57C5C9421B80E4700FF82B2 /* Data+Woo.swift in Sources */,
 				453A907925EFB6D6006EE892 /* ButtonActivityIndicator.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -55,6 +55,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.chevronImage)
     }
 
+    func testChevronLeftImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.chevronLeftImage)
+    }
+
     func testChevronDownImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.chevronDownImage)
     }


### PR DESCRIPTION
## Description

In https://github.com/woocommerce/woocommerce-ios/pull/4781 I introduced a minimal back button in a SwiftUI view. As discussed in https://github.com/woocommerce/woocommerce-ios/pull/4781#pullrequestreview-727681638, SwiftUI doesn't seem to have an equivalent to UIKit's `navigationItem.backButtonDisplayMode = .minimal` for removing text from the navigation bar back button. Instead, we have to remove the default back button and then display our own custom back button.

This PR moves that implementation into a custom view modifier so we can reuse it across SwiftUI views.

## Changes

* Adds the `minimalNavigationBarBackButton()` view modifier, which removes the default back button and adds a minimal (left chevron) button that navigates back.
* Introduces a left chevron icon and unit test.

View using minimal back button:

<img src="https://user-images.githubusercontent.com/8658164/129225607-302aa252-22e4-4551-bcaa-c10a88f114fa.png" width="300px">


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the "Add New Package" screen, confirm a minimal back button (chevron) appears and you can tap the back button to go back.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
