### PR TITLE
Shipping Labels: Fix font and foreground color for LearnMoreRow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
@@ -6,7 +6,9 @@ struct LearnMoreRow: View {
 
     var body: some View {
         AttributedText(learnMoreAttributedString)
-            .accentColor(Color(.textLink))
+            .font(.subheadline)
+            .attributedTextForegroundColor(Color(.textSubtle))
+            .attributedTextLinkColor(Color(.textLink))
             .customOpenURL(binding: $learnMoreURL)
             .padding(.horizontal, Constants.horizontalPadding)
             .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
@@ -15,8 +17,6 @@ struct LearnMoreRow: View {
 
     private var learnMoreAttributedString: NSAttributedString {
         let learnMoreAttributes: [NSAttributedString.Key: Any] = [
-            .font: StyleManager.subheadlineFont,
-            .foregroundColor: UIColor.textSubtle,
             .underlineStyle: 0
         ]
 


### PR DESCRIPTION
Fixes #4878 

# Description
This PR fixes text style for LearnMoreRow. Currently text style is set with attributes for the input attributed string, but these styles are ignored on SwiftUI. 

Applying `font` and `environment` (with `attributedTextForegroundColor` and `attributedTextLinkColor`) fixes the issue.

# Screenshots
| Before | After |
| ----- | ----- |
|  <img src="https://user-images.githubusercontent.com/5533851/131445785-a5385d6b-aa55-42df-ab1a-24541f50be4d.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/131445861-b466b115-2d12-4a6f-8469-bb2772d44414.png" width=400 /> |
| <img src="https://user-images.githubusercontent.com/5533851/130932644-ec879773-1875-4d2d-ab2e-afa53433ac3a.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/131445918-06b2de8d-4ed0-46af-9a02-63d5d8e6e0df.png" width=400 /> |

# Testing
1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an international order (origin and destination countries are different).
3. Navigate to Orders tab on iOS app, select the new order and select Create Shipping Label.
4. Configure Ship From, Ship To, Package Details.
5. Proceed to configure Customs. Notice that the rows with "Learn more..." has correct style (subheadline font and subtle text color) on both light mode and dark mode.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
