### PR TITLE
[What's New Component] Present latest features on app launch

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -62,7 +62,7 @@ target 'WooCommerce' do
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.6.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
-  pod 'Kingfisher', '~> 5.11.0'
+  pod 'Kingfisher', '~> 6.0.0'
   pod 'StripeTerminal', '~> 1.4.0'
   pod 'Wormholy', '~> 1.6.4', configurations: ['Debug']
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,9 +33,7 @@ PODS:
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.6.1)
   - KeychainAccess (3.2.1)
-  - Kingfisher (5.11.0):
-    - Kingfisher/Core (= 5.11.0)
-  - Kingfisher/Core (5.11.0)
+  - Kingfisher (6.0.1)
   - lottie-ios (3.1.9)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
@@ -100,7 +98,7 @@ DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 1.0)
   - KeychainAccess (~> 3.2)
-  - Kingfisher (~> 5.11.0)
+  - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 1.4.0)
   - WordPress-Editor-iOS (~> 1.11.0)
@@ -170,7 +168,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
-  Kingfisher: 4569606189149e19c7d9439f47e885d0679b7a90
+  Kingfisher: adde87a4f74f6a3845395769354efff593581740
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
@@ -199,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: ed2e7fdc41bb001f36ea14a262da1c180e1534c4
+PODFILE CHECKSUM: 3a44929fd11c151f108c11f263d90b2586b35f49
 
 COCOAPODS: 1.10.2

--- a/Storage/Storage/Model/Announcement.swift
+++ b/Storage/Storage/Model/Announcement.swift
@@ -4,18 +4,34 @@
 /// These entities will be serialised to a plist file
 
 public struct Announcement: Codable {
-    public let appVersion: String
-    public let features: [Feature]
+    public let appVersionName: String
+    public let minimumAppVersion: String
+    public let maximumAppVersion: String
+    public let appVersionTargets: [String]
+    public let detailsUrl: String
     public let announcementVersion: String
-    public let displayed: Bool
+    public let isLocalized: Bool
+    public let responseLocale: String
+    public let features: [Feature]
 
-    public init(appVersion: String,
-                features: [Feature],
+    public init(appVersionName: String,
+                minimumAppVersion: String,
+                maximumAppVersion: String,
+                appVersionTargets: [String],
+                detailsUrl: String,
                 announcementVersion: String,
+                isLocalized: Bool,
+                responseLocale: String,
+                features: [Feature],
                 displayed: Bool) {
-        self.appVersion = appVersion
-        self.features = features
+        self.appVersionName = appVersionName
+        self.minimumAppVersion = minimumAppVersion
+        self.maximumAppVersion = maximumAppVersion
+        self.appVersionTargets = appVersionTargets
+        self.detailsUrl = detailsUrl
         self.announcementVersion = announcementVersion
-        self.displayed = displayed
+        self.isLocalized = isLocalized
+        self.responseLocale = responseLocale
+        self.features = features
     }
 }

--- a/Storage/Storage/Model/Announcement.swift
+++ b/Storage/Storage/Model/Announcement.swift
@@ -13,6 +13,7 @@ public struct Announcement: Codable {
     public let isLocalized: Bool
     public let responseLocale: String
     public let features: [Feature]
+    public let displayed: Bool
 
     public init(appVersionName: String,
                 minimumAppVersion: String,
@@ -33,5 +34,6 @@ public struct Announcement: Codable {
         self.isLocalized = isLocalized
         self.responseLocale = responseLocale
         self.features = features
+        self.displayed = displayed
     }
 }

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Yosemite
+
+final class WhatsNewViewModel: ReportListConvertible, ReportListPresentable {
+    let items: [ReportItem]
+    let onDismiss: () -> Void
+    let title = Localization.title
+    let ctaTitle = Localization.ctaTitle
+
+    init(items: [Feature], onDismiss: @escaping () -> Void) {
+        self.items = items.map { ReportItem(title: $0.title, subtitle: $0.subtitle, iconUrl: $0.iconUrl, iconBase64: $0.iconBase64)}
+        self.onDismiss = onDismiss
+    }
+}
+
+// MARK: - Private data structures
+private extension WhatsNewViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("What’s New in WooCommerce", comment: "Title of Whats New Component")
+        static let ctaTitle = NSLocalizedString("Continue", comment: "Title of continue button")
+    }
+}

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -5,19 +5,11 @@ import Yosemite
 final class WhatsNewViewModel: ReportListPresentable {
     let items: [ReportItem]
     let onDismiss: () -> Void
-    let title = Localization.title
-    let ctaTitle = Localization.ctaTitle
+    let title = NSLocalizedString("What’s New in WooCommerce", comment: "Title of Whats New Component")
+    let ctaTitle = NSLocalizedString("Continue", comment: "Title of continue button")
 
     init(items: [Feature], onDismiss: @escaping () -> Void) {
         self.items = items.map { ReportItem(title: $0.title, subtitle: $0.subtitle, iconUrl: $0.iconUrl, iconBase64: $0.iconBase64)}
         self.onDismiss = onDismiss
-    }
-}
-
-// MARK: - Private data structures
-private extension WhatsNewViewModel {
-    enum Localization {
-        static let title = NSLocalizedString("What’s New in WooCommerce", comment: "Title of Whats New Component")
-        static let ctaTitle = NSLocalizedString("Continue", comment: "Title of continue button")
     }
 }

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Yosemite
 
-final class WhatsNewViewModel: ReportListConvertible, ReportListPresentable {
+final class WhatsNewViewModel: ReportListPresentable {
     let items: [ReportItem]
     let onDismiss: () -> Void
     let title = Localization.title

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 
+/// View model used to fill up the What's New Component, map from Features to ReportItems and dispatch analytics events
 final class WhatsNewViewModel: ReportListPresentable {
     let items: [ReportItem]
     let onDismiss: () -> Void

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -84,6 +84,9 @@ private extension AppCoordinator {
                 self?.tabBarController.dismiss(animated: true)
             }
             self.tabBarController.present(whatsNewViewController, animated: true, completion: nil)
+            self.stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { error in
+                error.flatMap { return DDLogInfo("💬 \($0.localizedDescription)") }
+            }))
         }))
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -63,24 +63,21 @@ private extension AppCoordinator {
     /// Displays the What's New Screen.
     ///
     func synchronizeWhatsNew() {
-        stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
-            guard let announcement = try? result.get() else { return }
-            self?.presentWhatsNew(for: announcement)
+        stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] _ in
+            self?.showtWhatsNewIfNeeded()
         }))
     }
 
