### PR TITLE
Shipping Labels: Fix parsing failure for carriers when insurance value is a string instead of double

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Carriers and Rates/ShippingLabelCarrierRate.swift
@@ -6,7 +6,7 @@ import Codegen
 public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
 
     public let title: String
-    public let insurance: Double
+    public let insurance: String
     public let retailRate: Double
     public let rate: Double
     public let rateID: String
@@ -20,7 +20,7 @@ public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
     public let deliveryDateGuaranteed: Bool
 
     public init(title: String,
-                insurance: Double,
+                insurance: String,
                 retailRate: Double,
                 rate: Double,
                 rateID: String,
@@ -55,7 +55,14 @@ extension ShippingLabelCarrierRate: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let title = try container.decode(String.self, forKey: .title)
-        let insurance = try container.decode(Double.self, forKey: .insurance)
+
+        let insurance: String
+        if let insuranceAmount = try? container.decode(Double.self, forKey: .insurance) {
+            insurance = String(insuranceAmount)
+        } else {
+            insurance = try container.decode(String.self, forKey: .insurance)
+        }
+
         let retailRate = try container.decode(Double.self, forKey: .retailRate)
         let rate = try container.decode(Double.self, forKey: .rate)
         let rateID = try container.decode(String.self, forKey: .rateID)

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -481,7 +481,7 @@ private extension ShippingLabelRemoteTests {
 
     func sampleShippingLabelCarrierRate() -> ShippingLabelCarrierRate {
         let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                            insurance: 0,
+                                            insurance: "0",
                                             retailRate: 40.060000000000002,
                                             rate: 40.060000000000002,
                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ef",

--- a/Networking/NetworkingTests/Responses/shipping-label-carriers-and-rates-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-carriers-and-rates-success.json
@@ -6,7 +6,7 @@
                 "default" : {
                     "rates" : [
                         {
-                            "insurance" : 0,
+                            "insurance" : "0",
                             "retail_rate" : 40.060000000000002,
                             "rate_id" : "rate_a8a29d5f34984722942f466c30ea27ef",
                             "service_id" : "ParcelSelect",
@@ -23,7 +23,7 @@
                             "list_rate" : 40.060000000000002
                         },
                         {
-                            "insurance" : 0,
+                            "insurance" : "0",
                             "retail_rate" : 40.409999999999997,
                             "rate_id" : "rate_99e38b9a69344a51a4fda0c13a0e68b9",
                             "service_id" : "MediaMail",
@@ -40,7 +40,7 @@
                             "list_rate" : 40.409999999999997
                         },
                         {
-                            "insurance" : 100,
+                            "insurance" : "100",
                             "retail_rate" : 47.799999999999997,
                             "rate_id" : "rate_0e21c0f7cff34ababa756a774e01ecdf",
                             "service_id" : "Priority",
@@ -57,7 +57,7 @@
                             "list_rate" : 40.560000000000002
                         },
                         {
-                            "insurance" : 100,
+                            "insurance" : "100",
                             "retail_rate" : 178.19999999999999,
                             "rate_id" : "rate_e066c77d80594d15a131c1af979cd650",
                             "service_id" : "Express",
@@ -81,7 +81,7 @@
                 "signature_required" : {
                     "rates" : [
                         {
-                            "insurance" : 0,
+                            "insurance" : "0",
                             "retail_rate" : 42.759999999999998,
                             "rate_id" : "rate_fcb686579b774c05875676b27e429599",
                             "service_id" : "ParcelSelect",
@@ -105,7 +105,7 @@
                 "adult_signature_required" : {
                     "rates" : [
                         {
-                            "insurance" : 0,
+                            "insurance" : "0",
                             "retail_rate" : 46.960000000000001,
                             "rate_id" : "rate_47603a8870d24d538de806a381b76f7f",
                             "service_id" : "ParcelSelect",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
@@ -146,7 +146,7 @@ struct ShippingLabelCarrierRow_Previews: PreviewProvider {
 
     private static func sampleRate(carrierID: String = "usps", rate: Double = 40.060000000000002) -> ShippingLabelCarrierRate {
         return ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                        insurance: 0,
+                                        insurance: "0",
                                         retailRate: rate,
                                         rate: rate,
                                         rateID: "rate_a8a29d5f34984722942f466c30ea27ef",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -73,10 +73,11 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
             extras.append(String(format: Localization.tracking, rate.carrierID.uppercased()))
         }
 
-        if let doubleInsurance = Double(rate.insurance),
-           doubleInsurance > 0 {
-            let insuranceFormatted = currencyFormatter.formatAmount(Decimal(doubleInsurance)) ?? ""
-            extras.append(String(format: Localization.insuranceAmount, insuranceFormatted))
+        if let doubleInsurance = Double(rate.insurance) {
+            if doubleInsurance > 0 {
+                let insuranceFormatted = currencyFormatter.formatAmount(Decimal(doubleInsurance)) ?? ""
+                extras.append(String(format: Localization.insuranceAmount, insuranceFormatted))
+            }
         } else if rate.insurance.isNotEmpty {
             extras.append(String(format: Localization.insuranceLiteral, rate.insurance))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -72,10 +72,15 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
         if rate.hasTracking {
             extras.append(String(format: Localization.tracking, rate.carrierID.uppercased()))
         }
-        if rate.insurance > 0 {
-            let insuranceFormatted = currencyFormatter.formatAmount(Decimal(rate.insurance)) ?? ""
-            extras.append(String(format: Localization.insurance, insuranceFormatted))
+
+        if let doubleInsurance = Double(rate.insurance),
+           doubleInsurance > 0 {
+            let insuranceFormatted = currencyFormatter.formatAmount(Decimal(doubleInsurance)) ?? ""
+            extras.append(String(format: Localization.insuranceAmount, insuranceFormatted))
+        } else if rate.insurance.isNotEmpty {
+            extras.append(String(format: Localization.insuranceLiteral, rate.insurance))
         }
+
         if rate.isPickupFree {
             extras.append(Localization.freePickup)
         }
@@ -130,8 +135,12 @@ private extension ShippingLabelCarrierRowViewModel {
             NSLocalizedString("%1$d business days", comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let tracking = NSLocalizedString("Includes %1$@ tracking",
                                                 comment: "Includes tracking of a specific carrier in Shipping Labels > Carrier and Rates")
-        static let insurance = NSLocalizedString("Insurance (up to %1$@)",
-                                                 comment: "Includes insurance of a specific carrier in Shipping Labels > Carrier and Rates")
+        static let insuranceLiteral = NSLocalizedString("Insurance (%1$@)",
+                                                        comment: "Includes insurance of a specific carrier in Shipping Labels > Carrier and Rates. " +
+                                                            "Placeholder is a literal, e.g \"limited\"")
+        static let insuranceAmount = NSLocalizedString("Insurance (up to %1$@)",
+                                                       comment: "Includes insurance of a specific carrier in Shipping Labels > Carrier and Rates. " +
+                                                            "Place holder is an amount.")
         static let freePickup = NSLocalizedString("Eligible for free pickup",
                                                   comment: "Carrier eligible for free pickup in Shipping Labels > Carrier and Rates")
         static let signatureRequired = NSLocalizedString("Signature required (+%1$@)",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -56,6 +56,7 @@ struct ShippingLabelCarriers: View {
                                     .frame(width: geometry.size.width)
                             }
                         }
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                         .frame(minHeight: geometry.size.height)
                     default:
                         EmptyView()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
@@ -148,7 +148,7 @@ private extension ShippingLabelCarriersViewModel {
 private extension ShippingLabelCarriersViewModel {
     private func sampleGhostRate() -> ShippingLabelCarrierRate {
         return ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                        insurance: 0,
+                                        insurance: "0",
                                         retailRate: 40.060000000000002,
                                         rate: 40.060000000000002,
                                         rateID: "rate_a8a29d5f34984722942f466c30ea27ef",

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -22,13 +22,15 @@ struct EmptyState: View {
                 .bodyStyle()
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .frame(width: Constants.width, alignment: .center)
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.horizontal, Constants.horizontalSpacing)
     }
 }
 
 private extension EmptyState {
     enum Constants {
         static let verticalSpacing: CGFloat = 16
+        static let horizontalSpacing: CGFloat = 24
         static let width: CGFloat = 168
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -20,6 +20,7 @@ struct EmptyState: View {
             Text(description)
                 .multilineTextAlignment(.center)
                 .bodyStyle()
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(width: Constants.width, alignment: .center)
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockShippingLabelCarrierRate.swift
@@ -6,9 +6,10 @@ import Foundation
 final class MockShippingLabelCarrierRate {
 
     static func makeRate(title: String = "USPS - Parcel Select Mail",
-                         rate: Double = 40.060000000000002) -> ShippingLabelCarrierRate {
+                         rate: Double = 40.060000000000002,
+                         insurance: String = "0") -> ShippingLabelCarrierRate {
         return ShippingLabelCarrierRate(title: title,
-                                        insurance: 0,
+                                        insurance: insurance,
                                         retailRate: rate,
                                         rate: rate,
                                         rateID: "rate_a8a29d5f34984722942f466c30ea27ef",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarriersViewModelTests.swift
@@ -17,33 +17,49 @@ final class ShippingLabelCarriersViewModelTests: XCTestCase {
         viewModel.generateRows(response: sampleShippingLabelCarriersAndRates())
 
         // Then
-        let row = viewModel.rows.first
-        XCTAssertEqual(row?.selected, false)
-        XCTAssertEqual(row?.signatureSelected, false)
-        XCTAssertEqual(row?.adultSignatureSelected, false)
-        XCTAssertEqual(row?.title, "USPS - Parcel Select Mail")
-        XCTAssertEqual(row?.subtitle, "2 business days")
-        XCTAssertEqual(row?.price, "$40.06")
-        XCTAssertEqual(row?.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
-        XCTAssertEqual(row?.extraInfo, "Includes USPS tracking, Eligible for free pickup")
-        XCTAssertEqual(row?.displaySignatureRequired, true)
-        XCTAssertEqual(row?.displayAdultSignatureRequired, true)
-        XCTAssertEqual(row?.signatureRequiredText, "Signature required (+$5.00)")
-        XCTAssertEqual(row?.adultSignatureRequiredText, "Adult signature required (+$10.00)")
+        XCTAssertEqual(viewModel.rows.count, 3)
 
-        let row2 = viewModel.rows.last
-        XCTAssertEqual(row2?.selected, false)
-        XCTAssertEqual(row2?.signatureSelected, false)
-        XCTAssertEqual(row2?.adultSignatureSelected, false)
-        XCTAssertEqual(row2?.title, "UPS")
-        XCTAssertEqual(row2?.subtitle, "2 business days")
-        XCTAssertEqual(row2?.price, "$40.06")
-        XCTAssertEqual(row2?.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
-        XCTAssertEqual(row2?.extraInfo, "Includes USPS tracking, Eligible for free pickup")
-        XCTAssertEqual(row2?.displaySignatureRequired, false)
-        XCTAssertEqual(row2?.displayAdultSignatureRequired, false)
-        XCTAssertEqual(row2?.signatureRequiredText, "")
-        XCTAssertEqual(row2?.adultSignatureRequiredText, "")
+        let row = viewModel.rows[0]
+        XCTAssertEqual(row.selected, false)
+        XCTAssertEqual(row.signatureSelected, false)
+        XCTAssertEqual(row.adultSignatureSelected, false)
+        XCTAssertEqual(row.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(row.subtitle, "2 business days")
+        XCTAssertEqual(row.price, "$40.06")
+        XCTAssertEqual(row.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(row.extraInfo, "Includes USPS tracking, Eligible for free pickup")
+        XCTAssertEqual(row.displaySignatureRequired, true)
+        XCTAssertEqual(row.displayAdultSignatureRequired, true)
+        XCTAssertEqual(row.signatureRequiredText, "Signature required (+$5.00)")
+        XCTAssertEqual(row.adultSignatureRequiredText, "Adult signature required (+$10.00)")
+
+        let row2 = viewModel.rows[1]
+        XCTAssertEqual(row2.selected, false)
+        XCTAssertEqual(row2.signatureSelected, false)
+        XCTAssertEqual(row2.adultSignatureSelected, false)
+        XCTAssertEqual(row2.title, "UPS")
+        XCTAssertEqual(row2.subtitle, "2 business days")
+        XCTAssertEqual(row2.price, "$40.06")
+        XCTAssertEqual(row2.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(row2.extraInfo, "Includes USPS tracking, Insurance (up to $2,500.00), Eligible for free pickup")
+        XCTAssertEqual(row2.displaySignatureRequired, false)
+        XCTAssertEqual(row2.displayAdultSignatureRequired, false)
+        XCTAssertEqual(row2.signatureRequiredText, "")
+        XCTAssertEqual(row2.adultSignatureRequiredText, "")
+
+        let row3 = viewModel.rows[2]
+        XCTAssertEqual(row3.selected, false)
+        XCTAssertEqual(row3.signatureSelected, false)
+        XCTAssertEqual(row3.adultSignatureSelected, false)
+        XCTAssertEqual(row3.title, "UPS")
+        XCTAssertEqual(row3.subtitle, "2 business days")
+        XCTAssertEqual(row3.price, "$40.06")
+        XCTAssertEqual(row3.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(row3.extraInfo, "Includes USPS tracking, Insurance (limited), Eligible for free pickup")
+        XCTAssertEqual(row3.displaySignatureRequired, false)
+        XCTAssertEqual(row3.displayAdultSignatureRequired, false)
+        XCTAssertEqual(row3.signatureRequiredText, "")
+        XCTAssertEqual(row3.adultSignatureRequiredText, "")
     }
 
     func test_isDoneButtonEnabled_returns_the_expected_value() {
@@ -128,10 +144,14 @@ final class ShippingLabelCarriersViewModelTests: XCTestCase {
 
 private extension ShippingLabelCarriersViewModelTests {
     func sampleShippingLabelCarriersAndRates() -> ShippingLabelCarriersAndRates {
-        return ShippingLabelCarriersAndRates(defaultRates: [MockShippingLabelCarrierRate.makeRate(), MockShippingLabelCarrierRate.makeRate(title: "UPS")],
+        return ShippingLabelCarriersAndRates(defaultRates: [
+                                                MockShippingLabelCarrierRate.makeRate(),
+                                                MockShippingLabelCarrierRate.makeRate(title: "UPS", insurance: "2500"),
+                                                MockShippingLabelCarrierRate.makeRate(title: "UPS", insurance: "limited")],
                                              signatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "USPS - Parcel Select Mail",
                                                                                                        rate: 45.060000000000002)],
-                                             adultSignatureRequired: [MockShippingLabelCarrierRate.makeRate(title: "USPS - Parcel Select Mail",
+                                             adultSignatureRequired:
+                                                [MockShippingLabelCarrierRate.makeRate(title: "USPS - Parcel Select Mail",
                                                                                                             rate: 50.060000000000002)])
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -997,7 +997,7 @@ private extension ShippingLabelStoreTests {
 
     func sampleShippingLabelCarrierRate() -> ShippingLabelCarrierRate {
         let rate = ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                            insurance: 0,
+                                            insurance: "0",
                                             retailRate: 40.060000000000002,
                                             rate: 40.060000000000002,
                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ef",


### PR DESCRIPTION
Fixes #4830 
⚠️ Testing for this PR requires that customs form validation is complete. So please make sure that #4829  is merged before this! ⚠️

# Description
Currently `ShippingLabelCarrierRate` view model is checking for insurance as a Double. However there are cases that this value can be returned as a string (e.g "limited") - making the parsing to fail and therefore unable to load the carrier and rate list.

This PR updates the parsing to check for both double and string values, and also fix clipped message on the empty state screen as found when the carrier and rate list is empty.

# Changes
- Made `insurance` property of `ShippingLabelCarrierRate` a string, and check for value of both types Double and String. If a double value is found, the value is converted to string.
- Updated view model for Carriers and Rates view to display insurance as before if possible, otherwise render the string value as is.
- Updated unit tests related to carriers and rates in WooCommerce and Networking frameworks.
- Fixed `EmptyState` view to display full length of message.

# Screenshots
| Empty list | List with data |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/130029621-7b35f235-a516-4d13-97a9-a448df1e21ad.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/130018713-20d4b8e7-f8b3-4771-84c4-cf1880d0da1b.png" width=400 /> |

# Testing steps
1. Make sure that your test store is eligible for creating shipping labels (has WCShip plugin installed and packages configured in WP Admin > WooCommerce > Settings > Shipping > Woocommerce Shipping).
2. Create an order that requires international shipping (origin country different from destination country).
3. Open app, navigate to Orders tab and select the created order.
4. Select Create Shipping Label.
5. Skip through Ship From and Ship To.
6. In Package Details, select a custom package or DHL package.
7. Skip through Customs (using default configs).
8. In Carriers and Rates screen, notice that the list is loaded properly. The row for DHL should display insurance as "(limited)".
9. For the fix of the empty state screen, turn off wifi before loading carriers and rates. After around 1 minute the empty state screen should display - notice that the text is not clipped off. Please test with iPhone 12 (or Pro) in simulator or device to make sure since this is where the error was found.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
