### PR TITLE
Shipping Labels: Custom package form validation (part 2)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -65,12 +65,6 @@ struct ShippingLabelCustomPackageForm: View {
                                              text: $viewModel.packageLength,
                                              symbol: viewModel.lengthUnit,
                                              keyboardType: .decimalPad)
-                            .onReceive(Just(viewModel.packageLength), perform: { newValue in
-                                let sanitized = viewModel.sanitizeNumericInput(newValue)
-                                if sanitized != newValue {
-                                    viewModel.packageLength = sanitized
-                                }
-                            })
                         Divider()
                             .padding(.leading, Constants.horizontalPadding)
                     }
@@ -92,13 +86,6 @@ struct ShippingLabelCustomPackageForm: View {
                                              text: $viewModel.packageWidth,
                                              symbol: viewModel.lengthUnit,
                                              keyboardType: .decimalPad)
-                            .onReceive(Just(viewModel.packageWidth), perform: { newValue in
-                                let sanitized = viewModel.sanitizeNumericInput(newValue)
-                                if sanitized != newValue {
-                                    viewModel.packageWidth = sanitized
-                                }
-                            })
-
                         Divider()
                             .padding(.leading, Constants.horizontalPadding)
                     }
@@ -114,21 +101,13 @@ struct ShippingLabelCustomPackageForm: View {
                     .renderedIf(!viewModel.isWidthValidated)
 
                     // Package height
-                    VStack(spacing: 0) {
-                        TitleAndTextFieldRow(title: Localization.heightLabel,
-                                             placeholder: "0",
-                                             text: $viewModel.packageHeight,
-                                             symbol: viewModel.lengthUnit,
-                                             keyboardType: .decimalPad)
-                            .onReceive(Just(viewModel.packageHeight), perform: { newValue in
-                                let sanitized = viewModel.sanitizeNumericInput(newValue)
-                                if sanitized != newValue {
-                                    viewModel.packageHeight = sanitized
-                                }
-                            })
-                    }
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
+                    TitleAndTextFieldRow(title: Localization.heightLabel,
+                                         placeholder: "0",
+                                         text: $viewModel.packageHeight,
+                                         symbol: viewModel.lengthUnit,
+                                         keyboardType: .decimalPad)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()
                     ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.packageHeight))
                         .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
@@ -144,12 +123,6 @@ struct ShippingLabelCustomPackageForm: View {
                                          text: $viewModel.emptyPackageWeight,
                                          symbol: viewModel.weightUnit,
                                          keyboardType: .decimalPad)
-                        .onReceive(Just(viewModel.emptyPackageWeight), perform: { newValue in
-                            let sanitized = viewModel.sanitizeNumericInput(newValue)
-                            if sanitized != newValue {
-                                viewModel.emptyPackageWeight = sanitized
-                            }
-                        })
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -48,7 +48,9 @@ struct ShippingLabelCustomPackageForm: View {
                     .padding(.horizontal, insets: safeAreaInsets)
                     .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()
-                    validationErrorRow
+                    ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.packageName))
+                        .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .renderedIf(!viewModel.isNameValidated)
                 }
 
@@ -75,11 +77,12 @@ struct ShippingLabelCustomPackageForm: View {
                     .padding(.horizontal, insets: safeAreaInsets)
                     .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     VStack(spacing: 0) {
-                        validationErrorRow
+                        ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.packageLength))
+                            .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
                         Divider()
-                            .padding(.horizontal, insets: safeAreaInsets)
                             .padding(.leading, Constants.horizontalPadding)
                     }
+                    .padding(.horizontal, insets: safeAreaInsets)
                     .renderedIf(!viewModel.isLengthValidated)
 
                     // Package width
@@ -102,11 +105,12 @@ struct ShippingLabelCustomPackageForm: View {
                     .padding(.horizontal, insets: safeAreaInsets)
                     .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     VStack(spacing: 0) {
-                        validationErrorRow
+                        ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.packageWidth))
+                            .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
                         Divider()
-                            .padding(.horizontal, insets: safeAreaInsets)
                             .padding(.leading, Constants.horizontalPadding)
                     }
+                    .padding(.horizontal, insets: safeAreaInsets)
                     .renderedIf(!viewModel.isWidthValidated)
 
                     // Package height
