### PR TITLE
Extract some app-agnostic UI tests helpers to XCUITestHelpers

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceUITests.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceUITests.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:WooCommerce.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F997170123DBB97500592D8E"
+               BuildableName = "WooCommerceScreenshots.xctest"
+               BlueprintName = "WooCommerceScreenshots"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -135,7 +135,7 @@ extension BaseScreen {
     func thenTakeScreenshot(named title: String) -> Self {
         screenshotCount += 1
 
-        let mode = isDarkMode ? "dark" : "light"
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
         snapshot(filename)
@@ -150,7 +150,7 @@ extension ScreenObject {
     func thenTakeScreenshot(named title: String) -> Self {
         screenshotCount += 1
 
-        let mode = isDarkMode ? "dark" : "light"
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(screenshotCount)-\(mode)-\(title)"
 
         snapshot(filename)

--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -141,10 +141,6 @@ private extension XCUIElementQuery {
 
         return self.containing(isStatusBar)
     }
-
-    func first(where predicate: (XCUIElement) throws -> Bool) rethrows -> XCUIElement? {
-        return try self.allElementsBoundByIndex.first(where: predicate)
-    }
 }
 
 private extension CGFloat {

--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -41,12 +41,6 @@ class BaseScreen {
         return expectedElement.exists
     }
 
-    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
-        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
-        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
-        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
-    }
-
     /// Scroll an element into view within another element.
     /// scrollView can be a UIScrollView, or anything that subclasses it like UITableView
     ///
@@ -128,18 +122,6 @@ private extension XCUIElementQuery {
         }
 
         return self.containing(isNetworkLoadingIndicator)
-    }
-
-    var deviceStatusBars: XCUIElementQuery {
-        let deviceWidth = XCUIApplication().frame.width
-
-        let isStatusBar = NSPredicate { (evaluatedObject, _) in
-            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
-
-            return element.isStatusBar(deviceWidth)
-        }
-
-        return self.containing(isStatusBar)
     }
 }
 

--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -47,13 +47,6 @@ class BaseScreen {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    func tapStatusBarToScrollToTop() {
-        // A hack to work around there being no status bar – just tap the appropriate spot on the navigation bar
-        XCUIApplication().navigationBars.allElementsBoundByIndex.forEach {
-           $0.coordinate(withNormalizedOffset: CGVector(dx: 20, dy: -20)).tap()
-        }
-    }
-
     /// Scroll an element into view within another element.
     /// scrollView can be a UIScrollView, or anything that subclasses it like UITableView
     ///

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
@@ -26,12 +26,12 @@ final class LoginPasswordScreen: BaseScreen {
     }
 
     func tryProceed(password: String) -> LoginPasswordScreen {
-        XCTAssert(passwordTextField.waitForHittability(timeout: 3))
+        XCTAssert(passwordTextField.waitForIsHittable(timeout: 3))
 
         passwordTextField.paste(text: password)
 
         XCTAssert(loginButton.waitForExistence(timeout: 3))
-        XCTAssert(loginButton.waitForHittability(timeout: 3))
+        XCTAssert(loginButton.waitForIsHittable(timeout: 3))
 
         loginButton.tap()
 

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/BetaFeaturesScreen.swift
@@ -21,7 +21,7 @@ class BetaFeaturesScreen: BaseScreen {
 
     @discardableResult
     func enableProducts() -> Self {
-        if enableProductsButton.switches.firstMatch.stringValue == "0" {
+        if enableProductsButton.switches.firstMatch.value as? String == "0" {
             enableProductsButton.tap()
         }
 

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -32,7 +32,7 @@ final class SettingsScreen: BaseScreen {
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
         // to stack. We need to detect these cases in order to reliably tap the correct button
-        if logOutAlert.buttons.allElementsShareCommonXAxis {
+        if logOutAlert.buttons.allElementsShareCommonAxisX {
             logOutAlert.buttons.element(boundBy: 0).tap()
         }
         else {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -127,13 +127,3 @@ extension XCUIElement {
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)
     }
 }
-
-extension XCUIElementQuery {
-
-    var allElementsShareCommonXAxis: Bool {
-        let elementXPositions = allElementsBoundByIndex.map { $0.frame.minX }
-
-        // Use a set to remove duplicates – if all elements are the same, only one should remain
-        return Set(elementXPositions).count == 1
-    }
-}

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -129,9 +129,6 @@ extension XCUIElement {
 }
 
 extension XCUIElementQuery {
-    var lastMatch: XCUIElement? {
-        return self.allElementsBoundByIndex.last
-    }
 
     var allElementsShareCommonXAxis: Bool {
         let elementXPositions = allElementsBoundByIndex.map { $0.frame.minX }

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -1,13 +1,5 @@
 import XCTest
 
-var isIPhone: Bool {
-    return UIDevice.current.userInterfaceIdiom == .phone
-}
-
-var isIpad: Bool {
-    return UIDevice.current.userInterfaceIdiom == .pad
-}
-
 let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
 
 extension XCUIElement {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -115,11 +115,6 @@ extension XCTestCase {
         guard element.exists && !element.frame.isEmpty && element.isHittable else { return false }
         return XCUIApplication().windows.element(boundBy: 0).frame.contains(element.frame)
     }
-
-    // A shortcut to scroll TableViews or CollectionViews to top
-    func tapStatusBarToScrollToTop() {
-        XCUIApplication().statusBars.firstMatch.tap()
-    }
 }
 
 extension XCUIElement {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -126,16 +126,6 @@ extension XCUIElement {
 
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)
     }
-
-    @discardableResult
-    func waitForHittability(timeout: TimeInterval) -> Bool {
-
-        let predicate = NSPredicate(format: "isHittable == true")
-        let elementPredicate = XCTNSPredicateExpectation(predicate: predicate, object: self)
-        let result = XCTWaiter.wait(for: [elementPredicate], timeout: timeout)
-
-        return result == .completed
-    }
 }
 
 extension XCUIElementQuery {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -8,10 +8,6 @@ var isIpad: Bool {
     return UIDevice.current.userInterfaceIdiom == .pad
 }
 
-var isDarkMode: Bool {
-    return UIViewController().traitCollection.userInterfaceStyle == .dark
-}
-
 let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
 
 extension XCUIElement {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -22,10 +22,6 @@ extension XCUIElement {
         self.tap()
         self.typeText(text)
     }
-
-    var stringValue: String? {
-        return self.value as? String
-    }
 }
 
 extension XCTestCase {


### PR DESCRIPTION
Extracts some helper code to XCUITestHelpers (see [this PR](https://github.com/Automattic/XCUITestHelpers/pull/3)) and remove some unused ones that didn't feel like they were worth porting over.

To test:

- Build the UI tests target, which will build both UI and screenshot generation tests
- Run the tests locally if you want
- Check that the UI tests I started in CI passed
 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.