### PR TITLE
Shipping Labels: Track states of customs in purchase flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -10,6 +10,7 @@ struct ShippingLabelCustomsFormList: View {
          onCompletion: @escaping ([ShippingLabelCustomsForm]) -> Void) {
         self.viewModel = viewModel
         self.onCompletion = onCompletion
+        ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "customs_started"])
     }
 
     var body: some View {
@@ -32,6 +33,7 @@ struct ShippingLabelCustomsFormList: View {
         .navigationBarItems(trailing: Button(action: {
             onCompletion(viewModel.validatedCustomsForms)
             presentation.wrappedValue.dismiss()
+            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "customs_complete"])
         }, label: {
             Text(Localization.doneButton)
         }).disabled(!viewModel.doneButtonEnabled)


### PR DESCRIPTION
Part of #4596

# Description
This PR updates new states for shipping label purchase flow tracks with events relating to customs form.

# Changes
Updated `ShippingLabelCustomsFormList` to log the start and end states of the customs step in the purchase flow.

# Testing
1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an international order (origin and destination countries are different).
3. Navigate to Orders tab on iOS app, select the new order and select Create Shipping Label.
4. Configure Ship From, Ship To, Package Details.
5. Proceed to configure Customs. Notice in Tracks / debug console, an event named `shipping_label_purchase_flow` with state `customs_started` is tracked.
6. Tap Done button. Notice in Tracks / debug console, an event named `shipping_label_purchase_flow` with state `customs_complete` is tracked.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
