### PR TITLE
Products: Shouldn't be able to schedule a sale without sale price

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] Fix an issue where some extension was not shown in order item details. [https://github.com/woocommerce/woocommerce-ios/pull/4753]
 - [*] Fix: The refund button within Order Details will be hidden if the refund is zero. [https://github.com/woocommerce/woocommerce-ios/pull/4789]
 - [*] Fix: Incorrect arrow direction for right-to-left languages on Shipping Label flow. [https://github.com/woocommerce/woocommerce-ios/pull/4796]
-- [*] Fix: Shouldn't be able to schedule a sale without sale price [https://github.com/woocommerce/woocommerce-ios/pull/4825]
+- [*] Fix: Shouldn't be able to schedule a sale without sale price. [https://github.com/woocommerce/woocommerce-ios/pull/4825]
 
 7.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix an issue where some extension was not shown in order item details. [https://github.com/woocommerce/woocommerce-ios/pull/4753]
 - [*] Fix: The refund button within Order Details will be hidden if the refund is zero. [https://github.com/woocommerce/woocommerce-ios/pull/4789]
 - [*] Fix: Incorrect arrow direction for right-to-left languages on Shipping Label flow. [https://github.com/woocommerce/woocommerce-ios/pull/4796]
+- [*] Fix: Shouldn't be able to schedule a sale without sale price [https://github.com/woocommerce/woocommerce-ios/pull/4825]
 
 7.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -170,7 +170,7 @@ private extension ProductPriceSettingsViewController {
     func displaySalePriceWithoutRegularPriceErrorNotice() {
         let message = NSLocalizedString("The sale price can't be added without the regular price.",
                                         comment: "Product price error notice message, when the sale price is added but the regular price is not")
-        self.displayNotice(for: message)
+        displayNotice(for: message)
     }
 
     /// Displays a Notice onscreen, indicating that the sale price need to be higher than the regular price
@@ -178,7 +178,7 @@ private extension ProductPriceSettingsViewController {
     func displaySalePriceErrorNotice() {
         let message = NSLocalizedString("The sale price should be lower than the regular price.",
                                         comment: "Product price error notice message, when the sale price is higher than the regular price")
-        self.displayNotice(for: message)
+        displayNotice(for: message)
     }
 
     /// Displays a Notice onscreen, indicating that the sale price must be set in order to create a new sale
@@ -186,7 +186,7 @@ private extension ProductPriceSettingsViewController {
     func displayMissingSalePriceErrorNotice() {
         let message = NSLocalizedString("Please enter a sale price for the scheduled sale",
                                         comment: "Product price error notice message, when the sale price was not set during a sale setup")
-        self.displayNotice(for: message)
+        displayNotice(for: message)
     }
 
     /// Displays a Notice onscreen for a given message

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -191,12 +191,10 @@ private extension ProductPriceSettingsViewController {
     ///
     func displayMissingSalePriceErrorNotice() {
         UIApplication.shared.currentKeyWindow?.endEditing(true)
-        let title = NSLocalizedString("Cannot Save Changes",
-                                      comment: "Product price error notice title, when the sale price was not set during a sale setup")
         let message = NSLocalizedString("Please enter a sale price for the scheduled sale",
                                         comment: "Product price error notice message, when the sale price was not set during a sale setup")
 
-        let notice = Notice(title: title, message: message, feedbackType: .error)
+        let notice = Notice(title: message, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -148,7 +148,7 @@ extension ProductPriceSettingsViewController {
                 case .salePriceHigherThanRegularPrice:
                     self?.displaySalePriceErrorNotice()
                 case .newSaleWithEmptySalePrice:
-                    // TODO: Handle new error state
+                    self?.displayMissingSalePriceErrorNotice()
                     break
                 }
         })
@@ -184,6 +184,19 @@ private extension ProductPriceSettingsViewController {
                                         comment: "Product price error notice message, when the sale price is higher than the regular price")
 
         let notice = Notice(title: message, feedbackType: .error)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Displays a Notice onscreen, indicating that the sale price must be set in order to create a new sale
+    ///
+    func displayMissingSalePriceErrorNotice() {
+        UIApplication.shared.currentKeyWindow?.endEditing(true)
+        let title = NSLocalizedString("Cannot Save Changes",
+                                      comment: "Product price error notice title, when the sale price was not set during a sale setup")
+        let message = NSLocalizedString("Please enter a sale price for the scheduled sale",
+                                        comment: "Product price error notice message, when the sale price was not set during a sale setup")
+
+        let notice = Notice(title: title, message: message, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -7,6 +7,14 @@ final class ProductPriceSettingsViewController: UIViewController {
 
     @IBOutlet weak private var tableView: UITableView!
 
+    /// Product Price Settings dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter due to modal page sheet situations)
+    ///
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     private let siteID: Int64
 
     private let viewModel: ProductPriceSettingsViewModelOutput & ProductPriceSettingsActionHandler
@@ -194,7 +202,7 @@ private extension ProductPriceSettingsViewController {
     func displayNotice(for message: String) {
         UIApplication.shared.currentKeyWindow?.endEditing(true)
         let notice = Notice(title: message, feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -147,6 +147,9 @@ extension ProductPriceSettingsViewController {
                     self?.displaySalePriceWithoutRegularPriceErrorNotice()
                 case .salePriceHigherThanRegularPrice:
                     self?.displaySalePriceErrorNotice()
+                case .newSaleWithEmptySalePrice:
+                    // TODO: Handle new error state
+                    break
                 }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -168,32 +168,31 @@ private extension ProductPriceSettingsViewController {
     /// Displays a Notice onscreen, indicating that you can't add a sale price without adding before the regular price
     ///
     func displaySalePriceWithoutRegularPriceErrorNotice() {
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
         let message = NSLocalizedString("The sale price can't be added without the regular price.",
                                         comment: "Product price error notice message, when the sale price is added but the regular price is not")
-
-        let notice = Notice(title: message, feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        self.displayNotice(for: message)
     }
 
     /// Displays a Notice onscreen, indicating that the sale price need to be higher than the regular price
     ///
     func displaySalePriceErrorNotice() {
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
         let message = NSLocalizedString("The sale price should be lower than the regular price.",
                                         comment: "Product price error notice message, when the sale price is higher than the regular price")
-
-        let notice = Notice(title: message, feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        self.displayNotice(for: message)
     }
 
     /// Displays a Notice onscreen, indicating that the sale price must be set in order to create a new sale
     ///
     func displayMissingSalePriceErrorNotice() {
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
         let message = NSLocalizedString("Please enter a sale price for the scheduled sale",
                                         comment: "Product price error notice message, when the sale price was not set during a sale setup")
+        self.displayNotice(for: message)
+    }
 
+    /// Displays a Notice onscreen for a given message
+    ///
+    func displayNotice(for message: String) {
+        UIApplication.shared.currentKeyWindow?.endEditing(true)
         let notice = Notice(title: message, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -238,7 +238,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
 
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSetingsError) -> Void) {
         // Check if sale price was set if there is a sale to be created
-        if dateOnSaleStart != nil && dateOnSaleEnd != nil && salePrice == nil {
+        if dateOnSaleStart != nil && dateOnSaleEnd != nil && getDecimalPrice(salePrice) == nil {
             onError(.newSaleWithEmptySalePrice)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -44,6 +44,7 @@ protocol ProductPriceSettingsActionHandler {
 enum ProductPriceSetingsError: Error {
     case salePriceWithoutRegularPrice
     case salePriceHigherThanRegularPrice
+    case newSaleWithEmptySalePrice
 }
 
 /// Provides view data for price settings, and handles init/UI/navigation actions needed in product price settings.
@@ -236,6 +237,11 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     // MARK: - Navigation actions
 
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSetingsError) -> Void) {
+        // Check if sale price was set if there is a sale to be created
+        if dateOnSaleStart != nil && dateOnSaleEnd != nil && salePrice == nil {
+            onError(.newSaleWithEmptySalePrice)
+            return
+        }
 
         // Check if the sale price is populated, and the regular price is not.
         if getDecimalPrice(salePrice) != nil, getDecimalPrice(regularPrice) == nil {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -237,10 +237,9 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     // MARK: - Navigation actions
 
     func completeUpdating(onCompletion: ProductPriceSettingsViewController.Completion, onError: (ProductPriceSetingsError) -> Void) {
-        // Check if sale price was set if there is a sale to be created
-        if dateOnSaleStart != nil && dateOnSaleEnd != nil && getDecimalPrice(salePrice) == nil {
-            onError(.newSaleWithEmptySalePrice)
-            return
+
+        guard doesScheduleDateHasPrice() else {
+            return onError(.newSaleWithEmptySalePrice)
         }
 
         // Check if the sale price is populated, and the regular price is not.
@@ -251,7 +250,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
 
         // Check if the sale price is less of the regular price, else show an error.
         if let decimalSalePrice = getDecimalPrice(salePrice), let decimalRegularPrice = getDecimalPrice(regularPrice),
-            decimalSalePrice.compare(decimalRegularPrice) != .orderedAscending {
+           decimalSalePrice.compare(decimalRegularPrice) != .orderedAscending {
             onError(.salePriceHigherThanRegularPrice)
             return
         }
@@ -276,6 +275,13 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
         }
 
         return false
+    }
+
+    func doesScheduleDateHasPrice() -> Bool {
+        if dateOnSaleStart != nil && dateOnSaleEnd != nil {
+            return getDecimalPrice(salePrice) != nil
+        }
+        return true
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -512,6 +512,26 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
 
+    func test_completeUpdating_new_sale_with_nil_sale_price() {
+        // Arrange
+        let dateOnSaleStart = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let product = Product.fake().copy(dateOnSaleStart: dateOnSaleStart, dateOnSaleEnd: dateOnSaleEnd, salePrice: nil)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductPriceSettingsViewModel(product: model)
+
+        // Act
+        let expectation = self.expectation(description: "Wait for error")
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
+            XCTFail("Completion block should not be called")
+        }, onError: { error in
+            // Assert
+            XCTAssertEqual(error, .newSaleWithEmptySalePrice)
+            expectation.fulfill()
+        })
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
     func testCompletingUpdatingWithZeroSalePrice() {
         // Arrange
         let product = Product.fake()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -521,15 +521,16 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         let viewModel = ProductPriceSettingsViewModel(product: model)
 
         // Act
-        let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
-            XCTFail("Completion block should not be called")
-        }, onError: { error in
-            // Assert
-            XCTAssertEqual(error, .newSaleWithEmptySalePrice)
-            expectation.fulfill()
-        })
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        let result = waitFor { promise in
+            viewModel.completeUpdating { _, _, _, _, _, _, _ in
+                XCTFail("Completion block should not be called")
+            } onError: { error in
+                promise(error)
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(result, .newSaleWithEmptySalePrice)
     }
 
     func testCompletingUpdatingWithZeroSalePrice() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -12,7 +12,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testInitSaleStartDateWithoutSaleEndDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let saleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
+        let saleStartDate = date(from: "2019-10-15T21:30:00")
         let saleEndDate: Date? = nil
         let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
         let model = EditableProductModel(product: product)
@@ -31,7 +31,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
         let saleStartDate: Date? = nil
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
+        let saleEndDate = date(from: "2019-10-15T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
         let model = EditableProductModel(product: product)
 
@@ -232,8 +232,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
     func testHandlingDisabledScheduleSale() {
         // Arrange
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-28T21:30:00")
+        let originalSaleStartDate = date(from: "2019-10-15T21:30:00")
+        let originalSaleEndDate = date(from: "2019-10-28T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
@@ -270,8 +270,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingEnabledScheduleSaleFromExistingSaleDates() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-28T21:30:00")
+        let originalSaleStartDate = date(from: "2019-10-15T21:30:00")
+        let originalSaleEndDate = date(from: "2019-10-28T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -291,7 +291,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingSaleStartDateWithoutSaleEndDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
+        let originalSaleStartDate = date(from: "2019-10-15T21:30:00")
         let originalSaleEndDate: Date? = nil
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
@@ -300,7 +300,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dateOnSaleEnd, originalSaleEndDate)
 
         // Act
-        let saleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-20T21:30:00")!
+        let saleStartDate = date(from: "2019-10-20T21:30:00")!
         viewModel.handleSaleStartDateChange(saleStartDate)
 
         // Assert
@@ -313,8 +313,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingSaleStartDateWithAnEarlierSaleEndDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-18T21:30:00")
+        let originalSaleStartDate = date(from: "2019-10-15T21:30:00")
+        let originalSaleEndDate = date(from: "2019-10-18T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -322,7 +322,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dateOnSaleEnd, originalSaleEndDate)
 
         // Act
-        let saleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-20T21:30:00")!
+        let saleStartDate = date(from: "2019-10-20T21:30:00")!
         viewModel.handleSaleStartDateChange(saleStartDate)
 
         // Assert
@@ -335,8 +335,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingSaleStartDateWithALaterSaleEndDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-18T21:30:00")
+        let originalSaleStartDate = date(from: "2019-10-15T21:30:00")
+        let originalSaleEndDate = date(from: "2019-10-18T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -344,7 +344,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dateOnSaleEnd, originalSaleEndDate)
 
         // Act
-        let saleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-16T21:30:00")!
+        let saleStartDate = date(from: "2019-10-16T21:30:00")!
         viewModel.handleSaleStartDateChange(saleStartDate)
 
         // Assert
@@ -360,13 +360,13 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
         let originalSaleStartDate: Date? = nil
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
+        let originalSaleEndDate = date(from: "2019-10-15T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
 
         // Act
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-20T21:30:00")!
+        let saleEndDate = date(from: "2019-10-20T21:30:00")!
         viewModel.handleSaleEndDateChange(saleEndDate)
 
         // Assert
@@ -399,8 +399,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingSaleEndDateWithAnEarlierSaleStartDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let originalSaleStartDate = date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -408,7 +408,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dateOnSaleEnd, originalSaleEndDate)
 
         // Act
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-20T21:30:00")!
+        let saleEndDate = date(from: "2019-09-20T21:30:00")!
         viewModel.handleSaleEndDateChange(saleEndDate)
 
         // Assert
@@ -421,8 +421,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingSaleEndDateWithALaterSaleStartDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let originalSaleStartDate = date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -430,7 +430,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dateOnSaleEnd, originalSaleEndDate)
 
         // Act
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-01T21:30:00")!
+        let saleEndDate = date(from: "2019-09-01T21:30:00")!
         viewModel.handleSaleEndDateChange(saleEndDate)
 
         // Assert
@@ -443,8 +443,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func testHandlingNilSaleEndDate() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let originalSaleStartDate = date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -514,8 +514,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
     func test_completeUpdating_new_sale_with_nil_sale_price() {
         // Arrange
-        let dateOnSaleStart = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let dateOnSaleEnd = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let dateOnSaleStart = date(from: "2019-09-02T21:30:00")
+        let dateOnSaleEnd = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: dateOnSaleStart, dateOnSaleEnd: dateOnSaleEnd, salePrice: nil)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model)
@@ -608,7 +608,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
         let saleStartDate: Date? = nil
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-15T21:30:00")
+        let saleEndDate = date(from: "2019-10-15T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: saleStartDate,
                                           dateOnSaleEnd: saleEndDate,
                                           taxStatusKey: ProductTaxStatus.taxable.rawValue,
@@ -750,15 +750,15 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func test_handling_nonnil_sale_end_date_does_not_hide_date_editing_rows() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let originalSaleStartDate = date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
 
         // Act
         viewModel.didTapScheduleSaleToRow()
-        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2020-09-20T21:30:00")!
+        let saleEndDate = date(from: "2020-09-20T21:30:00")!
         viewModel.handleSaleEndDateChange(saleEndDate)
 
         // Assert
@@ -772,8 +772,8 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
     func test_handling_nil_sale_end_date_hides_date_editing_rows() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
-        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
-        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let originalSaleStartDate = date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = date(from: "2019-09-27T21:30:00")
         let product = Product.fake().copy(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
         let model = EditableProductModel(product: product)
         let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
@@ -795,5 +795,9 @@ private extension ProductPriceSettingsViewModelTests {
     enum Strings {
         static let priceSectionTitle = NSLocalizedString("Price", comment: "Section header title for product price")
         static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
+    }
+
+    func date(from dateString: String) -> Date? {
+        DateFormatter.Defaults.dateTimeFormatter.date(from: dateString)
     }
 }


### PR DESCRIPTION
Closes #2496 

# Description

This PR fixes a behavior when saving a new sale without specifying a sale price.

# Changes

- Added a new error case `.newSaleWithEmptySalePrice` to be handled by `ProductPriceSettingsViewController`  
- Updated `ProductPriceSettingsViewModel` to trigger the new error in case of a sale without a salePrice
- Added tests + minor cleanups on `ProductPriceSettingsViewModelTests `

# Videos

| Before  |  After  |
| ------------------- | ------------------- |
|  <img src="https://user-images.githubusercontent.com/997521/129946428-15cd59ab-0729-4a57-ad07-4dd55aa6b575.mp4"> |  <img src="https://user-images.githubusercontent.com/997521/129945847-a27c06f9-52ce-4e42-b957-8f4c9a54b0b9.mp4">  |

# Testing

1. Make sure you are in a store with at least one product
1. In Products tab of the app, select any product
1. Select the **Price** cell
1. Toggle on the **Schedule sale** toggle
1. Press **Done** on the top right navigation bar button
1. **It should display an alert to warn users about the empty sale price** 
---

## Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.
