### PR TITLE
Show percentage options with percentage sign

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnViewModel.swift
@@ -92,8 +92,19 @@ extension ProductAddOnViewModel {
                 return nil
             }
             return Option(name: option.label ?? "",
-                          price: currencyFormatter.formatAmount(option.price ?? "") ?? "",
+                          price: ProductAddOnViewModel.formatPrice(option: option, currencyFormatter: currencyFormatter),
                           offSetDivider: index < (addOn.options.count - 1))
+        }
+    }
+
+    /// Returns the option price with specific format depending on its price type.
+    ///
+    private static func formatPrice(option: ProductAddOnOption, currencyFormatter: CurrencyFormatter) -> String {
+        switch option.priceType {
+        case .percentageBased:
+            return "\(option.price ?? "")%"
+        default:
+            return currencyFormatter.formatAmount(option.price ?? "") ?? ""
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Addons/ProductAddOnViewModelTests.swift
@@ -89,4 +89,22 @@ class ProductAddOnViewModelTests: XCTestCase {
         ])
         assertEqual(viewModel, expected)
     }
+
+    func test_percentage_options_are_properly_formatted_from_entity() {
+        // Given
+        let productAddOn = Yosemite.ProductAddOn.fake().copy(name: "Name", description: "Description", price: "20.0", options: [
+            ProductAddOnOption.fake().copy(label: "Option 1", price: "9", priceType: .percentageBased),
+            ProductAddOnOption.fake().copy(label: "Option 2", price: "5.3", priceType: .percentageBased),
+        ])
+
+        // When
+        let viewModel = ProductAddOnViewModel(addOn: productAddOn, currencyFormatter: currencyFormatter)
+
+        // Then
+        let expected = ProductAddOnViewModel(name: "Name", description: "Description", price: "$20.00", options: [
+            .init(name: "Option 1", price: "9%", offSetDivider: true),
+            .init(name: "Option 2", price: "5.3%", offSetDivider: false),
+        ])
+        assertEqual(viewModel, expected)
+    }
 }


### PR DESCRIPTION
fix #4842 

# Why

It was reported that when having a multiple option add-ons, if one of those options was percentage-based, the app displays that percentage formatted as a currency.

Core | App
--- | ---
<img width="611" alt="core-2" src="https://user-images.githubusercontent.com/562080/130240412-2f73306f-3385-4355-a09d-13d464c5bbce.png"> | <img width="384" alt="before" src="https://user-images.githubusercontent.com/562080/130240250-41c2060c-0742-47b8-b281-b8cd2799537d.png">

# How

This PR fixes that issue by applying a percentage symbol, instead of the currency symbol, when the add-on has a `.percentageBased` price type.

# Screenshots

<img width="381" alt="after" src="https://user-images.githubusercontent.com/562080/130240724-72416f5a-33db-40c7-9dfc-b8bd7bd82464.png">

# Testing Steps

- Make sure to set a product with add-ons when one of them has percentage based options
- Launch the app and navigate to that product (make sure the exp feature is enabled)
- Tap on the add-on button
- See the percentage-based option rendered with a percentage symbol.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
