### PR TITLE
[CPP Onboarding] Remove feature flag for In-Person Payments Onboarding

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -17,8 +17,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsMultiPackage:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .cardPresentOnboarding:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -38,10 +38,6 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsMultiPackage
 
-    /// Card-Present Payments Onboarding
-    ///
-    case cardPresentOnboarding
-
     /// Editing of notes, shipping, and billing addresses.
     ///
     case orderEditing

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -209,9 +209,6 @@ private extension SettingsViewController {
     private var storeSettingsRows: [Row] {
         var result = [Row]()
         if canCollectPayments {
-            result.append(.cardReadersV2)
-        }
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentOnboarding) {
             result.append(.inPersonPayments)
         }
         return result

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -333,8 +333,6 @@ private extension SettingsViewController {
             configurePlugins(cell: cell)
         case let cell as BasicTableViewCell where row == .support:
             configureSupport(cell: cell)
-        case let cell as BasicTableViewCell where row == .cardReadersV2:
-            configureCardReadersV2(cell: cell)
         case let cell as BasicTableViewCell where row == .inPersonPayments:
             configureInPersonPayments(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
@@ -381,12 +379,6 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Help & Support", comment: "Contact Support Action")
-    }
-
-    func configureCardReadersV2(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Manage Card Reader", comment: "Navigates to Card Reader management screen")
     }
 
     func configureInPersonPayments(cell: BasicTableViewCell) {
@@ -526,17 +518,6 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: HelpAndSupportViewController.self) else {
             fatalError("Cannot instantiate `HelpAndSupportViewController` from Dashboard storyboard")
         }
-        show(viewController, sender: self)
-    }
-
-    func cardReadersV2WasPressed() {
-        ServiceLocator.analytics.track(.settingsCardReadersTapped)
-        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
-            fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
-        }
-
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
-        viewController.configure(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
     }
 
@@ -680,8 +661,6 @@ extension SettingsViewController: UITableViewDelegate {
             sitePluginsWasPressed()
         case .support:
             supportWasPressed()
-        case .cardReadersV2:
-            cardReadersV2WasPressed()
         case .inPersonPayments:
             inPersonPaymentsWasPressed()
         case .privacy:
@@ -725,7 +704,6 @@ private enum Row: CaseIterable {
     case switchStore
     case plugins
     case support
-    case cardReadersV2
     case inPersonPayments
     case logout
     case privacy
@@ -745,8 +723,6 @@ private enum Row: CaseIterable {
         case .plugins:
             return BasicTableViewCell.self
         case .support:
-            return BasicTableViewCell.self
-        case .cardReadersV2:
             return BasicTableViewCell.self
         case .inPersonPayments:
             return BasicTableViewCell.self


### PR DESCRIPTION
Closes #4838 

This PR removes the feature flag for onboarding into In-Person Payments. The feature is still available only for stores gated into the beta.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/130130582-965d8deb-3746-482a-b1ad-a20a98e8b2a0.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/130130608-3c938047-c4ff-4a35-8ae9-12f6506d543b.png" width="350"/> |

## Changes
* Remove the feature flag.Bye!

## How to test
* On a store that is gated into In-Person Payments, navigate to Settings. Notice the previous "Manage Card Reader" entry is gone, and now it should read "In-Person Payments"
* Test that it is still possible to connect to a card reader
* Switch to a Store that is not gated into In-Person Payments. Navigate to Settings Check that "In-Person Payments" is not visible

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
