### PR TITLE
Order Editing: Adds Edit Note UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -45,6 +45,7 @@ struct EditCustomerNote: View {
                     }
                 }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -18,7 +18,8 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
 struct EditCustomerNote: View {
     var body: some View {
         NavigationView {
-            Text("Empty")
+            TextEditor(text: .constant("Placeholder"))
+                .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationBarItems(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -1,1 +1,30 @@
 import Foundation
+import SwiftUI
+
+/// Hosting controller that wraps an `EditCustomerNote` view.
+///
+final class EditCustomerNoteHostingController: UIHostingController<EditCustomerNote> {
+    init() {
+        super.init(rootView: EditCustomerNote())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Allows merchant to edit the customer provided note of an order.
+///
+struct EditCustomerNote: View {
+    var body: some View {
+        Text("Empty")
+    }
+}
+
+// MARK: Previews
+struct EditCustomerNote_Previews: PreviewProvider {
+    static var previews: some View {
+        EditCustomerNote()
+            .environment(\.colorScheme, .light)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -22,15 +22,13 @@ struct EditCustomerNote: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
+                .navigationBarItems(trailing: Button(Localization.done) { // I couldn't find a way to make the "Done" button bold using a toolbar :-(
+                    print("Done tapped")
+                })
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(Localization.cancel) {
                             print("Cancel tapped")
-                        }
-                    }
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button(Localization.done) {
-                            print("Done tapped")
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -17,6 +17,9 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
 ///
 struct EditCustomerNote: View {
 
+    // Needed to auto-dismiss the view
+    @Environment(\.presentationMode) var presentationMode
+
     // TODO: Replace with view model backed value
     @State private var textContent = "Tap and edit me"
 
@@ -33,8 +36,7 @@ struct EditCustomerNote: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(Localization.cancel) {
-                            // TODO: Dismiss
-                            print("Cancel tapped")
+                            presentationMode.wrappedValue.dismiss()
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -17,7 +17,28 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
 ///
 struct EditCustomerNote: View {
     var body: some View {
-        Text("Empty")
+        NavigationView {
+            Text("Empty")
+                .navigationTitle(Localization.title)
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationBarItems(
+                    leading: Button(Localization.cancel) {
+                        print("Cancel tapped")
+                    },
+                    trailing: Button(Localization.done) {
+                        print("Done tapped")
+                    }
+                )
+        }
+    }
+}
+
+// MARK: Constants
+private extension EditCustomerNote {
+    enum Localization {
+        static let title = NSLocalizedString("Edit Note", comment: "Title for the edit customer provided note screen")
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the edit customer provided note screen")
+        static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the edit customer provided note screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -16,18 +16,24 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
 /// Allows merchant to edit the customer provided note of an order.
 ///
 struct EditCustomerNote: View {
+
+    // TODO: Replace with view model backed value
+    @State private var textContent = "Tap and edit me"
+
     var body: some View {
         NavigationView {
-            TextEditor(text: .constant("Placeholder"))
+            TextEditor(text: $textContent)
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationBarItems(trailing: Button(Localization.done) { // I couldn't find a way to make the "Done" button bold using a toolbar :-(
+                    // TODO: submit done action
                     print("Done tapped")
                 })
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(Localization.cancel) {
+                            // TODO: Dismiss
                             print("Cancel tapped")
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -22,14 +22,18 @@ struct EditCustomerNote: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(
-                    leading: Button(Localization.cancel) {
-                        print("Cancel tapped")
-                    },
-                    trailing: Button(Localization.done) {
-                        print("Done tapped")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(Localization.cancel) {
+                            print("Cancel tapped")
+                        }
                     }
-                )
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button(Localization.done) {
+                            print("Done tapped")
+                        }
+                    }
+                }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -6,6 +6,11 @@ import SwiftUI
 final class EditCustomerNoteHostingController: UIHostingController<EditCustomerNote> {
     init() {
         super.init(rootView: EditCustomerNote())
+
+        // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -17,8 +22,9 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
 ///
 struct EditCustomerNote: View {
 
-    // Needed to auto-dismiss the view
-    @Environment(\.presentationMode) var presentationMode
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
 
     // TODO: Replace with view model backed value
     @State private var textContent = "Tap and edit me"
@@ -35,9 +41,7 @@ struct EditCustomerNote: View {
                 })
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
-                        Button(Localization.cancel) {
-                            presentationMode.wrappedValue.dismiss()
-                        }
+                        Button(Localization.cancel, action: dismiss)
                     }
                 }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -518,8 +518,7 @@ private extension OrderDetailsViewController {
         case let .viewAddOns(addOns):
             itemAddOnsButtonTapped(addOns: addOns)
         case .editCustomerNote:
-            // TODO: Navigate to edit customer note
-            print("Edit Note Tapped")
+            editCustomerNoteTapped()
         }
     }
 
@@ -638,6 +637,11 @@ private extension OrderDetailsViewController {
         popoverController?.sourceView = sourceView
 
         present(actionSheet, animated: true)
+    }
+
+    func editCustomerNoteTapped() {
+        let editNoteViewController = EditCustomerNoteHostingController()
+        present(editNoteViewController, animated: true, completion: nil)
     }
 
     @objc private func collectPayment(at: IndexPath) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -424,6 +424,7 @@
 		2688642125D323C600821BA5 /* EditAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2688642025D323C600821BA5 /* EditAttributesViewController.xib */; };
 		2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */; };
 		2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */; };
+		268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1787,6 +1788,7 @@
 		2688642025D323C600821BA5 /* EditAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditAttributesViewController.xib; sourceTree = "<group>"; };
 		2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModel.swift; sourceTree = "<group>"; };
 		2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModelTests.swift; sourceTree = "<group>"; };
+		268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNote.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -3748,6 +3750,14 @@
 			path = "Issue Refund";
 			sourceTree = "<group>";
 		};
+		268EC45D26CEA4E500716F5C /* Customer Note */ = {
+			isa = PBXGroup;
+			children = (
+				268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */,
+			);
+			path = "Customer Note";
+			sourceTree = "<group>";
+		};
 		26A630F8253F62AD00CBC3B1 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -5600,6 +5610,7 @@
 				45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */,
 				CE1EC8EF20B8A408009762BF /* OrderNoteTableViewCell.swift */,
 				CE1EC8EE20B8A408009762BF /* OrderNoteTableViewCell.xib */,
+				268EC45D26CEA4E500716F5C /* Customer Note */,
 				CE35F10B2343E55B007B2A6B /* Add Order Note */,
 			);
 			path = "Order Notes Section";
@@ -7190,6 +7201,7 @@
 				0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */,
 				E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */,
 				027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */,
+				268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,
 				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
 				0279F0DA252DB4BE0098D7DE /* ProductVariationDetailsFactory.swift in Sources */,


### PR DESCRIPTION
closes #4776

# Why

#4775 implemented the button to trigger editing the customer provider note, this PR creates the UI for merchants to edit that note.

# How 

Simple `SwiftUI` with a navigation bar and a text editor that is presented via a `UIHostingController`

* A few hacks had to be applied that are explained in comments :-(

# Demo

https://user-images.githubusercontent.com/562080/130144215-f549fcb2-a191-4502-a427-7af68c5d9c0d.mov

# Testing Steps

- Launch the app and navigate to any order
- Tap on the edit customer provided note button
- See that a UI is presented where you can edit the note and the cancel button dismisses the view


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
