### PR TITLE
Shipping Labels: Customs form validation for item details

### DIFF
--- a/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
+++ b/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
@@ -54,6 +54,14 @@ struct FootnoteStyle: ViewModifier {
     }
 }
 
+struct ErrorStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.body)
+            .foregroundColor(Color(.error))
+    }
+}
+
 // MARK: View extensions
 extension View {
     /// - Parameters:
@@ -78,5 +86,9 @@ extension View {
     ///     - isEnabled: Whether the view is enabled (to apply specific styles for disabled view)
     func footnoteStyle(_ isEnabled: Bool = true) -> some View {
         self.modifier(FootnoteStyle(isEnabled: isEnabled))
+    }
+
+    func errorStyle() -> some View {
+        self.modifier(ErrorStyle())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -21,6 +21,10 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 Image(uiImage: .inventoryImage)
                 Text(String(format: Localization.customLineTitle, itemNumber))
                     .bodyStyle()
+                Spacer()
+                Image(uiImage: .noticeImage)
+                    .foregroundColor(Color(.error))
+                    .renderedIf(viewModel.validatedItem == nil)
             }
         }, content: {
             // Item Description

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -20,7 +20,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
             HStack(spacing: Constants.horizontalSpacing) {
                 Image(uiImage: .inventoryImage)
                 Text(String(format: Localization.customLineTitle, itemNumber))
-                    .font(.body)
+                    .bodyStyle()
             }
         }, content: {
             VStack(spacing: 0) {
@@ -36,7 +36,8 @@ struct ShippingLabelCustomsFormItemDetails: View {
             VStack(spacing: 0) {
                 TitleAndTextFieldRow(title: Localization.hsTariffNumberTitle,
                                      placeholder: Localization.hsTariffNumberPlaceholder,
-                                     text: $viewModel.hsTariffNumber)
+                                     text: $viewModel.hsTariffNumber,
+                                     keyboardType: .numberPad)
                 Divider()
                     .padding(.leading, Constants.horizontalSpacing)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -35,7 +35,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .background(Color(.listForeground))
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ValidationErrorRow(errorMessage: ("Item description is required"))
+                    ValidationErrorRow(errorMessage: Localization.descriptionError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -57,7 +57,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .background(Color(.listForeground))
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ValidationErrorRow(errorMessage: ("HS Tariff Number must be 6 digits long"))
+                    ValidationErrorRow(errorMessage: Localization.hsTariffNumberError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -85,7 +85,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .background(Color(.listForeground))
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ValidationErrorRow(errorMessage: ("Item weight must be larger than 0"))
+                    ValidationErrorRow(errorMessage: Localization.weightError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -106,7 +106,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .background(Color(.listForeground))
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ValidationErrorRow(errorMessage: ("Item value must be larger than 0"))
+                    ValidationErrorRow(errorMessage: Localization.valueError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -132,7 +132,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .background(Color(.listForeground))
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ValidationErrorRow(errorMessage: ("Origin Country is required"))
+                    ValidationErrorRow(errorMessage: Localization.originError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -162,24 +162,34 @@ private extension ShippingLabelCustomsFormItemDetails {
         static let descriptionPlaceholder = NSLocalizedString("Enter description",
                                                               comment: "Placeholder of Description row of item details in " +
                                                                 "Customs screen of Shipping Label flow")
+        static let descriptionError = NSLocalizedString("Item description is required",
+                                                        comment: "Error message for missing value in Description row in Customs screen of Shipping Label flow")
         static let hsTariffNumberTitle = NSLocalizedString("HS Tariff Number",
                                                            comment: "Title of HS Tariff Number row in Package Content" +
                                                                 " section in Customs screen of Shipping Label flow")
         static let hsTariffNumberPlaceholder = NSLocalizedString("Enter number (Optional)",
                                                                  comment: "Placeholder of HS Tariff Number row in Package" +
                                                                     " Content section in Customs screen of Shipping Label flow")
+        static let hsTariffNumberError = NSLocalizedString("HS Tariff Number must be 6 digits long",
+                                                           comment: "Validation error for HS Tariff Number row in Customs screen of Shipping Label flow")
         static let learnMoreHSTariffText = NSLocalizedString(
             "<a href=\"https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29\">Learn more</a> " +
                 "about HS Tariff Number",
             comment: "A label prompting users to learn more about HS Tariff Number with an embedded hyperlink in Customs screen of Shipping Label flow")
         static let weightTitle = NSLocalizedString("Weight (%1$@ per unit)",
                                                    comment: "Title for the Weight row in item details in Customs screen of Shipping Label flow")
+        static let weightError = NSLocalizedString("Item weight must be larger than 0",
+                                                   comment: "Error message for missing value in Weight row in Customs screen of Shipping Label flow")
         static let valueTitle = NSLocalizedString("Value (%1$@ per unit)",
                                                   comment: "Title for the Value row in item details in Customs screen of Shipping Label flow")
+        static let valueError = NSLocalizedString("Item value must be larger than 0",
+                                                  comment: "Error message for missing value in Value row in Customs screen of Shipping Label flow")
         static let originTitle = NSLocalizedString("Origin Country",
                                                    comment: "Title for the Origin Country row in Customs screen of Shipping Label flow")
         static let originDescription = NSLocalizedString("Country where the product was manufactured or assembled",
                                                          comment: "Description for the Origin Country row in Customs screen of Shipping Label flow")
+        static let originError = NSLocalizedString("Origin Country is required",
+                                                   comment: "Error message for missing value in Origin Country row in Customs screen of Shipping Label flow")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -38,7 +38,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 }
                 .background(Color(.listForeground))
 
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     ValidationErrorRow(errorMessage: Localization.descriptionError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
@@ -60,7 +60,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     ValidationErrorRow(errorMessage: Localization.hsTariffNumberError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
@@ -88,7 +88,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 }
                 .background(Color(.listForeground))
 
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     ValidationErrorRow(errorMessage: Localization.weightError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
@@ -109,7 +109,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 }
                 .background(Color(.listForeground))
 
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     ValidationErrorRow(errorMessage: Localization.valueError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
@@ -119,7 +119,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
             .padding(.horizontal, insets: safeAreaInsets)
 
             // Origin country
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 0) {
                 VStack(spacing: 0) {
                     TitleAndValueRow(title: Localization.originTitle, value: viewModel.originCountry.name, selectable: true) {
                         isShowingCountries.toggle()
@@ -135,7 +135,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 }
                 .background(Color(.listForeground))
 
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     ValidationErrorRow(errorMessage: Localization.originError)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
@@ -144,6 +144,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
 
                 Text(Localization.originDescription)
                     .footnoteStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, Constants.horizontalSpacing)
                     .padding(.vertical, Constants.verticalSpacing)
                     .padding(.bottom, Constants.verticalSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -23,79 +23,128 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     .bodyStyle()
             }
         }, content: {
+            // Item Description
             VStack(spacing: 0) {
-                TitleAndTextFieldRow(title: Localization.descriptionTitle,
-                                     placeholder: Localization.descriptionPlaceholder,
-                                     text: $viewModel.description)
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
-            }
-            .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
-
-            VStack(spacing: 0) {
-                TitleAndTextFieldRow(title: Localization.hsTariffNumberTitle,
-                                     placeholder: Localization.hsTariffNumberPlaceholder,
-                                     text: $viewModel.hsTariffNumber,
-                                     keyboardType: .numberPad)
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
-            }
-            .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
-
-            VStack(spacing: 0) {
-                LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreHSTariffText)
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
-            }
-            .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
-
-            VStack(spacing: 0) {
-                TitleAndTextFieldRow(title: String(format: Localization.weightTitle, viewModel.weightUnit),
-                                     placeholder: "0",
-                                     text: $viewModel.weight,
-                                     keyboardType: .decimalPad)
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
-            }
-            .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
-
-            VStack(spacing: 0) {
-                TitleAndTextFieldRow(title: String(format: Localization.valueTitle, viewModel.currency),
-                                     placeholder: "0",
-                                     text: $viewModel.value,
-                                     keyboardType: .decimalPad)
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
-            }
-            .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
-
-            VStack(spacing: 0) {
-                TitleAndValueRow(title: Localization.originTitle, value: viewModel.originCountry.name, selectable: true) {
-                    isShowingCountries.toggle()
+                VStack(spacing: 0) {
+                    TitleAndTextFieldRow(title: Localization.descriptionTitle,
+                                         placeholder: Localization.descriptionPlaceholder,
+                                         text: $viewModel.description)
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
                 }
-                .sheet(isPresented: $isShowingCountries, content: {
-                    SelectionList(title: Localization.originTitle,
-                                  items: viewModel.allCountries,
-                                  contentKeyPath: \.name,
-                                  selected: $viewModel.originCountry)
-                })
-                Divider()
-                    .padding(.leading, Constants.horizontalSpacing)
+                .background(Color(.listForeground))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ValidationErrorRow(errorMessage: ("Item description is required"))
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .renderedIf(!viewModel.hasValidDescription)
             }
             .padding(.horizontal, insets: safeAreaInsets)
-            .background(Color(.listForeground))
 
-            Text(Localization.originDescription)
-                .footnoteStyle()
-                .padding(.horizontal, Constants.horizontalSpacing)
+            // HS Tariff Number, validation & learn more
+            VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    TitleAndTextFieldRow(title: Localization.hsTariffNumberTitle,
+                                         placeholder: Localization.hsTariffNumberPlaceholder,
+                                         text: $viewModel.hsTariffNumber,
+                                         keyboardType: .numberPad)
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
                 .padding(.horizontal, insets: safeAreaInsets)
-                .padding(.vertical, Constants.verticalSpacing)
-                .padding(.bottom, Constants.verticalSpacing)
+                .background(Color(.listForeground))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ValidationErrorRow(errorMessage: ("HS Tariff Number must be 6 digits long"))
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .renderedIf(!viewModel.hasValidHSTariffNumber)
+
+                VStack(spacing: 0) {
+                    LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreHSTariffText)
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .background(Color(.listForeground))
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
+
+            // Weight row and validation
+            VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    TitleAndTextFieldRow(title: String(format: Localization.weightTitle, viewModel.weightUnit),
+                                         placeholder: "0",
+                                         text: $viewModel.weight,
+                                         keyboardType: .decimalPad)
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .background(Color(.listForeground))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ValidationErrorRow(errorMessage: ("Item weight must be larger than 0"))
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .renderedIf(viewModel.validatedWeight == nil)
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
+
+            // Value row & validation
+            VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    TitleAndTextFieldRow(title: String(format: Localization.valueTitle, viewModel.currency),
+                                         placeholder: "0",
+                                         text: $viewModel.value,
+                                         keyboardType: .decimalPad)
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .background(Color(.listForeground))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ValidationErrorRow(errorMessage: ("Item value must be larger than 0"))
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .renderedIf(viewModel.validatedValue == nil)
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
+
+            // Origin country
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
+                    TitleAndValueRow(title: Localization.originTitle, value: viewModel.originCountry.name, selectable: true) {
+                        isShowingCountries.toggle()
+                    }
+                    .sheet(isPresented: $isShowingCountries, content: {
+                        SelectionList(title: Localization.originTitle,
+                                      items: viewModel.allCountries,
+                                      contentKeyPath: \.name,
+                                      selected: $viewModel.originCountry)
+                    })
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .background(Color(.listForeground))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    ValidationErrorRow(errorMessage: ("Origin Country is required"))
+                    Divider()
+                        .padding(.leading, Constants.horizontalSpacing)
+                }
+                .renderedIf(!viewModel.hasValidOriginCountry)
+
+                Text(Localization.originDescription)
+                    .footnoteStyle()
+                    .padding(.horizontal, Constants.horizontalSpacing)
+                    .padding(.vertical, Constants.verticalSpacing)
+                    .padding(.bottom, Constants.verticalSpacing)
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -36,6 +36,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
                 VStack(spacing: 0) {
@@ -43,9 +44,9 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .renderedIf(!viewModel.hasValidDescription)
             }
-            .padding(.horizontal, insets: safeAreaInsets)
 
             // HS Tariff Number, validation & learn more
             VStack(spacing: 0) {
@@ -65,6 +66,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .renderedIf(!viewModel.hasValidHSTariffNumber)
 
                 VStack(spacing: 0) {
@@ -72,9 +74,9 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
             }
-            .padding(.horizontal, insets: safeAreaInsets)
 
             // Weight row and validation
             VStack(spacing: 0) {
@@ -86,6 +88,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
                 VStack(spacing: 0) {
@@ -93,9 +96,9 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .renderedIf(viewModel.validatedWeight == nil)
             }
-            .padding(.horizontal, insets: safeAreaInsets)
 
             // Value row & validation
             VStack(spacing: 0) {
@@ -107,6 +110,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
                 VStack(spacing: 0) {
@@ -114,9 +118,9 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .renderedIf(viewModel.validatedValue == nil)
             }
-            .padding(.horizontal, insets: safeAreaInsets)
 
             // Origin country
             VStack(spacing: 0) {
@@ -133,6 +137,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .background(Color(.listForeground))
 
                 VStack(spacing: 0) {
@@ -140,6 +145,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
                 .renderedIf(!viewModel.hasValidOriginCountry)
 
                 Text(Localization.originDescription)
@@ -148,8 +154,8 @@ struct ShippingLabelCustomsFormItemDetails: View {
                     .padding(.horizontal, Constants.horizontalSpacing)
                     .padding(.vertical, Constants.verticalSpacing)
                     .padding(.bottom, Constants.verticalSpacing)
+                    .padding(.horizontal, insets: safeAreaInsets)
             }
-            .padding(.horizontal, insets: safeAreaInsets)
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -28,7 +28,11 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
 
     /// HS tariff number, empty if N/A.
     ///
-    @Published var hsTariffNumber: String
+    @Published var hsTariffNumber: String {
+        didSet {
+            limitHSTariffNumberLength()
+        }
+    }
 
     /// Origin country code of item.
     ///
@@ -102,10 +106,30 @@ extension ShippingLabelCustomsFormItemDetailsViewModel {
 
     var hasValidHSTariffNumber: Bool {
         if hsTariffNumber.isNotEmpty,
-           (hsTariffNumber.count != 6 ||
+           (hsTariffNumber.count != Constants.hsTariffNumberCharacterLimit ||
                 hsTariffNumber.filter({ "0"..."9" ~= $0 }).count != 6) {
             return false
         }
         return true
+    }
+}
+
+// MARK: - Helpers
+//
+private extension ShippingLabelCustomsFormItemDetailsViewModel {
+    /// Limit length HS Tariff Number to only 6 characters max.
+    ///
+    func limitHSTariffNumberLength() {
+        if hsTariffNumber.count > Constants.hsTariffNumberCharacterLimit {
+            hsTariffNumber = String(hsTariffNumber.prefix(Constants.hsTariffNumberCharacterLimit))
+        }
+    }
+}
+
+// MARK: - Subtypes
+//
+private extension ShippingLabelCustomsFormItemDetailsViewModel {
+    enum Constants {
+        static let hsTariffNumberCharacterLimit = 6
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
@@ -9,7 +9,7 @@ struct LearnMoreRow: View {
             .accentColor(Color(.textLink))
             .customOpenURL(binding: $learnMoreURL)
             .padding(.horizontal, Constants.horizontalPadding)
-            .frame(minHeight: Constants.rowHeight)
+            .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
             .safariSheet(url: $learnMoreURL)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Renders a row for validation error with error message in red.
+///
+struct ValidationErrorRow: View {
+    let errorMessage: String
+
+    var body: some View {
+        Text(errorMessage)
+            .errorStyle()
+            .padding(.horizontal, Constants.horizontalSpacing)
+            .frame(minHeight: Constants.rowHeight)
+    }
+}
+
+private extension ValidationErrorRow {
+    enum Constants {
+        static let rowHeight: CGFloat = 44
+        static let horizontalSpacing: CGFloat = 16
+    }
+}
+
+struct ValidationErrorRow_Previews: PreviewProvider {
+    static var previews: some View {
+        ValidationErrorRow(errorMessage: "Description is required")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ValidationErrorRow.swift
@@ -9,7 +9,7 @@ struct ValidationErrorRow: View {
         Text(errorMessage)
             .errorStyle()
             .padding(.horizontal, Constants.horizontalSpacing)
-            .frame(minHeight: Constants.rowHeight)
+            .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1219,6 +1219,7 @@
 		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
+		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */; };
 		DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */; };
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
@@ -2587,6 +2588,7 @@
 		D8F3A97E258865BD0085859B /* PasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
+		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionList.swift; sourceTree = "<group>"; };
 		DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreRow.swift; sourceTree = "<group>"; };
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
@@ -4212,6 +4214,7 @@
 				DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */,
 				CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */,
 				DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */,
+				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7159,6 +7162,7 @@
 				02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */,
 				D8C2A291231BD0FD00F503E9 /* DefaultReviewsDataSource.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
+				DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */,
 				0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */,
 				E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */,
 				027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1220,6 +1220,7 @@
 		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
+		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */; };
 		DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */; };
 		DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */; };
@@ -2589,6 +2590,7 @@
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
+		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionList.swift; sourceTree = "<group>"; };
 		DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreRow.swift; sourceTree = "<group>"; };
 		DE19BB1726C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetails.swift; sourceTree = "<group>"; };
@@ -6051,6 +6053,7 @@
 			isa = PBXGroup;
 			children = (
 				DE19BB1C26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift */,
+				DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */,
 			);
 			path = Customs;
 			sourceTree = "<group>";
@@ -7779,6 +7782,7 @@
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
+				DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */,
 				262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
+
+    func test_description_validation_succeeds_if_description_not_empty() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.description = "Lorem Ipsum"
+
+        // Then
+        XCTAssertTrue(viewModel.hasValidDescription)
+    }
+
+    func test_description_validation_fails_if_description_is_empty() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.description = ""
+
+        // Then
+        XCTAssertFalse(viewModel.hasValidDescription)
+    }
+
+    func test_description_validation_fails_if_description_contains_only_space() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.description = "   \n"
+
+        // Then
+        XCTAssertFalse(viewModel.hasValidDescription)
+    }
+
+    func test_value_validation_succeeds_if_value_is_valid_double() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.value = "10"
+
+        // Then
+        XCTAssertNotNil(viewModel.validatedValue)
+    }
+
+    func test_value_validation_fails_if_value_is_invalid_double() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When & then
+        viewModel.value = "1..0"
+        XCTAssertNil(viewModel.validatedValue)
+
+        viewModel.value = "abc"
+        XCTAssertNil(viewModel.validatedValue)
+    }
+
+    func test_weight_validation_succeeds_if_weight_is_valid_double() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.weight = "240"
+
+        // Then
+        XCTAssertNotNil(viewModel.validatedWeight)
+    }
+
+    func test_weight_validation_fails_if_weight_is_invalid_double() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When & then
+        viewModel.value = "1..0"
+        XCTAssertNil(viewModel.validatedWeight)
+
+        viewModel.value = "abc"
+        XCTAssertNil(viewModel.validatedWeight)
+    }
+
+    func test_origin_country_validation_succeeds_if_country_has_non_empty_code() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+
+        // Then
+        XCTAssertTrue(viewModel.hasValidOriginCountry)
+    }
+
+    func test_origin_country_validation_fails_if_country_has_empty_code() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.originCountry = Country(code: "", name: "", states: [])
+
+        // Then
+        XCTAssertFalse(viewModel.hasValidOriginCountry)
+    }
+
+    func test_HSTariffNumber_validation_succeeds_if_empty() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.hsTariffNumber = ""
+
+        // Then
+        XCTAssertTrue(viewModel.hasValidHSTariffNumber)
+    }
+
+    func test_HSTariffNumber_validation_succeeds_if_contains_6_digits() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When
+        viewModel.hsTariffNumber = "123456"
+
+        // Then
+        XCTAssertTrue(viewModel.hasValidHSTariffNumber)
+    }
+
+    func test_HSTariffNumber_validation_fails_if_does_not_contain_6_digits() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When & then
+        viewModel.hsTariffNumber = "12345"
+        XCTAssertFalse(viewModel.hasValidHSTariffNumber)
+
+        viewModel.hsTariffNumber = "1234@t"
+        XCTAssertFalse(viewModel.hasValidHSTariffNumber)
+    }
+}


### PR DESCRIPTION
Part of #4687
This PR is based on #4806, so please make sure that PR is reviewed first.

# Description
This PR adds validation for item details in customs form of Shipping Labels flow.

# Changes
1. Updated reusable view / view modifier:
- New modifier `ErrorStyle` for text with `.body` font and red color for errors.
- New view `ValidationErrorRow` to display validation error.
2. Updated view model for item details to add validations for item description, value, weight, HS tariff number, origin country.
3. Updated item details input view to add validation error rows when validation fails.

# Demo
![item-details-validation](https://user-images.githubusercontent.com/5533851/129563005-e573ff95-405c-4d81-a394-8ddbf39e4b19.gif)

# Testing steps
1. Make sure that your test store is eligible for creating shipping labels (has WCShip plugin installed).
2. Open Orders tab and select an order with international shipping (origin country different from destination country).
3. Select Create Shipping Label.
4. Skip through Ship From, Ship To, Package Detail to configure Customs.
5. Notice that a validation error appears when either description / value / weight is empty.
6. Notice that a validation error appears when tariff number is entered but the length is less than 6. You can also try pasting some random text in this field and see that the error says the number is invalid.
7. Notice that when a validation fails, there's a red notice icon shown in the header of the item detail input form.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
