### PR TITLE
[Mobile Payments] Move customer action from CardPresentPayment to PaymentGatewayAccount

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -23,7 +23,7 @@ final class PaymentCaptureOrchestrator {
         /// First ask the backend to create/assign a Stripe customer for the order
         ///
         var customerID: String?
-        let customerAction = CardPresentPaymentAction.fetchOrderCustomer(siteID: order.siteID, orderID: order.orderID) { [self] result in
+        let customerAction = PaymentGatewayAccountAction.fetchOrderCustomer(siteID: order.siteID, orderID: order.orderID) { [self] result in
             switch result {
             case .success(let customer):
                 customerID = customer.id

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -26,10 +26,6 @@ public enum CardPresentPaymentAction: Action {
     ///
     case observeConnectedReaders(onCompletion: ([CardReader]) -> Void)
 
-    /// Get a Stripe Customer for an order.
-    ///
-    case fetchOrderCustomer(siteID: Int64, orderID: Int64, onCompletion: (Result<WCPayCustomer, Error>) -> Void)
-
     /// Collected payment for an order.
     ///
     case collectPayment(siteID: Int64,

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAccountAction.swift
@@ -8,6 +8,10 @@ public enum PaymentGatewayAccountAction: Action {
     ///
     case loadAccounts(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Get a Stripe Customer for an order.
+    ///
+    case fetchOrderCustomer(siteID: Int64, orderID: Int64, onCompletion: (Result<WCPayCustomer, Error>) -> Void)
+
     /// Captures a payment intent ID, associated to an order and site
     case captureOrderPayment(siteID: Int64,
                              orderID: Int64,

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -49,8 +49,6 @@ public final class CardPresentPaymentStore: Store {
             disconnect(onCompletion: completion)
         case .observeConnectedReaders(let completion):
             observeConnectedReaders(onCompletion: completion)
-        case .fetchOrderCustomer(let siteID, let orderID, let completion):
-            fetchOrderCustomer(siteID: siteID, orderID: orderID, completion: completion)
         case .collectPayment(let siteID, let orderID, let parameters, let event, let completion):
             collectPayment(siteID: siteID,
                            orderID: orderID,
@@ -176,10 +174,6 @@ private extension CardPresentPaymentStore {
         } receiveValue: { intent in
             onCompletion(.success(intent))
         }
-    }
-
-    func fetchOrderCustomer(siteID: Int64, orderID: Int64, completion: @escaping (Result<WCPayCustomer, Error>) -> Void) {
-        remote.fetchOrderCustomer(for: siteID, orderID: orderID, completion: completion)
     }
 
     func cancelPayment(onCompletion: ((Result<Void, Error>) -> Void)?) {

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -34,6 +34,8 @@ public final class PaymentGatewayAccountStore: Store {
         case .loadAccounts(let siteID, let onCompletion):
             loadAccounts(siteID: siteID,
                          onCompletion: onCompletion)
+        case .fetchOrderCustomer(let siteID, let orderID, let completion):
+            fetchOrderCustomer(siteID: siteID, orderID: orderID, completion: completion)
         case .captureOrderPayment(let siteID,
                                   let orderID,
                                   let paymentIntentID,
@@ -70,6 +72,10 @@ private extension PaymentGatewayAccountStore {
                 return
             }
         }
+    }
+
+    func fetchOrderCustomer(siteID: Int64, orderID: Int64, completion: @escaping (Result<WCPayCustomer, Error>) -> Void) {
+        remote.fetchOrderCustomer(for: siteID, orderID: orderID, completion: completion)
     }
 
     func captureOrderPayment(siteID: Int64,


### PR DESCRIPTION
Fixes #4792 

To test:
- Verify you can successfully capture a in-person test payment for a COD order
- Login to the internal dashboard and ensure the most recent `payment_intent.created` test event for the account includes a customer ID (e.g. `cus_HGCFhCxxxxxxxx`)

No unit test changes were required for this test. The unit tests exercise the associated remote -- which is all that the action triggers.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
