### PR TITLE
[Order Editing] Fill customer note UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -36,12 +36,7 @@ struct EditCustomerNote: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(
-                    trailing: Button(Localization.done) { // I couldn't find a way to make the "Done" button bold using a toolbar :-(
-                        // TODO: submit done action
-                        print("Done tapped")
-                    }
-                    .disabled(!viewModel.doneEnabled))
+                .navigationBarItems(trailing: navigationBarTrailingItem()) // The only way I've found to make buttons bold is to set them here.
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(Localization.cancel, action: dismiss)
@@ -49,6 +44,19 @@ struct EditCustomerNote: View {
                 }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+    }
+
+    /// Decides if the navigation trailing item should be a done button or a loading indicator.
+    ///
+    @ViewBuilder private func navigationBarTrailingItem() -> some View {
+        if viewModel.showLoadingIndicator {
+            ProgressView()
+        } else {
+            Button(Localization.done) {
+                viewModel.updateNote()
+            }
+            .disabled(!viewModel.doneEnabled)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -73,7 +73,7 @@ private extension EditCustomerNote {
 // MARK: Previews
 struct EditCustomerNote_Previews: PreviewProvider {
     static var previews: some View {
-        EditCustomerNote(viewModel: .init(originalNote: "Note", newNote: "Note with an edit"))
+        EditCustomerNote(viewModel: .init(originalNote: "Note"))
             .environment(\.colorScheme, .light)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -52,7 +52,7 @@ struct EditCustomerNote: View {
         switch viewModel.navigationTrailingItem {
         case .done(let enabled):
             Button(Localization.done) {
-                viewModel.updateNote()
+                viewModel.updateNote(onFinish: dismiss)
             }
             .disabled(!enabled)
         case .loading:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -36,10 +36,12 @@ struct EditCustomerNote: View {
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(trailing: Button(Localization.done) { // I couldn't find a way to make the "Done" button bold using a toolbar :-(
-                    // TODO: submit done action
-                    print("Done tapped")
-                })
+                .navigationBarItems(
+                    trailing: Button(Localization.done) { // I couldn't find a way to make the "Done" button bold using a toolbar :-(
+                        // TODO: submit done action
+                        print("Done tapped")
+                    }
+                    .disabled(!viewModel.doneEnabled))
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(Localization.cancel, action: dismiss)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -49,13 +49,14 @@ struct EditCustomerNote: View {
     /// Decides if the navigation trailing item should be a done button or a loading indicator.
     ///
     @ViewBuilder private func navigationBarTrailingItem() -> some View {
-        if viewModel.showLoadingIndicator {
-            ProgressView()
-        } else {
+        switch viewModel.navigationTrailingItem {
+        case .done(let enabled):
             Button(Localization.done) {
                 viewModel.updateNote()
             }
-            .disabled(!viewModel.doneEnabled)
+            .disabled(!enabled)
+        case .loading:
+            ProgressView()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -4,8 +4,8 @@ import SwiftUI
 /// Hosting controller that wraps an `EditCustomerNote` view.
 ///
 final class EditCustomerNoteHostingController: UIHostingController<EditCustomerNote> {
-    init() {
-        super.init(rootView: EditCustomerNote())
+    init(viewModel: EditCustomerNoteViewModel) {
+        super.init(rootView: EditCustomerNote(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
@@ -26,12 +26,13 @@ struct EditCustomerNote: View {
     ///
     var dismiss: (() -> Void) = {}
 
-    // TODO: Replace with view model backed value
-    @State private var textContent = "Tap and edit me"
+    /// View Model for the view
+    ///
+    @ObservedObject private(set) var viewModel: EditCustomerNoteViewModel
 
     var body: some View {
         NavigationView {
-            TextEditor(text: $textContent)
+            TextEditor(text: $viewModel.newNote)
                 .padding()
                 .navigationTitle(Localization.title)
                 .navigationBarTitleDisplayMode(.inline)
@@ -61,7 +62,7 @@ private extension EditCustomerNote {
 // MARK: Previews
 struct EditCustomerNote_Previews: PreviewProvider {
     static var previews: some View {
-        EditCustomerNote()
+        EditCustomerNote(viewModel: .init(originalNote: "Note", newNote: "Note with an edit"))
             .environment(\.colorScheme, .light)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -37,13 +37,14 @@ final class EditCustomerNoteViewModel: ObservableObject {
         bindNavigationTrailingItemPublisher()
     }
 
-    /// Update the note remotely and fire and try to dismiss the view.
+    /// Update the note remotely and invoke a completion block when finished
     ///
-    func updateNote() {
-        // TODO: Fire network request & dismiss the view
+    func updateNote(onFinish: @escaping () -> Void) {
+        // TODO: Fire network request
         performingNetworkRequest.send(true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
             self?.performingNetworkRequest.send(false)
+            onFinish()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -23,4 +23,11 @@ final class EditCustomerNoteViewModel {
         self.originalNote = order.customerNote ?? ""
         self.newNote = self.originalNote
     }
+
+    /// Member wise initializer
+    ///
+    internal init(originalNote: String, newNote: String) {
+        self.originalNote = originalNote
+        self.newNote = newNote
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -20,6 +20,11 @@ final class EditCustomerNoteViewModel: ObservableObject {
         originalNote != newNote
     }
 
+    /// True when the loading spinner should be shown.
+    /// Like when performing a network operation
+    ///
+    private(set) var showLoadingIndicator: Bool = false
+
     init(order: Order) {
         self.originalNote = order.customerNote ?? ""
         self.newNote = originalNote
@@ -32,5 +37,16 @@ final class EditCustomerNoteViewModel: ObservableObject {
         self.originalNote = originalNote
         self.newNote = originalNote
         //self._newNote = Binding<String>.constant(originalNote)
+    }
+
+    /// Update the note remotely and fire and try to dismiss the view.
+    ///
+    func updateNote() {
+        // TODO: Fire network request & dismiss the view
+        // Dummy code
+        showLoadingIndicator = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            self?.showLoadingIndicator = false
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -9,9 +9,10 @@ final class EditCustomerNoteViewModel: ObservableObject {
     ///
     private let originalNote: String
 
-    /// New content to submit
+    /// New content to submit.
+    /// Binding property modified at the view level.
     ///
-    @Published private(set) var newNote: String
+    @Published var newNote: String
 
     /// True when there are changes to the `initialNote`. False otherwise.
     ///
@@ -21,13 +22,15 @@ final class EditCustomerNoteViewModel: ObservableObject {
 
     init(order: Order) {
         self.originalNote = order.customerNote ?? ""
-        self.newNote = self.originalNote
+        self.newNote = originalNote
+        //self._newNote = Binding<String>.constant(originalNote)
     }
 
     /// Member wise initializer
     ///
     internal init(originalNote: String, newNote: String) {
         self.originalNote = originalNote
-        self.newNote = newNote
+        self.newNote = originalNote
+        //self._newNote = Binding<String>.constant(originalNote)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -12,7 +12,12 @@ final class EditCustomerNoteViewModel: ObservableObject {
     /// New content to submit.
     /// Binding property modified at the view level.
     ///
-    var newNote: String
+    @Published var newNote: String
+
+    /// True when the loading spinner should be shown.
+    /// Like when performing a network operation
+    ///
+    @Published private(set) var showLoadingIndicator: Bool = false
 
     /// True when there are changes to the `initialNote`. False otherwise.
     ///
@@ -20,15 +25,9 @@ final class EditCustomerNoteViewModel: ObservableObject {
         originalNote != newNote
     }
 
-    /// True when the loading spinner should be shown.
-    /// Like when performing a network operation
-    ///
-    private(set) var showLoadingIndicator: Bool = false
-
     init(order: Order) {
         self.originalNote = order.customerNote ?? ""
         self.newNote = originalNote
-        //self._newNote = Binding<String>.constant(originalNote)
     }
 
     /// Member wise initializer
@@ -36,7 +35,6 @@ final class EditCustomerNoteViewModel: ObservableObject {
     internal init(originalNote: String, newNote: String) {
         self.originalNote = originalNote
         self.newNote = originalNote
-        //self._newNote = Binding<String>.constant(originalNote)
     }
 
     /// Update the note remotely and fire and try to dismiss the view.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// View Model for the Edit Customer Note screen
 ///
-final class EditCustomerNoteViewModel {
+final class EditCustomerNoteViewModel: ObservableObject {
 
     /// Original content of the order customer provided note
     ///
@@ -11,7 +11,7 @@ final class EditCustomerNoteViewModel {
 
     /// New content to submit
     ///
-    private var newNote: String
+    @Published private(set) var newNote: String
 
     /// True when there are changes to the `initialNote`. False otherwise.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -12,7 +12,7 @@ final class EditCustomerNoteViewModel: ObservableObject {
     /// New content to submit.
     /// Binding property modified at the view level.
     ///
-    @Published var newNote: String
+    var newNote: String
 
     /// True when there are changes to the `initialNote`. False otherwise.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -26,12 +26,12 @@ final class EditCustomerNoteViewModel: ObservableObject {
 
     convenience init(order: Order) {
         let note = order.customerNote ?? ""
-        self.init(originalNote: note, newNote: note)
+        self.init(originalNote: note)
     }
 
     /// Member wise initializer
     ///
-    init(originalNote: String, newNote: String) {
+    init(originalNote: String) {
         self.originalNote = originalNote
         self.newNote = originalNote
         bindNavigationTrailingItemPublisher()
@@ -53,7 +53,7 @@ final class EditCustomerNoteViewModel: ObservableObject {
 extension EditCustomerNoteViewModel {
     /// Representation of possible navigation bar trailing buttons
     ///
-    enum NavigationItem {
+    enum NavigationItem: Equatable {
         case done(enabled: Bool)
         case loading
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -1,7 +1,26 @@
 import Foundation
+import Yosemite
 
 /// View Model for the Edit Customer Note screen
 ///
 final class EditCustomerNoteViewModel {
 
+    /// Original content of the order customer provided note
+    ///
+    private let originalNote: String
+
+    /// New content to submit
+    ///
+    private var newNote: String
+
+    /// True when there are changes to the `initialNote`. False otherwise.
+    ///
+    var doneEnabled: Bool {
+        originalNote != newNote
+    }
+
+    init(order: Order) {
+        self.originalNote = order.customerNote ?? ""
+        self.newNote = self.originalNote
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// View Model for the Edit Customer Note screen
+///
+final class EditCustomerNoteViewModel {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -640,7 +640,8 @@ private extension OrderDetailsViewController {
     }
 
     func editCustomerNoteTapped() {
-        let editNoteViewController = EditCustomerNoteHostingController()
+        let viewModel = EditCustomerNoteViewModel(order: viewModel.order)
+        let editNoteViewController = EditCustomerNoteHostingController(viewModel: viewModel)
         present(editNoteViewController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 		2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */; };
 		2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */; };
 		268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */; };
+		268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1794,6 +1795,7 @@
 		2688643C25D470C000821BA5 /* EditAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModel.swift; sourceTree = "<group>"; };
 		2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNote.swift; sourceTree = "<group>"; };
+		268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModel.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -3764,6 +3766,7 @@
 			isa = PBXGroup;
 			children = (
 				268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */,
+				268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */,
 			);
 			path = "Customer Note";
 			sourceTree = "<group>";
@@ -7346,6 +7349,7 @@
 				45DB705A26124C710064A6CF /* TitleAndTextFieldRow.swift in Sources */,
 				DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */,
 				0270F47624D005B00005210A /* ProductFormViewModelProtocol.swift in Sources */,
+				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */; };
 		268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */; };
 		268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */; };
+		268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -1796,6 +1797,7 @@
 		2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		268EC45E26CEA50C00716F5C /* EditCustomerNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNote.swift; sourceTree = "<group>"; };
 		268EC46026D3F67800716F5C /* EditCustomerNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModel.swift; sourceTree = "<group>"; };
+		268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -3771,6 +3773,14 @@
 			path = "Customer Note";
 			sourceTree = "<group>";
 		};
+		268EC46226D3F9A800716F5C /* Customer Note */ = {
+			isa = PBXGroup;
+			children = (
+				268EC46326D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift */,
+			);
+			path = "Customer Note";
+			sourceTree = "<group>";
+		};
 		26A630F8253F62AD00CBC3B1 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -4429,6 +4439,7 @@
 			children = (
 				57F2C6CA246DEBBF0074063B /* Order Summary Section */,
 				0277AE99256CA86D00F45C4A /* Shipping Labels */,
+				268EC46226D3F9A800716F5C /* Customer Note */,
 				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 				578195FB25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift */,
 			);
@@ -7810,6 +7821,7 @@
 				D802547D26551EF2001B2CC1 /* CardPresentModalSuccessTests.swift in Sources */,
 				02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */,
 				45E9A6EB24DAFC3E00A600E8 /* ProductReviewsViewModelTests.swift in Sources */,
+				268EC46426D3F9C100716F5C /* EditCustomerNoteViewModelTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,
 				2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */,
 				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
@@ -26,4 +26,20 @@ class EditCustomerNoteViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(doneButtonEnabled)
     }
+
+    func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
+        // Given
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "New")
+        XCTAssertFalse(viewModel.showLoadingIndicator)
+
+        // When
+        viewModel.updateNote()
+
+        // Then
+        XCTAssertTrue(viewModel.showLoadingIndicator)
+        waitUntil {
+            !viewModel.showLoadingIndicator
+        }
+
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
@@ -1,5 +1,29 @@
 import XCTest
 import TestKit
 
+@testable import WooCommerce
+
 class EditCustomerNoteViewModelTests: XCTestCase {
+
+    func test_done_button_is_disabled_when_note_content_is_the_same() {
+        // Given
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "Original")
+
+        // When
+        let doneButtonEnabled = viewModel.doneEnabled
+
+        // Then
+        XCTAssertFalse(doneButtonEnabled)
+    }
+
+    func test_done_button_is_enabled_when_note_content_is_the_different() {
+        // Given
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "New")
+
+        // When
+        let doneButtonEnabled = viewModel.doneEnabled
+
+        // Then
+        XCTAssertTrue(doneButtonEnabled)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
@@ -7,39 +7,49 @@ class EditCustomerNoteViewModelTests: XCTestCase {
 
     func test_done_button_is_disabled_when_note_content_is_the_same() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "Original")
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
 
         // When
-        let doneButtonEnabled = viewModel.doneEnabled
+        let navigationItem = viewModel.navigationTrailingItem
 
         // Then
-        XCTAssertFalse(doneButtonEnabled)
+        assertEqual(navigationItem, .done(enabled: false))
     }
 
     func test_done_button_is_enabled_when_note_content_is_the_different() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "New")
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
 
         // When
-        let doneButtonEnabled = viewModel.doneEnabled
+        viewModel.newNote = "Edited"
 
         // Then
-        XCTAssertTrue(doneButtonEnabled)
+        assertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
+    }
+
+    func test_loading_indicator_gets_enabled_during_network_request() {
+        // Given
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
+
+        // When
+        viewModel.updateNote {}
+
+        // Then
+        assertEqual(viewModel.navigationTrailingItem, .loading)
     }
 
     func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original", newNote: "New")
-        XCTAssertFalse(viewModel.showLoadingIndicator)
+        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
 
         // When
-        viewModel.updateNote()
-
-        // Then
-        XCTAssertTrue(viewModel.showLoadingIndicator)
-        waitUntil {
-            !viewModel.showLoadingIndicator
+        let navigationItem = waitFor { promise in
+            viewModel.updateNote(onFinish: {
+                promise(viewModel.navigationTrailingItem)
+            })
         }
 
+        // Then
+        assertEqual(navigationItem, .done(enabled: false))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
@@ -1,0 +1,5 @@
+import XCTest
+import TestKit
+
+class EditCustomerNoteViewModelTests: XCTestCase {
+}


### PR DESCRIPTION
closes #4800 

# Why

As the edit customer provided note UI is now in place #4776, this PR makes sure to:
- Render the existing customer provider note
- Allow text editing of the note
- Enable/Disable the done button when the note is edited
- Provide mechanisms to show a loading spinner while the note is being updated remotely(network operation to be done in a separate PR)

# How

- Added `EditCustomerNoteViewModel` that handles:
  - Storing the original & new note content
  - Making sure the done & loading bar items are swapped when the view model state changes

- Update `EditCustomerNote` to render content based on the UI.

# Screenshot
https://user-images.githubusercontent.com/562080/130699873-2aad6acb-270c-4c48-a3bc-83ee673c4c3d.mov


# Testing Steps

- Navigate to an order
- Tap the edit customer note button
- If the order had a note, see it populated
- Edit the note and see the done button become enabled
- Tap on done and see a loading spinner for 3 seconds, then see the view get dismissed

# Todo
- Perform network operations
- Add error & success notices


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
