### PR TITLE
Shipping Labels: Complete validation for customs form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -48,7 +48,7 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
 
     /// Whether all fields are validated.
     ///
-    @Published private(set) var isItemValidated: Bool = false
+    @Published private(set) var validItem: Bool = false
 
     /// The validated tariff number to be observed by `ShippingLabelCustomsFormInputViewModel`
     /// to calculate total value for each tariff number.
@@ -161,6 +161,8 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
         return hsTariffNumber
     }
 
+    /// Observe changes in all fields to check if everything is validated.
+    ///
     func configureValidationCheck() {
         let groupOne = $description.combineLatest($value, $weight)
         let groupTwo = $hsTariffNumber.combineLatest($originCountry)
@@ -178,13 +180,9 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
                     self.getValidatedWeight(from: weight) != nil
             }
             .removeDuplicates()
-            .assign(to: &$isItemValidated)
+            .assign(to: &$validItem)
     }
-}
 
-// MARK: - Helpers
-//
-private extension ShippingLabelCustomsFormItemDetailsViewModel {
     /// Limit length HS Tariff Number to only 6 characters max.
     ///
     func limitHSTariffNumberLength() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -20,14 +20,7 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
 
     /// Price of item per unit.
     ///
-    @Published var value: String {
-        didSet {
-            guard let value = getValidatedValue(from: value) else {
-                return validatedTotalValue = nil
-            }
-            validatedTotalValue = Decimal(value) * quantity
-        }
-    }
+    @Published var value: String
 
     /// Weight of item per unit.
     ///
@@ -38,7 +31,6 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     @Published var hsTariffNumber: String {
         didSet {
             limitHSTariffNumberLength()
-            validatedHSTariffNumber = getValidateHSTariffNumber(hsTariffNumber)
         }
     }
 
@@ -99,6 +91,8 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
         self.weightUnit = weightUnit ?? ""
         self.originCountry = countries.first(where: { $0.code == item.originCountry }) ?? Country(code: "", name: "", states: [])
 
+        configureValidatedTotalValue()
+        configureValidatedHSTariffNumber()
         configureValidationCheck()
     }
 }
@@ -181,6 +175,30 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
             }
             .removeDuplicates()
             .assign(to: &$validItem)
+    }
+
+    /// Update validated total value on change of total value.
+    ///
+    func configureValidatedTotalValue() {
+        $value
+            .map { [weak self] value -> Decimal? in
+                guard let self = self,
+                      let validatedValue = self.getValidatedValue(from: value) else {
+                    return nil
+                }
+                return Decimal(validatedValue) * self.quantity
+            }
+            .assign(to: &$validatedTotalValue)
+    }
+
+    /// Update validated tariff number on change of tariff number.
+    ///
+    func configureValidatedHSTariffNumber() {
+        $hsTariffNumber
+            .map { [weak self] number -> String? in
+                self?.getValidateHSTariffNumber(number)
+            }
+            .assign(to: &$validatedHSTariffNumber)
     }
 
     /// Limit length HS Tariff Number to only 6 characters max.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -38,6 +38,10 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
     ///
     @Published var originCountry: Country
 
+    /// Whether all fields are validated.
+    ///
+    @Published private(set) var isItemValidated: Bool = false
+
     /// Persisted countries to select from.
     ///
     let allCountries: [Country]
@@ -76,6 +80,8 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
         self.currency = currency
         self.weightUnit = weightUnit ?? ""
         self.originCountry = countries.first(where: { $0.code == item.originCountry }) ?? Country(code: "", name: "", states: [])
+
+        configureValidationCheck()
     }
 }
 
