### PR TITLE
Fix Vertical Alignment of Empty State

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.5
 -----
-- [*] Fix empty states sometimes not centered vertically
+- [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
 
 7.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.5
 -----
-
+- [*] Fix empty states sometimes not centered vertically
 
 7.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -48,7 +48,10 @@ final class KeyboardFrameObserver {
                                        object: nil)
 
         if sendInitialEvent {
-            keyboardFrame = keyboardStateProvider.state.frameEnd
+            let currentState = keyboardStateProvider.state
+            // Always check the `isVisible` because `frameEnd` can still return a non-zero.
+            // See the `frameEnd` documentation why.
+            keyboardFrame = currentState.isVisible ? currentState.frameEnd : .zero
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -49,7 +49,7 @@ final class KeyboardFrameObserver {
 
         if sendInitialEvent {
             let currentState = keyboardStateProvider.state
-            // Always check the `isVisible` because `frameEnd` can still return a non-zero.
+            // Always check the `isVisible` because `frameEnd` can still return a non-zero value.
             // See the `frameEnd` documentation why.
             keyboardFrame = currentState.isVisible ? currentState.frameEnd : .zero
         }

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -8,7 +8,17 @@ struct KeyboardState: Equatable {
     let isVisible: Bool
     /// The frame of the keyboard when it is fully shown or hidden.
     ///
-    /// The value is usually from `UIResponder.keyboardFrameEndUserInfoKey`.
+    /// The value is from `UIResponder.keyboardFrameEndUserInfoKey`.
+    ///
+    /// Note that even if `isVisible` is `false`, this can still have a **non-zero** value. This
+    /// can happen in this scenario:
+    ///
+    /// 1. View-A is shown and the keyboard is shown.
+    /// 2. User taps on something which presents View-B **while** the keyboard is present.
+    ///    View-B does not have a user responder (text field) so the keyboard is not visible.
+    /// 3. NSNotificationCenter emits a `keyboardDidHideNotification` but with a
+    ///    `keyboardFrameEndUserInfoKey` value set to the **previously shown keyboard's frame**.
+    ///
     let frameEnd: CGRect
 }
 

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -6,6 +6,7 @@ import UIKit
 struct KeyboardState: Equatable {
     /// True if the keyboard is visible.
     let isVisible: Bool
+
     /// The frame of the keyboard when it is fully shown or hidden.
     ///
     /// The value is from `UIResponder.keyboardFrameEndUserInfoKey`.

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -16,7 +16,7 @@ struct KeyboardState: Equatable {
     /// 1. View-A is shown and the keyboard is shown.
     /// 2. User taps on something which presents View-B **while** the keyboard is present.
     ///    View-B does not have a user responder (text field) so the keyboard is not visible.
-    /// 3. NSNotificationCenter emits a `keyboardDidHideNotification` but with a
+    /// 3. NSNotificationCenter emits a `keyboardWillHideNotification` but with a
     ///    `keyboardFrameEndUserInfoKey` value set to the **previously shown keyboard's frame**.
     ///
     let frameEnd: CGRect

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -53,7 +53,7 @@ final class KeyboardStateProvider: KeyboardStateProviding {
     init(notificationCenter: NotificationCenter = NotificationCenter.default) {
         self.notificationCenter = notificationCenter
 
-        let notificationNames = [UIResponder.keyboardDidShowNotification, UIResponder.keyboardDidHideNotification]
+        let notificationNames = [UIResponder.keyboardWillShowNotification, UIResponder.keyboardWillHideNotification]
 
         observations.append(contentsOf: notificationNames.map { notificationName in
             notificationCenter.addObserver(forName: notificationName, object: nil, queue: nil) { [weak self] notification in
@@ -64,7 +64,7 @@ final class KeyboardStateProvider: KeyboardStateProviding {
 
     private func updateState(from notification: Notification) {
         state = KeyboardState(
-            isVisible: notification.name == UIResponder.keyboardDidShowNotification,
+            isVisible: notification.name == UIResponder.keyboardWillShowNotification,
             frameEnd: notification.keyboardFrameEnd ?? .zero
         )
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -59,7 +59,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     @IBOutlet private var contentView: UIView!
     /// The child of the contentView containing all the content (labels, image, etc).
     ///
-    @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet private weak var stackView: UIStackView!
 
 
     /// The height adjustment constraint for the content view.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -6,7 +6,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
     // If the keyboard frame is the same from multiple notification posts, it should only
     // notify the subscriber once.
-    func testObservingKeyboardFrameChangesWithTheSameFrame() {
+    func test_observing_keyboard_frame_changes_with_the_same_frame() {
         let notificationCenter = NotificationCenter()
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
@@ -36,7 +36,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
-    func testObservingKeyboardFrameChangesWithDifferentFrames() {
+    func test_observing_keyboard_frame_changes_with_different_frames() {
         let notificationCenter = NotificationCenter()
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
@@ -65,7 +65,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
-    func testObservingKeyboardFrameChangesWithNonKeyboardNotification() {
+    func test_observing_keyboard_frame_changes_with_non_keyboard_notification() {
         let notificationCenter = NotificationCenter()
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
@@ -83,7 +83,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
-    func testObservingKeyboardFrameChangesWithoutKeyboardUserInfo() {
+    func test_observing_keyboard_frame_changes_without_keyboard_user_info() {
         let notificationCenter = NotificationCenter()
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
@@ -101,7 +101,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
-    func testItWillNotEmitNewEventsWhenItIsDeallocated() {
+    func test_it_will_not_emit_new_events_when_it_is_deallocated() {
         // Arrange
         let notificationCenter = NotificationCenter()
 
@@ -126,7 +126,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         XCTAssertEqual(eventsLogged, 2)
     }
 
-    func testItCanSendInitialEvents() {
+    func test_it_can_send_initial_events() {
         // Arrange
         let expectedKeyboardState = KeyboardState(
             isVisible: true,
@@ -151,7 +151,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
     ///
     /// See the `KeyboardState.frameEnd` for more info about this behavior.
     ///
-    func testItWillSendAZeroFrameIfTheCurrentKeyboardIsNotVisible() {
+    func test_it_will_send_a_zero_frame_if_the_current_keyboard_is_not_visible() {
         // Arrange
         // Emit a non-zero frame
         let emittedKeyboardState = KeyboardState(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -145,6 +145,32 @@ final class KeyboardFrameObserverTests: XCTestCase {
         // Assert
         XCTAssertEqual(actualKeyboardFrame, expectedKeyboardState.frameEnd)
     }
+
+    /// iOS can send a non-zero frame even if the keyboard is visible. KeyboardStateFrameObserver
+    /// makes sure that a zero frame is sent if this happens.
+    ///
+    /// See the `KeyboardState.frameEnd` for more info about this behavior.
+    ///
+    func testItWillSendAZeroFrameIfTheCurrentKeyboardIsNotVisible() {
+        // Arrange
+        // Emit a non-zero frame
+        let emittedKeyboardState = KeyboardState(
+            isVisible: false,
+            frameEnd: CGRect(x: 2_100, y: 3_123, width: 9_981_123, height: 1_514)
+        )
+        let keyboardStateProvider = MockKeyboardStateProvider(state: emittedKeyboardState)
+
+        var actualKeyboardFrame: CGRect? = nil
+        var keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
+            actualKeyboardFrame = frame
+        }
+
+        // Act
+        keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
+
+        // Assert
+        XCTAssertEqual(actualKeyboardFrame, .zero)
+    }
 }
 
 private extension NotificationCenter {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -161,7 +161,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         let keyboardStateProvider = MockKeyboardStateProvider(state: emittedKeyboardState)
 
         var actualKeyboardFrame: CGRect? = nil
-        var keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
+        let keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
             actualKeyboardFrame = frame
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -12,7 +12,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         XCTAssertEqual(provider.state, KeyboardState(isVisible: false, frameEnd: .zero))
     }
 
-    func test_it_updates_the_state_when_the_keyboard_is_shown() {
+    func test_it_updates_the_state_when_the_keyboard_is_about_to_be_shown() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -26,7 +26,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedFrameEnd))
     }
 
-    func test_it_updates_the_state_when_the_keyboard_is_hidden() {
+    func test_it_updates_the_state_when_the_keyboard_is_about_to_be_hidden() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -91,4 +91,3 @@ private extension NotificationCenter {
         post(name: UIResponder.keyboardWillHideNotification, object: nil, userInfo: userInfo)
     }
 }
-

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -36,7 +36,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         let expectedFrameEnd = CGRect(x: 981, y: 5_135, width: 146, height: 561)
 
         // Act
-        notificationCenter.postKeyboardDidHideNotification(frameEnd: expectedFrameEnd)
+        notificationCenter.postKeyboardWillHideNotification(frameEnd: expectedFrameEnd)
 
         // Assert
         XCTAssertEqual(provider.state, KeyboardState(isVisible: false, frameEnd: expectedFrameEnd))
@@ -51,9 +51,9 @@ final class KeyboardStateProviderTests: XCTestCase {
         let expectedLastFrameEnd = CGRect(x: 888, y: 555, width: 121_411, height: 971_471)
 
         // Act
-        notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
+        notificationCenter.postKeyboardWillHideNotification(frameEnd: .zero)
         notificationCenter.postKeyboardWillShowNotification(frameEnd: CGRect(x: 1, y: 2, width: 3, height: 4))
-        notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
+        notificationCenter.postKeyboardWillHideNotification(frameEnd: .zero)
         notificationCenter.postKeyboardWillShowNotification(frameEnd: expectedLastFrameEnd)
 
         // Assert
@@ -86,9 +86,9 @@ private extension NotificationCenter {
         post(name: UIResponder.keyboardWillShowNotification, object: nil, userInfo: userInfo)
     }
 
-    func postKeyboardDidHideNotification(frameEnd: CGRect) {
+    func postKeyboardWillHideNotification(frameEnd: CGRect) {
         let userInfo = [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
-        post(name: UIResponder.keyboardDidHideNotification, object: nil, userInfo: userInfo)
+        post(name: UIResponder.keyboardWillHideNotification, object: nil, userInfo: userInfo)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -6,13 +6,13 @@ import UIKit
 /// Tests for the concrete `KeyboardStateProvider`
 ///
 final class KeyboardStateProviderTests: XCTestCase {
-    func testItDefaultsToNotVisibleAndNoFrame() {
+    func test_it_defaults_to_not_visible_and_no_frame() {
         let provider = KeyboardStateProvider()
 
         XCTAssertEqual(provider.state, KeyboardState(isVisible: false, frameEnd: .zero))
     }
 
-    func testItUpdatesTheStateWhenTheKeyboardIsShown() {
+    func test_it_updates_the_state_when_the_keyboard_is_shown() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -26,7 +26,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedFrameEnd))
     }
 
-    func testItUpdatesTheStateWhenTheKeyboardIsHidden() {
+    func test_it_updates_the_state_when_the_keyboard_is_hidden() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -43,7 +43,7 @@ final class KeyboardStateProviderTests: XCTestCase {
     }
 
     /// Test receiving multiple Notifications
-    func testItContinuouslyUpdatesTheStateWhenMultipleEventsHappen() {
+    func test_it_continuously_updates_the_state_when_multiple_events_happen() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -60,7 +60,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedLastFrameEnd))
     }
 
-    func testItUpdatesTheStateToZeroFrameEndWhenTheNotificationHasNoFrameEnd() {
+    func test_it_updates_the_state_to_zero_frame_end_when_the_notification_has_no_frame_end() {
         // Arrange
         let notificationCenter = NotificationCenter()
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
@@ -91,3 +91,4 @@ private extension NotificationCenter {
         post(name: UIResponder.keyboardDidHideNotification, object: nil, userInfo: userInfo)
     }
 }
+

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -20,7 +20,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         let expectedFrameEnd = CGRect(x: 1_981, y: 9_312, width: 311, height: 981)
 
         // Act
-        notificationCenter.postKeyboardDidShowNotification(frameEnd: expectedFrameEnd)
+        notificationCenter.postKeyboardWillShowNotification(frameEnd: expectedFrameEnd)
 
         // Assert
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedFrameEnd))
@@ -52,9 +52,9 @@ final class KeyboardStateProviderTests: XCTestCase {
 
         // Act
         notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
-        notificationCenter.postKeyboardDidShowNotification(frameEnd: CGRect(x: 1, y: 2, width: 3, height: 4))
+        notificationCenter.postKeyboardWillShowNotification(frameEnd: CGRect(x: 1, y: 2, width: 3, height: 4))
         notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
-        notificationCenter.postKeyboardDidShowNotification(frameEnd: expectedLastFrameEnd)
+        notificationCenter.postKeyboardWillShowNotification(frameEnd: expectedLastFrameEnd)
 
         // Assert
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedLastFrameEnd))
@@ -66,7 +66,7 @@ final class KeyboardStateProviderTests: XCTestCase {
         let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
 
         // Act
-        notificationCenter.postKeyboardDidShowNotification(frameEnd: nil)
+        notificationCenter.postKeyboardWillShowNotification(frameEnd: nil)
 
         // Assert
         XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: .zero))
@@ -74,7 +74,7 @@ final class KeyboardStateProviderTests: XCTestCase {
 }
 
 private extension NotificationCenter {
-    func postKeyboardDidShowNotification(frameEnd: CGRect? = nil) {
+    func postKeyboardWillShowNotification(frameEnd: CGRect? = nil) {
         let userInfo: [AnyHashable: Any]? = {
             if let frameEnd = frameEnd {
                 return [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
@@ -83,7 +83,7 @@ private extension NotificationCenter {
             }
         }()
 
-        post(name: UIResponder.keyboardDidShowNotification, object: nil, userInfo: userInfo)
+        post(name: UIResponder.keyboardWillShowNotification, object: nil, userInfo: userInfo)
     }
 
     func postKeyboardDidHideNotification(frameEnd: CGRect) {


### PR DESCRIPTION
Fixes #2252. The incorrectly aligned empty state content has been reported almost on every release. The most recent is p5T066-2yX-p2#comment-9591. I started fixing this [more than a year ago](https://github.com/woocommerce/woocommerce-ios/issues/2252#issuecomment-625330625) and didn't get around to it until now. I'm glad @designsimply never stopped reporting these. 😅 

## UI Changes

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/131189312-34b8ed2f-82a3-4aef-81a0-c58d19e10b0a.png" width="300">        |       <img src="https://user-images.githubusercontent.com/198826/131189321-cadcdc54-e11f-432b-87cc-6d94d59f9c2a.png" width="300">
<img src="https://user-images.githubusercontent.com/198826/131189404-5f17f443-7852-43da-8055-b7caaa38c133.png" width="300">  | <img src="https://user-images.githubusercontent.com/198826/131189417-60380c46-56c3-4e79-929a-cbe5ea452b58.png" width="300">
<img src="https://user-images.githubusercontent.com/198826/131189661-74f6699a-97b6-4985-a0c4-a317073d02db.png" width="300"> | <img src="https://user-images.githubusercontent.com/198826/131189667-944237b6-2c45-47aa-8834-6456804933e2.png" width="300">

Large Font Size Scrolling (Before) | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/131191364-f597cb8d-032b-4472-a3e0-9be31ba90299.png" width="300">|<img src="https://user-images.githubusercontent.com/198826/131189921-baa54e60-0770-459e-a769-e9d5ef818af3.png" width="300">

## Trials and Tribulations

There were two problems here. 

### Non-Zero Keyboard Frame

First, `EmptyStateViewController` [relies on `KeyboardFrameObserver`](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift#L90-L93) to correctly align the content. However, `KeyboardFrameObserver` [can sometimes (or often) return a non-zero `frame`](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift#L50-L52) even if the keyboard is not visible. This causes the [layout calculations in `EmptyStateViewController` ](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift#L208-L229) to incorrectly assume that there is a keyboard present even though there's not. That's why you'll see that the content is aligned at the top. The calculation expected a keyboard to be at the bottom. 🤦 

I fixed that by adding a check in `KeyboardFrameObserver` to always make sure that the `frame` is zero if the keyboard is not supposed to be visible (f94eab89bd728f391cf7fdd0bcca1fa155658cb0).

### Delayed Keyboard Visibility State

I expected the above to be enough to fix the problems. Of course, I have forgotten that life hates me. 🍋 😄 When navigating from Orders Search to an empty filter page, the `KeyboardFrameObserver` still [assumed that the keyboard was present](https://user-images.githubusercontent.com/198826/131189312-34b8ed2f-82a3-4aef-81a0-c58d19e10b0a.png). (╯°□°)╯︵ ┻━┻

What I found was that [`currentState.isVisible` was returning `true`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2252-fix-empty-state-alignment/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift#L54) even though the keyboard was being dismissed by the time the empty state was shown. And the culprit was `KeyboardStateProvider`, the object that we rely on to give us the keyboard state. It has a delay when [updating the `KeyboardState`](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift#L55-L60). The layout finishes first before `KeyboardStateProvider` gets a chance to change the `isVisible` state to `false`. 

The reason for the delay was `KeyboardFrameObserver` observes [`willShow` and `willHide` notifications](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift#L40-L48) while `KeyboardStateProvider` observes [`didShow` and `didHide` notifications](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift#L46-L52). Naturally, `KeyboardFrameObserver`'s notification handlers are executed first with incorrect `isVisible` values. 🤦 

I fixed this by changing `KeyboardStateProvider` to use the `willShow` and `willHide` notifications (5ce160fc7d7e0863eb703301490be370bac38fbd). Since `KeyboardStateProvider` [is initialized in the `ServiceLocator`](https://github.com/woocommerce/woocommerce-ios/blob/0d869cadc0016194e459dd366655a6173edc03f3/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift#L162-L167), we are guaranteed that it will update the `isVisible` value first before `KeyboardFrameObserver` instances.

All of these were obviously my mistakes. 😆 


## Known Problems

There's an issue with how the error banners (https://github.com/woocommerce/woocommerce-ios/pull/4407) interact with the rest of the empty state content. For example, the content does not automatically resize or expand if the banner content is expanded. 

Default (Looks Fine) | Expanded ([Sad Trombone](https://www.youtube.com/watch?v=yJxCdh1Ps48))
--------|-------
<img src="https://user-images.githubusercontent.com/198826/131190426-74598377-7614-458c-9928-3355156ce9da.png" width="300"> | <img src="https://user-images.githubusercontent.com/198826/131190677-49a824c7-fe34-4bf5-90a3-821061f39050.png" width="300">

The fix for this can be done separately. I have no idea where to start. ¯\\\_(ツ)\_/¯



## Testing

Please consider running these steps in `develop` first so you'll get a feel of what's being fixed. 🙂 

1. Navigate to Orders → Search. If you're using the simulator, make sure that the keyboard is visible (CMD+K).
2. Tap on an Order Status that has zero orders. 
3. Confirm that the “We're sorry, we couldn't find any .... orders” content is vertically centered. 
4. Navigate to Products. 
5. Tap + to add a product. Pick the Variable product option.
6. Tap on the Add Variations cell. 
7. Confirm that the “Create your first variation...” content is vertically centered.

### Regression Tests

If you can, please do a regression test of the banners by following the steps in #4407.  

## Reviewing 

Only 1 reviewer is needed but anyone can review.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] Create an issue for the error banner layout problem: https://github.com/woocommerce/woocommerce-ios/issues/4900