### PR TITLE
[Mobile Payments] [Card Reader Updates] Add retryable error modal, connect to reader update flow

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRetryableError.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+/// Modal presented on error. Provides a retry action.
+final class CardPresentModalRetryableError: CardPresentPaymentsModalViewModel {
+    private let primaryAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String?
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.tryAgain
+
+    let secondaryButtonTitle: String? = Localization.cancel
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    init(primaryAction: @escaping () -> Void) {
+        self.primaryAction = primaryAction
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true, completion: { [weak self] in
+            self?.primaryAction()
+        })
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        viewController?.dismiss(animated: true)
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalRetryableError {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Something went wrong",
+            comment: "Error message presented to users after a failure occurs"
+        )
+
+        static let tryAgain = NSLocalizedString(
+            "Try Again",
+            comment: "Button to try again. Presented to users after a failure occurs"
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to cancel (not try again). Presented to users after a failure occurs"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -77,6 +77,11 @@ final class OrderDetailsPaymentAlerts {
         let viewModel = nonRetryableErrorViewModel(amount: amount, error: error)
         presentViewModel(viewModel: viewModel)
     }
+
+    func retryableError(from: UIViewController?, tryAgain: @escaping () -> Void) {
+        let viewModel = retryableErrorViewModel(tryAgain: tryAgain)
+        presentViewModel(viewModel: viewModel)
+    }
 }
 
 private extension OrderDetailsPaymentAlerts {
@@ -106,6 +111,10 @@ private extension OrderDetailsPaymentAlerts {
 
     func errorViewModel(amount: String, error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalError(amount: amount, error: error, primaryAction: tryAgain)
+    }
+
+    func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalRetryableError(primaryAction: tryAgain)
     }
 
     func nonRetryableErrorViewModel(amount: String, error: Error) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -165,13 +165,10 @@ private extension CardReaderSettingsConnectedViewController {
         }
 
         // Otherwise, instantiate and present an updateViewController
-        updateViewController = UpdateViewController()
+        updateViewController = UpdateViewController(headline: Localization.updateHeadline, footnote: Localization.updateFootnote)
         guard let updateViewController = updateViewController else {
             return
         }
-
-        updateViewController.loadViewIfNeeded()
-        updateViewController.configure(headline: Localization.updateHeadline, footnote: Localization.updateFootnote)
         self.present(updateViewController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateViewController/UpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateViewController/UpdateViewController.swift
@@ -9,13 +9,23 @@ final class UpdateViewController: UIViewController {
     @IBOutlet private weak var headlineLabel: UILabel!
     @IBOutlet private weak var footnoteLabel: UILabel!
 
-    override func viewDidLoad() {
-        view.backgroundColor = .gray(.shade90)
+    private var headline: String
+    private var footnote: String
+
+    init(headline: String, footnote: String) {
+        self.headline = headline
+        self.footnote = footnote
+        super.init(nibName: Self.nibName, bundle: nil)
         modalPresentationStyle = .overFullScreen
     }
 
-    func configure(headline: String, footnote: String) {
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
         headlineLabel?.text = headline
         footnoteLabel?.text = footnote
+        view.backgroundColor = .gray(.shade90)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateViewController/UpdateViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateViewController/UpdateViewController.xib
@@ -15,7 +15,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view alpha="0.78000000000000003" contentMode="scaleToFill" id="iN0-l3-epB">
+        <view alpha="0.88" contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		318109EE25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */; };
 		318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */; };
 		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
+		3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */; };
 		3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */; };
 		31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */; };
 		31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */; };
@@ -1860,6 +1861,7 @@
 		318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NumberedListItemTableViewCell.xib; sourceTree = "<group>"; };
 		318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentingViewController.swift; sourceTree = "<group>"; };
 		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
+		3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentRetryableError.swift; sourceTree = "<group>"; };
 		3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKnownReadersProvider.swift; sourceTree = "<group>"; };
 		31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReader.swift; sourceTree = "<group>"; };
 		31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingToReader.swift; sourceTree = "<group>"; };
@@ -6055,6 +6057,7 @@
 				311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */,
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
 				E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */,
+				3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */,
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
@@ -6972,6 +6975,7 @@
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
+				3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */,
 				E138D4F6269EDE77006EA5C6 /* InPersonPaymentsUnavailableView.swift in Sources */,
 				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,
 				CE2A9FC623BFFADE002BEC1C /* RefundedProductsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 		318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */; };
 		3188533C2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */; };
 		3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */; };
+		3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */; };
 		3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */; };
 		31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */; };
 		31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */; };
@@ -1862,6 +1863,7 @@
 		318853352639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentingViewController.swift; sourceTree = "<group>"; };
 		3188533B2639FE5800F66A9C /* CardReaderSettingsPresentedViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPresentedViewViewModel.swift; sourceTree = "<group>"; };
 		3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentRetryableError.swift; sourceTree = "<group>"; };
+		3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRetryableErrorTests.swift; sourceTree = "<group>"; };
 		3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKnownReadersProvider.swift; sourceTree = "<group>"; };
 		31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReader.swift; sourceTree = "<group>"; };
 		31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingToReader.swift; sourceTree = "<group>"; };
@@ -5959,6 +5961,7 @@
 				D802549A265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift */,
 				E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */,
 				E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */,
+				3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -7659,6 +7662,7 @@
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
+				3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -9,19 +9,22 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
     private var failDiscovery: Bool
     private var readerUpdateAvailable: Bool
     private var failReaderUpdateCheck: Bool
