### PR TITLE
[CPP Onboarding] Fix colors in support link

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSupportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSupportLink.swift
@@ -5,7 +5,8 @@ struct InPersonPaymentsSupportLink: View {
 
     var body: some View {
         AttributedText(supportAttributedString)
-            .accentColor(Color(.textLink))
+            .attributedTextForegroundColor(Color(.text))
+            .attributedTextLinkColor(Color(.textLink))
     }
 
     private var supportAttributedString: NSAttributedString {


### PR DESCRIPTION
Fixes #4822 

This sets the correct colors for the "Contact us" text in the onboarding screens.

### Dark mode

Before|After
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 13 26](https://user-images.githubusercontent.com/8739/129888680-487cd5b6-78a1-48a9-9949-b703c25df290.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 18 27](https://user-images.githubusercontent.com/8739/129889354-4070fcbf-7443-46d6-838a-5f578236f41b.png)

### Light mode
Before|After
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 13 33](https://user-images.githubusercontent.com/8739/129888687-e1c54838-bfd3-4a37-8e3e-afa68dc951c6.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-18 at 13 18 19](https://user-images.githubusercontent.com/8739/129889350-f31b5f7c-9ac8-4fd5-9309-bd4400642ba2.png)

## To test

You can use a store with a Stripe account with pending requirements, or fake the state in `CardPresentPaymentsOnboardingUseCase.checkOnboardingState` and return `.stripeAccountOverdueRequirement`.

Then go to Settings > In-Person Payments

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
