### PR TITLE
[Mobile Payments] [Card Reader Software Updates] Remove feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -17,8 +17,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsMultiPackage:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .cardPresentSoftwareUpdates:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -38,10 +38,6 @@ enum FeatureFlag: Int {
     ///
     case shippingLabelsMultiPackage
 
-    /// Card-Present Payments Reader Software Updates
-    ///
-    case cardPresentSoftwareUpdates
-
     /// Editing of notes, shipping, and billing addresses.
     ///
     case orderEditing

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -67,9 +67,6 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
 //
 private extension CardReaderSettingsConnectedViewController {
     func checkForCardReaderUpdate() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentSoftwareUpdates) else {
-            return
-        }
         guard let viewModel = viewModel else {
             return
         }
@@ -83,9 +80,6 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     func shouldShowUpdateControls() -> Bool {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentSoftwareUpdates) else {
-            return false
-        }
         guard let viewModel = viewModel else {
             return false
         }


### PR DESCRIPTION
Closes #4059 

This is the last PR in the Card Reader Software Updates series. It removes the feature flag and related logic, thereby enabling card reader updates for all users.

Changes:
- On connecting to a card reader in settings, you will be prompted if a card reader software update is available. If you tap on the Update button, your reader will be updated. If you don't, it won't.
- IMPORTANT: Note that once a reader has been updated, you can't downgrade it. Also, reader updates are only posted by Stripe/BBPOS once or twice a year.

To test:

- IMPORTANT: If you don't want to update your card reader, either 1) don't use this feature, or 2) run with `-simulate-stripe-card-reader` enabled in your Xcode Run Scheme

OR, if you want to test updating an actual reader

- Connect a card reader that needs updating
- To determine this, set a breakpoint in the completion for Terminal.shared.connectReader in Stripe CardReaderService.swift
- Connect to the reader and verify the deviceSoftwareVersion is < v45 (v45 is the current version). For example, my reader was running v37 (1.00.03.34-SZZZ_Generic_v37-300001)
- Verify that, on connecting to a card reader in settings, you are prompted that a card reader software update is available. Tap on the Update button to begin the update.
- The update will take a minute or two to complete. When finished, verify the "update available" prompt and button go away and a notice "Reader Software Updated" is briefly displayed at the bottom of the screen
- Re-enable the breakpoint in the completion for Terminal.shared.connectReader in Stripe CardReaderService.swift and disconnect and reconnect to the reader
- Verify the deviceSoftwareVersion is v45
- Verify you can capture a payment with a test card

For more information on reader software versions, see https://stripe.com/docs/terminal/readers/bbpos-chipper2xbt#reader-software-releases

@Garance91540 @adamzelinski - I've included @woocommerce/mobile-designers as a reviewer here in case there is any thing you see in the video that needs changes before we launch this feature to everyone: pdfdoF-5V-p2

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