-    func presentWhatsNew(for announcement: Announcement) {
-        let viewModel = WhatsNewViewModel(items: announcement.features) { [weak self] in
-            self?.tabBarController.dismiss(animated: true)
-        }
-        let rootView = ReportListView(viewModel: viewModel)
-        let hostingViewController = UIHostingController(rootView: rootView)
-        if UIDevice.isPad() {
-            hostingViewController.preferredContentSize = CGSize(width: window.frame.width * 0.3,
-                                                                height: window.frame.height * 0.68)
-        }
-        hostingViewController.modalPresentationStyle = .formSheet
-        tabBarController.present(hostingViewController, animated: true, completion: nil)
+    func showtWhatsNewIfNeeded() {
+        stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
+            guard let self = self,
+                  let savedAnnouncement = try? result.get() else { return }
+
+            let whatsNewViewController = WhatsNewFactory.whatsNew(announcement: savedAnnouncement) { [weak self] in
+                self?.tabBarController.dismiss(animated: true)
+            }
+            self.tabBarController.present(whatsNewViewController, animated: true, completion: nil)
+        }))
     }
 
     /// Displays the WordPress.com Authentication UI.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -1,7 +1,6 @@
 import Combine
 import UIKit
 import Yosemite
-import SwiftUI
 import class AutomatticTracks.CrashLogging
 
 /// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -303,7 +303,7 @@ private extension SettingsViewController {
         sections.append(Section(title: appSettingsTitle, rows: [.privacy], footerHeight: UITableView.automaticDimension))
 
         // About the App
-        sections.append(Section(title: aboutTheAppTitle, rows: [.about, .whatsNew, .licenses], footerHeight: UITableView.automaticDimension))
+        sections.append(Section(title: aboutTheAppTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension))
 
         // Other
         #if DEBUG
@@ -351,8 +351,6 @@ private extension SettingsViewController {
             configureWormholy(cell: cell)
         case let cell as BasicTableViewCell where row == .logout:
             configureLogout(cell: cell)
-        case let cell as BasicTableViewCell where row == .whatsNew:
-            configureWhatsNew(cell: cell)
         default:
             fatalError()
         }
@@ -431,12 +429,6 @@ private extension SettingsViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Launch Wormholy Debug",
                                                  comment: "Opens an internal library called Wormholy. Not visible to users.")
