### PR TITLE
OE: Add edit button to "Customer Provided Note" row

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -377,10 +377,9 @@ private extension OrderDetailsDataSource {
         cell.body = customerNote.isNotEmpty ? localizedBody : " "
         cell.selectionStyle = .none
 
-        cell.onEditTapped = orderEditingEnabled ? nil : {
-            // TODO: Fire edit note action
-            print("Edit Note Tapped")
-        }
+        cell.onEditTapped = orderEditingEnabled ? { [weak self] in
+            self?.onCellAction?(.editCustomerNote, nil)
+        } : nil
     }
 
     private func configureBillingDetail(cell: WooBasicTableViewCell) {
@@ -1432,6 +1431,7 @@ extension OrderDetailsDataSource {
         case createShippingLabel
         case shippingLabelTrackingMenu(shippingLabel: ShippingLabel, sourceView: UIView)
         case viewAddOns(addOns: [OrderItemAttribute])
+        case editCustomerNote
     }
 
     struct Constants {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -377,7 +377,7 @@ private extension OrderDetailsDataSource {
         cell.body = customerNote.isNotEmpty ? localizedBody : " "
         cell.selectionStyle = .none
 
-        cell.onEditTapped = {
+        cell.onEditTapped = orderEditingEnabled ? nil : {
             // TODO: Fire edit note action
             print("Edit Note Tapped")
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -950,7 +950,7 @@ extension OrderDetailsDataSource {
             var rows: [Row] = []
 
             /// After `.orderEditing` is completed, this row should always be visible to let merchants update the customer note as required.
-            if   orderEditingEnabled || customerNote.isEmpty == false {
+            if orderEditingEnabled || customerNote.isEmpty == false {
                 rows.append(.customerNote)
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -945,7 +945,8 @@ extension OrderDetailsDataSource {
         let customerInformation: Section = {
             var rows: [Row] = []
 
-            if customerNote.isEmpty == false {
+            /// After `.orderEditing` is completed, this row should always be visible to let merchants update the customer note as required.
+            if   orderEditingEnabled || customerNote.isEmpty == false {
                 rows.append(.customerNote)
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -376,6 +376,11 @@ private extension OrderDetailsDataSource {
             customerNote)
         cell.body = customerNote.isNotEmpty ? localizedBody : " "
         cell.selectionStyle = .none
+
+        cell.onEditTapped = {
+            // TODO: Fire edit note action
+            print("Edit Note Tapped")
+        }
     }
 
     private func configureBillingDetail(cell: WooBasicTableViewCell) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -374,7 +374,7 @@ private extension OrderDetailsDataSource {
             NSLocalizedString("“%@”",
                               comment: "Customer note, wrapped in quotes"),
             customerNote)
-        cell.body = customerNote.isNotEmpty ? localizedBody : ""
+        cell.body = customerNote.isNotEmpty ? localizedBody : " "
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -192,11 +192,18 @@ final class OrderDetailsDataSource: NSObject {
 
     private let imageService: ImageService = ServiceLocator.imageService
 
+    /// Indicates if the order editing feature is enabled or not
+    /// Allows editing notes, shipping & billing addresses.
+    ///
+    private let orderEditingEnabled: Bool
+
     init(order: Order,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         orderEditingEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderEditing)) {
         self.storageManager = storageManager
         self.order = order
         self.couponLines = order.coupons
+        self.orderEditingEnabled = orderEditingEnabled
 
         super.init()
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -374,7 +374,7 @@ private extension OrderDetailsDataSource {
             NSLocalizedString("“%@”",
                               comment: "Customer note, wrapped in quotes"),
             customerNote)
-        cell.body = localizedBody
+        cell.body = customerNote.isNotEmpty ? localizedBody : ""
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -6,6 +6,8 @@ final class CustomerNoteTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var bodyLabel: UILabel!
 
+    @IBOutlet private weak var editButton: UIButton!
+
     /// Headline label text
     ///
     var headline: String? {
@@ -28,12 +30,27 @@ final class CustomerNoteTableViewCell: UITableViewCell {
         }
     }
 
+    /// Closure to be invoked when the edit icon is tapped
+    ///
+    var onEditTapped: (() -> Void)? {
+        didSet {
+            editButton.isHidden = onEditTapped == nil
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
         configureLabels()
+        configureEditButton()
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        headlineLabel.text = nil
+        bodyLabel.text = nil
+        onEditTapped = nil
+    }
 }
 
 
@@ -47,6 +64,15 @@ private extension CustomerNoteTableViewCell {
     func configureLabels() {
         headlineLabel.applyHeadlineStyle()
         bodyLabel.applyBodyStyle()
+    }
+
+    func configureEditButton() {
+        editButton.applyIconButtonStyle(icon: .pencilImage)
+        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+    }
+
+    @objc func editButtonTapped() {
+        onEditTapped?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -6,6 +6,8 @@ final class CustomerNoteTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var bodyLabel: UILabel!
 
+    @IBOutlet private weak var bodyLabelTrailingConstraint: NSLayoutConstraint!
+
     @IBOutlet private weak var editButton: UIButton!
 
     /// Headline label text
@@ -31,10 +33,13 @@ final class CustomerNoteTableViewCell: UITableViewCell {
     }
 
     /// Closure to be invoked when the edit icon is tapped
+    /// Setting a value makes the button visible and insets the body trailing constraint.
     ///
     var onEditTapped: (() -> Void)? {
         didSet {
-            editButton.isHidden = onEditTapped == nil
+            let shouldHideEditButton = onEditTapped == nil
+            editButton.isHidden = shouldHideEditButton
+            bodyLabelTrailingConstraint.constant = shouldHideEditButton ? 0 : -editButton.frame.width
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="79"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hBw-ST-ECJ" id="OND-C1-icR">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="78.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="79"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Headline Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T3S-nL-Xv3">
@@ -31,6 +28,13 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <button opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AEi-vO-v71">
+                        <rect key="frame" x="260" y="30" width="44" height="44"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="AEi-vO-v71" secondAttribute="height" multiplier="1:1" id="QS6-Re-4g0"/>
+                            <constraint firstAttribute="width" constant="44" id="jEO-lC-Tht"/>
+                        </constraints>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstItem="z0H-LC-lIr" firstAttribute="trailing" secondItem="T3S-nL-Xv3" secondAttribute="trailing" id="AuN-8r-SjX"/>
@@ -38,16 +42,19 @@
                     <constraint firstItem="T3S-nL-Xv3" firstAttribute="trailing" secondItem="OND-C1-icR" secondAttribute="trailingMargin" id="d9o-iH-3E2"/>
                     <constraint firstAttribute="bottomMargin" secondItem="z0H-LC-lIr" secondAttribute="bottom" constant="5" id="gao-id-FZ7"/>
                     <constraint firstItem="T3S-nL-Xv3" firstAttribute="top" secondItem="OND-C1-icR" secondAttribute="topMargin" constant="5" id="j7x-pf-RCp"/>
+                    <constraint firstItem="AEi-vO-v71" firstAttribute="centerY" secondItem="z0H-LC-lIr" secondAttribute="centerY" id="pYJ-sG-fZy"/>
                     <constraint firstItem="T3S-nL-Xv3" firstAttribute="leading" secondItem="OND-C1-icR" secondAttribute="leadingMargin" id="thJ-Ra-SNq"/>
+                    <constraint firstAttribute="trailing" secondItem="AEi-vO-v71" secondAttribute="trailing" constant="16" id="xps-O6-jUr"/>
                     <constraint firstItem="z0H-LC-lIr" firstAttribute="leading" secondItem="T3S-nL-Xv3" secondAttribute="leading" id="yUO-YZ-lQr"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="U1C-V1-Or8"/>
             <connections>
                 <outlet property="bodyLabel" destination="z0H-LC-lIr" id="eha-ch-GUr"/>
+                <outlet property="editButton" destination="AEi-vO-v71" id="kDj-Jd-NCM"/>
                 <outlet property="headlineLabel" destination="T3S-nL-Xv3" id="ogO-Et-oBd"/>
             </connections>
-            <point key="canvasLocation" x="48" y="125"/>
+            <point key="canvasLocation" x="47.826086956521742" y="124.88839285714285"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
@@ -51,6 +51,7 @@
             <viewLayoutGuide key="safeArea" id="U1C-V1-Or8"/>
             <connections>
                 <outlet property="bodyLabel" destination="z0H-LC-lIr" id="eha-ch-GUr"/>
+                <outlet property="bodyLabelTrailingConstraint" destination="AuN-8r-SjX" id="vyp-5o-HQO"/>
                 <outlet property="editButton" destination="AEi-vO-v71" id="kDj-Jd-NCM"/>
                 <outlet property="headlineLabel" destination="T3S-nL-Xv3" id="ogO-Et-oBd"/>
             </connections>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -517,6 +517,9 @@ private extension OrderDetailsViewController {
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)
         case let .viewAddOns(addOns):
             itemAddOnsButtonTapped(addOns: addOns)
+        case .editCustomerNote:
+            // TODO: Navigate to edit customer note
+            print("Edit Note Tapped")
         }
     }
 


### PR DESCRIPTION
closes #4775 

# Why

Editing the "customer provided note" will be done by tapping an edit button in the "customer provided note" row on the order details screen.

This PR makes sure that 
- The edit button is shown when the feature flag is enabled
- The row is always visible when the feature flag is enabled. 

# How

- In `OrderDetailsDataSource.swift` added an `orderEditingEnabled` variable to control new UI additions while we work on the project, as well as making sure the row is always visible and to configure correctly the edit action.

- In `CustomerNoteTableViewCell.swift` added and configure the edit button, also makes sure to add some padding to the body label by modifying its trailing constraint when the button is visible.

# Screenshots

## Feature Disabled
No note | Single Line Note | Multiple Line Note
--- | --- | ---
<img width="385" alt="Screen Shot 2021-08-18 at 3 02 19 PM" src="https://user-images.githubusercontent.com/562080/129966903-48dbb54a-80b6-47ed-baaf-e5e2a04e6070.png"> | <img width="380" alt="Screen Shot 2021-08-18 at 3 01 51 PM" src="https://user-images.githubusercontent.com/562080/129966908-3c4595aa-06bc-4900-9aa4-7f5b1f6e7dab.png"> | <img width="377" alt="Screen Shot 2021-08-18 at 3 06 30 PM" src="https://user-images.githubusercontent.com/562080/129966910-a914e249-9f88-44e1-a39e-202bd744cf2c.png">

## Feature Enabled
No note | Single Line Note | Multiple Line Note
--- | --- | ---
<img width="388" alt="Screen Shot 2021-08-18 at 3 08 14 PM" src="https://user-images.githubusercontent.com/562080/129966979-0a2bd62b-88e7-47d3-b712-79c2b6ee5752.png"> | <img width="389" alt="Screen Shot 2021-08-18 at 3 08 29 PM" src="https://user-images.githubusercontent.com/562080/129966985-5f8648f6-8e5a-479c-b5ce-2ded16e719e1.png"> | <img width="378" alt="Screen Shot 2021-08-18 at 3 10 06 PM" src="https://user-images.githubusercontent.com/562080/129966988-c6b25863-2b4d-4843-a551-6120e5d2476e.png">

# Testing Steps

- Navigate to an order without a customer note
- Verify that the app displays the empty customer note with the edit button
- Navigate to an order with a customer note
- Verify that the app displays the customer note with the edit button

----

- Launch the app with the feature flag toggled off
- See that no edit button is present in any order


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