@@ -126,7 +130,9 @@ struct ShippingLabelCustomPackageForm: View {
                     .padding(.horizontal, insets: safeAreaInsets)
                     .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()
-                    validationErrorRow
+                    ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.packageHeight))
+                        .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .renderedIf(!viewModel.isHeightValidated)
                 }
 
@@ -147,7 +153,9 @@ struct ShippingLabelCustomPackageForm: View {
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()
-                    validationErrorRow
+                    ValidationErrorRow(errorMessage: Localization.getErrorMessage(for: viewModel.emptyPackageWeight))
+                        .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .renderedIf(!viewModel.isWeightValidated)
                     ListHeaderView(text: Localization.weightFooter, alignment: .left)
                         .padding(.horizontal, insets: safeAreaInsets)
@@ -167,12 +175,6 @@ struct ShippingLabelCustomPackageForm: View {
                 })
             })
         }
-    }
-
-    private var validationErrorRow: some View {
-        ValidationErrorRow(errorMessage: Localization.validationError)
-            .background(Color(.listBackground).ignoresSafeArea(.container, edges: .horizontal))
-            .padding(.horizontal, insets: safeAreaInsets)
     }
 }
 
@@ -208,9 +210,19 @@ private extension ShippingLabelCustomPackageForm {
         static let weightFooter = NSLocalizedString(
             "Weight of empty package",
             comment: "Footer text for the empty package weight on the Add New Custom Package screen in Shipping Label flow")
-        static let validationError = NSLocalizedString(
+        static func getErrorMessage(for input: String) -> String {
+            if input.isEmpty {
+                return inputMissingError
+            } else {
+                return inputInvalidError
+            }
+        }
+        static let inputMissingError = NSLocalizedString(
             "This field is required",
             comment: "Error for missing package details on the Add New Custom Package screen in Shipping Label flow")
+        static let inputInvalidError = NSLocalizedString(
+            "Invalid value",
+            comment: "Error for invalid package details on the Add New Custom Package screen in Shipping Label flow")
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Custom Package screen in Shipping Label flow")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -63,6 +63,12 @@ struct ShippingLabelCustomPackageForm: View {
                                              text: $viewModel.packageLength,
                                              symbol: viewModel.lengthUnit,
                                              keyboardType: .decimalPad)
+                            .onReceive(Just(viewModel.packageLength), perform: { newValue in
+                                let sanitized = viewModel.sanitizeNumericInput(newValue)
+                                if sanitized != newValue {
+                                    viewModel.packageLength = sanitized
+                                }
+                            })
                         Divider()
                             .padding(.leading, Constants.horizontalPadding)
                     }
@@ -83,6 +89,12 @@ struct ShippingLabelCustomPackageForm: View {
                                              text: $viewModel.packageWidth,
                                              symbol: viewModel.lengthUnit,
                                              keyboardType: .decimalPad)
+                            .onReceive(Just(viewModel.packageWidth), perform: { newValue in
+                                let sanitized = viewModel.sanitizeNumericInput(newValue)
+                                if sanitized != newValue {
+                                    viewModel.packageWidth = sanitized
+                                }
+                            })
 
                         Divider()
                             .padding(.leading, Constants.horizontalPadding)
@@ -104,6 +116,12 @@ struct ShippingLabelCustomPackageForm: View {
                                              text: $viewModel.packageHeight,
                                              symbol: viewModel.lengthUnit,
                                              keyboardType: .decimalPad)
+                            .onReceive(Just(viewModel.packageHeight), perform: { newValue in
+                                let sanitized = viewModel.sanitizeNumericInput(newValue)
+                                if sanitized != newValue {
+                                    viewModel.packageHeight = sanitized
+                                }
+                            })
                     }
                     .padding(.horizontal, insets: safeAreaInsets)
                     .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
@@ -120,6 +138,12 @@ struct ShippingLabelCustomPackageForm: View {
                                          text: $viewModel.emptyPackageWeight,
                                          symbol: viewModel.weightUnit,
                                          keyboardType: .decimalPad)
