### PR TITLE
Edited NSLocalized strings

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1209,7 +1209,7 @@ extension OrderDetailsDataSource {
         static let payment = NSLocalizedString("Payment", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
         static let shippingLabelCreationInfoAction =
-            NSLocalizedString("Learn more about creating labels with your phone",
+            NSLocalizedString("Learn more about creating labels with your mobile device",
                               comment: "Title of button in order details > info link for creating a shipping label on the mobile device.")
         static let shippingLabelPackageFormat =
             NSLocalizedString("Package %d",
@@ -1223,7 +1223,7 @@ extension OrderDetailsDataSource {
             NSLocalizedString("%@ label refund requested",
                               comment: "Order refunded shipping label title. The string variable shows the shipping label service name (e.g. USPS).")
         static let shippingLabelPrintingInfoAction =
-            NSLocalizedString("Don’t know how to print from your phone?",
+            NSLocalizedString("Don’t know how to print from your mobile device?",
                               comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
                                 "a shipping label on the mobile device.")
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPrintingInstructionsViewController.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPrintingInstructionsViewController.swift
@@ -23,7 +23,7 @@ private extension ShippingLabelPrintingInstructionsViewController {
 private extension ShippingLabelPrintingInstructionsViewController {
     enum Localization {
         static let navigationBarTitle =
-            NSLocalizedString("Print from your Phone",
+            NSLocalizedString("Print from your mobile device",
                               comment: "Navigation bar title of shipping label printing instructions screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Info/ShippingLabelCreationInfoViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Info/ShippingLabelCreationInfoViewController.swift
@@ -50,7 +50,7 @@ private extension ShippingLabelCreationInfoViewController {
                                              comment: "Navigation bar title in the shipping label creation info screen")
         static let message = NSLocalizedString("Save time and money by fulfilling with WooCommerce Shipping",
                                                comment: "Message text in the shipping label creation info screen")
-        static let details = NSLocalizedString("Cut the post office line by printing shipping labels at home with your phone at discounted rates!",
+        static let details = NSLocalizedString("Cut the post office line by printing shipping labels at home with your mobile device at discounted rates!",
                                                comment: "Details text in the shipping label creation info screen")
         static let buttonTitle = NSLocalizedString("Learn more",
                                                    comment: "Button title in the shipping label creation info screen")


### PR DESCRIPTION
Fixes #4746 

# Description

This PR edits some instances of `NSLocalizedString` where we use "phone", but using "mobile device" instead would be more adequate.

# Changes 

I've changed several of the `NSLocalizedString` where it made sense to refer to a mobile device.

I skipped others where it makes more sense to leave it as `phone` instead, like:

```
NSLocalizedString("A phone number is required because this shipment requires a customs form")
NSLocalizedString("Custom forms require a 10-digit phone number")
NSLocalizedString("The phone number is not valid or you can't call the customer from this device")

```
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
