### PR TITLE
[Mobile Payments] [Several Readers Found] Switch to Bluetooth scan, handle multiple found readers

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -80,7 +80,7 @@ extension StripeCardReaderService: CardReaderService {
         Terminal.shared.logLevel = terminalLogLevel
 
         let config = DiscoveryConfiguration(
-            discoveryMethod: .bluetoothProximity,
+            discoveryMethod: .bluetoothScan,
             simulated: shouldUseSimulatedCardReader
         )
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -42,7 +42,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="135.5" y="0.0" width="41.5" height="49"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -56,12 +56,21 @@ final class CardReaderConnectionController {
     private var knownCardReadersProvider: CardReaderSettingsKnownReadersProvider
     private var alerts: CardReaderSettingsAlertsProvider
 
-    private var foundReader: CardReader?
+    /// Reader(s) discovered by the card reader service
+    ///
+    private var foundReaders: [CardReader]
+
+    /// Reader(s) known to us (i.e. we've connected to them in the past)
+    ///
     private var knownReaderIDs: [String]
+
+    /// Reader(s) discovered by the card reader service that the merchant declined to connect to
+    ///
+    private var skippedReaderIDs: [String]
+
     private var subscriptions = Set<AnyCancellable>()
 
     private var onCompletion: ((Result<Bool, Error>) -> Void)?
-
 
     init(
         forSiteID: Int64,
@@ -72,7 +81,9 @@ final class CardReaderConnectionController {
         siteID = forSiteID
         knownCardReadersProvider = knownReadersProvider
         alerts = alertsProvider
+        foundReaders = []
         knownReaderIDs = []
+        skippedReaderIDs = []
     }
 
     deinit {
@@ -112,6 +123,19 @@ private extension CardReaderConnectionController {
         }
     }
 
+    /// Updates the found readers list by removing any the user has asked
+    /// us to ignore (aka keep searching) during this discovery session
+    ///
+    func pruneSkippedReaders() {
+        self.foundReaders = self.foundReaders.filter({!skippedReaderIDs.contains($0.id)})
+    }
+
+    /// Returns the list of found readers which are also known
+    ///
+    func getFoundKnownReaders() -> [CardReader] {
+        self.foundReaders.filter({knownReaderIDs.contains($0.id)})
+    }
+
     /// Initial state of the controller
     ///
     func onIdle() {
@@ -122,6 +146,12 @@ private extension CardReaderConnectionController {
     /// Transitions state to `.beginSearch` after receiving the known readers list
     ///
     func onInitialization() {
+        /// Always start fresh - i.e. we haven't skipped connecting to any reader yet
+        ///
+        skippedReaderIDs = []
+
+        /// Fetch the list of known readers - i.e. readers we should automatically connect to when we see them
+        ///
         knownCardReadersProvider.knownReaders.sink(receiveValue: { [weak self] readerIDs in
             guard let self = self else {
                 return
@@ -151,25 +181,33 @@ private extension CardReaderConnectionController {
                     return
                 }
 
-                /// Surprisingly, onReaderDiscovered may be called with an empty array
+                /// First, update our copy of the foundReaders and prune
+                /// skipped ones
                 ///
-                guard cardReaders.count > 0 else {
+                self.foundReaders = cardReaders
+                self.pruneSkippedReaders()
+
+                /// This completion can be called repeatedly as more readers
+                /// become discovered. To avoid interrupting connecting to
+                /// a known reader, or interrupting the user prompt for a unknown
+                /// reader, ensure we are in the searching state first
+                ///
+                guard case .searching = self.state else {
                     return
                 }
 
-                /// For now, we only work with the first card reader returned
-                /// When we stop using proximity, we'll need more elaborate logic as we
-                /// won't be able to do that anymore
+                /// If we have a known reader, advance immediately to connect
                 ///
-                self.foundReader = cardReaders.first
-
-                guard let foundReaderID = self.foundReader?.id else {
-                    DDLogWarn("onBeginSearch unexpectedly handled a nil found reader")
+                if self.getFoundKnownReaders().isNotEmpty {
+                    self.state = .connectToReader
                     return
                 }
 
-                let knownReaderIDs = self.knownReaderIDs
-                self.state = knownReaderIDs.contains(foundReaderID) ? .connectToReader : .foundReader
+                /// If we have a found (but unknown) reader, advance to foundReader
+                ///
+                if self.foundReaders.isNotEmpty {
+                    self.state = .foundReader
+                }
             },
             onError: { [weak self] error in
                 guard let self = self else {
@@ -191,6 +229,14 @@ private extension CardReaderConnectionController {
             return
         }
 
+        /// In the case of multiple found readers, we may have another reader to show
+        /// to the user at this point, so don't open the searching modal, but go to
+        /// onFoundReader
+        if foundReaders.isNotEmpty {
+            self.state = .foundReader
+            return
+        }
+
         alerts.scanningForReader(from: from, cancel: {
             self.state = .cancel
         })
@@ -200,7 +246,11 @@ private extension CardReaderConnectionController {
     /// Opens a confirmation modal for the user to accept the found reader (or keep searching)
     ///
     func onFoundReader() {
-        guard let name = foundReader?.id else {
+        /// We always work with the zeroth reader in the foundReaders array
+        /// The array will have already had skipped (aka "keep searching") readers removed
+        /// by time we get here
+        ///
+        guard let readerID = foundReaders.first?.id else {
             return
         }
 
@@ -210,11 +260,13 @@ private extension CardReaderConnectionController {
 
         alerts.foundReader(
             from: from,
-            name: name,
+            name: readerID,
             connect: {
                 self.state = .connectToReader
             },
             continueSearch: {
+                self.skippedReaderIDs.append(readerID)
+                self.pruneSkippedReaders()
                 self.state = .searching
             })
     }
@@ -232,7 +284,11 @@ private extension CardReaderConnectionController {
     /// Connect to the card reader
     ///
     func onConnectToReader() {
-        guard let reader = foundReader else {
+        /// We always work with the first reader in the foundReaders array
+        /// The array will have already had skipped (aka "keep searching") readers removed
+        /// by time we get here
+        ///
+        guard let reader = foundReaders.first else {
             return
         }
 

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -93,7 +93,10 @@ private extension CardPresentPaymentStore {
                         onError(error)
                     }
                 },
-                receiveValue: onReaderDiscovered
+                receiveValue: { readers in
+                    let supportedReaders = readers.filter({$0.readerType != .notSupported})
+                    onReaderDiscovered(supportedReaders)
+                }
             ))
     }
 


### PR DESCRIPTION
Partially addresses #4333
Closes #4622 

Changes:
- Changes `StripeCardReaderService` to use scan (multiple reader support) instead of proximity
- Updates `CardReaderConnectionController` to handle multiple found readers and also properly handle "Continue Searching" UI which didn't really make sense for proximity
- Tweaks `CardPresentPaymentsModalViewController` to not cut off the reader name when present in the modal's headline by allowing the font to be downscaled further

To test:
- Power up two readers
- Enter Settings > In Person Payments > Manage card reader
- If either of your readers is a known reader, it will just automatically connect. This is expected. If there are multiple known readers found, the first known reader found will automatically connect.
- Go through the process to disconnect from any known reader and start search over again
- Ensure you are prompted whether you'd like to connect to each of your readers in turn, i.e.:

![IMG_0119](https://user-images.githubusercontent.com/1595739/131048795-94433b54-3465-41fa-9d46-af4d006d9790.PNG)
![IMG_0120](https://user-images.githubusercontent.com/1595739/131048800-c71186a8-7e67-421a-877d-32d97defb331.PNG)

Discussion:
- This PR does **not** test the Several Readers Found feature flag. There are two reasons for this: 1) `StripeCardReaderService` doesn't know about ServiceLocator and I'm not sure I want to go through the trouble of passing in that flag (I don't think Hardware layer should know about WooCommerce layer ServiceLocator) 2) this actually works just fine with just one reader, not unlike how it used to work, so there is no change from the users perspective - thoughts, @ctarda ?

What comes next:
- Next, instead of these successive dialogs (one-per-reader, one-after-the-other) we'll be implementing a single dialog listing the found readers from which the user can pick which reader to connect to. That will start in the next PR


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
