### PR TITLE
Shipping Labels: Fix error parsing purchased labels due to null tracking number

### DIFF
--- a/Networking/Networking/Mapper/OrderShippingLabelListMapper.swift
+++ b/Networking/Networking/Mapper/OrderShippingLabelListMapper.swift
@@ -81,11 +81,14 @@ private struct OrderShippingLabelListData: Decodable {
         // Shipping labels.
         let formData = try container.decode(OrderShippingLabelListFormData.self, forKey: .formData)
         let shippingLabelsWithoutAddresses = try container.decode([ShippingLabel].self, forKey: .labelsData)
-        // Populates each shipping label's `originAddress` and `destinationAddress` from `formData` because they are not available
+        // Filters only labels with a tracking number and status `.purchased`.
+        // Then populates each shipping label's `originAddress` and `destinationAddress` from `formData` because they are not available
         // in each shipping label response.
-        let shippingLabels = shippingLabelsWithoutAddresses.map {
-            $0.copy(originAddress: formData.originAddress, destinationAddress: formData.destinationAddress)
-        }
+        let shippingLabels = shippingLabelsWithoutAddresses
+            .filter { !$0.trackingNumber.isEmpty && $0.status == .purchased }
+            .map {
+                $0.copy(originAddress: formData.originAddress, destinationAddress: formData.destinationAddress)
+            }
 
         self.init(shippingLabels: shippingLabels, settings: settings)
     }

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabel.swift
@@ -115,7 +115,7 @@ extension ShippingLabel: Decodable {
         let packageName = try container.decode(String.self, forKey: .packageName)
         let rate = try container.decode(Double.self, forKey: .rate)
         let currency = try container.decode(String.self, forKey: .currency)
-        let trackingNumber = try container.decode(String.self, forKey: .trackingNumber)
+        let trackingNumber = (try container.decodeIfPresent(String.self, forKey: .trackingNumber)) ?? ""
         let serviceName = try container.decodeIfPresent(String.self, forKey: .serviceName) ?? ""
         let refund = try container.decodeIfPresent(ShippingLabelRefund.self, forKey: .refund)
         let refundableAmount = try container.decode(Double.self, forKey: .refundableAmount)

--- a/Networking/NetworkingTests/Responses/order-shipping-labels.json
+++ b/Networking/NetworkingTests/Responses/order-shipping-labels.json
@@ -112,6 +112,42 @@
                     "refund_date": 1
                 },
                 "label_cached": 1603715430000
+            },
+            {
+                "label_id": 2106,
+                "tracking": null,
+                "refundable_amount": 240.8,
+                "created": 1629878803224,
+                "carrier_id": "dhlexpress",
+                "service_name": "DHL - Express Worldwide",
+                "status": "PURCHASE_ERROR",
+                "commercial_invoice_url": "",
+                "package_name": "Food Secured Box",
+                "is_letter": false,
+                "product_names": [
+                    "Pesto Spaghetti",
+                    "Seafood Spaghetti",
+                    "Pho",
+                    "Ramen",
+                    "Tomyum Noodle",
+                    "Cold Udon",
+                    "Carbonara Spaghetti"
+                ],
+                "product_ids": [
+                    119,
+                    123,
+                    121,
+                    127,
+                    131,
+                    129,
+                    125
+                ],
+                "receipt_item_id": 24606630,
+                "created_date": 1629878803000,
+                "main_receipt_id": 19995467,
+                "rate": 240.8,
+                "currency": "USD",
+                "error": "There was a problem purchasing your shipping label. Please try again in a moment."
             }
         ],
         "storeOptions": {


### PR DESCRIPTION
Closes #4877 

# Description
This PR fixes issue fetching shipping labels on Order Details screen due to failure to parse the label list when one of the items is a failed label.

The solution is to not force shipping labels to have a non-nil tracking number; and to not return failed purchases in the list of labels.

# Changes
- Updated decoder of `ShippingLabel` to return `nil` tracking number as an empty string instead of throwing parsing error.
- Updated `OrderShippingLabelListMapper` to filter only the labels with non-empty tracking number and status `.purchased`.
- Updated test JSON response for the label list to test parsing of the label list.

# Testing
With the updated JSON response, unit tests should still pass for `OrderShippingLabelListMapper`.
This can also be tested by purchasing an international shipping label with DHL, however it's not 100% reproducible to get failed purchases for the edge case. These are the steps to test:

1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an international order (origin and destination countries are different).
3. Navigate to Orders tab on iOS app, select the new order and select Create Shipping Label.
4. Configure Ship From, Ship To, Package Details and Customs. Please make sure to enter phone number for both origin and destination addresses.
5. In Carriers and Rates, select DHL as the carrier.
6. Proceed to purchase the label.
7. After the purchase succeeds, dismiss the print view and get back to the Order Details screen.
8. Notice that Create Shipping Label button is no longer present, and instead you should see Shipping Label section with the label that was just purchased.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
