### PR TITLE
Order Editing: Add analytics & release customer note edit

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.5
 -----
-
+- [**] Merchants can now edit customer provided notes from orders. [https://github.com/woocommerce/woocommerce-ios/pull/4893]
 
 7.4
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -318,3 +318,36 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Order Details Edit
+//
+extension WooAnalyticsEvent {
+    // Namespace
+    enum OrderDetailsEdit {
+        /// Possible types of edit
+        ///
+        enum Subject: String {
+            fileprivate static let key = "subject"
+
+            case customerNote = "customer_note"
+            case shippingAddress = "shipping_address"
+            case billingAddress = "billing_address"
+        }
+
+        static func orderDetailEditFlowStarted(subject: Subject) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailEditFlowStarted, properties: [Subject.key: subject.rawValue])
+        }
+
+        static func orderDetailEditFlowCompleted(subject: Subject) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailEditFlowCompleted, properties: [Subject.key: subject.rawValue])
+        }
+
+        static func orderDetailEditFlowFailed(subject: Subject) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailEditFlowFailed, properties: [Subject.key: subject.rawValue])
+        }
+
+        static func orderDetailEditFlowCanceled(subject: Subject) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailEditFlowCanceled, properties: [Subject.key: subject.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -183,6 +183,10 @@ public enum WooAnalyticsStat: String {
     case orderShipmentTrackingAddButtonTapped   = "order_shipment_tracking_add_button_tapped"
     case orderShipmentTrackingCarrierSelected   = "order_shipment_tracking_carrier_selected"
     case orderShipmentTrackingCustomProviderSelected = "order_shipment_tracking_custom_provider_selected"
+    case orderDetailEditFlowStarted             = "order_detail_edit_flow_started"
+    case orderDetailEditFlowCompleted           = "order_detail_edit_flow_completed"
+    case orderDetailEditFlowCanceled            = "order_detail_edit_flow_canceled"
+    case orderDetailEditFlowFailed              = "order_detail_edit_flow_failed"
 
     // MARK: Order Data/Action Events
     //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -377,9 +377,9 @@ private extension OrderDetailsDataSource {
         cell.body = customerNote.isNotEmpty ? localizedBody : " "
         cell.selectionStyle = .none
 
-        cell.onEditTapped = orderEditingEnabled ? { [weak self] in
+        cell.onEditTapped = { [weak self] in
             self?.onCellAction?(.editCustomerNote, nil)
-        } : nil
+        }
     }
 
     private func configureBillingDetail(cell: WooBasicTableViewCell) {
@@ -953,10 +953,8 @@ extension OrderDetailsDataSource {
         let customerInformation: Section = {
             var rows: [Row] = []
 
-            /// After `.orderEditing` is completed, this row should always be visible to let merchants update the customer note as required.
-            if orderEditingEnabled || customerNote.isEmpty == false {
-                rows.append(.customerNote)
-            }
+            /// Always visible to allow editing.
+            rows.append(.customerNote)
 
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
                 return items.first(where: { $0.productID == product.productID}) != nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -50,10 +50,21 @@ final class EditCustomerNoteHostingController: UIHostingController<EditCustomerN
                 viewModel.presentNotice = nil
             }
             .store(in: &subscriptions)
+
+        // Set presentation delegate to track the user dismiss flow event
+        presentationController?.delegate = self
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Intercepts to the dismiss drag gesture.
+///
+extension EditCustomerNoteHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        rootView.viewModel.userDidCancelFlow()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNote.swift
@@ -78,7 +78,10 @@ struct EditCustomerNote: View {
                 .navigationBarItems(trailing: navigationBarTrailingItem()) // The only way I've found to make buttons bold is to set them here.
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
-                        Button(Localization.cancel, action: dismiss)
+                        Button(Localization.cancel, action: {
+                            viewModel.userDidCancelFlow()
+                            dismiss()
+                        })
                     }
                 }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -56,8 +56,10 @@ final class EditCustomerNoteViewModel: ObservableObject {
             switch result {
             case .success:
                 self.presentNotice = .success
+                self.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowCompleted(subject: .customerNote))
             case .failure(let error):
                 self.presentNotice = .error
+                self.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowFailed(subject: .customerNote))
                 DDLogError("⛔️ Unable to update the order: \(error)")
             }
 
@@ -68,7 +70,7 @@ final class EditCustomerNoteViewModel: ObservableObject {
         stores.dispatch(action)
     }
 
-    /// Track the cancel scenario
+    /// Track the flow cancel scenario.
     ///
     func userDidCancelFlow() {
         analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowCanceled(subject: .customerNote))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -67,6 +67,12 @@ final class EditCustomerNoteViewModel: ObservableObject {
         performingNetworkRequest.send(true)
         stores.dispatch(action)
     }
+
+    /// Track the cancel scenario
+    ///
+    func userDidCancelFlow() {
+        analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowCanceled(subject: .customerNote))
+    }
 }
 
 // MARK: Definitions

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -33,10 +33,15 @@ final class EditCustomerNoteViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    init(order: Order, stores: StoresManager = ServiceLocator.stores) {
+    /// Analytics center.
+    ///
+    private let analytics: Analytics
+
+    init(order: Order, stores: StoresManager = ServiceLocator.stores, analytics: Analytics = ServiceLocator.analytics) {
         self.order = order
         self.newNote = order.customerNote ?? ""
         self.stores = stores
+        self.analytics = analytics
         bindNavigationTrailingItemPublisher()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -646,6 +646,8 @@ private extension OrderDetailsViewController {
         let viewModel = EditCustomerNoteViewModel(order: viewModel.order)
         let editNoteViewController = EditCustomerNoteHostingController(viewModel: viewModel)
         present(editNoteViewController, animated: true, completion: nil)
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowStarted(subject: .customerNote))
     }
 
     @objc private func collectPayment(at: IndexPath) {


### PR DESCRIPTION
part of #4865 

# Why 

Now that the customer provided now is ready, this PR adds the necessary tracking, releases notes, and removes it from being behind a feature flag.

# How 

- Define events
- Adds tracking in the view model & tests
- Remove the feature flag conditionals
- Add release notes

# Testing Stets
- Play with the feature and see the proper events fired in the console.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
