### PR TITLE
Point XCUITestHelpers to latest version

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
           "branch": null,
-          "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
-          "version": "0.1.0"
+          "revision": "3212ac32f0a58ea10604b5cf31fe5450f908ff65",
+          "version": "0.3.0"
         }
       }
     ]

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -8631,7 +8631,7 @@
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.3.0;
 			};
 		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {


### PR DESCRIPTION
I forgot to do this before merging #4811 🤦‍♂️ `:shameonme:`

To test: If UI tests pass in CI, we're good.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
