### PR TITLE
[Mobile Payments] [Reader Updates] Add checkForCardReaderUpdate to CardReaderSettingsConnectedViewModel

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
+++ b/Hardware/Hardware/CardReader/CardReaderSoftwareUpdate.swift
@@ -1,5 +1,10 @@
 /// A struct representing a reader update.
 public struct CardReaderSoftwareUpdate {
+    public init(estimatedUpdateTime: UpdateTimeEstimate, deviceSoftwareVersion: String) {
+        self.estimatedUpdateTime = estimatedUpdateTime
+        self.deviceSoftwareVersion = deviceSoftwareVersion
+    }
+
     /// The estimated amount of time for the update.
     public let estimatedUpdateTime: UpdateTimeEstimate
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -10,6 +10,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var didGetConnectedReaders: Bool = false
     private var connectedReaders = [CardReader]()
     private let knownReadersProvider: CardReaderSettingsKnownReadersProvider?
+    private(set) var readerUpdateAvailable: CardReaderSettingsTriState = .isUnknown
 
     var connectedReaderID: String?
     var connectedReaderBatteryLevel: String?
@@ -54,6 +55,22 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         let batteryLevelPercent = Int(100 * batteryLevel)
         let batteryLevelString = NumberFormatter.localizedString(from: batteryLevelPercent as NSNumber, number: .decimal)
         connectedReaderBatteryLevel = String.localizedStringWithFormat(Localization.batteryLabelFormat, batteryLevelString)
+    }
+
+    /// Dispatch a request to check for reader updates
+    ///
+    func checkForCardReaderUpdate() {
+        let action = CardPresentPaymentAction.checkForCardReaderUpdate() { [weak self] result in
+            switch result {
+            case .success(let update):
+                self?.readerUpdateAvailable = update != nil ? .isTrue : .isFalse
+            case .failure(_):
+                DDLogError("Unexpected error when checking for reader update")
+                self?.readerUpdateAvailable = .isFalse
+            }
+            self?.didUpdate?()
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Dispatch a request to disconnect from a reader

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -64,7 +64,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
             switch result {
             case .success(let update):
                 self?.readerUpdateAvailable = update != nil ? .isTrue : .isFalse
-            case .failure(_):
+            case .failure:
                 DDLogError("Unexpected error when checking for reader update")
                 self?.readerUpdateAvailable = .isFalse
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -61,14 +61,17 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     ///
     func checkForCardReaderUpdate() {
         let action = CardPresentPaymentAction.checkForCardReaderUpdate() { [weak self] result in
+            guard let self = self else {
+                return
+            }
             switch result {
             case .success(let update):
-                self?.readerUpdateAvailable = update != nil ? .isTrue : .isFalse
+                self.readerUpdateAvailable = update != nil ? .isTrue : .isFalse
             case .failure:
                 DDLogError("Unexpected error when checking for reader update")
-                self?.readerUpdateAvailable = .isFalse
+                self.readerUpdateAvailable = .isFalse
             }
-            self?.didUpdate?()
+            self.didUpdate?()
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -36,4 +36,82 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    func test_checkForCardReaderUpdate_properly_handles_update_available() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            readerUpdateAvailable: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+
+        viewModel.didUpdate = {
+            if viewModel.readerUpdateAvailable == .isTrue {
+                expectation.fulfill()
+            }
+        }
+
+        // When
+        viewModel.checkForCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_checkForCardReaderUpdate_properly_handles_update_not_available() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            readerUpdateAvailable: false
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+
+        viewModel.didUpdate = {
+            if viewModel.readerUpdateAvailable == .isFalse {
+                expectation.fulfill()
+            }
+        }
+
+        // When
+        viewModel.checkForCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_checkForCardReaderUpdate_properly_handles_update_check_failure() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            failReaderUpdateCheck: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+
+        viewModel.didUpdate = {
+            if viewModel.readerUpdateAvailable == .isFalse {
+                expectation.fulfill()
+            }
+        }
+
+        // When
+        viewModel.checkForCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }


### PR DESCRIPTION
Partially addresses #4059 

Changes:
- This is the next PR to bring the card reader software updates to life
- It adds checkForCardReaderUpdate to CardReaderSettingsConnectedViewModel but does not connect it to anything user facing. That will come in an upcoming PR
- Also adds readerUpdateAvailable which the VC will be able to use to know when to show the update button
- Because nothing user facing is added by this PR ( and in fact outside of the unit tests, checkForCardReaderUpdate is not called ) there is no need to gate this particular change behind the feature flag being added in #4836 

To test:
- Ensure all the new unit tests added pass

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
