### PR TITLE
Shipping Labels: Fix tracking of packages selected state in purchase flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -22,7 +22,6 @@ struct ShippingLabelPackageList: View {
                             SelectableItemRow(title: package.title, subtitle: package.dimensions + " \(viewModel.dimensionUnit)", selected: selected)
                                 .onTapGesture {
                                     viewModel.didSelectPackage(package.title)
-                                    ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "packages_selected"])
                                 }
                                 .padding(.horizontal, insets: geometry.safeAreaInsets)
                                 .background(Color(.systemBackground))
@@ -41,8 +40,6 @@ struct ShippingLabelPackageList: View {
                                                   subtitle: package.dimensions + " \(viewModel.dimensionUnit)",
                                                   selected: selected).onTapGesture {
                                                     viewModel.didSelectPackage(package.id)
-                                                    ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
-                                                                                   withProperties: ["state": "packages_selected"])
                                                   }
                                     .padding(.horizontal, insets: geometry.safeAreaInsets)
                                     .background(Color(.systemBackground))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -77,6 +77,8 @@ struct ShippingLabelPackageDetails: View {
         }
         .navigationTitle(Localization.title)
         .navigationBarItems(trailing: Button(action: {
+            ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
+                                           withProperties: ["state": "packages_selected"])
             onCompletion(viewModel.selectedPackageID, viewModel.totalWeight)
             presentation.wrappedValue.dismiss()
         }, label: {


### PR DESCRIPTION
Fixes #4898 

# Description
Currently we're tracking state `packages_selected` of event `shipping_label_purchase_flow` in every selection of packages in package list. 

This PR corrects this tracking by remove these events and track the selection only upon tapping Done button of Package Details screen.

# Changes
- `ShippingLabelPackageList`: Remove tracking for selection of each item
- `ShippingLabelPackageDetails`: Add tracking for package selection when Done button is tapped.

# Testing
1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an order.
3. Navigate to Orders tab on iOS app, select the new order and select Create Shipping Label.
4. Skip through Ship From and Ship To.
5. On Package Details, switch between different packages and notice on Tracks / debug consoles that no event for `shipping_label_purchase_flow` is fired upon each selection.
6. Tap Done button on Package Details screen, notice that an event is fired for state `packages_selected` of event `shipping_label_purchase_flow`.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
