### PR TITLE
[Order Editing] Update customer provided note remotely

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -181,7 +181,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
 
 /// Defines all of the Order CodingKeys
 ///
-private extension Order {
+internal extension Order {
 
     enum CodingKeys: String, CodingKey {
         case orderID            = "id"

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -125,6 +125,23 @@ public class OrdersRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Updates the specified fields of a given order.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the Order.
+    ///     - order: Order to be updated.
+    ///     - fields: Fields from the order to be updated.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateOrder(from siteID: Int64, order: Order, fields: [String], completion: @escaping (Result<Order, Error>) -> Void) {
+        let path = "\(Constants.ordersPath)/\(order.orderID)"
+        let parameters: [String: AnyHashable] = [:]
+        let mapper = OrderMapper(siteID: siteID)
+
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Adds an order note to a specific Order.
     ///
     /// - Parameters:

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -145,7 +145,7 @@ public class OrdersRemote: Remote {
             }
         }()
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -139,7 +139,7 @@ public class OrdersRemote: Remote {
         let parameters: [String: AnyHashable] = {
             fields.reduce(into: [:]) { params, field in
                 switch field {
-                case.customerNote:
+                case .customerNote:
                     params[Order.CodingKeys.customerNote.rawValue] = order.customerNote
                 }
             }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -133,10 +133,17 @@ public class OrdersRemote: Remote {
     ///     - fields: Fields from the order to be updated.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateOrder(from siteID: Int64, order: Order, fields: [UpdateOrderFields], completion: @escaping (Result<Order, Error>) -> Void) {
+    public func updateOrder(from siteID: Int64, order: Order, fields: [UpdateOrderField], completion: @escaping (Result<Order, Error>) -> Void) {
         let path = "\(Constants.ordersPath)/\(order.orderID)"
-        let parameters: [String: AnyHashable] = [:]
         let mapper = OrderMapper(siteID: siteID)
+        let parameters: [String: AnyHashable] = {
+            fields.reduce(into: [:]) { params, field in
+                switch field {
+                case.customerNote:
+                    params[Order.CodingKeys.customerNote.rawValue] = order.customerNote
+                }
+            }
+        }()
 
         let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
@@ -201,7 +208,7 @@ public extension OrdersRemote {
 
     /// Order fields supported for update
     ///
-    enum UpdateOrderFields {
-        static let customerNote = Order.CodingKeys.customerNote
+    enum UpdateOrderField {
+        case customerNote
     }
 }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -133,7 +133,7 @@ public class OrdersRemote: Remote {
     ///     - fields: Fields from the order to be updated.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateOrder(from siteID: Int64, order: Order, fields: [String], completion: @escaping (Result<Order, Error>) -> Void) {
+    public func updateOrder(from siteID: Int64, order: Order, fields: [UpdateOrderFields], completion: @escaping (Result<Order, Error>) -> Void) {
         let path = "\(Constants.ordersPath)/\(order.orderID)"
         let parameters: [String: AnyHashable] = [:]
         let mapper = OrderMapper(siteID: siteID)
@@ -197,5 +197,11 @@ public extension OrdersRemote {
             discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,line_items,shipping,\
             billing,coupon_lines,shipping_lines,refunds,fee_lines
             """
+    }
+
+    /// Order fields supported for update
+    ///
+    enum UpdateOrderFields {
+        static let customerNote = Order.CodingKeys.customerNote
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -69,11 +69,3 @@ private extension EditCustomerNote {
         static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the edit customer provided note screen")
     }
 }
-
-// MARK: Previews
-struct EditCustomerNote_Previews: PreviewProvider {
-    static var previews: some View {
-        EditCustomerNote(viewModel: .init(originalNote: "Note"))
-            .environment(\.colorScheme, .light)
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -939,7 +939,7 @@ private extension OrderDetailsViewController {
     /// Returns an Order Update Action that will result in the specified Order Status updated accordingly.
     ///
     private func updateOrderStatusAction(siteID: Int64, orderID: Int64, status: OrderStatusEnum) -> Action {
-        return OrderAction.updateOrder(siteID: siteID, orderID: orderID, status: status, onCompletion: { [weak self] error in
+        return OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: status, onCompletion: { [weak self] error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
                 self?.syncNotes()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
@@ -66,7 +66,7 @@ final class OrderFulfillmentUseCase {
                                                              "to": targetStatus.rawValue])
 
         let result: Future<Void, FulfillmentError> = Future { promise in
-            let action = OrderAction.updateOrder(siteID: order.siteID, orderID: order.orderID, status: targetStatus) { error in
+            let action = OrderAction.updateOrderStatus(siteID: order.siteID, orderID: order.orderID, status: targetStatus) { error in
                 guard let error = error else {
                     NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
                     self.analytics.track(.orderStatusChangeSuccess)

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -59,7 +59,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(storesManager.receivedActions.count, 1)
 
         let action = try XCTUnwrap(storesManager.receivedActions.first as? OrderAction)
-        guard case let .updateOrder(siteID: siteID, orderID: orderID, status: status, onCompletion: _) = action else {
+        guard case let .updateOrderStatus(siteID: siteID, orderID: orderID, status: status, onCompletion: _) = action else {
             XCTFail("Expected \(action) to be \(OrderAction.self)")
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Customer Note/EditCustomerNoteViewModelTests.swift
@@ -2,12 +2,15 @@ import XCTest
 import TestKit
 
 @testable import WooCommerce
+@testable import Yosemite
 
 class EditCustomerNoteViewModelTests: XCTestCase {
 
+    private let order = Order.fake().copy(siteID: 123, orderID: 1234, customerNote: "Original")
+
     func test_done_button_is_disabled_when_note_content_is_the_same() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
+        let viewModel = EditCustomerNoteViewModel(order: order)
 
         // When
         let navigationItem = viewModel.navigationTrailingItem
@@ -18,7 +21,7 @@ class EditCustomerNoteViewModelTests: XCTestCase {
 
     func test_done_button_is_enabled_when_note_content_is_the_different() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
+        let viewModel = EditCustomerNoteViewModel(order: order)
 
         // When
         viewModel.newNote = "Edited"
@@ -29,7 +32,7 @@ class EditCustomerNoteViewModelTests: XCTestCase {
 
     func test_loading_indicator_gets_enabled_during_network_request() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
+        let viewModel = EditCustomerNoteViewModel(order: order)
 
         // When
         viewModel.updateNote {}
@@ -40,7 +43,16 @@ class EditCustomerNoteViewModelTests: XCTestCase {
 
     func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
         // Given
-        let viewModel = EditCustomerNoteViewModel(originalNote: "Original")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = EditCustomerNoteViewModel(order: order, stores: stores)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrder(_, order, _, onCompletion):
+                onCompletion(.success(order))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
 
         // When
         let navigationItem = waitFor { promise in
@@ -51,5 +63,29 @@ class EditCustomerNoteViewModelTests: XCTestCase {
 
         // Then
         assertEqual(navigationItem, .done(enabled: false))
+    }
+
+    func test_view_model_only_updates_customer_note_field() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = EditCustomerNoteViewModel(order: order, stores: stores)
+        viewModel.newNote = "Edited"
+
+        // When
+        let update: (order: Order, fields: [OrderUpdateField]) = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, fields, _):
+                    promise((order, fields))
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+            viewModel.updateNote {}
+        }
+
+        // Then
+        assertEqual(update.order.customerNote, "Edited")
+        assertEqual(update.fields, [.customerNote])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderFulfillmentUseCaseTests.swift
@@ -63,7 +63,7 @@ final class OrderFulfillmentUseCaseTests: XCTestCase {
         let useCase = OrderFulfillmentUseCase(order: order, stores: stores)
 
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            guard case let .updateOrder(siteID: _, orderID: _, status: status, onCompletion: onCompletion) = action else {
+            guard case let .updateOrderStatus(siteID: _, orderID: _, status: status, onCompletion: onCompletion) = action else {
                 XCTFail("Unexpected action \(action).")
                 return
             }
@@ -159,7 +159,7 @@ private extension OrderFulfillmentUseCaseTests {
                     file: StaticString = #file,
                     line: UInt = #line) {
 
-        guard case let .updateOrder(siteID: siteID, orderID: orderID, status: actualStatus, onCompletion: _) = statusUpdateAction else {
+        guard case let .updateOrderStatus(siteID: siteID, orderID: orderID, status: actualStatus, onCompletion: _) = statusUpdateAction else {
             XCTFail("Expected \(statusUpdateAction) to be \(OrderAction.self).updateOrder.", file: file, line: line)
             return
         }
@@ -174,7 +174,7 @@ private extension OrderFulfillmentUseCaseTests {
                                file: StaticString = #file,
                                line: UInt = #line) {
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            guard case let .updateOrder(siteID: _, orderID: _, status: _, onCompletion: onCompletion) = action else {
+            guard case let .updateOrderStatus(siteID: _, orderID: _, status: _, onCompletion: onCompletion) = action else {
                 XCTFail("Unexpected action \(action).", file: file, line: line)
                 return
             }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -53,5 +53,9 @@ public enum OrderAction: Action {
 
     /// Updates a given Order's Status.
     ///
-    case updateOrder(siteID: Int64, orderID: Int64, status: OrderStatusEnum, onCompletion: (Error?) -> Void)
+    case updateOrderStatus(siteID: Int64, orderID: Int64, status: OrderStatusEnum, onCompletion: (Error?) -> Void)
+
+    /// Updates the specified fields from an order.
+    ///
+    case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -42,6 +42,7 @@ public typealias OrderStatsV4 = Networking.OrderStatsV4
 public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval
 public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
+public typealias OrderUpdateField = Networking.OrdersRemote.UpdateOrderField
 public typealias PaymentGateway = Networking.PaymentGateway
 public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -54,8 +54,11 @@ public class OrderStore: Store {
                               pageNumber: pageNumber,
                               pageSize: pageSize,
                               onCompletion: onCompletion)
-        case .updateOrder(let siteID, let orderID, let statusKey, let onCompletion):
+        case .updateOrderStatus(let siteID, let orderID, let statusKey, let onCompletion):
             updateOrder(siteID: siteID, orderID: orderID, status: statusKey, onCompletion: onCompletion)
+
+        case let .updateOrder(siteID, order, fields, onCompletion):
+            break
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -522,7 +522,7 @@ final class OrderStoreTests: XCTestCase {
         // Update: Expected Status is actually coming from `order.json` (Status == .processing actually!)
         network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
 
-        let action = OrderAction.updateOrder(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
+        let action = OrderAction.updateOrderStatus(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
             XCTAssertNil(error)
 
             let storageOrder = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)
@@ -546,7 +546,7 @@ final class OrderStoreTests: XCTestCase {
 
         network.removeAllSimulatedResponses()
 
-        let action = OrderAction.updateOrder(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
+        let action = OrderAction.updateOrderStatus(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
             XCTAssertNotNil(error)
 
             let storageOrder = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)


### PR DESCRIPTION
part of #4477

# Why

After filling the UI with the real information #4800, now it's time to send the network request to update the customer note remotely.

# How

- Added a new `updateOrder` action that will receive from the consumer which fields to update. 
This is in order to not send a huge payload and prevent extra work on the server. 
This also forced me to rename the existing `updateOrder` action to `updateOrderStatus` because it only updates the status. 

- Added a new method on `OrderRemote` to fire the network request to update the order by listening to the provided fields.
Here I've made the Order's `CodingKeys` internal to not duplicate the fields key value.

- Updated `ViewModel` to modify the order with the new note content and dispatch the correct action

# Demo
https://user-images.githubusercontent.com/562080/130980177-3df6238c-847e-46d0-b068-e64391369095.mov

# Testing Steps

- Navigate to an order
- Tap on the edit icon on the customer provided note
- Modify the content and tap done
- Wait for the network operation to complete and see that the customer note got updated

# TODO:

- Success and error notices will be done in the next PR as I have to make sure they work well with `SwiftUI`.

- Work for disabling the user input while the network operation is ongoing will be done in a next PR.

- There is a separate action to update the order status, I will be working on unifying that into the new `updateOrder` action in a separate PR. https://github.com/woocommerce/woocommerce-ios/projects/39#card-67530782


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
