### PR TITLE
[Mobile Payments] [Reader Updates] Connect VC to VM, add prompt and button if update available

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -53,7 +53,7 @@ public protocol CardReaderService {
     func cancelPaymentIntent() -> Future<Void, Error>
 
     /// Checks for firmware updates.
-    func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error>
+    func checkForUpdate() -> Future<CardReaderSoftwareUpdate?, Error>
 
     /// Triggers a software update. This method requires that checkForUpdates
     /// has been completed successfully

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -302,7 +302,7 @@ extension StripeCardReaderService: CardReaderService {
         }
     }
 
-    public func checkForUpdate() -> Future<CardReaderSoftwareUpdate, Error> {
+    public func checkForUpdate() -> Future<CardReaderSoftwareUpdate?, Error> {
         return Future() { promise in
             Terminal.shared.checkForUpdate { [weak self] (softwareUpdate, error) in
                 guard let self = self else {
@@ -319,6 +319,10 @@ extension StripeCardReaderService: CardReaderService {
                     self.pendingSoftwareUpdate = softwareUpdate
                     let update = CardReaderSoftwareUpdate(update: softwareUpdate)
                     promise(.success(update))
+                } else {
+                    // There is no software update available
+                    self.pendingSoftwareUpdate = nil
+                    promise(.success(nil))
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -123,7 +123,10 @@ private extension CardReaderSettingsConnectedViewController {
     private func configureUpdatePrompt(cell: LeftImageTableViewCell) {
         cell.configure(image: .infoOutlineImage, text: Localization.updatePromptText)
         cell.selectionStyle = .none
-        cell.backgroundColor = .warning
+        cell.backgroundColor = .warningBackground
+        cell.imageView?.tintColor = .warning
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.textColor = .text
     }
 
     private func configureConnectedReader(cell: ConnectedReaderTableViewCell) {
@@ -140,6 +143,7 @@ private extension CardReaderSettingsConnectedViewController {
             // TODO in a following PR
         }
         cell.selectionStyle = .none
+        cell.backgroundColor = .clear
     }
 
     private func configureDisconnectButton(cell: ButtonTableViewCell) {
@@ -148,6 +152,7 @@ private extension CardReaderSettingsConnectedViewController {
             self?.viewModel?.disconnectReader()
         }
         cell.selectionStyle = .none
+        cell.backgroundColor = .clear
     }
 }
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -196,11 +196,8 @@ private extension CardPresentPaymentStore {
     func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
         cardReaderService.checkForUpdate()
             .subscribe(Subscribers.Sink { value in
-                switch value {
-                case .failure(let error):
+                if case .failure(let error) = value {
                     onCompletion(.failure(error))
-                case .finished:
-                    onCompletion(.success(nil))
                 }
             } receiveValue: {softwareUpdate in
                 onCompletion(.success(softwareUpdate))

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -195,13 +195,18 @@ private extension CardPresentPaymentStore {
 
     func checkForCardReaderUpdate(onCompletion: @escaping (Result<CardReaderSoftwareUpdate?, Error>) -> Void) {
         cardReaderService.checkForUpdate()
-            .subscribe(Subscribers.Sink { value in
-                if case .failure(let error) = value {
-                    onCompletion(.failure(error))
-                }
-            } receiveValue: {softwareUpdate in
-                onCompletion(.success(softwareUpdate))
-            })
+            .sink(
+                // If the future is a failure, it will only fire receiveCompletion
+                receiveCompletion: { value in
+                    if case .failure(let error) = value {
+                        onCompletion(.failure(error))
+                    }
+                },
+                // If the future is a success, it will fire receiveValue and receiveCompletion
+                receiveValue: { softwareUpdate in
+                    onCompletion(.success(softwareUpdate))
+                })
+            .store(in: &cancellables)
     }
 
     func startCardReaderUpdate(onProgress: @escaping (Float) -> Void,

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -201,11 +201,15 @@ private extension CardPresentPaymentStore {
                     if case .failure(let error) = value {
                         onCompletion(.failure(error))
                     }
+
                 },
                 // If the future is a success, it will fire receiveValue and receiveCompletion
                 receiveValue: { softwareUpdate in
                     onCompletion(.success(softwareUpdate))
                 })
+            // Note: We don't need to explicitly call cancel on this subscription since
+            // when the publisher completes, cancel will be called for us, and a Future
+            // completes after fulfilling its promise.
             .store(in: &cancellables)
     }
 

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -235,4 +235,83 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         XCTAssertTrue(mockCardReaderService.didHitDisconnect)
     }
+
+    func test_checkForUpdate_returns_success_and_update_when_there_is_an_update() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        mockCardReaderService.hasReaderUpdate = true
+        mockCardReaderService.shouldFailReaderUpdateCheck = false
+
+        let action = CardPresentPaymentAction.checkForCardReaderUpdate(onCompletion: { result in
+            if case .success(let update) = result {
+                if update != nil {
+                    expectation.fulfill()
+                }
+            }
+        })
+
+        // When
+        cardPresentStore.onAction(action)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_checkForUpdate_returns_success_and_nil_when_there_is_no_update() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        mockCardReaderService.hasReaderUpdate = false
+        mockCardReaderService.shouldFailReaderUpdateCheck = false
+
+        let action = CardPresentPaymentAction.checkForCardReaderUpdate(onCompletion: { result in
+            if case .success(let update) = result {
+                if update == nil {
+                    expectation.fulfill()
+                }
+            }
+        })
+
+        // When
+        cardPresentStore.onAction(action)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_checkForUpdate_returns_failure_when_an_error_occurs() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        mockCardReaderService.hasReaderUpdate = false
+        mockCardReaderService.shouldFailReaderUpdateCheck = true
+
+        let action = CardPresentPaymentAction.checkForCardReaderUpdate(onCompletion: { result in
+            if case .failure(_) = result {
+                expectation.fulfill()
+            }
+        })
+
+        // When
+        cardPresentStore.onAction(action)
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }


### PR DESCRIPTION
Ready for Review

Partially addresses #4059 

Note:
- Don't worry - although this PR detects whether your reader needs an update, it DOES NOT DO THE UPDATE

Changes:
- Kick off checkForCardReaderUpdate when view loads if feature flag is set
- Adds the top row and the button when viewModel readerUpdateAvailable is true
- Adds cell with prompt
- Adds button - doesn’t do anything yet
- Tweaks the CardReaderService protocol checkForUpdate to make CardReaderSoftwareUpdate an optional... I did this because the Stripe Terminal SDK will return a nil if there is no error and no update available and I had assumed this was also how our service worked, which was incorrect
- Tweaks the StripeCardReaderService to properly handle that success nil case
- Tweaks the CardPresentPaymentStore checkForUpdate publisher - it was firing twice because of the use of finished, and that finished was passing success(nil) which should indicate no update available

To test:
- In light mode and in dark mode...
- Tap on Settings (Gear) > In-Person Payments > Manage card reader
- Turn on a reader that needs a software update and connect to it
- A few seconds after connecting, the call to Stripe's servers will complete and display that a reader update is available and give a button to kick it off
- Pressing the button has no effect - that will come in a later PR

![update](https://user-images.githubusercontent.com/1595739/130159134-23ccbb8c-bc7f-4fea-b41a-4c6461895506.gif)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
