### PR TITLE
Shipping Labels: Update default item details for customs form

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -131,7 +131,7 @@ public extension ShippingLabelCustomsForm {
         public let description: String
 
         /// Quantity of item
-        public let quantity: Int
+        public let quantity: Decimal
 
         /// Price of item per unit.
         public let value: Double
@@ -148,7 +148,7 @@ public extension ShippingLabelCustomsForm {
         /// Product ID of item.
         public let productID: Int64
 
-        public init(description: String, quantity: Int, value: Double, weight: Double, hsTariffNumber: String, originCountry: String, productID: Int64) {
+        public init(description: String, quantity: Decimal, value: Double, weight: Double, hsTariffNumber: String, originCountry: String, productID: Int64) {
             self.description = description
             self.quantity = quantity
             self.value = value
@@ -177,7 +177,7 @@ extension ShippingLabelCustomsForm.Item {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let description = try container.decode(String.self, forKey: .description)
-        let quantity = try container.decode(Int.self, forKey: .quantity)
+        let quantity = try container.decode(Decimal.self, forKey: .quantity)
         let value = try container.decode(Double.self, forKey: .value)
         let weight = try container.decode(Double.self, forKey: .weight)
         let hsTariffNumber = (try? container.decode(String.self, forKey: .hsTariffNumber)) ?? ""

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -54,7 +54,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
             VStack(spacing: 0) {
                 // TODO: get weight unit for item ⚖️
                 TitleAndTextFieldRow(title: String(format: Localization.weightTitle, "oz"),
-                                     placeholder: Localization.weightPlaceholder,
+                                     placeholder: "0",
                                      text: $viewModel.weight)
                 Divider()
                     .padding(.leading, Constants.horizontalSpacing)
@@ -63,9 +63,8 @@ struct ShippingLabelCustomsFormItemDetails: View {
             .background(Color(.listForeground))
 
             VStack(spacing: 0) {
-                // TODO: get value unit for item 💵
-                TitleAndTextFieldRow(title: String(format: Localization.valueTitle, "$"),
-                                     placeholder: Localization.valuePlaceholder,
+                TitleAndTextFieldRow(title: String(format: Localization.valueTitle, viewModel.currency),
+                                     placeholder: "0",
                                      text: $viewModel.value)
                 Divider()
                     .padding(.leading, Constants.horizontalSpacing)
@@ -124,12 +123,8 @@ private extension ShippingLabelCustomsFormItemDetails {
             comment: "A label prompting users to learn more about HS Tariff Number with an embedded hyperlink in Customs screen of Shipping Label flow")
         static let weightTitle = NSLocalizedString("Weight (%1$@ per unit)",
                                                    comment: "Title for the Weight row in item details in Customs screen of Shipping Label flow")
-        static let weightPlaceholder = NSLocalizedString("Enter weight",
-                                                         comment: "Placeholder for the Weight row in item details in Customs screen of Shipping Label flow")
         static let valueTitle = NSLocalizedString("Value (%1$@ per unit)",
                                                   comment: "Title for the Value row in item details in Customs screen of Shipping Label flow")
-        static let valuePlaceholder = NSLocalizedString("Enter value",
-                                                        comment: "Title for the Value row in item details in Customs screen of Shipping Label flow")
         static let originTitle = NSLocalizedString("Origin Country",
                                                    comment: "Title for the Origin Country row in Customs screen of Shipping Label flow")
         static let originDescription = NSLocalizedString("Country where the product was manufactured or assembled",
@@ -146,7 +141,7 @@ struct ShippingLabelCustomsFormItemDetails_Previews: PreviewProvider {
                                                              originCountry: "US",
                                                              productID: 123)
 
-    static let sampleViewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: sampleDetails, countries: [])
+    static let sampleViewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: sampleDetails, countries: [], currency: "$")
 
     static var previews: some View {
         ShippingLabelCustomsFormItemDetails(itemNumber: 1, viewModel: sampleViewModel, safeAreaInsets: .zero)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -52,10 +52,10 @@ struct ShippingLabelCustomsFormItemDetails: View {
             .background(Color(.listForeground))
 
             VStack(spacing: 0) {
-                // TODO: get weight unit for item ⚖️
-                TitleAndTextFieldRow(title: String(format: Localization.weightTitle, "oz"),
+                TitleAndTextFieldRow(title: String(format: Localization.weightTitle, viewModel.weightUnit),
                                      placeholder: "0",
-                                     text: $viewModel.weight)
+                                     text: $viewModel.weight,
+                                     keyboardType: .decimalPad)
                 Divider()
                     .padding(.leading, Constants.horizontalSpacing)
             }
@@ -65,7 +65,8 @@ struct ShippingLabelCustomsFormItemDetails: View {
             VStack(spacing: 0) {
                 TitleAndTextFieldRow(title: String(format: Localization.valueTitle, viewModel.currency),
                                      placeholder: "0",
-                                     text: $viewModel.value)
+                                     text: $viewModel.value,
+                                     keyboardType: .decimalPad)
                 Divider()
                     .padding(.leading, Constants.horizontalSpacing)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -10,6 +10,10 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     ///
     let currency: String
 
+    /// Weight unit used in store.
+    ///
+    let weightUnit: String
+
     /// Description for the item.
     ///
     @Published var description: String
@@ -38,7 +42,7 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     ///
     private(set) var validatedItem: ShippingLabelCustomsForm.Item?
 
-    init(item: ShippingLabelCustomsForm.Item, countries: [Country], currency: String) {
+    init(item: ShippingLabelCustomsForm.Item, countries: [Country], currency: String, weightUnit: String? = ServiceLocator.shippingSettingsService.weightUnit) {
         self.productID = item.productID
         self.description = item.description
         self.value = String(item.value)
@@ -46,6 +50,7 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
         self.hsTariffNumber = item.hsTariffNumber
         self.allCountries = countries
         self.currency = currency
+        self.weightUnit = weightUnit ?? ""
         self.originCountry = countries.first(where: { $0.code == item.originCountry }) ?? Country(code: "", name: "", states: [])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -6,6 +6,10 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     ///
     let productID: Int64
 
+    /// Currency used in store.
+    ///
+    let currency: String
+
     /// Description for the item.
     ///
     @Published var description: String
@@ -34,13 +38,14 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     ///
     private(set) var validatedItem: ShippingLabelCustomsForm.Item?
 
-    init(item: ShippingLabelCustomsForm.Item, countries: [Country]) {
+    init(item: ShippingLabelCustomsForm.Item, countries: [Country], currency: String) {
         self.productID = item.productID
         self.description = item.description
         self.value = String(item.value)
         self.weight = String(item.weight)
         self.hsTariffNumber = item.hsTariffNumber
         self.allCountries = countries
+        self.currency = currency
         self.originCountry = countries.first(where: { $0.code == item.originCountry }) ?? Country(code: "", name: "", states: [])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -146,7 +146,7 @@ struct ShippingLabelCustomsFormInput_Previews: PreviewProvider {
     static let sampleViewModel: ShippingLabelCustomsFormInputViewModel = {
         let sampleOrder = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", packageName: "Food Package", productIDs: sampleOrder.items.map { $0.productID })
-        return .init(customsForm: sampleForm, countries: [])
+        return .init(customsForm: sampleForm, countries: [], currency: "$")
     }()
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -39,7 +39,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
     ///
     @Published var items: [ShippingLabelCustomsForm.Item] {
         didSet {
-            itemViewModels = items.map { .init(item: $0, countries: allCountries) }
+            itemViewModels = items.map { .init(item: $0, countries: allCountries, currency: currency) }
         }
     }
 
@@ -51,11 +51,15 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
     ///
     private(set) var validatedCustomsForm: ShippingLabelCustomsForm?
 
-    /// Persisted countries to send to item details form.
+    /// Persisted countries to send to item detail forms.
     ///
     private let allCountries: [Country]
 
-    init(customsForm: ShippingLabelCustomsForm, countries: [Country]) {
+    /// Currency to send to item detail forms.
+    ///
+    private let currency: String
+
+    init(customsForm: ShippingLabelCustomsForm, countries: [Country], currency: String) {
         self.packageID = customsForm.packageID
         self.packageName = customsForm.packageName
         self.returnOnNonDelivery = customsForm.nonDeliveryOption == .return
@@ -66,7 +70,8 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
         self.itn = customsForm.itn
         self.items = customsForm.items
         self.allCountries = countries
-        self.itemViewModels = customsForm.items.map { .init(item: $0, countries: countries) }
+        self.currency = currency
+        self.itemViewModels = customsForm.items.map { .init(item: $0, countries: countries, currency: currency) }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -37,11 +37,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 
     /// Items contained in the package.
     ///
-    @Published var items: [ShippingLabelCustomsForm.Item] {
-        didSet {
-            itemViewModels = items.map { .init(item: $0, countries: allCountries, currency: currency) }
-        }
-    }
+    @Published var items: [ShippingLabelCustomsForm.Item]
 
     /// References of item view models.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -116,7 +116,6 @@ private extension ShippingLabelCustomsFormListViewModel {
                     } else if let product = products.first(where: { $0.productID == orderItem.productID }) {
                         return Double(product.weight ?? "0") ?? 0
                     }
-
                     return 0
                 }()
 
@@ -125,7 +124,7 @@ private extension ShippingLabelCustomsFormListViewModel {
                              value: orderItem.price.doubleValue,
                              weight: weight,
                              hsTariffNumber: "",
-                             originCountry: "",
+                             originCountry: SiteAddress().countryCode, // Default value
                              productID: item.productID)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -126,7 +126,7 @@ private extension ShippingLabelCustomsFormListViewModel {
                 }()
 
                 return .init(description: orderItem.name,
-                             quantity: orderItem.quantity.intValue, // TODO: is this safe?
+                             quantity: orderItem.quantity,
                              value: orderItem.price.doubleValue,
                              weight: weight,
                              hsTariffNumber: "",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -104,6 +104,12 @@ private extension ShippingLabelCustomsFormListViewModel {
 
         for form in customsForms {
             let updatedItems = form.items.map { item -> ShippingLabelCustomsForm.Item in
+                // Only proceed for default items (with empty description).
+                // If an item has been validated, its description should not be empty.
+                guard item.description.isEmpty else {
+                    return item
+                }
+
                 // Find the matching order item
                 guard let orderItem = order.items.first(where: { $0.variationID == item.productID || $0.productID == item.productID }) else {
                     return item

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -104,9 +104,9 @@ private extension ShippingLabelCustomsFormListViewModel {
 
         for form in customsForms {
             let updatedItems = form.items.map { item -> ShippingLabelCustomsForm.Item in
-                // Only proceed for default items (with empty description).
-                // If an item has been validated, its description should not be empty.
-                guard item.description.isEmpty else {
+                // Only proceed for default items.
+                // If an item has been validated, its weight should be larger than 0.
+                guard item.weight == 0 else {
                     return item
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -47,6 +47,10 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     @Published private var productVariations: [ProductVariation] = []
 
+    /// Symbol of currency in the order.
+    ///
+    private let currencySymbol: String
+
     init(order: Order,
          customsForms: [ShippingLabelCustomsForm],
          countries: [Country],
@@ -57,7 +61,14 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.allCountries = countries
-        self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: countries, currency: order.currency) }
+        let currencySymbol: String = {
+            guard let currencyCode = CurrencySettings.CurrencyCode(rawValue: order.currency) else {
+                return ""
+            }
+            return ServiceLocator.currencySettings.symbol(from: currencyCode)
+        }()
+        self.currencySymbol = currencySymbol
+        self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: countries, currency: currencySymbol) }
 
         configureResultsControllers()
         updateItemDetails()
@@ -76,7 +87,7 @@ private extension ShippingLabelCustomsFormListViewModel {
         }
         .handleEvents(receiveOutput: { [weak self] customsForms in
             guard let self = self else { return }
-            self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: self.allCountries, currency: self.order.currency) }
+            self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: self.allCountries, currency: self.currencySymbol) }
         })
         .assign(to: &$customsForms)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -17,11 +17,7 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
 
     /// Input customs forms of the shipping label if added initially.
     ///
-    @Published var customsForms: [ShippingLabelCustomsForm] {
-        didSet {
-            inputViewModels = customsForms.map { .init(customsForm: $0, countries: allCountries, currency: order.currency) }
-        }
-    }
+    @Published var customsForms: [ShippingLabelCustomsForm]
 
     /// Associated order of the shipping label.
     ///
@@ -39,6 +35,18 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     private let allCountries: [Country]
 
+    /// Reusing Package Details results controllers since we're interested in the same models.
+    ///
+    private var resultsControllers: ShippingLabelPackageDetailsResultsControllers?
+
+    /// Products contained inside the Order and fetched from Core Data
+    ///
+    @Published private var products: [Product] = []
+
+    /// ProductVariations contained inside the Order and fetched from Core Data
+    ///
+    @Published private var productVariations: [ProductVariation] = []
+
     init(order: Order,
          customsForms: [ShippingLabelCustomsForm],
          countries: [Country],
@@ -50,5 +58,88 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
         self.storageManager = storageManager
         self.allCountries = countries
         self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: countries, currency: order.currency) }
+
+        configureResultsControllers()
+        updateItemDetails()
+    }
+}
+
+// MARK: - Fetching and updating item details.
+//
+private extension ShippingLabelCustomsFormListViewModel {
+    /// Update item details for current customs forms
+    /// with every change in products and product variations.
+    ///
+    func updateItemDetails() {
+        $products.combineLatest($productVariations) { [weak self] (products, variations) -> [ShippingLabelCustomsForm] in
+            self?.updateCustomsForms(products: products, productVariations: variations) ?? []
+        }
+        .handleEvents(receiveOutput: { [weak self] customsForms in
+            guard let self = self else { return }
+            self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: self.allCountries, currency: self.order.currency) }
+        })
+        .assign(to: &$customsForms)
+    }
+
+    /// Configure result controllers for products and product variations.
+    ///
+    func configureResultsControllers() {
+        resultsControllers = ShippingLabelPackageDetailsResultsControllers(siteID: order.siteID,
+                                                                           orderItems: order.items,
+                                                                           storageManager: storageManager,
+           onProductReload: { [weak self] (products) in
+            self?.products = products
+        }, onProductVariationsReload: { [weak self] (productVariations) in
+            self?.productVariations = productVariations
+        })
+
+        products = resultsControllers?.products ?? []
+        productVariations = resultsControllers?.productVariations ?? []
+    }
+
+    /// Return copy of customs forms with updated item details based on fetched products and variations.
+    ///
+    func updateCustomsForms(products: [Product], productVariations: [ProductVariation]) -> [ShippingLabelCustomsForm] {
+        var updatedForms: [ShippingLabelCustomsForm] = []
+
+        for form in customsForms {
+            let updatedItems = form.items.map { item -> ShippingLabelCustomsForm.Item in
+                // Find the matching order item
+                guard let orderItem = order.items.first(where: { $0.variationID == item.productID || $0.productID == item.productID }) else {
+                    return item
+                }
+
+                let weight: Double = {
+                    if orderItem.variationID > 0,
+                       let productVariation = productVariations.first(where: { $0.productVariationID == orderItem.variationID }) {
+                        return Double(productVariation.weight ?? "") ?? 0
+                    } else if let product = products.first(where: { $0.productID == orderItem.productID }) {
+                        return Double(product.weight ?? "0") ?? 0
+                    }
+
+                    return 0
+                }()
+
+                return .init(description: orderItem.name,
+                             quantity: orderItem.quantity.intValue, // TODO: is this safe?
+                             value: orderItem.price.doubleValue,
+                             weight: weight,
+                             hsTariffNumber: "",
+                             originCountry: "",
+                             productID: item.productID)
+            }
+
+            // Append new form with updated items
+            updatedForms.append(.init(packageID: form.packageID,
+                                      packageName: form.packageName,
+                                      contentsType: form.contentsType,
+                                      contentExplanation: form.contentExplanation,
+                                      restrictionType: form.restrictionType,
+                                      restrictionComments: form.restrictionComments,
+                                      nonDeliveryOption: form.nonDeliveryOption,
+                                      itn: form.itn,
+                                      items: updatedItems))
+        }
+        return updatedForms
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -19,7 +19,7 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     @Published var customsForms: [ShippingLabelCustomsForm] {
         didSet {
-            inputViewModels = customsForms.map { .init(customsForm: $0, countries: allCountries) }
+            inputViewModels = customsForms.map { .init(customsForm: $0, countries: allCountries, currency: order.currency) }
         }
     }
 
@@ -49,6 +49,6 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.allCountries = countries
-        self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: countries) }
+        self.inputViewModels = customsForms.map { .init(customsForm: $0, countries: countries, currency: order.currency) }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1223,6 +1223,7 @@
 		DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */; };
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
 		DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1926C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift */; };
+		DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */; };
 		DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */; };
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
@@ -2590,6 +2591,7 @@
 		DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreRow.swift; sourceTree = "<group>"; };
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
 		DE19BB1926C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModel.swift; sourceTree = "<group>"; };
+		DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModelTests.swift; sourceTree = "<group>"; };
 		DE1B030B268DD01A00804330 /* ReviewOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewController.swift; sourceTree = "<group>"; };
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
@@ -4020,6 +4022,7 @@
 		4569D3F225DC1BEC00CDC3E2 /* Create Shipping Label */ = {
 			isa = PBXGroup;
 			children = (
+				DE19BB1B26C6910500AB70D9 /* Customs */,
 				4569D3F325DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift */,
 				45B98E1E25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift */,
 				45DB7075261623410064A6CF /* ShippingLabelPackageDetailsViewModelTests.swift */,
@@ -6041,6 +6044,14 @@
 			path = ItemDetails;
 			sourceTree = "<group>";
 		};
+		DE19BB1B26C6910500AB70D9 /* Customs */ = {
+			isa = PBXGroup;
+			children = (
+				DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */,
+			);
+			path = Customs;
+			sourceTree = "<group>";
+		};
 		DE1B030A268DCFF200804330 /* Review Order */ = {
 			isa = PBXGroup;
 			children = (
@@ -7507,6 +7518,7 @@
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
+				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -60,6 +60,28 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
         XCTAssertEqual(form?.items.last?.weight, Double(10))
         XCTAssertEqual(form?.items.last?.value, items.last?.price.doubleValue)
     }
+
+    func test_virtual_products_are_excluded_in_customs_item_list() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
+                     MockOrderItem.sampleItem(name: "Ebook", productID: 49, quantity: 1, price: 15)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 49, virtual: true, weight: "0"))
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order, customsForms: [customsForm], countries: [], storageManager: storageManager)
+
+        // Then
+        let form = viewModel.customsForms.first
+        XCTAssertEqual(form?.items.count, 1)
+        XCTAssertEqual(form?.items.first?.description, items.first?.name)
+        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
+        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
+        XCTAssertEqual(form?.items.first?.weight, Double(120))
+        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+@testable import Storage
+
+class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 1234
+
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_customsForms_items_are_updated_correctly_after_fetching_products_and_variations() {
+        // Given
+        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
+                     MockOrderItem.sampleItem(name: "Jeans",
+                                              productID: 49,
+                                              variationID: 49,
+                                              quantity: 1,
+                                              price: 49,
+                                              attributes: orderItemAttributes)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
+        insert(ProductVariation.fake().copy(siteID: sampleSiteID,
+                                            productID: 49,
+                                            productVariationID: 49,
+                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")],
+                                            weight: "10.0"))
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order, customsForms: [customsForm], countries: [], storageManager: storageManager)
+
+        // Then
+        let form = viewModel.customsForms.first
+        XCTAssertEqual(form?.items.count, 2)
+        XCTAssertEqual(form?.items.first?.description, items.first?.name)
+        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
+        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
+        XCTAssertEqual(form?.items.first?.weight, Double(120))
+        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
+
+        XCTAssertEqual(form?.items.last?.description, items.last?.name)
+        XCTAssertEqual(form?.items.last?.productID, items.last?.productID)
+        XCTAssertEqual(form?.items.last?.quantity, items.last?.quantity)
+        XCTAssertEqual(form?.items.last?.weight, Double(10))
+        XCTAssertEqual(form?.items.last?.value, items.last?.price.doubleValue)
+    }
+}
+
+// MARK: - Utils
+private extension ShippingLabelCustomsFormListViewModelTests {
+    func insert(_ readOnlyOrderProduct: Yosemite.Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyOrderProduct)
+    }
+
+    func insert(_ readOnlyOrderProductVariation: Yosemite.ProductVariation) {
+        let productVariation = storage.insertNewObject(ofType: StorageProductVariation.self)
+        productVariation.update(with: readOnlyOrderProductVariation)
+    }
+
+    func insert(_ readOnlyAccountSettings: Yosemite.ShippingLabelAccountSettings) {
+        let accountSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
+        accountSettings.update(with: readOnlyAccountSettings)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -82,6 +82,27 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
         XCTAssertEqual(form?.items.first?.weight, Double(120))
         XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
     }
+
+    func test_nonexistent_products_are_excluded_in_customs_item_list() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
+                     MockOrderItem.sampleItem(name: "Ebook", productID: 49, quantity: 1, price: 15)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order, customsForms: [customsForm], countries: [], storageManager: storageManager)
+
+        // Then
+        let form = viewModel.customsForms.first
+        XCTAssertEqual(form?.items.count, 1)
+        XCTAssertEqual(form?.items.first?.description, items.first?.name)
+        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
+        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
+        XCTAssertEqual(form?.items.first?.weight, Double(120))
+        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
+    }
 }
 
 // MARK: - Utils

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -793,6 +793,11 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(defaultForms.first?.packageID, expectedPackageID)
         XCTAssertEqual(defaultForms.first?.items.count, 1)
         XCTAssertEqual(defaultForms.first?.items.first?.productID, expectedProductID)
+        XCTAssertEqual(defaultForms.first?.items.first?.weight, 0)
+        XCTAssertEqual(defaultForms.first?.items.first?.description, "")
+        XCTAssertEqual(defaultForms.first?.items.first?.hsTariffNumber, "")
+        XCTAssertEqual(defaultForms.first?.items.first?.value, 0)
+        XCTAssertEqual(defaultForms.first?.items.first?.originCountry, "")
     }
 }
 


### PR DESCRIPTION
Part of #4687

# Description
This PR update default item details form custom form based on fetched products and variations. Item details should now display correct data.

# Changes
- Updated ShippingLabelsCustomsForm quantity property type to Decimal to match with order item's for safety.
- Customs form list view model: 
   - Fetch currency from order details, then send the currency all the way down to item detail form view models to display on the UI.
   - Reuse `ShippingLabelPackageDetailsResultsControllers` to fetch products and variations.
   - Observe changes of products and variations to update default item details. 
- Updated item details view model to fetch weight unit from `shippingSettingsService` to display on the UI.

# Demo
![item-details](https://user-images.githubusercontent.com/5533851/129357344-741f935c-5202-4435-a521-3aa617c1be06.gif)

# Testing steps
1. Make sure that your test store has WCShip plugin installed and package details set up.
2. Navigate to Orders tab and select an order with international shipping (origin country different from destination).
3. Select Create Shipping Label.
4. Skip through Ship To, Ship From, Package Details to configure Customs.
5. Notice that in Package Details section, item details are displayed correctly: description, weight, value, weight unit, currency. Origin country is set the same as your site address country by default.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
