### PR TITLE
[CPP Onboarding] UI fixes for Learn More link

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -6,15 +6,22 @@ struct InPersonPaymentsLearnMore: View {
     var body: some View {
         HStack(alignment: .center, spacing: 20) {
             Image(uiImage: .infoOutlineImage)
-                .accentColor(Color(.lightGray))
-                .frame(width: 20, height: 20)
+                .resizable()
+                .foregroundColor(Color(.lightGray))
+                .frame(width: iconSize, height: iconSize)
             AttributedText(Localization.learnMore)
-                .accentColor(Color(.textLink))
+                .font(.subheadline)
+                .attributedTextForegroundColor(Color(.textSubtle))
+                .attributedTextLinkColor(Color(.textLink))
                 .customOpenURL { url in
                     ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
                     customOpenURL?(url)
                 }
         }
+    }
+
+    var iconSize: CGFloat {
+        UIFontMetrics(forTextStyle: .subheadline).scaledValue(for: 20)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsLearnMore: View {
         HStack(alignment: .center, spacing: 20) {
             Image(uiImage: .infoOutlineImage)
                 .resizable()
-                .foregroundColor(Color(.lightGray))
+                .foregroundColor(Color(.textSubtle))
                 .frame(width: iconSize, height: iconSize)
             AttributedText(Localization.learnMore)
                 .font(.subheadline)


### PR DESCRIPTION
Fixes #4805 
Fixes #4739 

The AttributedText SwiftUI view introduced in #4734 did not support much customization initially, so there was no way to set the right colors and font sizes. This PR implements the changes required to support:

- Setting the font
- Text color
- Link color
- Responding adequately to dynamic text

## Challenges

For whatever reason, SwiftUI's `.foregroundColor` is stored as an environment value, but is not publicly accessible (i.e. a view can't read a foregroundColor from the environment). If there is a better method, I'm happy to try it, but for now I added two custom modifiers (`attributedTextForegroundColor`/`attributedTextLinkColor`) to set the colors. 

I found [an alternative to read "private" environment values](https://gist.github.com/ole/7d18e9e4b656f8cc1f24c7284b493df8), but that requires using reflection and hoping the implementation details don't change, so it didn't seem like a good idea to use in production.

## Design notes

I looked at the Figma files for reference, but the specific colors and font sizes weren't clear in this case. Usually, Figma shows the named font style (e.g. caption) or color (e.g. Pink 50), but for some reason, I'm not seeing any color info for the text, and the icon shows `00. On Surface / Medium Emphasis`. Since this link was already implemented in the card reader settings screen, I've taken the specific colors/font from there, but it'd be good to double check.

Also, I've tweaked the icon dimensions to use the [methods iOS provides to scale an arbitrary metric relative to a font](https://developer.apple.com/documentation/uikit/uifontmetrics/2877387-scaledvalue) when the dynamic text size changes (see the screenshots below).

## To test

1. Use a store that doesn't have In-Person Payments fully set up (I used a store that had the plugin installed but not activated). The exact error isn't important, as most screens will include the learn more link.
2. Go to Settings > In-Person Payments

### Color schemes

Light|Dark
-|-
![normal-light](https://user-images.githubusercontent.com/8739/129721211-0298764c-7ac6-4e36-aa3b-b463c51177dd.png)|![normal-dark](https://user-images.githubusercontent.com/8739/129721205-ea131754-8d51-44a9-a253-224289e65350.png)

### Text sizes

XS | Normal | XXXL
-|-|-
![XS-light](https://user-images.githubusercontent.com/8739/129721214-4e27d55a-0ef6-4d93-b966-8f95d91e8fa5.png)|![normal-light](https://user-images.githubusercontent.com/8739/129721211-0298764c-7ac6-4e36-aa3b-b463c51177dd.png)|![XXXL-light](https://user-images.githubusercontent.com/8739/129721217-fc19c928-59db-4e62-aa30-6bba8416838a.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
