### PR TITLE
[CPP Onboarding] Add tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -149,6 +149,10 @@ public enum WooAnalyticsStat: String {
     case cardReaderConnectionSuccess            = "card_reader_connection_success"
     case cardReaderDisconnectTapped             = "card_reader_disconnect_tapped"
 
+    // MARK: Card-Present Payments Onboarding
+    case cardPresentOnboardingLearnMoreTapped   = "card_present_onboarding_learn_more_tapped"
+    case cardPresentOnboardingNotCompleted      = "card_present_onboarding_not_completed"
+
     // MARK: Order View Events
     //
     case ordersSelected                         = "main_tab_orders_selected"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsLearnMore: View {
+    @Environment(\.customOpenURL) var customOpenURL
+
     var body: some View {
         HStack(alignment: .center, spacing: 20) {
             Image(uiImage: .infoOutlineImage)
@@ -8,6 +10,10 @@ struct InPersonPaymentsLearnMore: View {
                 .frame(width: 20, height: 20)
             AttributedText(Localization.learnMore)
                 .accentColor(Color(.textLink))
+                .customOpenURL { url in
+                    ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
+                    customOpenURL?(url)
+                }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -13,6 +13,8 @@ final class InPersonPaymentsViewModel: ObservableObject {
         useCase.$state
             // Debounce values to prevent the loading screen flashing when there is no connection
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .handleEvents(receiveOutput: trackState(_:))
             .assign(to: &$state)
         refresh()
     }
@@ -29,4 +31,14 @@ final class InPersonPaymentsViewModel: ObservableObject {
     func refresh() {
         useCase.refresh()
     }
+}
+
+private func trackState(_ state: CardPresentPaymentOnboardingState) {
+    guard let reason = state.reasonForAnalytics else {
+        return
+    }
+    let properties = [
+        "reason": reason
+    ]
+    ServiceLocator.analytics.track(.cardPresentOnboardingNotCompleted, withProperties: properties)
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -59,3 +59,38 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case noConnectionError
 }
+
+extension CardPresentPaymentOnboardingState {
+    public var reasonForAnalytics: String? {
+        switch self {
+        case .loading:
+            return nil
+        case .completed:
+            return nil
+        case .countryNotSupported(countryCode: _):
+            return "country_not_supported"
+        case .wcpayNotInstalled:
+            return "wcpay_not_installed"
+        case .wcpayUnsupportedVersion:
+            return "wcpay_unsupported_version"
+        case .wcpayNotActivated:
+            return "wcpay_not_activated"
+        case .wcpaySetupNotCompleted:
+            return "wcpay_setup_not_completed"
+        case .wcpayInTestModeWithLiveStripeAccount:
+            return "wcpay_in_test_mode_with_live_account"
+        case .stripeAccountUnderReview:
+            return "account_under_review"
+        case .stripeAccountPendingRequirement(deadline: _):
+            return "account_pending_requirements"
+        case .stripeAccountOverdueRequirement:
+            return "account_overdue_requirements"
+        case .stripeAccountRejected:
+            return "account_rejected"
+        case .genericError:
+            return "generic_error"
+        case .noConnectionError:
+            return "no_connection_error"
+        }
+    }
+}


### PR DESCRIPTION
Part of #4611 

This adds tracking events for In-Person Payments Onboarding

See https://github.com/woocommerce/woocommerce-android/pull/4562 for the matching Android PR

## To test

I tested by looking at the Xcode console and filtering for `🔵` to see which events were being tracked.
I didn't test every single scenario, but there is a single point that triggers tracking based on state. A few things I tested:

1. Enable Airplane Mode and go to Settings > In-Person Payments. It should track `card_present_onboarding_not_completed` with `reason=no_connection_error`.
2. Disable Airplane Mode and retry. If the store hasn't finished onboarding, it should track `card_present_onboarding_not_completed` with a  reason that will depend on the state. On a store fully onboarded, it should track nothing.
3. Deactivating the payments plugin and going to Settings > In-Person Payments should track `card_present_onboarding_not_completed` with `reason=wcpay_not_activated`.
4. Tapping on the learn more link should track `card_present_onboarding_learn_more_tapped`

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