+                        .onReceive(Just(viewModel.emptyPackageWeight), perform: { newValue in
+                            let sanitized = viewModel.sanitizeNumericInput(newValue)
+                            if sanitized != newValue {
+                                viewModel.emptyPackageWeight = sanitized
+                            }
+                        })
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground).ignoresSafeArea(.container, edges: .horizontal))
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
@@ -23,19 +23,47 @@ final class ShippingLabelCustomPackageFormViewModel: ObservableObject {
 
     /// The length of the custom package
     ///
-    @Published var packageLength: String
+    @Published var packageLength: String {
+        didSet {
+            let sanitized = sanitizeNumericInput(packageLength)
+            if packageLength != sanitized {
+                packageLength = sanitized
+            }
+        }
+    }
 
     /// The width of the custom package
     ///
-    @Published var packageWidth: String
+    @Published var packageWidth: String {
+        didSet {
+            let sanitized = sanitizeNumericInput(packageWidth)
+            if packageWidth != sanitized {
+                packageWidth = sanitized
+            }
+        }
+    }
 
     /// The height of the custom package
     ///
-    @Published var packageHeight: String
+    @Published var packageHeight: String {
+        didSet {
+            let sanitized = sanitizeNumericInput(packageHeight)
+            if packageHeight != sanitized {
+                packageHeight = sanitized
+            }
+        }
+    }
 
     /// The weight of the custom package when empty
     ///
-    @Published var emptyPackageWeight: String
+    @Published var emptyPackageWeight: String {
+        didSet {
+            let sanitized = sanitizeNumericInput(emptyPackageWeight)
+            if emptyPackageWeight != sanitized {
+                emptyPackageWeight = sanitized
+            }
+        }
+    }
 
     /// Validated custom package
     ///
@@ -125,7 +153,7 @@ extension ShippingLabelCustomPackageFormViewModel {
             .assign(to: &$isWeightValidated)
     }
 
-    /// Configure form sanitization for numeric input
+    /// Sanitize string input to return only valid Double values
     ///
     func sanitizeNumericInput(_ value: String) -> String {
         guard Double(value) != nil else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
@@ -53,7 +53,7 @@ final class ShippingLabelCustomPackageFormViewModel: ObservableObject {
                                           maxWeight: 0)
     }
 
-    // MARK: Validation Properties & Publishers
+    // MARK: Validation Properties
 
     @Published private(set) var isNameValidated = true
     @Published private(set) var isLengthValidated = true
@@ -82,7 +82,7 @@ final class ShippingLabelCustomPackageFormViewModel: ObservableObject {
     }
 }
 
-// MARK: - Validation
+// MARK: - Validation & Sanitization
 extension ShippingLabelCustomPackageFormViewModel {
 
     /// Validate each field on demand.
@@ -123,6 +123,15 @@ extension ShippingLabelCustomPackageFormViewModel {
             .dropFirst()
             .map { self.validatePackageWeight($0) }
             .assign(to: &$isWeightValidated)
+    }
+
+    /// Configure form sanitization for numeric input
+    ///
+    func sanitizeNumericInput(_ value: String) -> String {
+        guard Double(value) != nil else {
+            return String(value.dropLast())
+        }
+        return value
     }
 
     private func validatePackageName(_ name: String) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCustomPackageFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCustomPackageFormViewModelTests.swift
@@ -71,14 +71,10 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelCustomPackageFormViewModel()
 
-        // When & Then
+        // When
         viewModel.packageLength = "0"
-        XCTAssertFalse(viewModel.isLengthValidated)
 
-        viewModel.packageLength = "1..0"
-        XCTAssertFalse(viewModel.isLengthValidated)
-
-        viewModel.packageLength = "abc"
+        // Then
         XCTAssertFalse(viewModel.isLengthValidated)
     }
 
@@ -101,14 +97,10 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelCustomPackageFormViewModel()
 
-        // When & Then
+        // When
         viewModel.packageWidth = "0"
-        XCTAssertFalse(viewModel.isWidthValidated)
 
-        viewModel.packageWidth = "1..0"
-        XCTAssertFalse(viewModel.isWidthValidated)
-
-        viewModel.packageWidth = "abc"
+        // Then
         XCTAssertFalse(viewModel.isWidthValidated)
     }
 
@@ -131,14 +123,10 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelCustomPackageFormViewModel()
 
-        // When & Then
+        // When
         viewModel.packageHeight = "0"