+    private var failUpdate: Bool
 
     init(connectedReaders: [CardReader],
          discoveredReader: CardReader? = nil,
          sessionManager: SessionManager,
          failDiscovery: Bool = false,
          readerUpdateAvailable: Bool = false,
-         failReaderUpdateCheck: Bool = false
+         failReaderUpdateCheck: Bool = false,
+         failUpdate: Bool = false
     ) {
         self.connectedReaders = connectedReaders
         self.discoveredReader = discoveredReader
         self.failDiscovery = failDiscovery
         self.readerUpdateAvailable = readerUpdateAvailable
         self.failReaderUpdateCheck = failReaderUpdateCheck
+        self.failUpdate = failUpdate
         super.init(sessionManager: sessionManager)
     }
 
@@ -60,6 +63,13 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
                 return
             }
             onCompletion(Result.success(mockUpdate()))
+        case .startCardReaderUpdate(let onProgress, let onCompletion):
+            onProgress(0.5)
+            guard !failUpdate else {
+                onCompletion(Result.failure(MockErrors.readerUpdateFailure))
+                return
+            }
+            onCompletion(Result.success(()))
         default:
             fatalError("Not available")
         }
@@ -70,6 +80,7 @@ extension MockCardPresentPaymentsStoresManager {
     enum MockErrors: Error {
         case discoveryFailure
         case readerUpdateCheckFailure
+        case readerUpdateFailure
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRetryableErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalRetryableErrorTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalRetryableErrorTests: XCTestCase {
+    private var viewModel: CardPresentModalRetryableError!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalRetryableError(primaryAction: closures.primaryAction())
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_auxiliary_button_title_is_nil() {
+        XCTAssertNil(viewModel.auxiliaryButtonTitle)
+    }
+
+    func test_bottom_title_is_nil() {
+        XCTAssertNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+
+    func test_primary_button_action_calls_closure() {
+        viewModel.didTapPrimaryButton(in: UIViewController())
+
+        XCTAssertTrue(closures.didTapRetry)
+    }
+}
+
+
+private extension CardPresentModalRetryableErrorTests {
+    enum Expectations {
+        static var image = UIImage.paymentErrorImage
+    }
+}
+
+private final class Closures {
+    var didTapRetry = false
+
+    func primaryAction() -> () -> Void {
+        return {[weak self] in
+            self?.didTapRetry = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsConnectedViewModelTests.swift
@@ -114,4 +114,84 @@ final class CardReaderSettingsConnectedViewModelTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    func test_startCardReaderUpdate_properly_handles_successful_update() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            readerUpdateAvailable: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+
+        var updateDidBegin = false
+
+        viewModel.didUpdate = {
+            if viewModel.readerUpdateInProgress {
+                updateDidBegin = true
+            }
+
+            // Update began
+            if updateDidBegin {
+                // But now it has stopped
+                if !viewModel.readerUpdateInProgress {
+                    // But did it succeed?
+                    if viewModel.readerUpdateCompletedSuccessfully {
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+
+
+        // When
+        viewModel.startCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_startCardReaderUpdate_properly_handles_update_failure() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [MockCardReader.bbposChipper2XBT()],
+            sessionManager: SessionManager.testingInstance,
+            readerUpdateAvailable: true,
+            failUpdate: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+
+        let viewModel = CardReaderSettingsConnectedViewModel(didChangeShouldShow: nil)
+
+        var updateDidBegin = false
+
+        viewModel.didUpdate = {
+            if viewModel.readerUpdateInProgress {
+                updateDidBegin = true
+            }
+
+            // Update began
+            if updateDidBegin {
+                // But now it has stopped
+                if !viewModel.readerUpdateInProgress {
+                    // But did it fail?
+                    if !viewModel.readerUpdateCompletedSuccessfully {
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+
+        // When
+        viewModel.startCardReaderUpdate()
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }


### PR DESCRIPTION
Partially addresses #4059 

Changes:
- Adds a `CardPresentRetryableError` modal to `OrderDetailsPaymentAlerts`
- Adds it to `CardReaderSettingsConnectedViewController` for when update fails
- Updates the UpdateViewController guarding to be more inline with our style
- Adds Unit Tests
- Updates UpdateViewController initialization to not require loadViewIfNeeded props @ctarda 
- Increases alpha of UpdateViewController background slightly for better legibility

To test:
- **IMPORTANT Set `-simulate-stripe-card-reader` in your Run Scheme to use the simulator**
- Edit `StripeCardReaderService.swift` to immediately fail on update, e.g.:

```
let installFuture = Future<Bool, Error> { promise in
            // Just immediately fail
            promise(.failure(CardReaderServiceError.bluetoothDenied))
```

- Kick off an update. Note that it fails immediately and presents the modal:

![IMG](https://user-images.githubusercontent.com/1595739/130863200-e83167eb-d374-4daf-9ff4-e69ea77352fa.PNG)

- Tap try again and verify it tries again
- Tap cancel and verify it doesn't

What's coming in the next PR?
- Test with an actual reader
- Remove the feature flag

@Garance91540 Screenshots of opacity change:

Before

![IMG_0115](https://user-images.githubusercontent.com/1595739/130875513-762782f6-8fa5-4956-8785-f6280a3ffcc9.PNG)

After

![IMG_0114](https://user-images.githubusercontent.com/1595739/130875524-283e5aff-728c-4784-a45a-9b384ba879c3.PNG)


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
