### PR TITLE
Shipping Labels: Add custom package creation form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -5,18 +5,30 @@ struct ShippingLabelAddNewPackage: View {
     @ObservedObject private var viewModel = ShippingLabelAddNewPackageViewModel()
 
     var body: some View {
-        VStack(spacing: 0) {
+        GeometryReader { geometry in
             VStack(spacing: 0) {
-                SegmentedView(selection: $viewModel.selectedIndex, views: [Text(Localization.customPackage), Text(Localization.servicePackage)])
-                    .frame(height: 44)
-                Divider()
+                VStack(spacing: 0) {
+                    SegmentedView(selection: $viewModel.selectedIndex, views: [Text(Localization.customPackage), Text(Localization.servicePackage)])
+                        .frame(height: 44)
+                    Divider()
+                }
+                .padding(.horizontal, insets: geometry.safeAreaInsets)
+
+                ScrollView {
+                    switch viewModel.selectedView {
+                    case .customPackage:
+                        ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
+                    case .servicePackage:
+                        EmptyView() // TODO-4743: Show service package view
+                    }
+                }
+                 .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))
             }
-            ScrollView {
-            }
+            .ignoresSafeArea(.container, edges: .horizontal)
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .minimalNavigationBarBackButton()
         }
-        .navigationTitle(Localization.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .minimalNavigationBarBackButton()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -5,15 +5,15 @@ import SwiftUI
 ///
 final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     @Published var selectedIndex: Int
-    var selectedView: SelectedIndex {
-        SelectedIndex(rawValue: selectedIndex) ?? .customPackage
+    var selectedView: PackageViewType {
+        PackageViewType(rawValue: selectedIndex) ?? .customPackage
     }
 
-    init(_ selectedIndex: Int = SelectedIndex.customPackage.rawValue) {
+    init(_ selectedIndex: Int = PackageViewType.customPackage.rawValue) {
         self.selectedIndex = selectedIndex
     }
 
-    enum SelectedIndex: Int {
+    enum PackageViewType: Int {
         case customPackage = 0
         case servicePackage = 1
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -5,6 +5,9 @@ import SwiftUI
 ///
 final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     @Published var selectedIndex: Int
+    var selectedView: SelectedIndex {
+        SelectedIndex(rawValue: selectedIndex) ?? .customPackage
+    }
 
     init(_ selectedIndex: Int = SelectedIndex.customPackage.rawValue) {
         self.selectedIndex = selectedIndex

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -10,7 +10,7 @@ struct ShippingLabelCustomPackageForm: View {
     }
 
     var body: some View {
-            VStack {
+        VStack(spacing: Constants.verticalSpacing) {
                 ListHeaderView(text: Localization.customPackageHeader, alignment: .left)
                     .padding(.horizontal, insets: safeAreaInsets)
 
@@ -131,6 +131,7 @@ private extension ShippingLabelCustomPackageForm {
 
     enum Constants {
         static let horizontalPadding: CGFloat = 16
+        static let verticalSpacing: CGFloat = 16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Form to create a new custom package to use with shipping labels.
+struct ShippingLabelCustomPackageForm: View {
+    @ObservedObject private var viewModel = ShippingLabelCustomPackageFormViewModel()
+    private let safeAreaInsets: EdgeInsets
+
+    init(safeAreaInsets: EdgeInsets) {
+        self.safeAreaInsets = safeAreaInsets
+    }
+
+    var body: some View {
+            VStack {
+                ListHeaderView(text: Localization.customPackageHeader, alignment: .left)
+                    .padding(.horizontal, insets: safeAreaInsets)
+
+                VStack(spacing: 0) {
+                    Divider()
+
+                    VStack(spacing: 0) {
+                        TitleAndValueRow(title: Localization.packageTypeLabel,
+                                         value: Localization.packageTypePlaceholder,
+                                         selectable: true) {
+                            // TODO-4743: Navigate to Package Type screen
+                        }
+
+                        Divider()
+                            .padding(.leading, Constants.horizontalPadding)
+
+                        TitleAndTextFieldRow(title: Localization.packageNameLabel,
+                                             placeholder: Localization.packageNamePlaceholder,
+                                             text: $viewModel.packageName,
+                                             symbol: nil,
+                                             keyboardType: .default)
+                    }
+                    .padding(.horizontal, insets: safeAreaInsets)
+
+                    Divider()
+                }
+                .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
+
+                VStack(spacing: 0) {
+                    Divider()
+
+                    VStack(spacing: 0) {
+                        TitleAndTextFieldRow(title: Localization.lengthLabel,
+                                             placeholder: "0",
+                                             text: $viewModel.packageLength,
+                                             symbol: viewModel.lengthUnit,
+                                             keyboardType: .decimalPad)
+
+                        Divider()
+                            .padding(.leading, Constants.horizontalPadding)
+
+                        TitleAndTextFieldRow(title: Localization.widthLabel,
+                                             placeholder: "0",
+                                             text: $viewModel.packageWidth,
+                                             symbol: viewModel.lengthUnit,
+                                             keyboardType: .decimalPad)
+
+                        Divider()
+                            .padding(.leading, Constants.horizontalPadding)
+
+                        TitleAndTextFieldRow(title: Localization.heightLabel,
+                                             placeholder: "0",
+                                             text: $viewModel.packageHeight,
+                                             symbol: viewModel.lengthUnit,
+                                             keyboardType: .decimalPad)
+                    }
+                    .padding(.horizontal, insets: safeAreaInsets)
+
+                    Divider()
+                }
+                .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
+
+                VStack(spacing: 0) {
+                    Divider()
+
+                    TitleAndTextFieldRow(title: Localization.emptyPackageWeightLabel,
+                                         placeholder: "0",
+                                         text: $viewModel.emptyPackageWeight,
+                                         symbol: viewModel.weightUnit,
+                                         keyboardType: .decimalPad)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
+
+                    Divider()
+
+                    ListHeaderView(text: Localization.weightFooter, alignment: .left)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                }
+        }
+        .background(Color(.listBackground))
+        .ignoresSafeArea(.container, edges: .horizontal)
+    }
+}
+
+private extension ShippingLabelCustomPackageForm {
+    enum Localization {
+        static let customPackageHeader = NSLocalizedString(
+            "Set up the package you'll be using to ship your products. We'll save it for future orders.",
+            comment: "Header text on Add New Custom Package screen in Shipping Label flow")
+        static let packageTypeLabel = NSLocalizedString(
+            "Package Type",
+            comment: "Title for the row to select the package type (box or envelope) on the Add New Custom Package screen in Shipping Label flow")
+        static let packageTypePlaceholder = NSLocalizedString(
+            "Select Type",
+            comment: "Placeholder for the row to select the package type (box or envelope) on the Add New Custom Package screen in Shipping Label flow")
+        static let packageNameLabel = NSLocalizedString(
+            "Package Name",
+            comment: "Title for the row to enter the package name on the Add New Custom Package screen in Shipping Label flow")
+        static let packageNamePlaceholder = NSLocalizedString(
+            "Enter Name",
+            comment: "Placeholder for the row to enter the package name on the Add New Custom Package screen in Shipping Label flow")
+        static let lengthLabel = NSLocalizedString(
+            "Length",
+            comment: "Title for the row to enter the package length on the Add New Custom Package screen in Shipping Label flow")
+        static let widthLabel = NSLocalizedString(
+            "Width",
+            comment: "Title for the row to enter the package width on the Add New Custom Package screen in Shipping Label flow")
+        static let heightLabel = NSLocalizedString(
+            "Height",
+            comment: "Title for the row to enter the package height on the Add New Custom Package screen in Shipping Label flow")
+        static let emptyPackageWeightLabel = NSLocalizedString(
+            "Empty Package Weight",
+            comment: "Title for the row to enter the empty package weight on the Add New Custom Package screen in Shipping Label flow")
+        static let weightFooter = NSLocalizedString(
+            "Weight of empty package",
+            comment: "Footer text for the empty package weight on the Add New Custom Package screen in Shipping Label flow")
+    }
+
+    enum Constants {
+        static let horizontalPadding: CGFloat = 16
+    }
+}
+
+struct ShippingLabelAddCustomPackage_Previews: PreviewProvider {
+    static var previews: some View {
+        ShippingLabelCustomPackageForm(safeAreaInsets: .zero)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// View model for `ShippingLabelCustomPackageForm`.
+///
+final class ShippingLabelCustomPackageFormViewModel: ObservableObject {
+    /// The length unit used in the store (e.g. "in")
+    ///
+    let lengthUnit: String
+
+    /// The weight unit used in the store (e.g. "oz")
+    ///
+    let weightUnit: String
+
+    /// The name of the custom package
+    ///
+    @Published var packageName: String = ""
+
+    /// The length of the custom package
+    ///
+    @Published var packageLength: String = "0"
+
+    /// The width of the custom package
+    ///
+    @Published var packageWidth: String = "0"
+
+    /// The height of the custom package
+    ///
+    @Published var packageHeight: String = "0"
+
+    /// The weight of the custom package when empty
+    ///
+    @Published var emptyPackageWeight: String = "0"
+
+    init() {
+        self.lengthUnit = "in" // TODO-4743: Initialize this with the store's length unit
+        self.weightUnit = "oz" // TODO-4743: Initialize this with the store's weight unit
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -933,6 +933,8 @@
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
 		CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */; };
 		CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */; };
+		CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */; };
+		CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */; };
 		CC254F3A26C54AD4005F3C82 /* View+Toolbars.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3926C54AD4005F3C82 /* View+Toolbars.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
@@ -2312,6 +2314,8 @@
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
 		CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModel.swift; sourceTree = "<group>"; };
 		CC254F3326C4113B005F3C82 /* ShippingLabelPackageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageSelection.swift; sourceTree = "<group>"; };
+		CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageForm.swift; sourceTree = "<group>"; };
+		CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModel.swift; sourceTree = "<group>"; };
 		CC254F3926C54AD4005F3C82 /* View+Toolbars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Toolbars.swift"; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
@@ -5178,6 +5182,8 @@
 			children = (
 				CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */,
 				CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */,
+				CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */,
+				CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */,
 			);
 			path = "Package Creation";
 			sourceTree = "<group>";
@@ -6807,6 +6813,7 @@
 				D85A3C5026C153A500C0E026 /* InPersonPaymentsPluginNotActivatedView.swift in Sources */,
 				D8815AE726383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
+				CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
@@ -7380,6 +7387,7 @@
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
 				4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */,
 				451B1747258BD7B600836277 /* AddAttributeOptionsViewModel.swift in Sources */,
+				CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
 				3178C1F726409216000D771A /* CardReaderSettingsConnectedViewModel.swift in Sources */,
 				CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */,


### PR DESCRIPTION
Part of: #4743 
Based on: #4797 **Do not merge until this PR is merged**

## Description

In the shipping label creation flow, this introduces the UI to enter the details for a new custom package to use for your shipping label. For now, the form is visual only — the "Package Type" row does nothing (it will eventually open another screen, to be implemented) and data cannot be saved (data handling will be implemented later).

## Changes

* Adds a `ShippingLabelCustomPackageForm` and view model with all of the rows for creating a new custom package.
* Changes to `ShippingLabelAddNewPackage`:
   * Adds a `selectedView` property to the `ShippingLabelAddNewPackageViewModel`, and uses that property to display the selected subview on `ShippingLabelAddNewPackage`.
   * Updates the view with a `GeometryReader` to allow the custom form backgrounds to extend edge-to-edge while keeping the content in the safe area.

/|Portrait|Landscape
-|-|-
Light|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-12 at 20 45 07](https://user-images.githubusercontent.com/8658164/129262044-4b8741f8-72e1-4741-8be2-c6a35fdde48d.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-12 at 20 45 29](https://user-images.githubusercontent.com/8658164/129262050-0f60df46-dcca-47d4-bf0f-a35516e0deaf.png)
Dark|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-12 at 20 45 16](https://user-images.githubusercontent.com/8658164/129262066-7e1ed49b-9b93-4826-91f4-ba1d2ea38c6f.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-08-12 at 20 50 53](https://user-images.githubusercontent.com/8658164/129262073-97218fec-ed81-453c-b109-923434e4188f.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the "Add New Package" screen, confirm that when "Custom Package" is selected you see the expected form to enter the details for your custom package.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
