### PR TITLE
Order Editing: Show notices after updating order customer note.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -1,9 +1,15 @@
 import Foundation
+import Combine
 import SwiftUI
 
 /// Hosting controller that wraps an `EditCustomerNote` view.
 ///
 final class EditCustomerNoteHostingController: UIHostingController<EditCustomerNote> {
+
+    /// References to keep the Combine subscriptions alive within the lifecycle of the object.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
     init(viewModel: EditCustomerNoteViewModel) {
         super.init(rootView: EditCustomerNote(viewModel: viewModel))
 
@@ -11,6 +17,20 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
         rootView.dismiss = { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }
+
+        // Observe the present notice request and set it back after presented
+        viewModel.$presentNotice
+            .compactMap { $0 }
+            .removeDuplicates()
+            .sink { notice in
+                switch notice {
+                case .success:
+                    print("Show success")
+                case .error:
+                    print("Show Error")
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -16,6 +16,11 @@ final class EditCustomerNoteViewModel: ObservableObject {
     ///
     @Published private(set) var navigationTrailingItem: NavigationItem = .done(enabled: false)
 
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var presentNotice: Notice?
+
     /// Order to be edited.
     ///
     private let order: Order
@@ -40,9 +45,18 @@ final class EditCustomerNoteViewModel: ObservableObject {
     func updateNote(onFinish: @escaping () -> Void) {
         let modifiedOrder = order.copy(customerNote: newNote)
         let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, fields: [.customerNote]) { [weak self] result in
-            self?.performingNetworkRequest.send(false)
+            guard let self = self else { return }
+            self.performingNetworkRequest.send(false)
+
+            switch result {
+            case .success:
+                self.presentNotice = .success
+            case .failure(let error):
+                self.presentNotice = .error
+                // Log error
+            }
+
             onFinish()
-            // TODO: Show success or error notice
         }
 
         performingNetworkRequest.send(true)
@@ -57,6 +71,12 @@ extension EditCustomerNoteViewModel {
     enum NavigationItem: Equatable {
         case done(enabled: Bool)
         case loading
+    }
+
+    /// Representation of possible notices that can be displayed
+    enum Notice: Equatable {
+        case success
+        case error
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -42,21 +42,21 @@ final class EditCustomerNoteViewModel: ObservableObject {
 
     /// Update the note remotely and invoke a completion block when finished
     ///
-    func updateNote(onFinish: @escaping () -> Void) {
+    func updateNote(onFinish: @escaping (Bool) -> Void) {
         let modifiedOrder = order.copy(customerNote: newNote)
         let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, fields: [.customerNote]) { [weak self] result in
             guard let self = self else { return }
-            self.performingNetworkRequest.send(false)
 
+            self.performingNetworkRequest.send(false)
             switch result {
             case .success:
                 self.presentNotice = .success
             case .failure(let error):
                 self.presentNotice = .error
-                // Log error
+                DDLogError("⛔️ Unable to update the order: \(error)")
             }
 
-            onFinish()
+            onFinish(result.isSuccess)
         }
 
         performingNetworkRequest.send(true)


### PR DESCRIPTION
closes #4777

# Why

To inform the merchant if the order was successfully updated or not, this PR shows a success/error notice after the update order request has finished.

# How 

The `ViewModel` exposes a `@Published` variable to let the consumer know what notice to show. 
`nil` -> No notice
`.success`  -> Success notice
`.error` -> Error notice

I choose to make this a publisher instead of a closure to be ready when we migrate the notice presenter to `SwiftUI` where the information is consumed via a publisher.

I also had to use two instances of `noticePresenter` one to be used in a modal context and one to be used in the tabbed context.

----

Also made some changes like:

- Prevent view controller to be dismissed when there is an error.
- Log error messages
- Hide the keyboard before showing the notice because it was being hidden. https://github.com/woocommerce/woocommerce-ios/projects/39#card-67675068

# Demo

## Success
https://user-images.githubusercontent.com/562080/131198808-8fe8bc21-9564-42be-aae9-0b0753edd43b.mov

## Error
https://user-images.githubusercontent.com/562080/131198814-167a3c09-3582-4299-b378-502af5a17ef5.mov

# Testing Steps

- Navigate to an order and tap the edit customer provided note icon
- Edit the note and tap done
- See a `success` notice after the note has been updated.

# Next PR
- Add analytics
- Update changelog
- Remove login under feature flag

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
