### PR TITLE
Shipping Labels: Fix issue Shipping Adress screen being pushed twice when address name is missing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix: The refund button within Order Details will be hidden if the refund is zero. [https://github.com/woocommerce/woocommerce-ios/pull/4789]
 - [*] Fix: Incorrect arrow direction for right-to-left languages on Shipping Label flow. [https://github.com/woocommerce/woocommerce-ios/pull/4796]
 - [*] Fix: Shouldn't be able to schedule a sale without sale price. [https://github.com/woocommerce/woocommerce-ios/pull/4825]
+- [*] Fix: Edit address screen is pushed twice in Shipping Label flow when missing name in origin or destination address. [https://github.com/woocommerce/woocommerce-ios/pull/4845]
 
 7.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -652,9 +652,10 @@ extension ShippingLabelFormViewModel {
         // Validate name field locally before validating the address remotely.
         // The name field cannot be empty when creating a shipping label, but this is not part of the remote validation.
         // See: https://github.com/Automattic/woocommerce-services/issues/2457
-        if address.name.isEmpty {
+        guard address.name.isNotEmpty else {
             let missingNameError = ShippingLabelAddressValidationError(addressError: nil, generalError: "Name is required")
             onCompletion?(.validationError(missingNameError), nil)
+            return
         }
 
         updateValidatingAddressState(true, type: type)


### PR DESCRIPTION
Closes #4701 

# Description
Currently when either origin or destination address doesn't have a name, tapping on Continue button of Ship From / Ship To row in Shipping Label form will push to Edit Address screen twice. This PR aims to fix that issue.

# Changes
- In `validatedAddress` method we're sending a callback with error if address name is missing. This local check was updated to a `guard` instead of `if`, and return early after sending callback to avoid triggering the remote validation action.
- Updated unit tests to check for triggering of the validation action.

# Demo
![edit-address](https://user-images.githubusercontent.com/5533851/130182571-2feeba53-353f-4631-aebd-9d74408602b5.gif)

# Testing
1. Make sure that your test store is eligible for creating shipping labels (has WCShip plugin installed).
2. Create an order with at least one physical item and no name on the shipping address.
3. Navigate to Orders tab on the app and select the new order.
4. Select Create Shipping Label and skip through Ship From.
5. Tap Continue on Ship To, notice that the Edit Address screen is pushed immediately, with no loading state before that. Wait for around 1 second to see that no extra screen is pushed after that.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
