### PR TITLE
[CPP Onboarding] Support landscape orientation and larger text sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLoadingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLoadingView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsLoading: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -16,7 +16,6 @@ struct InPersonPaymentsLoading: View {
 
             Spacer()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsUnavailable: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsUnavailable: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsCountryNotSupported: View {
     let countryCode: String
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -24,7 +24,6 @@ struct InPersonPaymentsCountryNotSupported: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 
     var title: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsNoConnection: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsNoConnection: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.bottom, 24.0)
         }
-          .padding(24.0)
       }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotActivated: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -26,7 +26,6 @@ struct InPersonPaymentsPluginNotActivated: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -27,7 +27,6 @@ struct InPersonPaymentsPluginNotInstalled: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -26,7 +26,6 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
     var body: some View {
-         VStack {
+        ScrollableVStack {
              Spacer()
 
              VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeAccountOverdue: View {
 
              InPersonPaymentsLearnMore()
          }
-         .padding(24.0)
      }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
 
     var body: some View {
-          VStack {
+        ScrollableVStack {
               Spacer()
 
               VStack(alignment: .center, spacing: 42) {
@@ -24,7 +24,6 @@ struct InPersonPaymentsStripeAccountPending: View {
 
               InPersonPaymentsLearnMore()
           }
-          .padding(24.0)
       }
 
     private var message: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAcountReview: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeAcountReview: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeRejected: View {
     var body: some View {
-          VStack {
+        ScrollableVStack {
               Spacer()
 
               VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeRejected: View {
 
               InPersonPaymentsLearnMore()
           }
-          .padding(24.0)
       }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsWCPayNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsWCPayNotSetup.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsWCPayNotSetup: View {
     @State var presentedSetupURL: URL? = nil
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -32,7 +32,6 @@ struct InPersonPaymentsWCPayNotSetup: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -24,7 +24,7 @@ struct ScrollableVStack<Content: View>: View {
                     content
                 }
                 .padding(24)
-                .frame(width: geometry.size.width, height: geometry.size.height)
+                .frame(minHeight: geometry.size.height)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Wraps a VStack inside a ScrollView, ensuring the content expands to fill the available space
+///
+struct ScrollableVStack<Content: View>: View {
+    let alignment: HorizontalAlignment
+    let spacing: CGFloat?
+    let content: Content
+
+    init(
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.alignment = alignment
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: alignment, spacing: spacing) {
+                    content
+                }
+                .padding(24)
+                .frame(width: geometry.size.width, height: geometry.size.height)
+            }
+        }
+    }
+}
+
+struct ScrollableVStack_Previews: PreviewProvider {
+    static var previews: some View {
+        ScrollableVStack(spacing: 20) {
+            Spacer()
+            Text("A title")
+                .font(.largeTitle)
+            Text("""
+                Lorem ipsum dolor sit amet, consectetur adipiscing
+                elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip
+                ex ea commodo consequat. Duis aute irure dolor in
+                reprehenderit in voluptate velit esse cillum dolore eu
+                fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum.
+                """)
+            Spacer()
+            Text("Footer")
+                .font(.footnote)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -24,7 +24,7 @@ struct ScrollableVStack<Content: View>: View {
                     content
                 }
                 .padding(24)
-                .frame(minHeight: geometry.size.height)
+                .frame(minWidth: geometry.size.width, minHeight: geometry.size.height)
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1254,6 +1254,7 @@
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
 		E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */; };
+		E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
 		E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */; };
@@ -2627,6 +2628,7 @@
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
 		E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSupportLink.swift; sourceTree = "<group>"; };
+		E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableVStack.swift; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLoadingView.swift; sourceTree = "<group>"; };
@@ -4227,6 +4229,7 @@
 				DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */,
 				CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */,
 				DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */,
+				E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */,
 				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
 			);
 			path = "SwiftUI Components";
@@ -7424,6 +7427,7 @@
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
+				E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,


### PR DESCRIPTION
Fixes #4804 

All the onboarding screens implemented so far used a VStack, which would not adapt correctly when the content didn't fit on the screen.

This PR introduces a new ScrollableVStack which behaves like a VStack, but will make the content scrollable if it doesn't fit on screen.

## To test

1. Use a store that's not fully onboarded for in-person payments (I used one where the WCPay plugin was installed but not active)
2. Go to Settings > In-Person Payments
3. Verify the error screens in landscape and with larger text sizes

Landscape | Larger font size
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 01 39](https://user-images.githubusercontent.com/8739/129888245-3df093ac-b4c6-4f60-b6b2-452c54e7dcd6.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 02 10](https://user-images.githubusercontent.com/8739/129888255-16883ffc-c51e-4f29-bf9d-7aab65c2c0a5.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
