### PR TITLE
Shipping Labels: Display list of unactivated service packages on Add New Package > Service Package tab

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1141,7 +1141,8 @@ extension ShippingLabelPackagesResponse {
         .init(
             storeOptions: .fake(),
             customPackages: .fake(),
-            predefinedOptions: .fake()
+            predefinedOptions: .fake(),
+            unactivatedPredefinedOptions: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -10,14 +10,20 @@ public struct ShippingLabelPackagesResponse: Equatable, GeneratedFakeable {
 
     public let customPackages: [ShippingLabelCustomPackage]
 
+    /// Activated predefined options
     public let predefinedOptions: [ShippingLabelPredefinedOption]
+
+    /// Unactivated predefined options
+    public let unactivatedPredefinedOptions: [ShippingLabelPredefinedOption]
 
     public init(storeOptions: ShippingLabelStoreOptions,
                 customPackages: [ShippingLabelCustomPackage],
-                predefinedOptions: [ShippingLabelPredefinedOption]) {
+                predefinedOptions: [ShippingLabelPredefinedOption],
+                unactivatedPredefinedOptions: [ShippingLabelPredefinedOption]) {
         self.storeOptions = storeOptions
         self.customPackages = customPackages
         self.predefinedOptions = predefinedOptions
+        self.unactivatedPredefinedOptions = unactivatedPredefinedOptions
     }
 }
 
@@ -44,6 +50,7 @@ extension ShippingLabelPackagesResponse: Decodable {
 
 
         var predefinedOptions: [ShippingLabelPredefinedOption] = []
+        var unactivatedPredefinedOptions: [ShippingLabelPredefinedOption] = []
 
         // Iterate around keys of `formSchema` and `formData` for creating the predefined options available for this website.
         //
@@ -52,19 +59,32 @@ extension ShippingLabelPackagesResponse: Decodable {
             let provider: [String: Any]? = try? value.toDictionary()
             provider?.forEach({ (providerKey, providerValue) in
 
-                let packageIDs: [Any?] = rawPredefinedFormData[key]?.value as? [Any?] ?? []
                 let providerValueDict = providerValue as? [String: Any]
-                let predefinedPackages = ShippingLabelPackagesResponse.getPredefinedPackages(packageIDs: packageIDs,
-                                                                                             packageDefinitions: providerValueDict)
-                if !predefinedPackages.isEmpty {
+                let packages = ShippingLabelPackagesResponse.getAllPredefinedPackages(packageDefinitions: providerValueDict)
+
+                let packageIDs: [Any?] = rawPredefinedFormData[key]?.value as? [Any?] ?? []
+                let activatedPredefinedPackages = ShippingLabelPackagesResponse.getPredefinedPackages(withIDs: packageIDs, in: packages)
+
+                if !activatedPredefinedPackages.isEmpty {
                     let titleOption: String = providerValueDict?["title"] as? String ?? ""
-                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: predefinedPackages)
+                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: activatedPredefinedPackages)
                     predefinedOptions.append(option)
+                }
+
+                let unactivatedPredefinedPackages = packages.filter({ !activatedPredefinedPackages.contains($0) })
+
+                if !unactivatedPredefinedPackages.isEmpty {
+                    let titleOption: String = providerValueDict?["title"] as? String ?? ""
+                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: unactivatedPredefinedPackages)
+                    unactivatedPredefinedOptions.append(option)
                 }
             })
         }
 
-        self.init(storeOptions: storeOptions, customPackages: customPackages, predefinedOptions: predefinedOptions)
+        self.init(storeOptions: storeOptions,
+                  customPackages: customPackages,
+                  predefinedOptions: predefinedOptions,
+                  unactivatedPredefinedOptions: unactivatedPredefinedOptions)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -84,12 +104,10 @@ extension ShippingLabelPackagesResponse: Decodable {
 }
 
 private extension ShippingLabelPackagesResponse {
-    static func getPredefinedPackages(packageIDs: [Any?], packageDefinitions: [String: Any]?) -> [ShippingLabelPredefinedPackage] {
+    /// Get activated predefined packages
+    ///
+    static func getPredefinedPackages(withIDs packageIDs: [Any?], in packages: [ShippingLabelPredefinedPackage]) -> [ShippingLabelPredefinedPackage] {
         var predefinedPackages: [ShippingLabelPredefinedPackage] = []
-        guard let definitions = packageDefinitions?["definitions"], let jsonData = try? JSONSerialization.data(withJSONObject: definitions, options: []) else {
-            return []
-        }
-        let packages = (try? JSONDecoder().decode([ShippingLabelPredefinedPackage].self, from: jsonData)) ?? []
 
         packageIDs.compactMap { $0 }.forEach { (packageID) in
             packages.forEach { (package) in
@@ -99,5 +117,14 @@ private extension ShippingLabelPackagesResponse {
             }
         }
         return predefinedPackages
+    }
+
+    /// Get all possible predefined packages (including those not activated on the store)
+    ///
+    static func getAllPredefinedPackages(packageDefinitions: [String: Any]?) -> [ShippingLabelPredefinedPackage] {
+        guard let definitions = packageDefinitions?["definitions"], let jsonData = try? JSONSerialization.data(withJSONObject: definitions, options: []) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([ShippingLabelPredefinedPackage].self, from: jsonData)) ?? []
     }
 }

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -15,6 +15,8 @@ final class ShippingLabelPackagesMapperTests: XCTestCase {
         XCTAssertEqual(shippingLabelPackages.customPackages, sampleShippingLabelCustomPackages())
         XCTAssertTrue(shippingLabelPackages.predefinedOptions.contains(sampleShippingLabelPredefinedOptions().first!))
         XCTAssertTrue(shippingLabelPackages.predefinedOptions.contains(sampleShippingLabelPredefinedOptions()[1]))
+        XCTAssertTrue(shippingLabelPackages.unactivatedPredefinedOptions.contains(sampleShippingLabelUnactivatedPredefinedOption()))
+        XCTAssertFalse(shippingLabelPackages.unactivatedPredefinedOptions.contains(sampleShippingLabelPredefinedOptions()[1]))
     }
 }
 
@@ -80,5 +82,32 @@ private extension ShippingLabelPackagesMapperTests {
                                                               predefinedPackages: predefinedPackages2)
 
         return [predefinedOption1, predefinedOption2]
+    }
+
+    func sampleShippingLabelUnactivatedPredefinedOption() -> ShippingLabelPredefinedOption {
+        let predefinedPackages = [ShippingLabelPredefinedPackage(id: "SmallPaddedPouch",
+                                                                  title: "Small Padded Pouch",
+                                                                  isLetter: true,
+                                                                  dimensions: "24.89 x 30.48 x 2.54"),
+                                  ShippingLabelPredefinedPackage(id: "Box2Cube",
+                                                                 title: "Box #2 Cube",
+                                                                 isLetter: false,
+                                                                 dimensions: "25.65 x 14.73 x 14.99"),
+                                  ShippingLabelPredefinedPackage(id: "Box2Small",
+                                                                 title: "Box #2 Small",
+                                                                 isLetter: false,
+                                                                 dimensions: "31.75 x 28.19 x 3.81"),
+                                  ShippingLabelPredefinedPackage(id: "Box2Medium",
+                                                                 title: "Box #2 Medium",
+                                                                 isLetter: false,
+                                                                 dimensions: "33.53 x 32 x 5.08"),
+                                  ShippingLabelPredefinedPackage(id: "Box3Large",
+                                                                 title: "Box #3 Large",
+                                                                 isLetter: false,
+                                                                 dimensions: "44.45 x 31.75 x 7.62")]
+        let predefinedOption = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              predefinedPackages: predefinedPackages)
+
+        return predefinedOption
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -8,10 +8,10 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
     ///
     @Published var packagesResponse: ShippingLabelPackagesResponse?
 
