### PR TITLE
Shipping Labels: Initial UI for selecting/activating a service package screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -3,12 +3,7 @@ import Yosemite
 
 struct ShippingLabelAddNewPackage: View {
     @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
-
-    private var packagesResponse: ShippingLabelPackagesResponse?
-
-    init(packagesResponse: ShippingLabelPackagesResponse?) {
-        self.packagesResponse = packagesResponse
-    }
+    let packagesResponse: ShippingLabelPackagesResponse?
 
     var body: some View {
         GeometryReader { geometry in
@@ -25,8 +20,7 @@ struct ShippingLabelAddNewPackage: View {
                     case .customPackage:
                         ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        let viewModel = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
-                        ShippingLabelServicePackageList(viewModel: viewModel, safeAreaInsets: geometry.safeAreaInsets)
+                        ShippingLabelServicePackageList(packagesResponse: packagesResponse, safeAreaInsets: geometry.safeAreaInsets)
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -18,7 +18,7 @@ struct ShippingLabelAddNewPackage: View {
                     case .customPackage:
                         ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        EmptyView() // TODO-4743: Show service package view
+                        ShippingLabelServicePackageList()
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -1,7 +1,14 @@
 import SwiftUI
+import Yosemite
 
 struct ShippingLabelAddNewPackage: View {
     @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
+
+    private var packagesResponse: ShippingLabelPackagesResponse?
+
+    init(packagesResponse: ShippingLabelPackagesResponse?) {
+        self.packagesResponse = packagesResponse
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -18,7 +25,8 @@ struct ShippingLabelAddNewPackage: View {
                     case .customPackage:
                         ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        ShippingLabelServicePackageList()
+                        let viewModel = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
+                        ShippingLabelServicePackageList(viewModel: viewModel, safeAreaInsets: geometry.safeAreaInsets)
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))
@@ -40,6 +48,6 @@ private extension ShippingLabelAddNewPackage {
 
 struct ShippingLabelAddNewPackage_Previews: PreviewProvider {
     static var previews: some View {
-        ShippingLabelAddNewPackage()
+        ShippingLabelAddNewPackage(packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -29,7 +29,7 @@ struct ShippingLabelServicePackageList: View {
                                       subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
                                       selected: selected)
                         .onTapGesture {
-                            viewModel.didSelectPackage(package.id)
+                            viewModel.selectedPackage = package
                         }
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -1,16 +1,11 @@
 import SwiftUI
+import Yosemite
 
 struct ShippingLabelServicePackageList: View {
-    private let safeAreaInsets: EdgeInsets
-
     @Environment(\.presentationMode) var presentation
-    @ObservedObject var viewModel: ShippingLabelServicePackageListViewModel
-
-    init(viewModel: ShippingLabelServicePackageListViewModel,
-         safeAreaInsets: EdgeInsets) {
-        self.viewModel = viewModel
-        self.safeAreaInsets = safeAreaInsets
-    }
+    @StateObject var viewModel = ShippingLabelServicePackageListViewModel()
+    let packagesResponse: ShippingLabelPackagesResponse?
+    let safeAreaInsets: EdgeInsets
 
     var body: some View {
         LazyVStack(spacing: 0) {
@@ -37,6 +32,9 @@ struct ShippingLabelServicePackageList: View {
                 }
             }
         }
+        .onAppear(perform: {
+            viewModel.packagesResponse = packagesResponse
+        })
         .background(Color(.listBackground))
         .ignoresSafeArea(.container, edges: .horizontal)
         .minimalNavigationBarBackButton()
@@ -67,9 +65,9 @@ private extension ShippingLabelServicePackageList {
 
 struct ShippingLabelServicePackageList_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ShippingLabelServicePackageListViewModel(packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+        let packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
 
-        ShippingLabelServicePackageList(viewModel: viewModel, safeAreaInsets: .zero)
+        ShippingLabelServicePackageList(packagesResponse: packagesResponse, safeAreaInsets: .zero)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -28,7 +28,9 @@ struct ShippingLabelServicePackageList: View {
                         }
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.systemBackground))
-                    Divider().padding(.leading, Constants.horizontalPadding)
+                    Divider()
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .padding(.leading, Constants.dividerPadding)
                 }
             }
         }
@@ -58,7 +60,7 @@ private extension ShippingLabelServicePackageList {
     }
 
     enum Constants {
-        static let horizontalPadding: CGFloat = 16
+        static let dividerPadding: CGFloat = 48
         static let verticalSpacing: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ShippingLabelServicePackageList: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+
+struct ShippingLabelServicePackageList_Previews: PreviewProvider {
+    static var previews: some View {
+        ShippingLabelServicePackageList()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -1,13 +1,75 @@
 import SwiftUI
 
 struct ShippingLabelServicePackageList: View {
+    private let safeAreaInsets: EdgeInsets
+
+    @Environment(\.presentationMode) var presentation
+    @ObservedObject var viewModel: ShippingLabelServicePackageListViewModel
+
+    init(viewModel: ShippingLabelServicePackageListViewModel,
+         safeAreaInsets: EdgeInsets) {
+        self.viewModel = viewModel
+        self.safeAreaInsets = safeAreaInsets
+    }
+
     var body: some View {
-        EmptyView()
+        LazyVStack(spacing: 0) {
+            ListHeaderView(text: Localization.servicePackageHeader, alignment: .left)
+                .padding(.horizontal, insets: safeAreaInsets)
+
+            /// Packages
+            ///
+            ForEach(viewModel.predefinedOptions, id: \.title) { option in
+
+                ListHeaderView(text: option.title.uppercased(), alignment: .left)
+                    .padding(.horizontal, insets: safeAreaInsets)
+                ForEach(option.predefinedPackages) { package in
+                    let selected = package == viewModel.selectedPackage
+                    SelectableItemRow(title: package.title,
+                                      subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
+                                      selected: selected)
+                        .onTapGesture {
+                            viewModel.didSelectPackage(package.id)
+                        }
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(.systemBackground))
+                    Divider().padding(.leading, Constants.horizontalPadding)
+                }
+            }
+        }
+        .background(Color(.listBackground))
+        .ignoresSafeArea(.container, edges: .horizontal)
+        .minimalNavigationBarBackButton()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing, content: {
+                Button(Localization.doneButton, action: {
+                    // TODO-4744: Add selected service package and go back to package list
+                    presentation.wrappedValue.dismiss()
+                })
+            })
+        }
+    }
+}
+
+private extension ShippingLabelServicePackageList {
+    enum Localization {
+        static let servicePackageHeader = NSLocalizedString(
+            "Set up the package you'll be using to ship your products. We'll save it for future orders.",
+            comment: "Header text on Add New Custom Package screen in Shipping Label flow")
+        static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Custom Package screen in Shipping Label flow")
+    }
+
+    enum Constants {
+        static let horizontalPadding: CGFloat = 16
+        static let verticalSpacing: CGFloat = 16
     }
 }
 
 struct ShippingLabelServicePackageList_Previews: PreviewProvider {
     static var previews: some View {
-        ShippingLabelServicePackageList()
+        let viewModel = ShippingLabelServicePackageListViewModel(packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+
+        ShippingLabelServicePackageList(viewModel: viewModel, safeAreaInsets: .zero)
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -53,7 +53,7 @@ private extension ShippingLabelServicePackageList {
     enum Localization {
         static let servicePackageHeader = NSLocalizedString(
             "Set up the package you'll be using to ship your products. We'll save it for future orders.",
-            comment: "Header text on Add New Custom Package screen in Shipping Label flow")
+            comment: "Header text on Add New Service Package screen in Shipping Label flow")
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Custom Package screen in Shipping Label flow")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -14,7 +14,7 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
         packagesResponse?.predefinedOptions ?? []
     }
 
-    @Published private(set) var selectedPackage: ShippingLabelPredefinedPackage?
+    @Published var selectedPackage: ShippingLabelPredefinedPackage?
 
     var dimensionUnit: String {
         packagesResponse?.storeOptions.dimensionUnit ?? ""
@@ -22,19 +22,5 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
 
     init(packagesResponse: ShippingLabelPackagesResponse?) {
         self.packagesResponse = packagesResponse
-    }
-}
-
-// MARK: - Helper Methods
-extension ShippingLabelServicePackageListViewModel {
-    func didSelectPackage(_ id: String) {
-        for option in predefinedOptions {
-            for predefinedPackage in option.predefinedPackages {
-                if predefinedPackage.id == id {
-                    selectedPackage = predefinedPackage
-                    return
-                }
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -6,7 +6,7 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
 
     /// The packages response fetched from API
     ///
-    private let packagesResponse: ShippingLabelPackagesResponse?
+    @Published var packagesResponse: ShippingLabelPackagesResponse?
 
     // TODO-4744: Get the options not yet enabled on the store
     // These are the already enabled options, used temporarily for creating the initial UI
@@ -18,9 +18,5 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
 
     var dimensionUnit: String {
         packagesResponse?.storeOptions.dimensionUnit ?? ""
-    }
-
-    init(packagesResponse: ShippingLabelPackagesResponse?) {
-        self.packagesResponse = packagesResponse
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -1,0 +1,40 @@
+import Yosemite
+
+/// View model for `ShippingLabelServicePackageList`.
+///
+final class ShippingLabelServicePackageListViewModel: ObservableObject {
+
+    /// The packages response fetched from API
+    ///
+    private let packagesResponse: ShippingLabelPackagesResponse?
+
+    // TODO-4744: Get the options not yet enabled on the store
+    // These are the already enabled options, used temporarily for creating the initial UI
+    var predefinedOptions: [ShippingLabelPredefinedOption] {
+        packagesResponse?.predefinedOptions ?? []
+    }
+
+    @Published private(set) var selectedPackage: ShippingLabelPredefinedPackage?
+
+    var dimensionUnit: String {
+        packagesResponse?.storeOptions.dimensionUnit ?? ""
+    }
+
+    init(packagesResponse: ShippingLabelPackagesResponse?) {
+        self.packagesResponse = packagesResponse
+    }
+}
+
+// MARK: - Helper Methods
+extension ShippingLabelServicePackageListViewModel {
+    func didSelectPackage(_ id: String) {
+        for option in predefinedOptions {
+            for predefinedPackage in option.predefinedPackages {
+                if predefinedPackage.id == id {
+                    selectedPackage = predefinedPackage
+                    return
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -63,7 +63,8 @@ struct ShippingLabelPackageList: View {
                 }))
 
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages) {
-                    NavigationLink(destination: ShippingLabelAddNewPackage(), isActive: $isShowingNewPackageCreation) {
+                    NavigationLink(destination: ShippingLabelAddNewPackage(packagesResponse: viewModel.packagesResponse),
+                                   isActive: $isShowingNewPackageCreation) {
                         EmptyView()
                     }
                     BottomButtonView(style: LinkButtonStyle(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageSelection: View {
             if viewModel.hasCustomOrPredefinedPackages {
                 ShippingLabelPackageList(viewModel: viewModel)
             } else {
-                ShippingLabelAddNewPackage()
+                ShippingLabelAddNewPackage(packagesResponse: viewModel.packagesResponse)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -26,7 +26,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     /// The packages  response fetched from API
     ///
-    @Published private var packagesResponse: ShippingLabelPackagesResponse?
+    @Published private(set) var packagesResponse: ShippingLabelPackagesResponse?
 
     var dimensionUnit: String {
         return packagesResponse?.storeOptions.dimensionUnit ?? ""

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -960,6 +960,7 @@
 		CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */; };
 		CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */; };
 		CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */; };
+		CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
 		CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
@@ -2356,6 +2357,7 @@
 		CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomPackageFormViewModelTests.swift; sourceTree = "<group>"; };
 		CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModel.swift; sourceTree = "<group>"; };
 		CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModelTests.swift; sourceTree = "<group>"; };
+		CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelServicePackageList.swift; sourceTree = "<group>"; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -5256,6 +5258,7 @@
 				CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */,
 				CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */,
 				CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */,
+				CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */,
 			);
 			path = "Package Creation";
 			sourceTree = "<group>";
@@ -7189,6 +7192,7 @@
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
 				26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */,
+				CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */,
 				45FDDD65267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift in Sources */,
 				45DB70662614CE3F0064A6CF /* Decimal+Helpers.swift in Sources */,
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -961,6 +961,7 @@
 		CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */; };
 		CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */; };
 		CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */; };
+		CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
 		CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
@@ -2358,6 +2359,7 @@
 		CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModel.swift; sourceTree = "<group>"; };
 		CCD2E68825DD52C100BD975D /* ProductVariationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewModelTests.swift; sourceTree = "<group>"; };
 		CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelServicePackageList.swift; sourceTree = "<group>"; };
+		CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelServicePackageListViewModel.swift; sourceTree = "<group>"; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -5259,6 +5261,7 @@
 				CC254F3526C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift */,
 				CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */,
 				CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */,
+				CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */,
 			);
 			path = "Package Creation";
 			sourceTree = "<group>";
@@ -6962,6 +6965,7 @@
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
 				02DD81FB242CAA400060E50B /* WordPressMediaLibraryPickerDataSource.swift in Sources */,
 				0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */,
+				CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */,
 				E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */,
 				74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */,
 				0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */,


### PR DESCRIPTION
Part of: #4744

## Description

In the shipping label creation flow, this introduces the UI to select a new (not yet enabled) service package to use for your shipping label. This view is visible when you select the "Service Package" tab on the Add New Package screen.

For now, this screen shows a list of the enabled service packages on your store, for demo purposes. Getting the list of not yet enabled service packages requires changes in the networking model, which will be done in a future PR. This also doesn't yet handle the empty state (when the service package list is empty), which will come in a future PR.

## Changes

* Adds `ShippingLabelServicePackageList` and view model, which is based on the UI in `ShippingLabelPackageDetails` (but simplified to fit this simpler view).
* Updates `ShippingLabelAddNewPackage` to display `ShippingLabelServicePackageList` when the "Service Package" tab is selected.

Design:

<img src="https://user-images.githubusercontent.com/8658164/128549046-71a0cb0a-a1dd-4004-811f-c7be9795098c.png" width="600px">

Portrait|Landscape
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-26 at 17 35 51](https://user-images.githubusercontent.com/8658164/131011434-ca22c687-0569-4f1c-8f34-a10b0a2d5e1b.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-26 at 17 36 10](https://user-images.githubusercontent.com/8658164/131011438-55e3144a-d678-422a-a44b-9b9904e32c1a.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the Add New Package screen, select "Service Package" and confirm a list of service (predefined) packages appears, organized by shipping provider. Confirm you can select a package from the list and a checkmark appears next to the selected package.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
