### PR TITLE
[CPP Onboarding] UI review

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLoadingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLoadingView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsLoading: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -16,7 +16,6 @@ struct InPersonPaymentsLoading: View {
 
             Spacer()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSupportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSupportLink.swift
@@ -5,7 +5,8 @@ struct InPersonPaymentsSupportLink: View {
 
     var body: some View {
         AttributedText(supportAttributedString)
-            .accentColor(Color(.textLink))
+            .attributedTextForegroundColor(Color(.text))
+            .attributedTextLinkColor(Color(.textLink))
     }
 
     private var supportAttributedString: NSAttributedString {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsTesterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsTesterViewController.swift
@@ -1,0 +1,72 @@
+import UIKit
+import Yosemite
+
+final class InPersonPaymentsTesterViewController: UITableViewController {
+    init() {
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    struct Row {
+        let label: String
+        let targetState: CardPresentPaymentOnboardingState
+    }
+
+    private let model: [Row] = [
+        Row(label: "Loading", targetState: .loading),
+        Row(label: "Country not supported", targetState: .countryNotSupported(countryCode: "ES")),
+        Row(label: "Plugin not installed", targetState: .wcpayNotInstalled),
+        Row(label: "Plugin outdated", targetState: .wcpayUnsupportedVersion),
+        Row(label: "Plugin not active", targetState: .wcpayNotActivated),
+        Row(label: "WCPay not set up", targetState: .wcpaySetupNotCompleted),
+        Row(label: "Test mode with live account", targetState: .wcpayInTestModeWithLiveStripeAccount),
+        Row(label: "Account under review", targetState: .stripeAccountUnderReview),
+        Row(label: "Account with pending requirements", targetState: .stripeAccountPendingRequirement(deadline: Date(timeIntervalSinceNow: 86400))),
+        Row(label: "Account with overdue requirements", targetState: .stripeAccountOverdueRequirement),
+        Row(label: "Account rejected", targetState: .stripeAccountRejected),
+        Row(label: "Generic error", targetState: .genericError),
+        Row(label: "No connection", targetState: .noConnectionError),
+        Row(label: "Completed", targetState: .completed),
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTableView()
+    }
+
+    func configureTableView() {
+        tableView.registerNib(for: BasicTableViewCell.self)
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        model.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        "Onboarding state"
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: BasicTableViewCell.reuseIdentifier, for: indexPath)
+        let row = model[indexPath.row]
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = row.label
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let row = model[indexPath.row]
+        let viewModel = InPersonPaymentsViewModel(fixedState: row.targetState)
+        let controller = InPersonPaymentsViewController(viewModel: viewModel)
+        show(controller, sender: self)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsUnavailableView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsUnavailable: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsUnavailable: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsCountryNotSupported: View {
     let countryCode: String
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -24,7 +24,6 @@ struct InPersonPaymentsCountryNotSupported: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 
     var title: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsNoConnection: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsNoConnection: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.bottom, 24.0)
         }
-          .padding(24.0)
       }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotActivated: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -26,7 +26,6 @@ struct InPersonPaymentsPluginNotActivated: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -27,7 +27,6 @@ struct InPersonPaymentsPluginNotInstalled: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
     let onRefresh: () -> Void
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -26,7 +26,6 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
                 .padding(.bottom, 24.0)
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
     var body: some View {
-         VStack {
+        ScrollableVStack {
              Spacer()
 
              VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeAccountOverdue: View {
 
              InPersonPaymentsLearnMore()
          }
-         .padding(24.0)
      }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -4,7 +4,7 @@ struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
 
     var body: some View {
-          VStack {
+        ScrollableVStack {
               Spacer()
 
               VStack(alignment: .center, spacing: 42) {
@@ -24,7 +24,6 @@ struct InPersonPaymentsStripeAccountPending: View {
 
               InPersonPaymentsLearnMore()
           }
-          .padding(24.0)
       }
 
     private var message: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAcountReview: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeAcountReview: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeRejected: View {
     var body: some View {
-          VStack {
+        ScrollableVStack {
               Spacer()
 
               VStack(alignment: .center, spacing: 42) {
@@ -22,7 +22,6 @@ struct InPersonPaymentsStripeRejected: View {
 
               InPersonPaymentsLearnMore()
           }
-          .padding(24.0)
       }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsWCPayNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsWCPayNotSetup.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsWCPayNotSetup: View {
     @State var presentedSetupURL: URL? = nil
 
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             VStack(alignment: .center, spacing: 42) {
@@ -32,7 +32,6 @@ struct InPersonPaymentsWCPayNotSetup: View {
 
             InPersonPaymentsLearnMore()
         }
-        .padding(24.0)
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -544,8 +544,9 @@ private extension SettingsViewController {
     }
 
     func inPersonPaymentsWasPressed() {
-        let viewModel = InPersonPaymentsViewModel()
-        let viewController = InPersonPaymentsViewController(viewModel: viewModel)
+//        let viewModel = InPersonPaymentsViewModel()
+//        let viewController = InPersonPaymentsViewController(viewModel: viewModel)
+        let viewController = InPersonPaymentsTesterViewController()
         show(viewController, sender: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -24,7 +24,7 @@ struct ScrollableVStack<Content: View>: View {
                     content
                 }
                 .padding(24)
-                .frame(width: geometry.size.width, height: geometry.size.height)
+                .frame(minHeight: geometry.size.height)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Wraps a VStack inside a ScrollView, ensuring the content expands to fill the available space
+///
+struct ScrollableVStack<Content: View>: View {
+    let alignment: HorizontalAlignment
+    let spacing: CGFloat?
+    let content: Content
+
+    init(
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.alignment = alignment
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: alignment, spacing: spacing) {
+                    content
+                }
+                .padding(24)
+                .frame(width: geometry.size.width, height: geometry.size.height)
+            }
+        }
+    }
+}
+
+struct ScrollableVStack_Previews: PreviewProvider {
+    static var previews: some View {
+        ScrollableVStack(spacing: 20) {
+            Spacer()
+            Text("A title")
+                .font(.largeTitle)
+            Text("""
+                Lorem ipsum dolor sit amet, consectetur adipiscing
+                elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip
+                ex ea commodo consequat. Duis aute irure dolor in
+                reprehenderit in voluptate velit esse cillum dolore eu
+                fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum.
+                """)
+            Spacer()
+            Text("Footer")
+                .font(.footnote)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ScrollableVStack.swift
@@ -24,7 +24,7 @@ struct ScrollableVStack<Content: View>: View {
                     content
                 }
                 .padding(24)
-                .frame(minHeight: geometry.size.height)
+                .frame(minWidth: geometry.size.width, minHeight: geometry.size.height)
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1254,6 +1254,7 @@
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
 		E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */; };
+		E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
 		E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */; };
@@ -2627,6 +2628,7 @@
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
 		E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsSupportLink.swift; sourceTree = "<group>"; };
+		E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableVStack.swift; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLoadingView.swift; sourceTree = "<group>"; };
@@ -4227,6 +4229,7 @@
 				DE19BB0B26C2688B00AB70D9 /* SelectionList.swift */,
 				CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */,
 				DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */,
+				E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */,
 				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
 			);
 			path = "SwiftUI Components";
@@ -7424,6 +7427,7 @@
 				F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */,
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
+				E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1273,6 +1273,7 @@
 		E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */; };
 		E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */; };
 		E1906E9A26C4126300CA6819 /* InPersonPaymentsMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */; };
+		E19C2E9E26CD0D6200A9A4F6 /* InPersonPaymentsTesterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19C2E9D26CD0D6200A9A4F6 /* InPersonPaymentsTesterViewController.swift */; };
 		E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */; };
 		E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */; };
 		E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
@@ -2647,6 +2648,7 @@
 		E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailedTests.swift; sourceTree = "<group>"; };
 		E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequiredTests.swift; sourceTree = "<group>"; };
 		E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewController.swift; sourceTree = "<group>"; };
+		E19C2E9D26CD0D6200A9A4F6 /* InPersonPaymentsTesterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsTesterViewController.swift; sourceTree = "<group>"; };
 		E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningFailed.swift; sourceTree = "<group>"; };
 		E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingStack.swift; sourceTree = "<group>"; };
@@ -6154,6 +6156,7 @@
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
+				E19C2E9D26CD0D6200A9A4F6 /* InPersonPaymentsTesterViewController.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
 				E138D4F5269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
@@ -7234,6 +7237,7 @@
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
 				CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */,
+				E19C2E9E26CD0D6200A9A4F6 /* InPersonPaymentsTesterViewController.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,
 				318109DC25E5B51900EE0BE7 /* ImageTableViewCell.swift in Sources */,
 				57C5FF7F250925C90074EC26 /* OrderListViewModel.swift in Sources */,


### PR DESCRIPTION
Using this PR to do a full UI review for CPP Onboarding. This is not meant to be merged, we'll handle the necessary fixes in separate PRs.

I replaced the link to In-Person Payments with a temporary selector so it's easier to inspect all the possible states:

![CPP-selector](https://user-images.githubusercontent.com/8739/129891269-e09479eb-fad7-4adf-b016-de92814f017e.png)

I've recorded a video showcasing light vs dark mode and portrait vs landscape, but I'd recommend reviewing by running this branch directly on a device, and going to Settings > In-Person Payments:

https://cloudup.com/chFJNF2YTxg

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
