### PR TITLE
[Mobile Payments] [Several Readers Found] Add feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -21,6 +21,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .cardPresentSeveralReadersFound:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -45,4 +45,8 @@ enum FeatureFlag: Int {
     /// Editing of notes, shipping, and billing addresses.
     ///
     case orderEditing
+
+    /// Card-Present Payments Several Readers Found
+    ///
+    case cardPresentSeveralReadersFound
 }


### PR DESCRIPTION
Partially addresses #4333 

Changes:
- Adds a feature flag for supporting detecting multiple readers
- In the next PR, we'll change to Bluetooth "Scan" (not Proximity) and update CardReaderConnectionController onConnectToReader to connect to the most recently found reader

To test:
- It's just a feature flag - make sure the app compiles

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
