### PR TITLE
Order Editing: Add basic edit address form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -2,12 +2,12 @@ import Foundation
 import Combine
 import SwiftUI
 
-/// Hosting controller that wraps an `EditAddressView`.
+/// Hosting controller that wraps an `EditAddressForm`.
 ///
-final class EditAddressHostingController: UIHostingController<EditAddressView> {
+final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
     init() {
-        super.init(rootView: EditAddressView())
+        super.init(rootView: EditAddressForm())
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -17,7 +17,7 @@ final class EditAddressHostingController: UIHostingController<EditAddressView> {
 
 /// Allows merchant to edit the customer provided address of an order.
 ///
-struct EditAddressView: View {
+struct EditAddressForm: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -119,42 +119,44 @@ struct EditAddressView: View {
 }
 
 // MARK: Constants
-private extension EditAddressView {
+private extension EditAddressForm {
     enum Constants {
         static let dividerPadding: CGFloat = 16
     }
 
     enum Localization {
-        static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address screen")
-        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address screen")
+        static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address Form")
 
-        static let detailsSection = NSLocalizedString("DETAILS", comment: "Details section title in the Edit Address screen")
-        static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address screen")
+        static let detailsSection = NSLocalizedString("DETAILS", comment: "Details section title in the Edit Address Form")
+        static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address Form")
 
-        static let firstNameField = NSLocalizedString("First name", comment: "Text field name in Edit Address screen")
-        static let lastNameField = NSLocalizedString("Last name", comment: "Text field name in Edit Address screen")
-        static let emailField = NSLocalizedString("Email", comment: "Text field email in Edit Address screen")
-        static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Edit Address screen")
+        static let firstNameField = NSLocalizedString("First name", comment: "Text field name in Edit Address Form")
+        static let lastNameField = NSLocalizedString("Last name", comment: "Text field name in Edit Address Form")
+        static let emailField = NSLocalizedString("Email", comment: "Text field email in Edit Address Form")
+        static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Edit Address Form")
 
-        static let companyField = NSLocalizedString("Company", comment: "Text field company in Edit Address screen")
-        static let address1Field = NSLocalizedString("Address 1", comment: "Text field address 1 in Edit Address screen")
-        static let address2Field = NSLocalizedString("Address 2", comment: "Text field address 2 in Edit Address screen")
-        static let cityField = NSLocalizedString("City", comment: "Text field city in Edit Address screen")
-        static let postcodeField = NSLocalizedString("Postcode", comment: "Text field postcode in Edit Address screen")
-        static let countryField = NSLocalizedString("Country", comment: "Text field country in Edit Address screen")
-        static let stateField = NSLocalizedString("State", comment: "Text field state in Edit Address screen")
+        static let companyField = NSLocalizedString("Company", comment: "Text field company in Edit Address Form")
+        static let address1Field = NSLocalizedString("Address 1", comment: "Text field address 1 in Edit Address Form")
+        static let address2Field = NSLocalizedString("Address 2", comment: "Text field address 2 in Edit Address Form")
+        static let cityField = NSLocalizedString("City", comment: "Text field city in Edit Address Form")
+        static let postcodeField = NSLocalizedString("Postcode", comment: "Text field postcode in Edit Address Form")
+        static let countryField = NSLocalizedString("Country", comment: "Text field country in Edit Address Form")
+        static let stateField = NSLocalizedString("State", comment: "Text field state in Edit Address Form")
 
-        static let placeholderRequired = NSLocalizedString("Required", comment: "Text field placeholder in Edit Address screen")
-        static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address screen")
-        static let placeholderSelectOption = NSLocalizedString("Select an option", comment: "Text field placeholder in Edit Address screen")
+        static let placeholderRequired = NSLocalizedString("Required", comment: "Text field placeholder in Edit Address Form")
+        static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address Form")
+        static let placeholderSelectOption = NSLocalizedString("Select an option", comment: "Text field placeholder in Edit Address Form")
     }
 }
 
 #if DEBUG
 
-struct EditAddressView_Previews: PreviewProvider {
+struct EditAddressForm_Previews: PreviewProvider {
     static var previews: some View {
-        EditAddressView()
+        NavigationView {
+            EditAddressForm()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Combine
+import SwiftUI
+
+/// Hosting controller that wraps an `EditAddressView`.
+///
+final class EditAddressHostingController: UIHostingController<EditAddressView> {
+
+    init() {
+        super.init(rootView: EditAddressView())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Allows merchant to edit the customer provided address of an order.
+///
+struct EditAddressView: View {
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                ListHeaderView(text: Localization.detailsSection, alignment: .left)
+                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                VStack(spacing: 0) {
+                    TitleAndTextFieldRow(title: Localization.firstNameField,
+                                         placeholder: "",
+                                         text: .constant(""),
+                                         symbol: nil,
+                                         keyboardType: .default)
+                    Divider()
+                        .padding(.leading, Constants.dividerPadding)
+                    TitleAndTextFieldRow(title: Localization.lastNameField,
+                                         placeholder: "",
+                                         text: .constant(""),
+                                         symbol: nil,
+                                         keyboardType: .default)
+                    Divider()
+                        .padding(.leading, Constants.dividerPadding)
+                    TitleAndTextFieldRow(title: Localization.emailField,
+                                         placeholder: "",
+                                         text: .constant(""),
+                                         symbol: nil,
+                                         keyboardType: .emailAddress)
+                    Divider()
+                        .padding(.leading, Constants.dividerPadding)
+                    TitleAndTextFieldRow(title: Localization.phoneField,
+                                         placeholder: "",
+                                         text: .constant(""),
+                                         symbol: nil,
+                                         keyboardType: .phonePad)
+                }
+                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                .background(Color(.systemBackground))
+
+                ListHeaderView(text: Localization.shippingAddressSection, alignment: .left)
+                    .padding(.horizontal, insets: geometry.safeAreaInsets)
+                VStack(spacing: 0) {
+                    Group {
+                        TitleAndTextFieldRow(title: Localization.companyField,
+                                             placeholder: Localization.placeholderOptional,
+                                             text: .constant(""),
+                                             symbol: nil,
+                                             keyboardType: .default)
+                        Divider()
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                            .padding(.leading, Constants.dividerPadding)
+                        TitleAndTextFieldRow(title: Localization.address1Field,
+                                             placeholder: "",
+                                             text: .constant(""),
+                                             symbol: nil,
+                                             keyboardType: .default)
+                        Divider()
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                            .padding(.leading, Constants.dividerPadding)
+                        TitleAndTextFieldRow(title: Localization.address2Field,
+                                             placeholder: "Optional",
+                                             text: .constant(""),
+                                             symbol: nil,
+                                             keyboardType: .default)
+                        Divider()
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                            .padding(.leading, Constants.dividerPadding)
+                        TitleAndTextFieldRow(title: Localization.cityField,
+                                             placeholder: "",
+                                             text: .constant(""),
+                                             symbol: nil,
+                                             keyboardType: .default)
+                        Divider()
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                            .padding(.leading, Constants.dividerPadding)
+                        TitleAndTextFieldRow(title: Localization.postcodeField,
+                                             placeholder: "",
+                                             text: .constant(""),
+                                             symbol: nil,
+                                             keyboardType: .default)
+                        Divider()
+                            .padding(.leading, insets: geometry.safeAreaInsets)
+                            .padding(.leading, Constants.dividerPadding)
+                    }
+
+                    Group {
+                        TitleAndValueRow(title: Localization.countryField, value: "Select an option", selectable: true) { }
+                        Divider()
+                            .padding(.leading, Constants.dividerPadding)
+                        TitleAndValueRow(title: Localization.stateField, value: "Select an option", selectable: true) { }
+                    }
+                }
+                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                .background(Color(.systemBackground))
+            }
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+        }
+        .navigationTitle(Localization.shippingTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarItems(trailing: Button(Localization.done) {
+            // TODO: save changes
+        }
+        .disabled(true) // TODO: enable if there are pending changes
+        )
+    }
+}
+
+// MARK: Constants
+private extension EditAddressView {
+    enum Constants {
+        static let dividerPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address screen")
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address screen")
+
+        static let detailsSection = NSLocalizedString("DETAILS", comment: "Details section title in the Edit Address screen")
+        static let shippingAddressSection = NSLocalizedString("SHIPPING ADDRESS", comment: "Details section title in the Edit Address screen")
+
+        static let firstNameField = NSLocalizedString("First name", comment: "Text field name in Edit Address screen")
+        static let lastNameField = NSLocalizedString("Last name", comment: "Text field name in Edit Address screen")
+        static let emailField = NSLocalizedString("Email", comment: "Text field email in Edit Address screen")
+        static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Edit Address screen")
+
+        static let companyField = NSLocalizedString("Company", comment: "Text field company in Edit Address screen")
+        static let address1Field = NSLocalizedString("Address 1", comment: "Text field address 1 in Edit Address screen")
+        static let address2Field = NSLocalizedString("Address 2", comment: "Text field address 2 in Edit Address screen")
+        static let cityField = NSLocalizedString("City", comment: "Text field city in Edit Address screen")
+        static let postcodeField = NSLocalizedString("Postcode", comment: "Text field postcode in Edit Address screen")
+        static let countryField = NSLocalizedString("Country", comment: "Text field country in Edit Address screen")
+        static let stateField = NSLocalizedString("State", comment: "Text field state in Edit Address screen")
+
+        static let placeholderRequired = NSLocalizedString("Required", comment: "Text field placeholder in Edit Address screen")
+        static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address screen")
+    }
+}
+
+#if DEBUG
+
+struct EditAddressView_Previews: PreviewProvider {
+    static var previews: some View {
+        EditAddressView()
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
@@ -64,7 +64,6 @@ struct EditAddressView: View {
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
-                            .padding(.leading, insets: geometry.safeAreaInsets)
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.address1Field,
                                              placeholder: "",
@@ -72,7 +71,6 @@ struct EditAddressView: View {
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
-                            .padding(.leading, insets: geometry.safeAreaInsets)
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.address2Field,
                                              placeholder: "Optional",
@@ -80,7 +78,6 @@ struct EditAddressView: View {
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
-                            .padding(.leading, insets: geometry.safeAreaInsets)
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.cityField,
                                              placeholder: "",
@@ -88,7 +85,6 @@ struct EditAddressView: View {
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
-                            .padding(.leading, insets: geometry.safeAreaInsets)
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.postcodeField,
                                              placeholder: "",
@@ -96,7 +92,6 @@ struct EditAddressView: View {
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
-                            .padding(.leading, insets: geometry.safeAreaInsets)
                             .padding(.leading, Constants.dividerPadding)
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressView.swift
@@ -101,10 +101,10 @@ struct EditAddressView: View {
                     }
 
                     Group {
-                        TitleAndValueRow(title: Localization.countryField, value: "Select an option", selectable: true) { }
+                        TitleAndValueRow(title: Localization.countryField, value: Localization.placeholderSelectOption, selectable: true) { }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
-                        TitleAndValueRow(title: Localization.stateField, value: "Select an option", selectable: true) { }
+                        TitleAndValueRow(title: Localization.stateField, value: Localization.placeholderSelectOption, selectable: true) { }
                     }
                 }
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -151,6 +151,7 @@ private extension EditAddressView {
 
         static let placeholderRequired = NSLocalizedString("Required", comment: "Text field placeholder in Edit Address screen")
         static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address screen")
+        static let placeholderSelectOption = NSLocalizedString("Select an option", comment: "Text field placeholder in Edit Address screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -521,8 +521,7 @@ private extension OrderDetailsViewController {
         case .editCustomerNote:
 			editCustomerNoteTapped()
         case .editShippingAddress:
-            // TODO: Navigate to edit shipping address
-            print("Edit Shipping Address Tapped")
+            editShippingAddressTapped()
         }
     }
 
@@ -656,6 +655,11 @@ private extension OrderDetailsViewController {
         let viewModel = EditCustomerNoteViewModel(order: viewModel.order)
         let editNoteViewController = EditCustomerNoteHostingController(viewModel: viewModel)
         present(editNoteViewController, animated: true, completion: nil)
+    }
+
+    func editShippingAddressTapped() {
+        let editAddressViewController = EditAddressHostingController()
+        show(editAddressViewController, sender: self)
     }
 
     @objc private func collectPayment(at: IndexPath) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */; };
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
+		AECD57D226DFDF7500A3B580 /* EditAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditAddressView.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
@@ -2183,6 +2184,7 @@
 		A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModelTests.swift; sourceTree = "<group>"; };
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
+		AECD57D126DFDF7500A3B580 /* EditAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressView.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -4743,6 +4745,14 @@
 			path = "Edit Product Variation";
 			sourceTree = "<group>";
 		};
+		AECD57D026DFDF3E00A3B580 /* Address Edit */ = {
+			isa = PBXGroup;
+			children = (
+				AECD57D126DFDF7500A3B580 /* EditAddressView.swift */,
+			);
+			path = "Address Edit";
+			sourceTree = "<group>";
+		};
 		AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */ = {
 			isa = PBXGroup;
 			children = (
@@ -5642,6 +5652,7 @@
 			children = (
 				CEE006072077D14C0079161F /* OrderDetailsViewController.swift */,
 				B53B3F36219C75AC00DF1EB6 /* OrderLoaderViewController.swift */,
+				AECD57D026DFDF3E00A3B580 /* Address Edit */,
 				DE1B030A268DCFF200804330 /* Review Order */,
 				26578C3F26277AA700A15097 /* AddOns */,
 				CE35F10F2343E694007B2A6B /* Order Summary Section */,
@@ -7039,6 +7050,7 @@
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
+				AECD57D226DFDF7500A3B580 /* EditAddressView.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -801,7 +801,7 @@
 		A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */; };
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
-		AECD57D226DFDF7500A3B580 /* EditAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditAddressView.swift */; };
+		AECD57D226DFDF7500A3B580 /* EditAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
@@ -2184,7 +2184,7 @@
 		A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModelTests.swift; sourceTree = "<group>"; };
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
-		AECD57D126DFDF7500A3B580 /* EditAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressView.swift; sourceTree = "<group>"; };
+		AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressForm.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -4748,7 +4748,7 @@
 		AECD57D026DFDF3E00A3B580 /* Address Edit */ = {
 			isa = PBXGroup;
 			children = (
-				AECD57D126DFDF7500A3B580 /* EditAddressView.swift */,
+				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
 			);
 			path = "Address Edit";
 			sourceTree = "<group>";
@@ -7050,7 +7050,7 @@
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
-				AECD57D226DFDF7500A3B580 /* EditAddressView.swift in Sources */,
+				AECD57D226DFDF7500A3B580 /* EditAddressForm.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/4778.

## Description

This PR adds simple SwiftUI implementation of Address Form that'll be used on shipping and billing address screens.
It doesn't include data flow, only UI with labels, buttons and textfields.

### Considerations

- In design we have this screen as part of navigation stack. But note editing is implemented as a modal. Should we unify this?
- Alignment between textfields is slightly different then design (right alignment). We can improve it later, but I consider it unnecessary complex for now. For comparison, address form in shipping labels (UIKit) is not aligned between cells too.

## Screenshots

portrait | landscape
--|--
![Simulator Screen Shot - iPhone 12](https://user-images.githubusercontent.com/3132438/131722770-a7c150bd-d0cf-4fe6-b04e-acf8e21f7eda.png)|![Simulator Screen Shot - iPhone 12](https://user-images.githubusercontent.com/3132438/131722774-b9f76d23-3cfe-4fb6-b132-9aafc05d2bd6.png)

## Test

1. Open existing order details in development build (with feature flag enabled)
2. Tap edit button on shipping address cell

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