-        XCTAssertFalse(viewModel.isHeightValidated)
 
-        viewModel.packageHeight = "1..0"
-        XCTAssertFalse(viewModel.isHeightValidated)
-
-        viewModel.packageHeight = "abc"
+        // Then
         XCTAssertFalse(viewModel.isHeightValidated)
     }
 
@@ -158,14 +146,10 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelCustomPackageFormViewModel()
 
-        // When & Then
+        // When
         viewModel.emptyPackageWeight = "-1"
-        XCTAssertFalse(viewModel.isWeightValidated)
 
-        viewModel.emptyPackageWeight = "1..0"
-        XCTAssertFalse(viewModel.isWeightValidated)
-
-        viewModel.emptyPackageWeight = "abc"
+        // Then
         XCTAssertFalse(viewModel.isWeightValidated)
     }
 
@@ -221,5 +205,49 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
 
         input = "1.5."
         XCTAssertEqual(viewModel.sanitizeNumericInput(input), "1.5")
+    }
+
+    func test_packageLength_is_sanitized() {
+        // Given
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        // When
+        viewModel.packageLength = "1.."
+
+        // Then
+        XCTAssertEqual(viewModel.packageLength, "1.")
+    }
+
+    func test_packageWidth_is_sanitized() {
+        // Given
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        // When
+        viewModel.packageWidth = "1.."
+
+        // Then
+        XCTAssertEqual(viewModel.packageWidth, "1.")
+    }
+
+    func test_packageHeight_is_sanitized() {
+        // Given
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        // When
+        viewModel.packageHeight = "1.."
+
+        // Then
+        XCTAssertEqual(viewModel.packageHeight, "1.")
+    }
+
+    func test_emptyPackageWeight_is_sanitized() {
+        // Given
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        // When
+        viewModel.emptyPackageWeight = "1.."
+
+        // Then
+        XCTAssertEqual(viewModel.emptyPackageWeight, "1.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCustomPackageFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCustomPackageFormViewModelTests.swift
@@ -198,4 +198,28 @@ class ShippingLabelCustomPackageFormViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(viewModel.validatedCustomPackage)
     }
+
+    func test_sanitizeNumericInput_returns_expected_sanitized_values() {
+        // Given
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        // When & Then
+        var input = "1"
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), input)
+
+        input = "1."
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), input)
+
+        input = "1.5"
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), input)
+
+        input = "a"
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), "")
+
+        input = "1a"
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), "1")
+
+        input = "1.5."
+        XCTAssertEqual(viewModel.sanitizeNumericInput(input), "1.5")
+    }
 }


### PR DESCRIPTION
Part of: #4743

## Description

This PR finishes the validation for the custom package creation form started in #4857, when creating a new custom package in the Shipping Label flow. As of this PR:

* There are two validation error messages that can be displayed: "This field is required" if the field is empty, or "Invalid value" if there is input but it's not valid.
* The numeric input (package dimensions and weight) is now sanitized, so only `Double` values can be entered.

## Changes

* Introduces `sanitizeNumericInput(_:)` to the view model. This is used with `didSet` on the package dimensions and weight properties to sanitize the input as those properties are changed.
* Introduces `getErrorMessage(for:)` to the `Localization` enum in `ShippingLabelCustomPackageForm`. It checks if the field input is empty and returns the appropriate error message. (To use this method, the reusable `validationErrorRow` property was removed and a `ValidationErrorRow` is added separately for each field, so the appropriate error message can be fetched.)

Missing input errors | Invalid input errors
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-24 at 21 05 28](https://user-images.githubusercontent.com/8658164/130685172-c2a9cc2b-45fb-4c7e-a4a4-30315c77aa44.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-24 at 21 05 14](https://user-images.githubusercontent.com/8658164/130685177-d49c8110-44b3-498e-98f5-20fb1ba844e6.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. Open the package details section and tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the Add New Package screen:
   * Enter invalid input in one or more fields (e.g. only spaces for the package name, 0 for the package dimensions, or a negative number for the package weight) and confirm the error "Invalid value" appears.
   * Remove the input from one or more fields and confirm the error "This field is required" appears.
   * Try entering non-numeric input in the package dimensions or weight fields and confirm it's sanitized as expected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