@@ -83,34 +89,78 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
 //
 extension ShippingLabelCustomsFormItemDetailsViewModel {
     var hasValidDescription: Bool {
-        description.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty
+        validateDescription(description)
     }
 
     var validatedValue: Double? {
+        getValidatedValue(from: value)
+    }
+
+    var validatedWeight: Double? {
+        getValidatedWeight(from: weight)
+    }
+
+    var hasValidOriginCountry: Bool {
+        validateCountry(originCountry)
+    }
+
+    var hasValidHSTariffNumber: Bool {
+        validateHSTariffNumber(hsTariffNumber)
+    }
+}
+
+// MARK: - Helper methods
+//
+private extension ShippingLabelCustomsFormItemDetailsViewModel {
+    func validateDescription(_ description: String) -> Bool {
+        description.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty
+    }
+
+    func getValidatedValue(from value: String) -> Double? {
         guard let numericValue = Double(value), numericValue > 0 else {
             return nil
         }
         return numericValue
     }
 
-    var validatedWeight: Double? {
+    func getValidatedWeight(from weight: String) -> Double? {
         guard let numericWeight = Double(weight), numericWeight > 0 else {
             return nil
         }
         return numericWeight
     }
 
-    var hasValidOriginCountry: Bool {
+    func validateCountry(_ originCountry: Country) -> Bool {
         originCountry.code.isNotEmpty
     }
 
-    var hasValidHSTariffNumber: Bool {
+    func validateHSTariffNumber(_ hsTariffNumber: String) -> Bool {
         if hsTariffNumber.isNotEmpty,
            (hsTariffNumber.count != Constants.hsTariffNumberCharacterLimit ||
                 hsTariffNumber.filter({ "0"..."9" ~= $0 }).count != 6) {
             return false
         }
         return true
+    }
+
+    func configureValidationCheck() {
+        let groupOne = $description.combineLatest($value, $weight)
+        let groupTwo = $hsTariffNumber.combineLatest($originCountry)
+        groupOne.combineLatest(groupTwo)
+            .map { [weak self] groupOne, groupTwo -> Bool in
+                guard let self = self else {
+                    return false
+                }
+                let (description, value, weight) = groupOne
+                let (hsTariffNumber, originCountry) = groupTwo
+                return self.validateDescription(description) &&
+                    self.validateCountry(originCountry) &&
+                    self.validateHSTariffNumber(hsTariffNumber) &&
+                    self.getValidatedValue(from: value) != nil &&
+                    self.getValidatedWeight(from: weight) != nil
+            }
+            .removeDuplicates()
+            .assign(to: &$isItemValidated)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -38,7 +38,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 
     /// Items contained in the package.
     ///
-    @Published var items: [ShippingLabelCustomsForm.Item]
+    let items: [ShippingLabelCustomsForm.Item]
 
     /// References of item view models.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -142,7 +142,7 @@ extension ShippingLabelCustomsFormInputViewModel {
     }
 
     var missingITNForClassesAbove2500usd: Bool {
-        checkMissingITNForClassesAbove2500usd(itn)
+        checkMissingITN(itn, for: classesAbove2500usd)
     }
 
     var invalidITN: Bool {
@@ -174,7 +174,7 @@ private extension ShippingLabelCustomsFormInputViewModel {
         return false
     }
 
-    func checkMissingITNForClassesAbove2500usd(_ itn: String) -> Bool {
+    func checkMissingITN(_ itn: String, for classesAbove2500usd: [String]) -> Bool {
         if classesAbove2500usd.isNotEmpty && itn.isEmpty {
             return true
         }
@@ -190,19 +190,19 @@ private extension ShippingLabelCustomsFormInputViewModel {
     }
 
     func configureValidationCheck() {
-        let groupOne = $contentExplanation.combineLatest($contentsType)
+        let groupOne = $classesAbove2500usd.combineLatest($contentsType, $contentExplanation)
         let groupTwo = $itn.combineLatest($restrictionType, $restrictionComments)
         groupOne.combineLatest(groupTwo)
             .map { [weak self] groupOne, groupTwo -> Bool in
                 guard let self = self else {
                     return false
                 }
-                let (contentExplanation, contentsType) = groupOne
+                let (classesAbove2500usd, contentsType, contentExplanation) = groupOne
                 let (itn, restrictionType, restrictionComments) = groupTwo
                 return !self.checkMissingContentExplanation(contentExplanation, with: contentsType) &&
                     !self.checkMissingRestrictionComment(restrictionComments, with: restrictionType) &&
                     !self.checkMissingITNForDestination(itn) &&
-                    !self.checkMissingITNForClassesAbove2500usd(itn) &&
+                    !self.checkMissingITN(itn, for: classesAbove2500usd) &&
                     !self.checkInvalidITN(itn)
             }
             .removeDuplicates()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -174,8 +174,10 @@ private extension ShippingLabelCustomsFormInputViewModel {
         return false
     }
 
-    var missingITNForClassesAbove2500usd: Bool {
-        // TODO: check for accumulated value of each tariff number.
+    func checkMissingITNForClassesAbove2500usd(_ itn: String) -> Bool {
+        if classesAbove2500usd.isNotEmpty && itn.isEmpty {
+            return true
+        }
         return false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -45,7 +45,25 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 
     /// Validated customs form
     ///
-    private(set) var validatedCustomsForm: ShippingLabelCustomsForm?
+    var validatedCustomsForm: ShippingLabelCustomsForm? {
+        guard !missingContentExplanation,
+              !missingRestrictionComments,
+              !missingITNForDestination,
+              !missingITNForClassesAbove2500usd,
+              !invalidITN,
+              itemViewModels.filter({ $0.validatedItem == nil }).isEmpty else {
+            return nil
+        }
+        return ShippingLabelCustomsForm(packageID: packageID,
+                                        packageName: packageName,
+                                        contentsType: contentsType,
+                                        contentExplanation: contentExplanation,
+                                        restrictionType: restrictionType,
+                                        restrictionComments: restrictionComments,
+                                        nonDeliveryOption: returnOnNonDelivery ? .return : .abandon,
+                                        itn: itn,
+                                        items: itemViewModels.compactMap { $0.validatedItem })
+    }
 
     /// Destination country for the shipment.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -43,6 +43,10 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
     ///
     private(set) var itemViewModels: [ShippingLabelCustomsFormItemDetailsViewModel]
 
+    /// Whether all fields and items are validated.
+    ///
+    @Published private(set) var isFormValidated: Bool = false
+
     /// Validated customs form
     ///
     var validatedCustomsForm: ShippingLabelCustomsForm? {
@@ -98,6 +102,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
         self.currency = currency
         self.itemViewModels = customsForm.items.map { .init(item: $0, countries: countries, currency: currency) }
 
+        configureValidationCheck()
         resetContentExplanationIfNeeded()
         resetRestrictionCommentsIfNeeded()
     }
@@ -107,20 +112,44 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 //
 extension ShippingLabelCustomsFormInputViewModel {
     var missingContentExplanation: Bool {
+        checkMissingContentExplanation(contentExplanation, with: contentsType)
+    }
+
+    var missingRestrictionComments: Bool {
+        checkMissingRestrictionComment(restrictionComments, with: restrictionType)
+    }
+
+    var missingITNForDestination: Bool {
+        checkMissingITNForDestination(itn)
+    }
+
+    var missingITNForClassesAbove2500usd: Bool {
+        checkMissingITNForClassesAbove2500usd(itn)
+    }
+
+    var invalidITN: Bool {
+        checkInvalidITN(itn)
+    }
+}
+
+// MARK: - Private validation helpers
+//
+private extension ShippingLabelCustomsFormInputViewModel {
+    func checkMissingContentExplanation(_ contentExplanation: String, with contentsType: ShippingLabelCustomsForm.ContentsType) -> Bool {
         if contentsType == .other, contentExplanation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return true
         }
         return false
     }
 
-    var missingRestrictionComments: Bool {
+    func checkMissingRestrictionComment(_ restrictionComment: String, with restrictionType: ShippingLabelCustomsForm.RestrictionType) -> Bool {
         if restrictionType == .other, restrictionComments.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return true
         }
         return false
     }
 
-    var missingITNForDestination: Bool {
+    func checkMissingITNForDestination(_ itn: String) -> Bool {
         if itnValidationRequired && itn.isEmpty {
             return true
         }
@@ -132,12 +161,32 @@ extension ShippingLabelCustomsFormInputViewModel {
         return false
     }
 
-    var invalidITN: Bool {
+    func checkInvalidITN(_ itn: String) -> Bool {
         if itn.isNotEmpty,
            itn.range(of: Constants.itnRegex, options: .regularExpression, range: nil, locale: nil) == nil {
             return true
         }
         return false
+    }
+
+    func configureValidationCheck() {
+        let groupOne = $contentExplanation.combineLatest($contentsType)
+        let groupTwo = $itn.combineLatest($restrictionType, $restrictionComments)
+        groupOne.combineLatest(groupTwo)
+            .map { [weak self] groupOne, groupTwo -> Bool in
+                guard let self = self else {
+                    return false
+                }
+                let (contentExplanation, contentsType) = groupOne
+                let (itn, restrictionType, restrictionComments) = groupTwo
+                return !self.checkMissingContentExplanation(contentExplanation, with: contentsType) &&
+                    !self.checkMissingRestrictionComment(restrictionComments, with: restrictionType) &&
+                    !self.checkMissingITNForDestination(itn) &&
+                    !self.checkMissingITNForClassesAbove2500usd(itn) &&
+                    !self.checkInvalidITN(itn)
+            }
+            .removeDuplicates()
+            .assign(to: &$isFormValidated)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Yosemite
 
@@ -41,7 +42,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 
     /// References of item view models.
     ///
-    private(set) var itemViewModels: [ShippingLabelCustomsFormItemDetailsViewModel]
+    let itemViewModels: [ShippingLabelCustomsFormItemDetailsViewModel]
 
     /// Whether all fields and items are validated.
     ///
@@ -87,6 +88,22 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
         Constants.uspsITNRequiredDestinations.contains(destinationCountry.code)
     }()
 
+    /// Tariff numbers with total values above $2500.
+    ///
+    @Published private var classesAbove2500usd: [String] = []
+
+    /// Keeping track of all items tariff numbers and total values to calculate `classesAbove2500usd`.
+    ///
+    private var itemTariffNumbersAndValues: [Int64: (hsTariffNumber: String, totalValue: Decimal)] = [:] {
+        didSet {
+            configureClassesAbove2500usd()
+        }
+    }
+
+    /// References to keep the Combine subscriptions alive with the class.
+    ///
+    private var cancellables: Set<AnyCancellable> = []
+
     init(customsForm: ShippingLabelCustomsForm, destinationCountry: Country, countries: [Country], currency: String) {
         self.packageID = customsForm.packageID
         self.packageName = customsForm.packageName
@@ -103,6 +120,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
         self.itemViewModels = customsForm.items.map { .init(item: $0, countries: countries, currency: currency) }
 
         configureValidationCheck()
+        configureItemTariffNumbersAndValues()
         resetContentExplanationIfNeeded()
         resetRestrictionCommentsIfNeeded()
     }
@@ -193,6 +211,42 @@ private extension ShippingLabelCustomsFormInputViewModel {
 // MARK: - Private helpers
 //
 private extension ShippingLabelCustomsFormInputViewModel {
+    /// Observe changes of each item's tariff number and value,
+    /// and save them by product ID.
+    ///
+    func configureItemTariffNumbersAndValues() {
+        itemViewModels.forEach { viewModel in
+            viewModel.$validatedHSTariffNumber.combineLatest(viewModel.$validatedTotalValue)
+                .sink { [weak self] number, totalValue in
+                    if let number = number, number.isNotEmpty,
+                       let totalValue = totalValue {
+                        self?.itemTariffNumbersAndValues[viewModel.productID] = (hsTariffNumber: number, totalValue: totalValue)
+                    } else {
+                        self?.itemTariffNumbersAndValues.removeValue(forKey: viewModel.productID)
+                    }
+                }
+                .store(in: &cancellables)
+        }
+    }
+
+    /// Check for items and list ones with same HS Tariff Number
+    /// whose values accumulate to more than $2500.
+    ///
+    func configureClassesAbove2500usd() {
+        classesAbove2500usd = itemTariffNumbersAndValues.values
+            .reduce([String: Decimal]()) { accumulator, item in
+                var result = accumulator
+                if let currentTotal = result[item.hsTariffNumber] {
+                    result[item.hsTariffNumber] = currentTotal + item.totalValue
+                } else {
+                    result[item.hsTariffNumber] = item.totalValue
+                }
+                return result
+            }
+            .filter { $0.value > Constants.minimumValueRequiredForITNValidation }
+            .keys
+            .map { String($0) }
+    }
 
     /// Reset content explanation if content type is not Other.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -46,7 +46,7 @@ final class ShippingLabelCustomsFormInputViewModel: ObservableObject {
 
     /// Whether all fields and items are validated.
     ///
-    @Published private(set) var isFormValidated: Bool = false
+    @Published private(set) var validForm: Bool = false
 
     /// Validated customs form
     ///
@@ -206,7 +206,7 @@ private extension ShippingLabelCustomsFormInputViewModel {
                     !self.checkInvalidITN(itn)
             }
             .removeDuplicates()
-            .assign(to: &$isFormValidated)
+            .assign(to: &$validForm)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -30,7 +30,7 @@ struct ShippingLabelCustomsFormList: View {
         }
         .navigationTitle(Localization.navigationTitle)
         .navigationBarItems(trailing: Button(action: {
-            onCompletion(viewModel.customsForms)
+            onCompletion(viewModel.validatedCustomsForms)
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -34,7 +34,8 @@ struct ShippingLabelCustomsFormList: View {
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)
-        }))
+        }).disabled(!viewModel.doneButtonEnabled)
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -18,7 +18,7 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
 
     /// Input customs forms of the shipping label if added initially.
     ///
-    @Published var customsForms: [ShippingLabelCustomsForm]
+    @Published private(set) var customsForms: [ShippingLabelCustomsForm]
 
     /// Whether done button should be enabled.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -64,12 +64,16 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     private let currencySymbol: String
 
+    /// Validation states of all customs forms.
+    ///
     private var customsFormValidation: [String: Bool] = [:] {
         didSet {
-            doneButtonEnabled = customsFormValidation.values.first(where: { !$0 }) == nil
+            configureDoneButton()
         }
     }
 
+    /// References to keep the Combine subscriptions alive with the class.
+    ///
     private var cancellables: Set<AnyCancellable> = []
 
     init(order: Order,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -104,14 +104,22 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
 // MARK: - Validation
 //
 private extension ShippingLabelCustomsFormListViewModel {
+    /// Observe changes in all customs forms and save their validation states by package ID.
+    ///
     func configureFormsValidation() {
         inputViewModels.forEach { viewModel in
-            viewModel.$isFormValidated
-                .sink { [weak self] validated in
-                    self?.customsFormValidation[viewModel.packageID] = validated
+            viewModel.$validForm
+                .sink { [weak self] isValid in
+                    self?.customsFormValidation[viewModel.packageID] = isValid
                 }
                 .store(in: &cancellables)
         }
+    }
+
+    /// Check if all forms are validated to enable Done button.
+    ///
+    func configureDoneButton() {
+        doneButtonEnabled = customsFormValidation.values.first(where: { !$0 }) == nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -44,6 +44,10 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     private let destinationCountry: Country
 
+    var validatedCustomsForms: [ShippingLabelCustomsForm] {
+        inputViewModels.compactMap { $0.validatedCustomsForm }
+    }
+
     /// Reusing Package Details results controllers since we're interested in the same models.
     ///
     private var resultsControllers: ShippingLabelPackageDetailsResultsControllers?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
@@ -162,7 +162,7 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
         viewModel.itn = ""
         viewModel.itemViewModels.first?.hsTariffNumber = "123456"
         viewModel.itemViewModels.first?.value = "2600"
- 
+
         // Then
         XCTAssertTrue(viewModel.missingITNForClassesAbove2500usd)
     }
@@ -197,5 +197,55 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.restrictionComments.isEmpty)
+    }
+
+    func test_validForm_returns_true_when_all_fields_are_valid() {
+        // Given
+        let item = ShippingLabelCustomsForm.Item.fake()
+        let viewModel = ShippingLabelCustomsFormInputViewModel(customsForm: ShippingLabelCustomsForm.fake().copy(items: [item]),
+                                                               destinationCountry: Country.fake(),
+                                                               countries: [],
+                                                               currency: "$")
+
+        // When
+        viewModel.contentsType = .other
+        viewModel.contentExplanation = "Test"
+        viewModel.restrictionType = .none
+        viewModel.restrictionComments = ""
+        viewModel.itn = ""
+        viewModel.itemViewModels.first?.description = "Lorem ipsum"
+        viewModel.itemViewModels.first?.value = "1.5"
+        viewModel.itemViewModels.first?.weight = "10"
+        viewModel.itemViewModels.first?.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+        viewModel.itemViewModels.first?.hsTariffNumber = ""
+
+        // Then
+        XCTAssertTrue(viewModel.validForm)
+    }
+
+    func test_validForm_returns_false_when_not_all_fields_are_valid() {
+        // Given
+        let item = ShippingLabelCustomsForm.Item.fake().copy(description: "Test",
+                                                             quantity: 1,
+                                                             value: 10,
+                                                             weight: 1.5,
+                                                             hsTariffNumber: "",
+                                                             originCountry: "US",
+                                                             productID: 123)
+        let viewModel = ShippingLabelCustomsFormInputViewModel(customsForm: ShippingLabelCustomsForm.fake().copy(items: [item]),
+                                                               destinationCountry: Country.fake(),
+                                                               countries: [],
+                                                               currency: "$")
+
+        // When
+        viewModel.contentsType = .other
+        viewModel.contentExplanation = "Test"
+        viewModel.restrictionType = .none
+        viewModel.restrictionComments = ""
+        viewModel.itn = ""
+        viewModel.itemViewModels.first?.description = ""
+
+        // Then
+        XCTAssertFalse(viewModel.validForm)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
@@ -150,6 +150,23 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.invalidITN)
     }
 
+    func test_missingITNForClassesAbove2500usd_returns_true_when_there_is_total_of_more_than_$2500_value_for_a_tariff_number_and_itn_is_empty() {
+        // Given
+        let item = ShippingLabelCustomsForm.Item.fake().copy(quantity: 1)
+        let viewModel = ShippingLabelCustomsFormInputViewModel(customsForm: ShippingLabelCustomsForm.fake().copy(items: [item]),
+                                                               destinationCountry: Country.fake(),
+                                                               countries: [],
+                                                               currency: "$")
+
+        // When
+        viewModel.itn = ""
+        viewModel.itemViewModels.first?.hsTariffNumber = "123456"
+        viewModel.itemViewModels.first?.value = "2600"
+ 
+        // Then
+        XCTAssertTrue(viewModel.missingITNForClassesAbove2500usd)
+    }
+
     func test_contentExplanation_is_reset_when_contentType_is_not_other() {
         // Given
         let viewModel = ShippingLabelCustomsFormInputViewModel(customsForm: ShippingLabelCustomsForm.fake(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormInputViewModelTests.swift
@@ -199,7 +199,7 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.restrictionComments.isEmpty)
     }
 
-    func test_validForm_returns_true_when_all_fields_are_valid() {
+    func test_validForm_and_validatedCustomsForm_return_correctly_when_all_fields_are_valid() {
         // Given
         let item = ShippingLabelCustomsForm.Item.fake()
         let viewModel = ShippingLabelCustomsFormInputViewModel(customsForm: ShippingLabelCustomsForm.fake().copy(items: [item]),
@@ -221,9 +221,10 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.validForm)
+        XCTAssertNotNil(viewModel.validatedCustomsForm)
     }
 
-    func test_validForm_returns_false_when_not_all_fields_are_valid() {
+    func test_validForm_and_validatedCustomsForm_return_correctly_when_not_all_fields_are_valid() {
         // Given
         let item = ShippingLabelCustomsForm.Item.fake().copy(description: "Test",
                                                              quantity: 1,
@@ -247,5 +248,6 @@ final class ShippingLabelCustomsFormInputViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.validForm)
+        XCTAssertNil(viewModel.validatedCustomsForm)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
@@ -195,4 +195,34 @@ class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.validItem)
     }
+
+    func test_validatedItem_is_not_nil_when_all_fields_are_valid() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
+
+        // When
+        viewModel.description = "Test description"
+        viewModel.value = "10"
+        viewModel.weight = "1.5"
+        viewModel.hsTariffNumber = ""
+        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+
+        // Then
+        XCTAssertNotNil(viewModel.validatedItem)
+    }
+
+    func test_validatedItem_is_nil_when_not_all_fields_are_valid() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
+
+        // When
+        viewModel.description = ""
+        viewModel.value = "10"
+        viewModel.weight = "1.5"
+        viewModel.hsTariffNumber = ""
+        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+
+        // Then
+        XCTAssertNil(viewModel.validatedItem)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
@@ -166,7 +166,7 @@ class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.validatedTotalValue)
     }
 
-    func test_validItem_returns_true_when_all_fields_are_valid() {
+    func test_validItem_and_validatedItem_return_correctly_when_all_fields_are_valid() {
         // Given
         let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
 
@@ -179,9 +179,10 @@ class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.validItem)
+        XCTAssertNotNil(viewModel.validatedItem)
     }
 
-    func test_validItem_returns_false_when_not_all_fields_are_valid() {
+    func test_validItem_and_validatedItem_return_correctly_when_not_all_fields_are_valid() {
         // Given
         let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
 
@@ -194,35 +195,6 @@ class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.validItem)
-    }
-
-    func test_validatedItem_is_not_nil_when_all_fields_are_valid() {
-        // Given
-        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
-
-        // When
-        viewModel.description = "Test description"
-        viewModel.value = "10"
-        viewModel.weight = "1.5"
-        viewModel.hsTariffNumber = ""
-        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
-
-        // Then
-        XCTAssertNotNil(viewModel.validatedItem)
-    }
-
-    func test_validatedItem_is_nil_when_not_all_fields_are_valid() {
-        // Given
-        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
-
-        // When
-        viewModel.description = ""
-        viewModel.value = "10"
-        viewModel.weight = "1.5"
-        viewModel.hsTariffNumber = ""
-        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
-
-        // Then
         XCTAssertNil(viewModel.validatedItem)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormItemDetailsViewModelTests.swift
@@ -138,4 +138,61 @@ class ShippingLabelCustomsFormItemDetailsViewModelTests: XCTestCase {
         viewModel.hsTariffNumber = "1234@t"
         XCTAssertFalse(viewModel.hasValidHSTariffNumber)
     }
+
+    func test_validatedHSTariffNumber_returns_correctly() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake(), countries: [], currency: "")
+
+        // When & then
+        viewModel.hsTariffNumber = ""
+        XCTAssertEqual(viewModel.validatedHSTariffNumber, "")
+
+        viewModel.hsTariffNumber = "123456"
+        XCTAssertEqual(viewModel.validatedHSTariffNumber, "123456")
+
+        viewModel.hsTariffNumber = "12345"
+        XCTAssertNil(viewModel.validatedHSTariffNumber)
+    }
+
+    func test_validatedTotalValue_returns_correctly() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
+
+        // When & then
+        viewModel.value = "10"
+        XCTAssertEqual(viewModel.validatedTotalValue, 20)
+
+        viewModel.value = "1..0"
+        XCTAssertNil(viewModel.validatedTotalValue)
+    }
+
+    func test_validItem_returns_true_when_all_fields_are_valid() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
+
+        // When
+        viewModel.description = "Test description"
+        viewModel.value = "10"
+        viewModel.weight = "1.5"
+        viewModel.hsTariffNumber = ""
+        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+
+        // Then
+        XCTAssertTrue(viewModel.validItem)
+    }
+
+    func test_validItem_returns_false_when_not_all_fields_are_valid() {
+        // Given
+        let viewModel = ShippingLabelCustomsFormItemDetailsViewModel(item: ShippingLabelCustomsForm.Item.fake().copy(quantity: 2), countries: [], currency: "")
+
+        // When
+        viewModel.description = ""
+        viewModel.value = "10"
+        viewModel.weight = "1.5"
+        viewModel.hsTariffNumber = ""
+        viewModel.originCountry = Country(code: "VN", name: "Vietnam", states: [])
+
+        // Then
+        XCTAssertFalse(viewModel.validItem)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -115,6 +115,71 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
         XCTAssertEqual(form?.items.first?.weight, Double(120))
         XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
     }
+
+    func test_done_button_is_enabled_when_all_fields_are_valid() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1])
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
+                                                              customsForms: [customsForm],
+                                                              destinationCountry: Country.fake(),
+                                                              countries: [],
+                                                              storageManager: storageManager)
+
+        let firstInputModel = viewModel.inputViewModels.first
+        firstInputModel?.returnOnNonDelivery = true
+        firstInputModel?.contentsType = .documents
+        firstInputModel?.contentExplanation = ""
+        firstInputModel?.restrictionType = .quarantine
+        firstInputModel?.restrictionComments = ""
+        firstInputModel?.itn = ""
+        let firstItem = firstInputModel?.itemViewModels.first
+        firstItem?.description = "Lorem Ipsum"
+        firstItem?.value = "15"
+        firstItem?.weight = "2.0"
+        firstItem?.originCountry = Yosemite.Country(code: "VN", name: "Vietnam", states: [])
+        firstItem?.hsTariffNumber = ""
+
+        // Then
+        XCTAssertTrue(viewModel.doneButtonEnabled)
+    }
+
+    func test_done_button_is_disable_when_not_all_fields_are_valid() {
+        // Given
+        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1, price: 15)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1])
+
+        // When
+        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
+        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
+                                                              customsForms: [customsForm],
+                                                              destinationCountry: Country.fake(),
+                                                              countries: [],
+                                                              storageManager: storageManager)
+
+        let firstInputModel = viewModel.inputViewModels.first
+        firstInputModel?.returnOnNonDelivery = true
+        firstInputModel?.contentsType = .documents
+        firstInputModel?.contentExplanation = ""
+        firstInputModel?.restrictionType = .quarantine
+        firstInputModel?.restrictionComments = ""
+        // missing ITN when total value of tariff number 111111 is 2600
+        firstInputModel?.itn = ""
+        let firstItem = firstInputModel?.itemViewModels.first
+        firstItem?.description = "Lorem Ipsum"
+        firstItem?.value = "2600"
+        firstItem?.weight = "2.0"
+        firstItem?.originCountry = Yosemite.Country(code: "VN", name: "Vietnam", states: [])
+        firstItem?.hsTariffNumber = "111111"
+
+        // Then
+        XCTAssertFalse(viewModel.doneButtonEnabled)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Closes #4687 

# Description
This PR aims to complete validation of customs form with two parts:
### Customs form list Done button. 
To prepare for multi-package support of Shipping Labels, the customs screen was structured like so: Customs Form List -> Customs Form -> Item Details. 

For validation, we want to enable / disable Done button on the Customs Form List immediately when any field is updated. So the validation states have to be sent upward from a child item to its parent form, all the way to the containing form list.

### ITN field validation
It is required that that if total value of items that share the same HS tariff number exceeds $2,500, ITN field in the customs form is required.

To do this, each item has to let its parent know of the latest validation states of the item's value and tariff number. The parent will collect these states to calculate whether any tariff number valued more than $2,500, to decide whether ITN field should be required.

# Changes
### Item details view model
- Added new `@Published` variables for validated tariff number and total value of the item. These will be observed by the parent form to check which tariff number's value exceed $2,500 and requires ITN.
- Added ~~property observers~~ mappers for `value` and `hsTariffNumber` to update the validated total value and tariff number.
- Added new `@Published` variable `validItem` to let parent form know if all the fields in the item details are valid or not.
- Added private method helpers for validation, which are reused between calculated variables and overall validation check.

### Customs form input view model
- Added new `@Published` variable for `validForm` to let parent list know if all the fields as well as items in the form are valid.
- Observe all item view models' `validItem` to save the validation states for all items. These states are used to validate the form.
- Observe all item view models' `validatedHSTariffNumber` and `validatedTotalValue` and save them to configure a list of tariff numbers that require ITN.
- Added private method helpers for validation, which are reused between calculated variables and overall validation check.

### Customs form list view model
- Observe validation states of all child forms and save them locally.
- Configured Done button to enable only when all child forms are valid.
- Configured validated form list by fetching validated form from all input view models.

### Customs form list UI
- Return the validated form list when Done button is tapped.
- Disable Done button when it should not be enabled

### Update unit tests for view models.

# Demo
![customs-validation](https://user-images.githubusercontent.com/5533851/130007313-1641eb4b-74d3-4d46-9a39-f1abb798ab1d.gif)

# Testing steps
1. Make sure that your test store is eligible for creating shipping labels (has WCShip plugin installed and packages configured in WP Admin > WooCommerce > Settings > Shipping > Woocommerce Shipping).
2. Create an order that requires international shipping (origin country different from destination country).
3. Open app, navigate to Orders tab and select the created order.
4. Select Create Shipping Label.
5. Skip through Ship From, Ship To, Package Details to configure Customs.
6. Edit an item in the customs form to have a 6-digit tariff number, and a value of more than $2500 (or if there are more than 1 item, update all item to have same tariff number and total value more than $2500). Notice that there's an validation error in ITN field showing up asking for input.
7. Edit fields in the form to invalid values, notice that Done button is disabled. Update the fields to be valid, Done button should be enabled.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
