### PR TITLE
Merge 7.3 release notes into develop

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,13 +57,13 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v7.2-whats-new"
+msgctxt "v7.3-whats-new"
 msgid ""
-"Merchants in the US wanting to create shipping labels for their US customers will find several minor improvements. If you’re not already printing labels from the app, start by installing the WooCommerce Shipping & Tax extension on your site.\n"
+"E-mailing a note to a customer for an order with no e-mail address doesn’t make much sense – so we’re hiding that option now in that case.\n"
 "\n"
-"We also took a look at how the app looked on different screen sizes and phone types. We corrected a bunch of minor but meaningful visual issues, especially noticeable on iPads.\n"
+"Some merchants mentioned to us that orders with negative prices weren’t showing up correctly. We’ve fixed that issue, and now you should feel more positive!\n"
 "\n"
-"As always, we welcome your feedback about the app. Reach out to us through the app under Settings in the My store tab.\n"
+"This release also contains a bunch of tiny improvements to make your experience smoother overall. We hope you notice the love we put into our software.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,11 +1,5 @@
-- [*] Order Detail: now we do not offer the "email note to customer" option if no email is available. [https://github.com/woocommerce/woocommerce-ios/pull/4680]
-- [*] My Store: If there are errors loading the My Store screen, a banner now appears at the top of the screen with links to troubleshoot or contact support. [https://github.com/woocommerce/woocommerce-ios/pull/4704]
-- [*] Fix: Added 'Product saved' confirmation message when a product is updated [https://github.com/woocommerce/woocommerce-ios/pull/4709]
-- [*] Shipping Labels: Updated address validation to automatically use trivially normalized address for origin and destination. [https://github.com/woocommerce/woocommerce-ios/pull/4719]
-- [*] Fix: Order details for products with negative prices now will show correctly [https://github.com/woocommerce/woocommerce-ios/pull/4683]
-- [*] Fix: Order list not extend edge-to-edge in dark mode. [https://github.com/woocommerce/woocommerce-ios/pull/4728]
-- [*] Plugins: Added list of active and inactive plugins that can be reached by admins in the settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/4735]
-- [*] Login: Updated appearance of back buttons in navigation bar to minimal style. [https://github.com/woocommerce/woocommerce-ios/pull/4726]
-- [internal] Upgraded Zendesk SDK to version 5.3.0. [https://github.com/woocommerce/woocommerce-ios/pull/4699]
-- [internal] Updated GoogleSignIn to version 6.0.1 through WordPressAuthenticator. There should be no functional changes, but may impact Google sign in flow. [https://github.com/woocommerce/woocommerce-ios/pull/4725]
+E-mailing a note to a customer for an order with no e-mail address doesn’t make much sense – so we’re hiding that option now in that case.
 
+Some merchants mentioned to us that orders with negative prices weren’t showing up correctly. We’ve fixed that issue, and now you should feel more positive!
+
+This release also contains a bunch of tiny improvements to make your experience smoother overall. We hope you notice the love we put into our software.


### PR DESCRIPTION
Merges the WCiOS 7.3 release notes into `develop`