### PR TITLE
Shipping Labels: Hide bottom bar on creation form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 7.5
 -----
 - [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
+- [*] Hide bottom bar on shipping label purchase form. [https://github.com/woocommerce/woocommerce-ios/pull/4902]
 
 7.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -513,6 +513,7 @@ private extension OrderDetailsViewController {
                 guard let self = self else { return }
                 self.navigationController?.popToViewController(self, animated: true)
             }
+            shippingLabelFormVC.hidesBottomBarWhenPushed = true
             navigationController?.show(shippingLabelFormVC, sender: self)
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -62,8 +62,9 @@ struct ShippingLabelCarriers: View {
                         EmptyView()
                     }
                 }
+                .padding(.bottom, insets: geometry.safeAreaInsets)
             }
-            .edgesIgnoringSafeArea(.horizontal)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .navigationTitle(Localization.titleView)
             .navigationBarItems(trailing: Button(action: {
                 onCompletion(viewModel.getSelectedRates().selectedRate,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -24,9 +24,10 @@ struct ShippingLabelCustomsFormList: View {
                                                           viewModel: inputModel)
                         }
                 }
+                .padding(.bottom, insets: geometry.safeAreaInsets)
             }
             .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: .horizontal)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .navigationTitle(Localization.navigationTitle)
         .navigationBarItems(trailing: Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -71,9 +71,10 @@ struct ShippingLabelPackageDetails: View {
                     ListHeaderView(text: Localization.footer, alignment: .left)
                         .padding(.horizontal, insets: geometry.safeAreaInsets)
                 }
+                .padding(.bottom, insets: geometry.safeAreaInsets)
             }
             .background(Color(.listBackground))
-            .ignoresSafeArea(.container, edges: .horizontal)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
         .navigationTitle(Localization.title)
         .navigationBarItems(trailing: Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -68,9 +68,10 @@ struct ShippingLabelPaymentMethods: View {
                         .background(Color(.systemBackground))
                         .disabled(!viewModel.canEditNonpaymentSettings)
                 }
+                .padding(.bottom, insets: geometry.safeAreaInsets)
             }
             .background(Color(.listBackground))
-            .edgesIgnoringSafeArea(.horizontal)
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .navigationBarTitle(Localization.navigationBarTitle)
             .navigationBarItems(trailing: Button(action: {
                 viewModel.updateShippingLabelAccountSettings { newSettings in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.xib
@@ -20,7 +20,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="6I4-gt-sh2">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
             </subviews>
@@ -28,7 +28,7 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="6I4-gt-sh2" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="1D1-e3-U8c"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="6I4-gt-sh2" secondAttribute="bottom" id="QpY-Su-aKb"/>
+                <constraint firstAttribute="bottom" secondItem="6I4-gt-sh2" secondAttribute="bottom" id="QpY-Su-aKb"/>
                 <constraint firstItem="6I4-gt-sh2" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="d42-3b-CTF"/>
                 <constraint firstItem="6I4-gt-sh2" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="y8r-rG-EEC"/>
             </constraints>


### PR DESCRIPTION
Closes #4852 

# Description
To preserve more real estate on shipping label form, this PR aims to hide bottom bar entirely from the main creation form and its subsequent screens: Edit Address, Package Details, Customs, Carriers, Payment Method. The screens should then have edge-to-edge look where the bottom bar used to be, but content should be displayed inside safe area.

# Changes
- Set `hidesBottomBarWhenPushed` to true for the shipping label form controller before pushing.
- Updated shipping label form table view to extend to bottom.
- Update bottom padding for SwiftUI screens: Package Details, Customs, Carriers, Payment Method to show contents within safe area.

# Demo
![no-tab-bar](https://user-images.githubusercontent.com/5533851/131637735-bf18d124-837d-4f37-9349-fd32b5c08aae.gif)

# Testing
1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an international order (origin and destination countries are different).
3. Navigate to Orders tab, select the new order and select Create Shipping Label.
4. Notice that the shipping label form no longer shows bottom bar, and the list is extended to bottom edge while its contents stay within safe area when scrolled all the way to the bottom.
5. Configure each field: address, package, customs, carrier, payment method and notice that all screens extend to bottom edge while contents stay within safe area when scrolled all the way to the bottom.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