-    // TODO-4744: Get the options not yet enabled on the store
-    // These are the already enabled options, used temporarily for creating the initial UI
+    /// Service packages not yet activated on the store, organized by shipping provider
+    ///
     var predefinedOptions: [ShippingLabelPredefinedOption] {
-        packagesResponse?.predefinedOptions ?? []
+        packagesResponse?.unactivatedPredefinedOptions ?? []
     }
 
     @Published var selectedPackage: ShippingLabelPredefinedPackage?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -492,7 +492,8 @@ extension ShippingLabelPackageDetailsViewModel {
     static func samplePackageDetails() -> ShippingLabelPackagesResponse {
         return ShippingLabelPackagesResponse(storeOptions: sampleShippingLabelStoreOptions(),
                                              customPackages: sampleShippingLabelCustomPackages(),
-                                             predefinedOptions: sampleShippingLabelPredefinedOptions())
+                                             predefinedOptions: sampleShippingLabelPredefinedOptions(),
+                                             unactivatedPredefinedOptions: sampleShippingLabelPredefinedOptions())
     }
 
     static func sampleShippingLabelStoreOptions() -> ShippingLabelStoreOptions {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -532,7 +532,8 @@ private extension ShippingLabelPackageDetailsViewModelTests {
 
         let packagesResponse = ShippingLabelPackagesResponse(storeOptions: storeOptions,
                                                              customPackages: withCustom ? customPackages : [],
-                                                             predefinedOptions: withPredefined ? predefinedOptions : [])
+                                                             predefinedOptions: withPredefined ? predefinedOptions : [],
+                                                             unactivatedPredefinedOptions: [])
 
         return packagesResponse
     }

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -913,7 +913,8 @@ private extension ShippingLabelStoreTests {
     func sampleShippingLabelPackagesResponse() -> Yosemite.ShippingLabelPackagesResponse {
         return ShippingLabelPackagesResponse(storeOptions: sampleShippingLabelStoreOptions(),
                                              customPackages: sampleShippingLabelCustomPackages(),
-                                             predefinedOptions: sampleShippingLabelPredefinedOptions())
+                                             predefinedOptions: sampleShippingLabelPredefinedOptions(),
+                                             unactivatedPredefinedOptions: [])
 
     }
 


