### PR TITLE
Added dismiss upon selection to product 'Order By'

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -78,7 +78,6 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
             command.handleSelectedChange(selected: selected)
             tableView.reloadData()
         }
-        dismiss(animated: true, completion: nil)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -78,6 +78,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
             command.handleSelectedChange(selected: selected)
             tableView.reloadData()
         }
+        dismiss(animated: true, completion: nil)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/WooCommerce/Classes/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommand.swift
@@ -31,8 +31,9 @@ final class ProductsSortOrderBottomSheetListSelectorCommand: BottomSheetListSele
     ]
 
     var selected: ProductsSortOrder?
-
-    init(selected: ProductsSortOrder?) {
+    private let onSelection: (ProductsSortOrder) -> Void
+    init(selected: ProductsSortOrder?, onSelection: @escaping (ProductsSortOrder) -> Void) {
+        self.onSelection = onSelection
         self.selected = selected
     }
 
@@ -43,7 +44,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommand: BottomSheetListSele
     }
 
     func handleSelectedChange(selected: ProductsSortOrder) {
-        self.selected = selected
+        onSelection(selected)
     }
 
     func isSelected(model: ProductsSortOrder) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -645,19 +645,16 @@ private extension ProductsViewController {
         let title = NSLocalizedString("Sort by",
                                       comment: "Message title for sort products action bottom sheet")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: sortOrder)
-        let sortOrderListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties,
-                                                                      command: command) { [weak self] selectedSortOrder in
-                                                                        defer {
-                                                                            self?.dismiss(animated: true, completion: nil)
-                                                                        }
-
-                                                                        guard let selectedSortOrder = selectedSortOrder else {
-                                                                            return
-                                                                        }
-                                                                        self?.sortOrder = selectedSortOrder
-         ServiceLocator.analytics.track(.productSortingListOptionSelected, withProperties: ["order": selectedSortOrder.analyticsDescription])
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: sortOrder) { [weak self] selectedSortOrder in
+            self?.dismiss(animated: true, completion: nil)
+            guard let selectedSortOrder = selectedSortOrder as ProductsSortOrder? else {
+                    return
+                }
+            self?.sortOrder = selectedSortOrder
         }
+        let sortOrderListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties,
+                                                                      command: command)
+
         sortOrderListPresenter.show(from: self, sourceView: sender, arrowDirections: .up)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Yosemite
 
 final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
-    func testInitialSelectedValue() {
+    func test_initial_selected_value_is_stored_in_command() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
         var selectedActions = [ProductsSortOrder]()
@@ -16,44 +16,35 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
         XCTAssertEqual(command.selected, selected)
     }
 
-    func testSelectedValueAfterChange() {
+    func test_selected_value_after_change() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
-        var selectedActions = [ProductsSortOrder]()
         let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
-            selectedActions.append(selected)
+            // noop
         }
-        // Action
-        let newSelected = ProductsSortOrder.dateDescending
-        command.handleSelectedChange(selected: newSelected)
-
         // Assert
-        XCTAssertEqual(command.selected, newSelected)
+        XCTAssertEqual(command.selected, selected)
     }
 
-    func testIsSelectedValueAfterChange() {
+    func test_isSelected_returns_true_if_given_the_initial_value() {
         // Arrange
-        let selected = ProductsSortOrder.nameAscending
-        var selectedActions = [ProductsSortOrder]()
-        let notSelected: [ProductsSortOrder] = [.nameDescending, .dateAscending, .dateDescending]
-        //
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
-            selectedActions.append(selected)
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (selected) in
+            // noop
         }
-        XCTAssertTrue(command.isSelected(model: selected))
-        notSelected.forEach { notSelectedSortOrder in
-            XCTAssertFalse(command.isSelected(model: notSelectedSortOrder))
-        }
-
         // Action
-        let newSelected = ProductsSortOrder.dateDescending
-        let newNotSelected: [ProductsSortOrder] = [.nameDescending, .nameAscending, .dateAscending]
-        command.handleSelectedChange(selected: newSelected)
-
+        let isSelected = command.isSelected(model: .nameAscending)
         // Assert
-        XCTAssertTrue(command.isSelected(model: newSelected))
-        newNotSelected.forEach { notSelectedSortOrder in
-            XCTAssertFalse(command.isSelected(model: notSelectedSortOrder))
-        }
+        XCTAssertTrue(isSelected)
     }
+    func test_isSelected_returns_false_if_given_a_different_value() {
+        // Arrange
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (selected) in
+            // noop
+        }
+        // Action
+        let isSelected = command.isSelected(model: .nameDescending)
+        // Assert
+        XCTAssertFalse(isSelected)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
@@ -4,16 +4,25 @@ import XCTest
 
 final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     func testInitialSelectedValue() {
+        // Arrange
         let selected = ProductsSortOrder.nameAscending
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected)
+        var selectedActions = [ProductsSortOrder]()
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
+            selectedActions.append(selected)
+        }
+        // Action
+        command.handleSelectedChange(selected: .nameAscending)
+        // Assert
         XCTAssertEqual(command.selected, selected)
     }
 
     func testSelectedValueAfterChange() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected)
-
+        var selectedActions = [ProductsSortOrder]()
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
+            selectedActions.append(selected)
+        }
         // Action
         let newSelected = ProductsSortOrder.dateDescending
         command.handleSelectedChange(selected: newSelected)
@@ -25,8 +34,12 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     func testIsSelectedValueAfterChange() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
+        var selectedActions = [ProductsSortOrder]()
         let notSelected: [ProductsSortOrder] = [.nameDescending, .dateAscending, .dateDescending]
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected)
+        //
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
+            selectedActions.append(selected)
+        }
         XCTAssertTrue(command.isSelected(model: selected))
         notSelected.forEach { notSelectedSortOrder in
             XCTAssertFalse(command.isSelected(model: notSelectedSortOrder))


### PR DESCRIPTION
Fixes #4496 

## Description

This PR fixes the Products List "Sort by" modal that appears when the button is tapped. Now the modal will disappear after the user has selected one of the available choices.

![4496-fix](https://user-images.githubusercontent.com/3812076/129719028-d80d8272-48b4-4d84-b83c-a25fde0a64ce.gif)

## Changes

I added a `dismiss()` call at the end of the current `tableView(_:didSelectRowAt:)` delegate method for `BottomSheetListSelectorViewController`, so is triggered after the user selects one of the options.

The original issue mentions the Filter button as well, but this one does not display a modal when tapped, possibly has been changed since the original issue was reported, so this change only affects the "Order by" button.

## Testing steps

1 - Navigate to Products List
2 - Tap on `Sort by` 
3 - Pick a different option.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