-    }
-
-    func configureWhatsNew(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("What's New in WooCommerce", comment: "Navigates to screen containing the latest WooCommerce Features")
     }
 
     func configureLogout(cell: BasicTableViewCell) {
@@ -582,16 +574,6 @@ private extension SettingsViewController {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
     }
 
-    func whatsNewWasPressed() {
-        ServiceLocator.stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
-            guard let self = self, let (announcement, _) = try? result.get() else { return }
-            let viewController = WhatsNewFactory.whatsNew(announcement) { [weak self] in
-                self?.dismiss(animated: true)
-            }
-            self.present(viewController, animated: true, completion: nil)
-        }))
-    }
-
     func logOutUser() {
         ServiceLocator.stores.deauthenticate()
         navigationController?.popToRootViewController(animated: true)
@@ -695,8 +677,6 @@ extension SettingsViewController: UITableViewDelegate {
             deviceSettingsWasPressed()
         case .wormholy:
             wormholyWasPressed()
-        case .whatsNew:
-            whatsNewWasPressed()
         case .logout:
             logoutWasPressed()
         default:
@@ -733,7 +713,6 @@ private enum Row: CaseIterable {
     case licenses
     case deviceSettings
     case wormholy
-    case whatsNew
 
     var type: UITableViewCell.Type {
         switch self {
@@ -762,8 +741,6 @@ private enum Row: CaseIterable {
         case .deviceSettings:
             return BasicTableViewCell.self
         case .wormholy:
-            return BasicTableViewCell.self
-        case .whatsNew:
             return BasicTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -303,7 +303,7 @@ private extension SettingsViewController {
         sections.append(Section(title: appSettingsTitle, rows: [.privacy], footerHeight: UITableView.automaticDimension))
 
         // About the App
-        sections.append(Section(title: aboutTheAppTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension))
+        sections.append(Section(title: aboutTheAppTitle, rows: [.about, .whatsNew, .licenses], footerHeight: UITableView.automaticDimension))
 
         // Other
         #if DEBUG
@@ -351,6 +351,8 @@ private extension SettingsViewController {
             configureWormholy(cell: cell)
         case let cell as BasicTableViewCell where row == .logout:
             configureLogout(cell: cell)
+        case let cell as BasicTableViewCell where row == .whatsNew:
+            configureWhatsNew(cell: cell)
         default:
             fatalError()
         }
@@ -429,6 +431,12 @@ private extension SettingsViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Launch Wormholy Debug",
                                                  comment: "Opens an internal library called Wormholy. Not visible to users.")
+    }
+
+    func configureWhatsNew(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("What's New in WooCommerce", comment: "Navigates to screen containing the latest WooCommerce Features")
     }
 
     func configureLogout(cell: BasicTableViewCell) {
@@ -574,6 +582,16 @@ private extension SettingsViewController {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
     }
 
+    func whatsNewWasPressed() {
+        ServiceLocator.stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
+            guard let self = self, let (announcement, _) = try? result.get() else { return }
+            let viewController = WhatsNewFactory.whatsNew(announcement) { [weak self] in
+                self?.dismiss(animated: true)
+            }
+            self.present(viewController, animated: true, completion: nil)
+        }))
+    }
+
     func logOutUser() {
         ServiceLocator.stores.deauthenticate()
         navigationController?.popToRootViewController(animated: true)
@@ -677,6 +695,8 @@ extension SettingsViewController: UITableViewDelegate {
             deviceSettingsWasPressed()
         case .wormholy:
             wormholyWasPressed()
+        case .whatsNew:
+            whatsNewWasPressed()
         case .logout:
             logoutWasPressed()
         default:
@@ -713,6 +733,7 @@ private enum Row: CaseIterable {
     case licenses
     case deviceSettings
     case wormholy
+    case whatsNew
 
     var type: UITableViewCell.Type {
         switch self {
@@ -741,6 +762,8 @@ private enum Row: CaseIterable {
         case .deviceSettings:
             return BasicTableViewCell.self
         case .wormholy:
+            return BasicTableViewCell.self
+        case .whatsNew:
             return BasicTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -48,22 +48,11 @@ private extension IconListItem {
 }
 
 // MARK: - Preview
-//
 struct IconListItem_Previews: PreviewProvider {
     static var previews: some View {
-        IconListItem(title: "Title",
-                     subtitle: "Subtitle",
-                     iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
-                     icon: nil)
+        IconListItem(title: "Title", subtitle: "Subtitle", iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png", icon: nil)
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Regular Icon List Item")
-
-        IconListItem(title: "Title",
-                     subtitle: "Subtitle",
-                     iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
-                     icon: nil)
-            .previewLayout(.fixed(width: 375, height: 100))
-            .environment(\.layoutDirection, .rightToLeft)
-            .previewDisplayName("RightToLeft Regular Icon List Item")
+            .environment(\.layoutDirection, .leftToRight)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -14,11 +14,11 @@ struct IconListItem: View {
             if let icon = icon {
                 Image(uiImage: icon)
                     .resizable()
-                    .frame(width: 40, height: 40)
+                    .frame(width: Constants.iconSize.width, height: Constants.iconSize.height)
             } else if let url = URL(string: iconUrl) {
                 KFImage(url)
                     .resizable()
-                    .frame(width: 40, height: 40)
+                    .frame(width: Constants.iconSize.width, height: Constants.iconSize.height)
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -38,6 +38,12 @@ struct IconListItem: View {
             ? UIColor(red: 1, green: 1, blue: 1, alpha: 0.6)
             : UIColor(red: 0, green: 0, blue: 0, alpha: 0.6)
         })
+    }
+}
+
+private extension IconListItem {
+    enum Constants {
+        static let iconSize = CGSize(width: 40, height: 40)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -1,0 +1,59 @@
+import Kingfisher
+import SwiftUI
+
+struct IconListItem: View {
+    let title: String
+    let subtitle: String
+    let iconUrl: String
+    let icon: UIImage?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            if let icon = icon {
+                Image(uiImage: icon)
+                    .resizable()
+                    .frame(width: 40, height: 40)
+            } else if let url = URL(string: iconUrl) {
+                KFImage(url)
+                    .resizable()
+                    .frame(width: 40, height: 40)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 17, weight: .semibold, design: .default))
+                Text(subtitle)
+                    .font(.system(size: 17, weight: .regular, design: .default))
+                    .foregroundColor(subtitleColor)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 40)
+        .padding(.vertical, 16)
+    }
+
+    var subtitleColor: Color {
+        Color(UIColor { $0.userInterfaceStyle == .dark
+            ? UIColor(red: 1, green: 1, blue: 1, alpha: 0.6)
+            : UIColor(red: 0, green: 0, blue: 0, alpha: 0.6)
+        })
+    }
+}
+
+struct IconListItem_Previews: PreviewProvider {
+    static var previews: some View {
+        IconListItem(title: "Title",
+                          subtitle: "Subtitle",
+                          iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
+                          icon: nil)
+            .previewLayout(.fixed(width: 375, height: 100))
+            .previewDisplayName("Regular Icon List Item")
+
+        IconListItem(title: "Title",
+                          subtitle: "Subtitle",
+                          iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
+                          icon: nil)
+            .previewLayout(.fixed(width: 375, height: 100))
+            .environment(\.layoutDirection, .rightToLeft)
+            .previewDisplayName("RightToLeft Regular Icon List Item")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -33,7 +33,7 @@ struct IconListItem: View {
         .padding(.vertical, 16)
     }
 
-    var subtitleColor: Color {
+    private var subtitleColor: Color {
         Color(UIColor { $0.userInterfaceStyle == .dark
             ? UIColor(red: 1, green: 1, blue: 1, alpha: 0.6)
             : UIColor(red: 0, green: 0, blue: 0, alpha: 0.6)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -1,6 +1,8 @@
 import Kingfisher
 import SwiftUI
 
+/// Represent a row with a title, subtitle and icon. Used to fill up reports such as What's New in WooCommerce
+///
 struct IconListItem: View {
     let title: String
     let subtitle: String
@@ -39,19 +41,21 @@ struct IconListItem: View {
     }
 }
 
+// MARK: - Preview
+//
 struct IconListItem_Previews: PreviewProvider {
     static var previews: some View {
         IconListItem(title: "Title",
-                          subtitle: "Subtitle",
-                          iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
-                          icon: nil)
+                     subtitle: "Subtitle",
+                     iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
+                     icon: nil)
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Regular Icon List Item")
 
         IconListItem(title: "Title",
-                          subtitle: "Subtitle",
-                          iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
-                          icon: nil)
+                     subtitle: "Subtitle",
+                     iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png",
+                     icon: nil)
             .previewLayout(.fixed(width: 375, height: 100))
             .environment(\.layoutDirection, .rightToLeft)
             .previewDisplayName("RightToLeft Regular Icon List Item")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
@@ -12,6 +12,8 @@ struct LargeTitleView: View {
     }
 }
 
+// MARK: - Preview
+//
 struct LargeTitleView_Previews: PreviewProvider {
     static var previews: some View {
         LargeTitleView(text: "What's New in WooCommerce")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
@@ -7,9 +7,7 @@ struct LargeTitleView: View {
     var body: some View {
         Text(text)
             .multilineTextAlignment(.center)
-            .font(.system(size: 34,
-                          weight: .bold,
-                          design: .default))
+            .font(.system(size: 34, weight: .bold, design: .default))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Represents a large title, mostly to be used at the top of view controllers like What's New Component
 struct LargeTitleView: View {
     let text: String
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
@@ -14,7 +14,6 @@ struct LargeTitleView: View {
 }
 
 // MARK: - Preview
-//
 struct LargeTitleView_Previews: PreviewProvider {
     static var previews: some View {
         LargeTitleView(text: "What's New in WooCommerce")

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LargeTitleView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct LargeTitleView: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .multilineTextAlignment(.center)
+            .font(.system(size: 34,
+                          weight: .bold,
+                          design: .default))
+    }
+}
+
+struct LargeTitleView_Previews: PreviewProvider {
+    static var previews: some View {
+        LargeTitleView(text: "What's New in WooCommerce")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
@@ -25,12 +25,13 @@ struct ReportItem: Identifiable {
 
 struct ReportListView: View {
     let viewModel: ReportListConvertible & ReportListPresentable
+    private var isPad: Bool { UIDevice.isPad() }
 
     var body: some View {
         VStack {
-            Spacer(minLength: 75)
+            Spacer(minLength: isPad ? 40 : 75)
             LargeTitleView(text: viewModel.title)
-            Spacer(minLength: 40)
+            Spacer(minLength: isPad ? 32 : 40)
             ScrollView {
                 ForEach(viewModel.items, id: \.title) {
                     IconListItem(title: $0.title,
@@ -41,10 +42,9 @@ struct ReportListView: View {
             }
             Spacer()
             Button(viewModel.ctaTitle, action: viewModel.onDismiss)
-                .frame(height: 50)
                 .buttonStyle(PrimaryButtonStyle())
-                .padding()
-            Spacer(minLength: 60)
+                .padding(.horizontal, isPad ? 40 : 24)
+                .padding(.bottom, isPad ? 40 : 60)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
@@ -50,14 +50,13 @@ struct ReportListView: View {
 }
 
 // MARK: - Preview
-//
 struct ReportListView_Previews: PreviewProvider {
     static var features: [Feature] {
-        let featureJson = ["title": "foo",
-                           "subtitle": "bar",
-                           "iconBase64": "",
-                           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"]
-        let jsonData = try? JSONSerialization.data(withJSONObject: featureJson, options: .fragmentsAllowed)
+        let jsonData = try? JSONSerialization.data(withJSONObject: ["title": "foo",
+                                                                    "subtitle": "bar",
+                                                                    "iconBase64": "",
+                                                                    "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"],
+                                                   options: .fragmentsAllowed)
         let feature = try? JSONDecoder().decode(Feature.self, from: jsonData ?? Data())
         return [feature, feature, feature].compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+protocol ReportListConvertible {
+    var items: [ReportItem] { get }
+}
+
+protocol ReportListPresentable {
+    var title: String { get }
+    var ctaTitle: String { get }
+    var onDismiss: () -> Void { get }
+}
+
+struct ReportItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String
+    let iconUrl: String
+    let iconBase64: String?
+
+    var icon: UIImage? {
+        guard let base64String = iconBase64 else { return nil }
+        return Data(base64Encoded: base64String).flatMap { UIImage(data: $0) }
+    }
+}
+
+struct ReportListView: View {
+    let viewModel: ReportListConvertible & ReportListPresentable
+
+    var body: some View {
+        VStack {
+            Spacer(minLength: 75)
+            LargeTitleView(text: viewModel.title)
+            Spacer(minLength: 40)
+            ScrollView {
+                ForEach(viewModel.items, id: \.title) {
+                    IconListItem(title: $0.title,
+                                 subtitle: $0.subtitle,
+                                 iconUrl: $0.iconUrl,
+                                 icon: $0.icon)
+                }
+            }
+            Spacer()
+            Button(viewModel.ctaTitle, action: viewModel.onDismiss)
+                .frame(height: 50)
+                .buttonStyle(PrimaryButtonStyle())
+                .padding()
+            Spacer(minLength: 60)
+        }
+    }
+}
+
+struct ReportListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ReportListView(viewModel: WhatsNewViewModel(items: [], onDismiss: {}))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
@@ -1,10 +1,8 @@
 import SwiftUI
-
-protocol ReportListConvertible {
-    var items: [ReportItem] { get }
-}
+import Yosemite
 
 protocol ReportListPresentable {
+    var items: [ReportItem] { get }
     var title: String { get }
     var ctaTitle: String { get }
     var onDismiss: () -> Void { get }
@@ -23,8 +21,10 @@ struct ReportItem: Identifiable {
     }
 }
 
+/// Represent a screen with a list of IconListItems. Mainly used to present reports such as What's New in WooCommerce.
+///
 struct ReportListView: View {
-    let viewModel: ReportListConvertible & ReportListPresentable
+    let viewModel: ReportListPresentable
     private var isPad: Bool { UIDevice.isPad() }
 
     var body: some View {
@@ -49,8 +49,20 @@ struct ReportListView: View {
     }
 }
 
+// MARK: - Preview
+//
 struct ReportListView_Previews: PreviewProvider {
+    static var features: [Feature] {
+        let featureJson = ["title": "foo",
+                           "subtitle": "bar",
+                           "iconBase64": "",
+                           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"]
+        let jsonData = try? JSONSerialization.data(withJSONObject: featureJson, options: .fragmentsAllowed)
+        let feature = try? JSONDecoder().decode(Feature.self, from: jsonData ?? Data())
+        return [feature, feature, feature].compactMap { $0 }
+    }
+
     static var previews: some View {
-        ReportListView(viewModel: WhatsNewViewModel(items: [], onDismiss: {}))
+        ReportListView(viewModel: WhatsNewViewModel(items: features, onDismiss: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportListView.swift
@@ -33,7 +33,7 @@ struct ReportListView: View {
             LargeTitleView(text: viewModel.title)
             Spacer(minLength: isPad ? 32 : 40)
             ScrollView {
-                ForEach(viewModel.items, id: \.title) {
+                ForEach(viewModel.items, id: \.id) {
                     IconListItem(title: $0.title,
                                  subtitle: $0.subtitle,
                                  iconUrl: $0.iconUrl,

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -7,7 +7,7 @@ struct WhatsNewFactory {
     /// - Parameters:
     ///   - announcement: Announcement model
     ///   - onDismiss: called when the CTA button is pressed, mainly for dismissing the screen
-    static func whatsNew(announcement: Announcement,
+    static func whatsNew(_ announcement: Announcement,
                          onDismiss: @escaping () -> Void) -> UIViewController {
 
         let viewModel = WhatsNewViewModel(items: announcement.features, onDismiss: onDismiss)

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -14,9 +14,15 @@ struct WhatsNewFactory {
         let rootView = ReportListView(viewModel: viewModel)
         let hostingViewController = UIHostingController(rootView: rootView)
         if UIDevice.isPad() {
-            hostingViewController.preferredContentSize = CGSize(width: 360, height: 574)
+            hostingViewController.preferredContentSize = Constants.iPadContentSize
         }
         hostingViewController.modalPresentationStyle = .formSheet
         return hostingViewController
+    }
+}
+
+private extension WhatsNewFactory {
+    enum Constants {
+        static let iPadContentSize = CGSize(width: 360, height: 574)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import Yosemite
+
+struct WhatsNewFactory {
+    /// Creates a What's New view controller for a given announcement
+    ///
+    /// - Parameters:
+    ///   - announcement: Announcement model
+    ///   - onDismiss: called when the CTA button is pressed, mainly for dismissing the screen
+    static func whatsNew(announcement: Announcement,
+                         onDismiss: @escaping () -> Void) -> UIViewController {
+
+        let viewModel = WhatsNewViewModel(items: announcement.features, onDismiss: onDismiss)
+        let rootView = ReportListView(viewModel: viewModel)
+        let hostingViewController = UIHostingController(rootView: rootView)
+        if UIDevice.isPad() {
+            hostingViewController.preferredContentSize = CGSize(width: 360, height: 574)
+        }
+        hostingViewController.modalPresentationStyle = .formSheet
+        return hostingViewController
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1108,6 +1108,7 @@
 		D41C9F2926D99E9700993558 /* LargeTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2826D99E9700993558 /* LargeTitleView.swift */; };
 		D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */; };
 		D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */; };
+		D41C9F3426DD439200993558 /* WhatsNewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3326DD439200993558 /* WhatsNewFactory.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
@@ -2500,6 +2501,7 @@
 		D41C9F2826D99E9700993558 /* LargeTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
 		D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewViewModel.swift; sourceTree = "<group>"; };
 		D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewViewModelTests.swift; sourceTree = "<group>"; };
+		D41C9F3326DD439200993558 /* WhatsNewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewFactory.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
@@ -4969,6 +4971,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				D41C9F3226DD436D00993558 /* WhatsNew */,
 				571B850024CF7E1600CF58A7 /* InAppFeedback */,
 				0235594024496414004BE2B8 /* BottomSheet */,
 				D8815ADC26383E3E00EDAD62 /* CardPresentPayments */,
@@ -5972,6 +5975,14 @@
 			isa = PBXGroup;
 			children = (
 				D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */,
+			);
+			path = WhatsNew;
+			sourceTree = "<group>";
+		};
+		D41C9F3226DD436D00993558 /* WhatsNew */ = {
+			isa = PBXGroup;
+			children = (
+				D41C9F3326DD439200993558 /* WhatsNewFactory.swift */,
 			);
 			path = WhatsNew;
 			sourceTree = "<group>";
@@ -7501,6 +7512,7 @@
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
+				D41C9F3426DD439200993558 /* WhatsNewFactory.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1103,6 +1103,11 @@
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
+		D41C9F2526D97D5400993558 /* IconListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2426D97D5400993558 /* IconListItem.swift */; };
+		D41C9F2726D994CD00993558 /* ReportListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2626D994CD00993558 /* ReportListView.swift */; };
+		D41C9F2926D99E9700993558 /* LargeTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2826D99E9700993558 /* LargeTitleView.swift */; };
+		D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */; };
+		D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
@@ -2490,6 +2495,11 @@
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
+		D41C9F2426D97D5400993558 /* IconListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconListItem.swift; sourceTree = "<group>"; };
+		D41C9F2626D994CD00993558 /* ReportListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListView.swift; sourceTree = "<group>"; };
+		D41C9F2826D99E9700993558 /* LargeTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
+		D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewViewModel.swift; sourceTree = "<group>"; };
+		D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewViewModelTests.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
@@ -4283,6 +4293,9 @@
 				DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */,
 				E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */,
 				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
+				D41C9F2426D97D5400993558 /* IconListItem.swift */,
+				D41C9F2626D994CD00993558 /* ReportListView.swift */,
+				D41C9F2826D99E9700993558 /* LargeTitleView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -4384,6 +4397,7 @@
 		5791FB4024EC833200117FD6 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				D41C9F2F26D9A41F00993558 /* WhatsNew */,
 				D8025469265517F9001B2CC1 /* CardPresentPayments */,
 				5791FB4124EC834300117FD6 /* MainTabViewModelTests.swift */,
 			);
@@ -5755,6 +5769,7 @@
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				D41C9F2A26D9A04A00993558 /* WhatsNew */,
 				D8815AE526383FC200EDAD62 /* CardPresentPayments */,
 				D817585C22BB5E6900289CFE /* Order Details */,
 				D843D5D82248EE90001BFA55 /* ManualTrackingViewModel.swift */,
@@ -5943,6 +5958,22 @@
 				CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */,
 			);
 			path = AppRatings;
+			sourceTree = "<group>";
+		};
+		D41C9F2A26D9A04A00993558 /* WhatsNew */ = {
+			isa = PBXGroup;
+			children = (
+				D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */,
+			);
+			path = WhatsNew;
+			sourceTree = "<group>";
+		};
+		D41C9F2F26D9A41F00993558 /* WhatsNew */ = {
+			isa = PBXGroup;
+			children = (
+				D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */,
+			);
+			path = WhatsNew;
 			sourceTree = "<group>";
 		};
 		D8025469265517F9001B2CC1 /* CardPresentPayments */ = {
@@ -7090,6 +7121,7 @@
 				021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				317F679826420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift in Sources */,
+				D41C9F2926D99E9700993558 /* LargeTitleView.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
@@ -7149,6 +7181,7 @@
 				02E8B17723E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift in Sources */,
 				CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
+				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,
 				B57C5C9221B80E3C00FF82B2 /* APNSDevice+Woo.swift in Sources */,
 				D8EF1E562605121C00380EA4 /* OrderPaymentMethod.swift in Sources */,
@@ -7377,6 +7410,7 @@
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
 				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
+				D41C9F2726D994CD00993558 /* ReportListView.swift in Sources */,
 				CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */,
 				029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */,
 				DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */,
@@ -7436,6 +7470,7 @@
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,
 				45D875D22611EA2100226C3F /* ListHeaderView.swift in Sources */,
 				026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */,
+				D41C9F2526D97D5400993558 /* IconListItem.swift in Sources */,
 				4590B64C261C673B00A6FCE0 /* WeightFormatter.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
@@ -7835,6 +7870,7 @@
 				45B98E1F25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift in Sources */,
 				02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */,
 				CCCC5B1326CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift in Sources */,
+				D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */,
 				57A5D8DF253500F300AA54D6 /* RefundConfirmationViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
@@ -6,7 +6,7 @@ import Yosemite
 class WhatsNewViewModelTests: XCTestCase {
 
     func test_on_init_with_no_items_it_has_no_items() {
-        // Arrange
+        // Arrange, Act
         let viewModel = WhatsNewViewModel(items: [], onDismiss: {})
 
         // Assert
@@ -14,18 +14,19 @@ class WhatsNewViewModelTests: XCTestCase {
     }
 
     func test_on_init_with_features_it_has_items() throws {
-        // Arrange
-        let viewModel = WhatsNewViewModel(items: [try makeFeature()], onDismiss: {})
+        // Arrange, Act
+        let feature = try makeFeature()
+        let viewModel = WhatsNewViewModel(items: [feature], onDismiss: {})
 
         // Assert
-        XCTAssertEqual(viewModel.items.first?.title, Expectations.Feature.title)
-        XCTAssertEqual(viewModel.items.first?.subtitle, Expectations.Feature.subtitle)
-        XCTAssertEqual(viewModel.items.first?.iconUrl, Expectations.Feature.iconUrl)
-        XCTAssertEqual(viewModel.items.first?.iconBase64, Expectations.Feature.iconBase64)
+        XCTAssertEqual(viewModel.items.first?.title, feature.title)
+        XCTAssertEqual(viewModel.items.first?.subtitle, feature.subtitle)
+        XCTAssertEqual(viewModel.items.first?.iconUrl, feature.iconUrl)
+        XCTAssertEqual(viewModel.items.first?.iconBase64, feature.iconBase64)
     }
 
     func test_it_has_expected_localized_texts() {
-        // Arrange
+        // Arrange, Act
         let viewModel = WhatsNewViewModel(items: [], onDismiss: {})
 
         // Assert
@@ -35,26 +36,18 @@ class WhatsNewViewModelTests: XCTestCase {
 }
 
 private extension WhatsNewViewModelTests {
-
     enum Expectations {
-        enum Feature {
-            static let title = "foo"
-            static let subtitle = "bar"
-            static let iconUrl = "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
-            static let iconBase64 = "test"
-        }
         static let title = "What’s New in WooCommerce"
         static let ctaTitle = "Continue"
     }
 
     func makeFeature() throws -> Feature {
-        let featureDictionary: [String: Any] = [
+        let jsonData = try JSONSerialization.data(withJSONObject: [
             "title": "foo",
             "subtitle": "bar",
             "iconBase64": "test",
             "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
-        ]
-        let jsonData = try JSONSerialization.data(withJSONObject: featureDictionary)
+        ])
         return try JSONDecoder().decode(Feature.self, from: jsonData)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+/// Test cases for `WhatsNewViewModel`.
+class WhatsNewViewModelTests: XCTestCase {
+
+    func test_on_init_with_no_items_it_has_no_items() {
+        // Arrange
+        let viewModel = WhatsNewViewModel(items: [], onDismiss: {})
+
+        // Assert
+        XCTAssertTrue(viewModel.items.isEmpty)
+    }
+
+    func test_on_init_with_features_it_has_items() throws {
+        // Arrange
+        let viewModel = WhatsNewViewModel(items: [try makeFeature()], onDismiss: {})
+
+        // Assert
+        XCTAssertEqual(viewModel.items.first?.title, Expectations.Feature.title)
+        XCTAssertEqual(viewModel.items.first?.subtitle, Expectations.Feature.subtitle)
+        XCTAssertEqual(viewModel.items.first?.iconUrl, Expectations.Feature.iconUrl)
+        XCTAssertEqual(viewModel.items.first?.iconBase64, Expectations.Feature.iconBase64)
+    }
+
+    func test_it_has_expected_localized_texts() {
+        // Arrange
+        let viewModel = WhatsNewViewModel(items: [], onDismiss: {})
+
+        // Assert
+        XCTAssertEqual(viewModel.title, Expectations.title)
+        XCTAssertEqual(viewModel.ctaTitle, Expectations.ctaTitle)
+    }
+}
+
+private extension WhatsNewViewModelTests {
+
+    enum Expectations {
+        enum Feature {
+            static let title = "foo"
+            static let subtitle = "bar"
+            static let iconUrl = "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
+            static let iconBase64 = "test"
+        }
+        static let title = "What’s New in WooCommerce"
+        static let ctaTitle = "Continue"
+    }
+
+    func makeFeature() throws -> Feature {
+        let featureDictionary: [String: Any] = [
+            "title": "foo",
+            "subtitle": "bar",
+            "iconBase64": "test",
+            "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
+        ]
+        let jsonData = try JSONSerialization.data(withJSONObject: featureDictionary)
+        return try JSONDecoder().decode(Feature.self, from: jsonData)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import Yosemite
 @testable import WooCommerce
 
-/// Test cases for `WhatsNewViewModel`.
 class WhatsNewViewModelTests: XCTestCase {
 
     func test_on_init_with_no_items_it_has_no_items() {

--- a/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
@@ -5,5 +5,8 @@ public enum AnnouncementsAction: Action {
     /// Synchronizes the latest Announcements and save it on disk
     ///
     case synchronizeAnnouncements(onCompletion: (Result<Announcement, Error>) -> Void)
-    case loadSavedAnnouncement(onCompletion: (Result<Announcement, Error>) -> Void)
+
+    /// Load latest saved announcement along with a boolean indicating if it was already presented to the user on app launch
+    ///
+    case loadSavedAnnouncement(onCompletion: (Result<(Announcement, IsDisplayed), Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
@@ -9,4 +9,8 @@ public enum AnnouncementsAction: Action {
     /// Load latest saved announcement along with a boolean indicating if it was already presented to the user on app launch
     ///
     case loadSavedAnnouncement(onCompletion: (Result<(Announcement, IsDisplayed), Error>) -> Void)
+
+    /// Marks the saved announcement as displayed
+    ///
+    case markSavedAnnouncementAsDisplayed(onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
@@ -5,4 +5,5 @@ public enum AnnouncementsAction: Action {
     /// Synchronizes the latest Announcements and save it on disk
     ///
     case synchronizeAnnouncements(onCompletion: (Result<Announcement, Error>) -> Void)
+    case loadSavedAnnouncement(onCompletion: (Result<Announcement, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -58,6 +58,9 @@ public class AnnouncementsStore: Store {
         switch action {
         case .synchronizeAnnouncements(let onCompletion):
             synchronizeAnnouncements(onCompletion: onCompletion)
+
+        case .loadSavedAnnouncement(let onCompletion):
+            loadSavedAnnouncement(onCompletion: onCompletion)
         }
     }
 }
@@ -110,6 +113,18 @@ private extension AnnouncementsStore {
         }
         try fileStorage.write(mappedAnnouncement, to: fileURL)
     }
+
+    /// Load the latest saved `Announcement`. Returns an Error if there is no saved announcement.
+    func loadSavedAnnouncement(onCompletion: (Result<Announcement, Error>) -> Void) {
+        guard let fileURL = featureAnnouncementsFileURL else {
+            return onCompletion(.failure(AnnouncementsStorageError.unableToFindFileURL))
+        }
+        do {
+            onCompletion(.success(try fileStorage.data(for: fileURL)))
+        } catch {
+            onCompletion(.failure(AnnouncementsStorageError.noAnnouncementSaved))
+        }
+    }
 }
 
 // MARK: - Constants
@@ -127,6 +142,7 @@ private enum Constants {
 //
 enum AnnouncementsStorageError: Error {
     case unableToFindFileURL
+    case noAnnouncementSaved
 }
 
 enum AnnouncementsError: Error {

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -23,7 +23,7 @@ public class AnnouncementsStore: Store {
 
     private let remote: AnnouncementsRemoteProtocol
     private let fileStorage: FileStorage
-    private let appVersion = UserAgent.bundleShortVersion
+    private let appVersion =  "107.4" //UserAgent.bundleShortVersion
 
     public init(dispatcher: Dispatcher,
                 storageManager: StorageManagerType,
@@ -99,10 +99,16 @@ private extension AnnouncementsStore {
                            iconBase64: $0.iconBase64)
         }
 
-        return StorageAnnouncement(appVersion: announcement.appVersionName,
-                                   features: mappedFeatures,
+        return StorageAnnouncement(appVersionName: announcement.appVersionName,
+                                   minimumAppVersion: announcement.minimumAppVersion,
+                                   maximumAppVersion: announcement.maximumAppVersion,
+                                   appVersionTargets: announcement.appVersionTargets,
+                                   detailsUrl: announcement.detailsUrl,
                                    announcementVersion: announcement.announcementVersion,
-                                   displayed: false)
+                                   isLocalized: announcement.isLocalized,
+                                   responseLocale: announcement.responseLocale,
+                                   features: mappedFeatures,
+                                   displayed: true)
     }
 
     /// Save the `Announcement` to the appropriate file.
@@ -120,7 +126,10 @@ private extension AnnouncementsStore {
             return onCompletion(.failure(AnnouncementsStorageError.unableToFindFileURL))
         }
         do {
-            onCompletion(.success(try fileStorage.data(for: fileURL)))
+            let savedModel: StorageAnnouncement = try fileStorage.data(for: fileURL)
+            let encodedObject = try JSONEncoder().encode(savedModel)
+            let convertedModel = try JSONDecoder().decode(Announcement.self, from: encodedObject)
+            onCompletion(.success(convertedModel))
         } catch {
             onCompletion(.failure(AnnouncementsStorageError.noAnnouncementSaved))
         }

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -159,8 +159,7 @@ private extension AnnouncementsStore {
 // MARK: - Announcement Extension
 private extension Announcement {
     func isSameVersion(_ announcement: StorageAnnouncement) -> Bool {
-        return self.appVersionName == announcement.appVersionName &&
-            self.announcementVersion == announcement.announcementVersion
+        self.appVersionName == announcement.appVersionName && self.announcementVersion == announcement.announcementVersion
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -76,7 +76,6 @@ public class AnnouncementsStore: Store {
 }
 
 private extension AnnouncementsStore {
-
     /// Get Announcements from Announcements API and persist this information on disk.
     func synchronizeAnnouncements(onCompletion: @escaping (Result<Announcement, Error>) -> Void) {
 
@@ -103,10 +102,7 @@ private extension AnnouncementsStore {
     /// Map `WordPressKit.Announcement` to `StorageAnnouncement` model
     func mapAnnouncementToStorageModel(_ announcement: Announcement, displayed: Bool) -> StorageAnnouncement {
         let mappedFeatures = announcement.features.map {
-            StorageFeature(title: $0.title,
-                           subtitle: $0.subtitle,
-                           iconUrl: $0.iconUrl,
-                           iconBase64: $0.iconBase64)
+            StorageFeature(title: $0.title, subtitle: $0.subtitle, iconUrl: $0.iconUrl, iconBase64: $0.iconBase64)
         }
 
         return StorageAnnouncement(appVersionName: announcement.appVersionName,
@@ -125,20 +121,14 @@ private extension AnnouncementsStore {
     func saveAnnouncement(_ announcement: Announcement) throws {
         let displayed = lastSavedAnnouncement.flatMap { announcement.isSameVersion($0) } ?? false
         let mappedAnnouncement = self.mapAnnouncementToStorageModel(announcement, displayed: displayed)
-        guard let fileURL = featureAnnouncementsFileURL else {
-            throw AnnouncementsStorageError.unableToFindFileURL
-        }
+        guard let fileURL = featureAnnouncementsFileURL else { throw AnnouncementsStorageError.unableToFindFileURL }
         try fileStorage.write(mappedAnnouncement, to: fileURL)
     }
 
     /// Load the latest saved `Announcement`. Returns an Error if there is no saved announcement.
     func loadSavedAnnouncement(onCompletion: (Result<(Announcement, IsDisplayed), Error>) -> Void) {
-        guard let fileURL = featureAnnouncementsFileURL else {
-            return onCompletion(.failure(AnnouncementsStorageError.unableToFindFileURL))
-        }
         do {
-            let savedStorageModel: StorageAnnouncement = try fileStorage.data(for: fileURL)
-            onCompletion(.success((try savedAnnouncement(), savedStorageModel.displayed)))
+            onCompletion(.success((try savedAnnouncement(), lastSavedAnnouncement?.displayed == true)))
         } catch {
             onCompletion(.failure(AnnouncementsStorageError.noAnnouncementSaved))
         }
@@ -155,9 +145,7 @@ private extension AnnouncementsStore {
     }
 
     func savedAnnouncement() throws -> Announcement {
-        guard let fileURL = featureAnnouncementsFileURL else {
-            throw AnnouncementsStorageError.unableToFindFileURL
-        }
+        guard let fileURL = featureAnnouncementsFileURL else { throw AnnouncementsStorageError.unableToFindFileURL }
         do {
             let savedModel: StorageAnnouncement = try fileStorage.data(for: fileURL)
             let encodedObject = try JSONEncoder().encode(savedModel)
@@ -169,7 +157,6 @@ private extension AnnouncementsStore {
 }
 
 // MARK: - Announcement Extension
-//
 private extension Announcement {
     func isSameVersion(_ announcement: StorageAnnouncement) -> Bool {
         return self.appVersionName == announcement.appVersionName &&
@@ -178,9 +165,7 @@ private extension Announcement {
 }
 
 // MARK: - Constants
-//
 private enum Constants {
-
     // MARK: File Names
     static let featureAnnouncementsFileName = "feature-announcements.plist"
 
@@ -189,7 +174,6 @@ private enum Constants {
 }
 
 // MARK: - Errors
-//
 enum AnnouncementsStorageError: Error {
     case unableToFindFileURL
     case noAnnouncementSaved

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -114,7 +114,7 @@ final class AnnouncementsStoreTests: XCTestCase {
 
     func test_load_newly_saved_announcement_returns_an_announcement_not_yet_displayed() throws {
         //Arrange
-        try fileStorage?.write(makeStorageAnnouncement(), to: expectedFeatureAnnouncementsFileURL)
+        try fileStorage?.write(makeStorageAnnouncement(), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
 
         // Act
         let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
@@ -131,7 +131,7 @@ final class AnnouncementsStoreTests: XCTestCase {
 
     func test_load_saved_announcement_already_displayed_returns_a_displayed_announcement() throws {
         //Arrange
-        try fileStorage?.write(makeStorageAnnouncement(displayed: true), to: expectedFeatureAnnouncementsFileURL)
+        try fileStorage?.write(makeStorageAnnouncement(displayed: true), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
 
         // Act
         let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
@@ -148,7 +148,7 @@ final class AnnouncementsStoreTests: XCTestCase {
 
     func test_on_mark_announcement_as_displayed_it_updates_storage_model() throws {
         //Arrange
-        try fileStorage?.write(makeStorageAnnouncement(displayed: false), to: expectedFeatureAnnouncementsFileURL)
+        try fileStorage?.write(makeStorageAnnouncement(displayed: false), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
 
         // Act
         let error: Error? = waitFor { [weak self] promise in
@@ -175,14 +175,12 @@ final class AnnouncementsStoreTests: XCTestCase {
 // MARK: - Utils
 //
 private extension AnnouncementsStoreTests {
-
-    var expectedFeatureAnnouncementsFileURL: URL {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        return documents!.appendingPathComponent("feature-announcements.plist")
+    var expectedFeatureAnnouncementsFileURL: URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("feature-announcements.plist")
     }
 
     func makeWordPressAnnouncement() throws -> WordPressKit.Announcement {
-        let announcementJson: [String: Any] = [
+        let jsonData = try JSONSerialization.data(withJSONObject: [
             "appVersionName": "1",
             "minimumAppVersion": "",
             "maximumAppVersion": "",
@@ -197,22 +195,13 @@ private extension AnnouncementsStoreTests {
             "announcementVersion": "2",
             "isLocalized": true,
             "responseLocale": "en_US"
-        ]
+        ])
 
-        let jsonData = try JSONSerialization.data(withJSONObject: announcementJson)
         return try JSONDecoder().decode(Announcement.self, from: jsonData)
     }
 
     func makeStorageAnnouncement(displayed: Bool = false) -> StorageAnnouncement {
-        StorageAnnouncement(appVersionName: "1",
-                            minimumAppVersion: "1",
-                            maximumAppVersion: "2",
-                            appVersionTargets: [],
-                            detailsUrl: "",
-                            announcementVersion: "",
-                            isLocalized: true,
-                            responseLocale: "",
-                            features: [],
-                            displayed: displayed)
+        StorageAnnouncement(appVersionName: "1", minimumAppVersion: "1", maximumAppVersion: "2", appVersionTargets: [], detailsUrl: "",
+                            announcementVersion: "", isLocalized: true, responseLocale: "", features: [], displayed: displayed)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -98,6 +98,19 @@ final class AnnouncementsStoreTests: XCTestCase {
         // Assert
         XCTAssertEqual(resultError, .announcementNotFound)
     }
+
+    func test_load_saved_announcement_without_saved_data_returns_error() {
+        // Arrange, Act
+        let resultError: AnnouncementsStorageError? = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(result.failure as? AnnouncementsStorageError)
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertEqual(resultError, .noAnnouncementSaved)
+    }
 }
 
 // MARK: - Mocks

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -145,6 +145,31 @@ final class AnnouncementsStoreTests: XCTestCase {
         XCTAssertNotNil(announcement)
         XCTAssertTrue(isDisplayed)
     }
+
+    func test_on_mark_announcement_as_displayed_it_updates_storage_model() throws {
+        //Arrange
+        try fileStorage?.write(makeStorageAnnouncement(displayed: false), to: expectedFeatureAnnouncementsFileURL)
+
+        // Act
+        let error: Error? = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.markSavedAnnouncementAsDisplayed { error in
+                promise(error)
+            }
+            self?.subject?.onAction(action)
+        }
+
+        let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(try! result.get())
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertNil(error)
+        XCTAssertNotNil(announcement)
+        XCTAssertTrue(isDisplayed)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Part of: #4863 

# Description 📜

This PR introduces the User Interface designed to show to users what's new in WooCommerce!

Now, when user opens the app, an action will synchronize the latest announcements, persist on disk and we are going to display it right away in case it was not displayed before.

# Main Changes ⚙️
- Added a few SwiftUI components **_(Most of the naming for every SwiftUI component was considering its reusability, as this screen may be used to present different content like reports, etc.)_**
  -  LargeTitleView: For displaying Large texts at the top of the screen
  - IconListItem: A view with a thumbnail, title and subtitle. 
  - ReportListView: A view with a large title, a list of iconListItems and a CTA button to dismiss the screen.  
- Bump Kingfisher to version 6.0 to have support for swiftUI Async Images
- Create a new action (`AnnouncementsAction.loadSavedAnnouncement`) to load latest saved announcement along with a boolean indicating if it was already presented to the user on app launch or not.
- Create a new action (`AnnouncementsAction.markSavedAnnouncementAsDisplayed`) to toggle the boolean indiction that a given announcement was already presented to users upon app launch
- Create **WhatsNewFactory** , responsible for creating all the necessary entities to display the What's new Screen: (viewModel, viewController, setup iPad sizing, etc)

# Screenshots 📱

| iPhone 12 Pro Max  |  Phone 12 Pro Max (Dark mode)  | Phone 12 Pro Max (Dark mode) + RTL  | Phone SE |
| ------------------- | ------------------- | ------------------- | ------------------- |
|  <img width="229" alt="image" src="https://user-images.githubusercontent.com/997521/131412757-5166ce1c-cc11-428d-a443-998f0e204b0c.png"> |  <img width="229" alt="Captura de Tela 2021-08-30 às 11 13 15 PM" src="https://user-images.githubusercontent.com/997521/131412656-66e257e2-b395-4cc3-bffc-88b366a17107.png"> | <img width="229" alt="Captura de Tela 2021-08-30 às 7 32 02 PM" src="https://user-images.githubusercontent.com/997521/131412637-1b4b75e4-39e5-45bf-a5c0-1111388869a6.png"> | <img width="229" alt="image" src="https://user-images.githubusercontent.com/997521/131413739-1be794bc-5062-4f6d-8b6d-3b92a1a84508.png">  |

| iPad Pro | iPad Pro  (Dark mode)  |
| ------------------- | ------------------- |
|  <img width="450" alt="image" src="https://user-images.githubusercontent.com/997521/131413286-b5eeae0c-69bc-4c6e-900d-2416b8539fe0.png"> | <img width="450" alt="image" src="https://user-images.githubusercontent.com/997521/131413355-a1bbd60b-442a-4dd6-92f8-7d8645cb89f7.png"> | 


# Testing 🧑‍🔬🧪

### ⚠️ Pre-requisite ⚠️
_Please do the following change_
<img width="495" alt="image" src="https://user-images.githubusercontent.com/997521/131144031-136d2892-cb05-495a-8532-dbc924d8ee02.png">

## Scenario 1
1. Run the app
2. What's New component should be displayed upon app launch
3. Tap Continue to dismiss the modal

## Scenario 2
1. Run the app again (after seeing the What's New component once)
2. What's New component should **NOT** be displayed

## Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.