### PR TITLE
Product variations: Allow alternative type for regular price

### DIFF
--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -178,7 +178,10 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                                                       alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
             ?? ""
 
-        let regularPrice = try container.decodeIfPresent(String.self, forKey: .regularPrice)
+        let regularPrice = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                             forKey: .regularPrice,
+                                                             alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })])
+            ?? ""
         let onSale = try container.decode(Bool.self, forKey: .onSale)
 
         // Even though a plain install of WooCommerce Core provides string values,

--- a/Networking/NetworkingTests/Mapper/ProductVariationListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationListMapperTests.swift
@@ -74,6 +74,7 @@ final class ProductVariationListMapperTests: XCTestCase {
 
         XCTAssertEqual(productVariation.price, "16")
         XCTAssertEqual(productVariation.salePrice, "12.5")
+        XCTAssertEqual(productVariation.regularPrice, "12")
         XCTAssertFalse(productVariation.manageStock)
     }
 

--- a/Networking/NetworkingTests/Responses/product-variations-load-all-alternative-types.json
+++ b/Networking/NetworkingTests/Responses/product-variations-load-all-alternative-types.json
@@ -10,7 +10,7 @@
             "permalink": "https://chocolate.com/marble",
             "sku": "99%-nuts-marble",
             "price": 16,
-            "regular_price": "12",
+            "regular_price": 12,
             "sale_price": 12.5,
             "date_on_sale_from": "2019-10-16T00:00:00",
             "date_on_sale_from_gmt": "2019-10-15T21:30:00",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 7.5
 -----
 - [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
+- [*] Fix error syncing products due to decoding failure of regular_price in product variations. [https://github.com/woocommerce/woocommerce-ios/pull/4901]
 
 7.4
 -----


### PR DESCRIPTION
Fixes #4737 

# Description
Some merchants have reported issue syncing their product lists. Looking through their error logs it seems that some third-party plugins have altered the return type of product variation regular price to numeric values instead of string as we're expecting the values to be. This causes parsing failure and hence the syncing failure.

Update: It seems from 4261887-zd-woothemes that WCPay is the source for this altering of response.

It looks like @jaclync has done some fix for alternative type of prices for `Product` in #3679. Also, fields like `price` and `sale_price` of `ProductVariation` are already accepting alternative types - so I'm going ahead to do the same fix for `regular_price`.

# Changes
- In `ProductVariation`: update decoding of `regularPrice` to accept both string and alternative decimal value.
- Updated test response JSON and unit test for parsing of numeric regular price.

# Demo
| Before | After |
| ----- | ----- |
|  ![variation-before](https://user-images.githubusercontent.com/5533851/131649423-a8e8a932-873f-46a9-9040-b530967018ba.gif) | ![variation-after](https://user-images.githubusercontent.com/5533851/131649458-e6936fc5-f4ba-4e3f-b335-4d8c4339d448.gif) |


# Testing
~I can't seem to figure out which third-party plugin is causing the issue, so I cannot find reproducible steps for a test store.
However, with unit test updated I'm fairly positive that we can rely on its result for confidence.~

1. Setup WCPay for your test store. I followed this guide PdfdoF-D-p2 for the setup.
2. Create a variable product with variations for your store if you haven't already.
3. Navigate to Products tab on the app, find the variable product and select the variation list. The list should be fetched successfully without any error notice presented.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.