### PR TITLE
Shipping Labels: Require phone number for destination address for international shipments

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -369,12 +369,12 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
-        let phoneNumberRequired = viewModel.customsFormRequired
+        let isPhoneNumberRequired = viewModel.customsFormRequired
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,
             address: address,
-            phoneNumberRequired: phoneNumberRequired,
+            phoneNumberRequired: isPhoneNumberRequired,
             validationError: validationError,
             countries: viewModel.filteredCountries(for: type),
             completion: { [weak self] (newShippingLabelAddress) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -369,7 +369,7 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
-        let phoneNumberRequired = type == .origin && viewModel.customsFormRequired
+        let phoneNumberRequired = viewModel.customsFormRequired
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -243,6 +243,14 @@ private extension ShippingLabelFormViewController {
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
 
+            // Skip remote validation and navigate to edit address
+            // if customs form is required and phone number is not found.
+            if self.viewModel.customsFormRequired,
+               let destinationAddress = self.viewModel.destinationAddress,
+               destinationAddress.phone.isEmpty {
+                return self.displayEditAddressFormVC(address: destinationAddress, validationError: nil, type: .origin)
+            }
+
             self.viewModel.validateAddress(type: .destination) { [weak self] (validationState, response) in
                 guard let self = self else { return }
                 let shippingLabelAddress = self.viewModel.destinationAddress

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -248,7 +248,7 @@ private extension ShippingLabelFormViewController {
             if self.viewModel.customsFormRequired,
                let destinationAddress = self.viewModel.destinationAddress,
                destinationAddress.phone.isEmpty {
-                return self.displayEditAddressFormVC(address: destinationAddress, validationError: nil, type: .origin)
+                return self.displayEditAddressFormVC(address: destinationAddress, validationError: nil, type: .destination)
             }
 
             self.viewModel.validateAddress(type: .destination) { [weak self] (validationState, response) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -26,16 +26,8 @@ final class ShippingLabelFormViewModel {
 
     /// Address
     ///
-    private(set) var originAddress: ShippingLabelAddress? {
-        didSet {
-            updateRowsForCustomsIfNeeded()
-        }
-    }
-    private(set) var destinationAddress: ShippingLabelAddress? {
-        didSet {
-            updateRowsForCustomsIfNeeded()
-        }
-    }
+    private(set) var originAddress: ShippingLabelAddress?
+    private(set) var destinationAddress: ShippingLabelAddress?
 
     /// Packages
     ///
@@ -181,6 +173,8 @@ final class ShippingLabelFormViewModel {
         // the carrier and rate change accordingly
         handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
 
+        updateRowsForCustomsIfNeeded()
+
         if dateState == .validated {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_complete"])
         }
@@ -194,6 +188,8 @@ final class ShippingLabelFormViewModel {
         // We reset the carrier and rates selected because if the address change
         // the carrier and rate change accordingly
         handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+
+        updateRowsForCustomsIfNeeded()
 
         if dateState == .validated {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "destination_address_complete"])
@@ -465,11 +461,11 @@ private extension ShippingLabelFormViewModel {
     func updateRowsForCustomsIfNeeded() {
         insertOrRemoveCustomsRowIfNeeded()
 
-        guard let originAddress = originAddress else {
-            return
-        }
         // Require user to update phone address if customs form is required
-        if customsFormRequired && originAddress.phone.isEmpty {
+        if customsFormRequired && destinationAddress?.phone.isEmpty == true {
+            updateRowState(type: .shipTo, dataState: .pending, displayMode: .editable)
+        }
+        if customsFormRequired && originAddress?.phone.isEmpty == true {
             updateRowState(type: .shipFrom, dataState: .pending, displayMode: .editable)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -462,11 +462,11 @@ private extension ShippingLabelFormViewModel {
         insertOrRemoveCustomsRowIfNeeded()
 
         // Require user to update phone address if customs form is required
-        if customsFormRequired && destinationAddress?.phone.isEmpty == true {
-            updateRowState(type: .shipTo, dataState: .pending, displayMode: .editable)
-        }
         if customsFormRequired && originAddress?.phone.isEmpty == true {
             updateRowState(type: .shipFrom, dataState: .pending, displayMode: .editable)
+        }
+        if customsFormRequired && destinationAddress?.phone.isEmpty == true {
+            updateRowState(type: .shipTo, dataState: .pending, displayMode: .editable)
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -218,7 +218,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
-        shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
+        shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0987654321", country: "VN"),
+                                                                        validated: true)
         shippingLabelFormViewModel.handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm.fake()], isValidated: true)
         shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
                                                                      selectedSignatureRate: nil,
@@ -798,7 +799,35 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.state.sections.first?.rows.first(where: { $0.type == .customs }))
     }
 
-    func test_updateRowsForCustomsIfNeeded_updates_row_states_correctly() {
+    func test_updateRowsForCustomsIfNeeded_updates_row_states_correctly_when_phone_number_is_missing_in_both_origin_address_only() {
+        // Given
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+        viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "CA"), validated: true)
+        viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "NY"), validated: true)
+
+        let rows = viewModel.state.sections.first?.rows
+        XCTAssertEqual(rows?[0].dataState, .validated)
+        XCTAssertEqual(rows?[0].displayMode, .editable)
+        XCTAssertEqual(rows?[1].dataState, .validated)
+        XCTAssertEqual(rows?[1].displayMode, .editable)
+        XCTAssertEqual(rows?[2].dataState, .pending)
+        XCTAssertEqual(rows?[2].displayMode, .editable)
+
+        // When
+        viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0987654321", country: "VN", state: ""),
+                                                       validated: true)
+
+        // Then
+        let updatedRows = viewModel.state.sections.first?.rows
+        XCTAssertEqual(updatedRows?[0].dataState, .pending)
+        XCTAssertEqual(updatedRows?[0].displayMode, .editable)
+        XCTAssertEqual(updatedRows?[1].dataState, .validated)
+        XCTAssertEqual(updatedRows?[1].displayMode, .editable)
+        XCTAssertEqual(updatedRows?[2].dataState, .pending)
+        XCTAssertEqual(updatedRows?[2].displayMode, .disabled)
+    }
+
+    func test_updateRowsForCustomsIfNeeded_updates_row_states_correctly_when_phone_number_is_missing_in_both_origin_and_destination_addresses() {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "CA"), validated: true)
@@ -819,8 +848,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let updatedRows = viewModel.state.sections.first?.rows
         XCTAssertEqual(updatedRows?[0].dataState, .pending)
         XCTAssertEqual(updatedRows?[0].displayMode, .editable)
-        XCTAssertEqual(updatedRows?[1].dataState, .validated)
-        XCTAssertEqual(updatedRows?[1].displayMode, .editable)
+        XCTAssertEqual(updatedRows?[1].dataState, .pending)
+        XCTAssertEqual(updatedRows?[1].displayMode, .disabled)
         XCTAssertEqual(updatedRows?[2].dataState, .pending)
         XCTAssertEqual(updatedRows?[2].displayMode, .disabled)
     }


### PR DESCRIPTION
Closes #4874 

# Description
There's a known issue that DHL is currently requiring phone number on destination address for the shipping label purchase to succeed. This PR updates the logic in shipping label creation form to require phone number on destination address (regardless of carrier).

# Changes
## ShippingLabelsFormViewController
- Updated to force navigating user to Edit Address form when detecting international shipping.

## ShippingLabelsFormViewModel
- Updated `updateRowsForCustomsIfNeeded` to update row state of Ship To row when phone number is missing and needs updating.
- Trigger `updateRowsForCustomsIfNeeded` near the end of `handleOriginAddressValueChanges` and `handleDestinationAddressValueChanges` instead of in property observers of `originAddress` and `destinationAddress`. This is to make sure that all other row updates (e.g for Customs or Carrier rows) are done before the final update of the address rows.

## Unit tests updates

# Demo
![destination-phone](https://user-images.githubusercontent.com/5533851/130951968-64242041-4f78-42b2-bd7a-b79de4d5c46f.gif)

# Testing
1. Make sure that your test store is eligible for creating shipping labels (has WCShip plugin installed and packages configured in WP Admin > WooCommerce > Settings > Shipping > Woocommerce Shipping).
2. Create an order that requires international shipping (origin country different from destination country). Leave the phone number in the shipping & billing address empty.
3. Open app, navigate to Orders tab, select the new order and select Create Shipping Label.
4. Notice that phone number is required in Ship From. Enter 10-digit number and proceed.
5. Notice that phone number is required in Ship To. You should be able to proceed only after entering 10-digit number for it too.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
