### PR TITLE
Shipping Labels: Add divider under list headers

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -18,6 +18,7 @@ struct ShippingLabelServicePackageList: View {
 
                 ListHeaderView(text: option.title.uppercased(), alignment: .left)
                     .padding(.horizontal, insets: safeAreaInsets)
+                Divider()
                 ForEach(option.predefinedPackages) { package in
                     let selected = package == viewModel.selectedPackage
                     SelectableItemRow(title: package.title,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -16,6 +16,7 @@ struct ShippingLabelPackageList: View {
                         if viewModel.showCustomPackagesHeader {
                             ListHeaderView(text: Localization.customPackageHeader.uppercased(), alignment: .left)
                                 .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            Divider()
                         }
                         ForEach(viewModel.customPackages, id: \.title) { package in
                             let selected = package == viewModel.selectedCustomPackage
@@ -35,6 +36,7 @@ struct ShippingLabelPackageList: View {
 
                             ListHeaderView(text: option.title.uppercased(), alignment: .left)
                                 .padding(.horizontal, insets: geometry.safeAreaInsets)
+                            Divider()
                             ForEach(option.predefinedPackages) { package in
                                 let selected = package == viewModel.selectedPredefinedPackage
                                 SelectableItemRow(title: package.title,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -32,6 +32,8 @@ struct ShippingLabelPackageDetails: View {
                     ListHeaderView(text: Localization.itemsToFulfillHeader, alignment: .left)
                         .padding(.horizontal, insets: geometry.safeAreaInsets)
 
+                    Divider()
+
                     ForEach(viewModel.itemsRows) { productItemRow in
                         productItemRow
                             .padding(.horizontal, insets: geometry.safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -33,6 +33,7 @@ struct ShippingLabelPaymentMethods: View {
                     ListHeaderView(text: Localization.paymentMethodsHeader, alignment: .left)
                         .textCase(.uppercase)
                         .padding(.horizontal, insets: geometry.safeAreaInsets)
+                    Divider()
 
                     ForEach(viewModel.paymentMethods, id: \.paymentMethodID) { method in
                         let selected = method.paymentMethodID == viewModel.selectedPaymentMethodID


### PR DESCRIPTION
## Description

As discussed in https://github.com/woocommerce/woocommerce-ios/pull/4882#discussion_r699788980, there should be a divider below the header for lists in the shipping label purchase flow.

## Changes

Adds a divider below the list header in the following screens:

* Package Details ("Items to fulfill")
* Package Selected ("Custom Packages" and each shipping provider)
* Add New Package > Service Package (each shipping provider)
* Payment Method ("Payment Method Selected")

Before|After
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 10 52](https://user-images.githubusercontent.com/8658164/131669073-6cd03218-3dbf-465c-adbe-ed5401dc9da7.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 28 52](https://user-images.githubusercontent.com/8658164/131669079-0a54d592-479c-4833-8fbe-edbbf839a750.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 11 00](https://user-images.githubusercontent.com/8658164/131669082-16234e05-d740-4e27-9b9d-3f15a4980b18.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 29 00](https://user-images.githubusercontent.com/8658164/131669085-03af1555-ab16-474f-b0bd-d5ce20fa2dd4.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 11 06](https://user-images.githubusercontent.com/8658164/131669089-e990500d-c720-482a-a29e-270df3472db8.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 41 27](https://user-images.githubusercontent.com/8658164/131669093-07c9fbb8-d0d9-4607-b085-f4a89f558c8d.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 11 38](https://user-images.githubusercontent.com/8658164/131669097-ec37376a-0fe1-4ef8-b0c6-c1185137fb41.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 12 29 45](https://user-images.githubusercontent.com/8658164/131669101-8c510d74-1840-4cfa-9285-2fddc0579b4f.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. Tap on "Package Details" and confirm there is a divider below the "Items to fulfill" header on the package details screen.
7. Tap on "Package Selected" and confirm there is a divider below each of the headers in the packages list ("Custom Packages" and each shipping provider).
8. Tap the “Create new package” button at the bottom of the screen.
9. On the Add New Package screen, select "Service Package" and confirm there is a divider below each of the headers in the packages list (each shipping provider).
10. Go back and confirm your package selection.
11. Confirm "Shipping Carrier and Rates."
12. Tap on "Payment Method" and confirm there is a divider below the "Payment Method Selected" header.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
