### PR TITLE
OE: Adds feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -19,6 +19,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentOnboarding:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .orderEditing:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -41,4 +41,8 @@ enum FeatureFlag: Int {
     /// Card-Present Payments Onboarding
     ///
     case cardPresentOnboarding
+
+    /// Editing of notes, shipping, and billing addresses.
+    ///
+    case orderEditing
 }


### PR DESCRIPTION
close #4767 

# Why 

Feature flag to prevent "Order Editing" work to leak to the public before it is completed.

This initially will hide editing icons on order Shipping/Billing Address and order notes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