### PR DESCRIPTION
Part of: #4744

## Description

In the shipping label creation flow, https://github.com/woocommerce/woocommerce-ios/pull/4882 added the initial UI on the "Add New Package" screen to select a new (not yet activated) service package to use for your shipping label. This PR makes the changes to display the correct list of service packages on that screen.

In wp-admin, these packages are found under WooCommerce > Settings > Shipping > WooCommerce Shipping (`/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`) by selecting Add Package > Service package. The activated packages have a checkmark there (and are shown on the "Package Selected" list in the app), while the unactivated packages are unchecked there (and are now shown on Add New Package > Service Package in the app).

There are a couple limitations that will be addressed in a future PR:

* If you switch tabs on the "Add New Package" screen, your selection is lost.
* There is not yet an empty state screen, so if all service packages are enabled on your site you will see a blank list.

## Changes

* The networking model `ShippingLabelPackagesResponse` now has a property `unactivatedPredefinedOptions` created from the shipping label packages API response. This property contains the predefined options that are not yet activated on the store. It's populated by getting a list of all the predefined packages on the store and filtering out the ones that are already activated, and then organizing it by provider.
* `ShippingLabelServicePackageListViewModel` (the view model for the Add New Package > Service Package tab view) is updated to use the new `unactivatedPredefinedOptions` property.
* Updated fakes and unit tests, including a check in `ShippingLabelPackagesMapperTests` to confirm that `unactivatedPredefinedOptions` contains all of the unactivated service packages and none of the activated service packages for a shipping provider (DHL Express).

**Add New Package > Service Package**

<img src="https://user-images.githubusercontent.com/8658164/131712521-35450fa8-c074-41e5-b7f9-db03bc187f27.png" width="300px">

**Related screen in wp-admin**

![Screen Shot 2021-09-01 at 2 58 14 PM](https://user-images.githubusercontent.com/8658164/131712525-101d04d7-193c-41ed-9683-061b39662bcc.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the Add New Package screen, select "Service Package" and confirm a list of new (not yet activated) service packages appears, organized by shipping provider. There should be no overlap between the list of service packages that appear on the "Package Selected" screen and on this screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
