### PR TITLE
[Whats New Component] Show What's New on app launch

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
 - [**] Merchants can now edit customer provided notes from orders. [https://github.com/woocommerce/woocommerce-ios/pull/4893]
 - [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
 - [*] Hide bottom bar on shipping label purchase form. [https://github.com/woocommerce/woocommerce-ios/pull/4902]
-- [*] Show "What's New on WooCommerce" on app launch [https://github.com/woocommerce/woocommerce-ios/pull/4908]
 
 7.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [**] Merchants can now edit customer provided notes from orders. [https://github.com/woocommerce/woocommerce-ios/pull/4893]
 - [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
 - [*] Hide bottom bar on shipping label purchase form. [https://github.com/woocommerce/woocommerce-ios/pull/4902]
-- [*] Display Announcements on app launch [https://github.com/woocommerce/woocommerce-ios/pull/4908]
+- [*] Show "What's New on WooCommerce" on app launch [https://github.com/woocommerce/woocommerce-ios/pull/4908]
 
 7.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [**] Merchants can now edit customer provided notes from orders. [https://github.com/woocommerce/woocommerce-ios/pull/4893]
 - [*] Fix empty states sometimes not centered vertically [https://github.com/woocommerce/woocommerce-ios/pull/4890]
 - [*] Hide bottom bar on shipping label purchase form. [https://github.com/woocommerce/woocommerce-ios/pull/4902]
+- [*] Display Announcements on app launch [https://github.com/woocommerce/woocommerce-ios/pull/4908]
 
 7.4
 -----

--- a/Storage/Storage/Model/Announcement.swift
+++ b/Storage/Storage/Model/Announcement.swift
@@ -4,18 +4,36 @@
 /// These entities will be serialised to a plist file
 
 public struct Announcement: Codable {
-    public let appVersion: String
-    public let features: [Feature]
+    public let appVersionName: String
+    public let minimumAppVersion: String
+    public let maximumAppVersion: String
+    public let appVersionTargets: [String]
+    public let detailsUrl: String
     public let announcementVersion: String
+    public let isLocalized: Bool
+    public let responseLocale: String
+    public let features: [Feature]
     public let displayed: Bool
 
-    public init(appVersion: String,
-                features: [Feature],
+    public init(appVersionName: String,
+                minimumAppVersion: String,
+                maximumAppVersion: String,
+                appVersionTargets: [String],
+                detailsUrl: String,
                 announcementVersion: String,
+                isLocalized: Bool,
+                responseLocale: String,
+                features: [Feature],
                 displayed: Bool) {
-        self.appVersion = appVersion
-        self.features = features
+        self.appVersionName = appVersionName
+        self.minimumAppVersion = minimumAppVersion
+        self.maximumAppVersion = maximumAppVersion
+        self.appVersionTargets = appVersionTargets
+        self.detailsUrl = detailsUrl
         self.announcementVersion = announcementVersion
+        self.isLocalized = isLocalized
+        self.responseLocale = responseLocale
+        self.features = features
         self.displayed = displayed
     }
 }

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -28,9 +28,9 @@ final class WhatsNewViewModel: ReportListPresentable {
         stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { result in
             switch result {
             case .success:
-                return DDLogInfo("📣 Announcement was marked as displayed! ✅")
+                DDLogInfo("📣 Announcement was marked as displayed! ✅")
             case .failure(let error):
-                return DDLogInfo("📣 Failed to mark announcement as displayed: \(error.localizedDescription)")
+                DDLogInfo("⛔️ Failed to mark announcement as displayed: \(error.localizedDescription)")
             }
         }))
     }

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -15,9 +15,24 @@ final class WhatsNewViewModel: ReportListPresentable {
     /// Title of the Call to action button
     let ctaTitle = Localization.ctaTitle
 
-    init(items: [ReportItem], onDismiss: @escaping () -> Void) {
+    /// StoresManager that will be handling actions
+    private let stores: StoresManager
+
+    init(items: [ReportItem], stores: StoresManager = ServiceLocator.stores, onDismiss: @escaping () -> Void) {
         self.items = items
+        self.stores = stores
         self.onDismiss = onDismiss
+    }
+
+    func onAppear() {
+        stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { result in
+            switch result {
+            case .success:
+                return DDLogInfo("📣 Announcement was marked as displayed! ✅")
+            case .failure(let error):
+                return DDLogInfo("📣 Failed to mark announcement as displayed: \(error.localizedDescription)")
+            }
+        }))
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/WhatsNew/WhatsNewViewModel.swift
@@ -30,7 +30,7 @@ final class WhatsNewViewModel: ReportListPresentable {
             case .success:
                 DDLogInfo("📣 Announcement was marked as displayed! ✅")
             case .failure(let error):
-                DDLogInfo("⛔️ Failed to mark announcement as displayed: \(error.localizedDescription)")
+                DDLogError("⛔️ Failed to mark announcement as displayed: \(error.localizedDescription)")
             }
         }))
     }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -74,6 +74,8 @@ private extension AppCoordinator {
         }))
     }
 
+    /// Load saved announcement and display it on What's New component if it was not displayed yet
+    ///
     func showWhatsNewIfNeeded() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
             guard let self = self, let (announcement, displayed) = try? result.get(), !displayed else {
@@ -83,8 +85,14 @@ private extension AppCoordinator {
                 self?.tabBarController.dismiss(animated: true)
             }
             self.tabBarController.present(whatsNewViewController, animated: true, completion: nil)
-            self.stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { error in
-                error.flatMap { return DDLogInfo("💬 \($0.localizedDescription)") }
+
+            self.stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { result in
+                switch result {
+                case .success:
+                    return DDLogInfo("📣 Announcement of version \(announcement.appVersionName) was marked as read! ✅")
+                case .failure(let error):
+                    return DDLogInfo("📣 Failed to mark announcement as displayed: \(error.localizedDescription)")
+                }
             }))
         }))
     }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -86,15 +86,6 @@ private extension AppCoordinator {
                 self?.tabBarController.dismiss(animated: true)
             }
             self.tabBarController.present(whatsNewViewController, animated: true, completion: nil)
-
-            self.stores.dispatch(AnnouncementsAction.markSavedAnnouncementAsDisplayed(onCompletion: { result in
-                switch result {
-                case .success:
-                    return DDLogInfo("📣 Announcement of version \(announcement.appVersionName) was marked as read! ✅")
-                case .failure(let error):
-                    return DDLogInfo("📣 Failed to mark announcement as displayed: \(error.localizedDescription)")
-                }
-            }))
         }))
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -62,6 +62,8 @@ private extension AppCoordinator {
     /// Synchronize announcements and present What's New Screen if needed
     ///
     func synchronizeAndShowWhatsNew() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.whatsNewOnWooCommerce) else { return }
+
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -77,8 +79,6 @@ private extension AppCoordinator {
     /// Load saved announcement and display it on What's New component if it was not displayed yet
     ///
     func showWhatsNewIfNeeded() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.whatsNewOnWooCommerce) else { return }
-
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
             guard let self = self else { return }
             guard let (announcement, displayed) = try? result.get(), !displayed else {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -68,7 +68,7 @@ private extension AppCoordinator {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
             case.failure(let error):
-                DDLogInfo("⛔️ Failed to synchronize announcements: \(error.localizedDescription)")
+                DDLogError("⛔️ Failed to synchronize announcements: \(error.localizedDescription)")
             }
             self.showWhatsNewIfNeeded()
         }))

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -68,7 +68,7 @@ private extension AppCoordinator {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
             case.failure(let error):
-                DDLogInfo("📣 Failed to synchronize announcements: \(error.localizedDescription)")
+                DDLogInfo("⛔️ Failed to synchronize announcements: \(error.localizedDescription)")
             }
             self.showWhatsNewIfNeeded()
         }))

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -78,7 +78,8 @@ private extension AppCoordinator {
     ///
     func showWhatsNewIfNeeded() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
-            guard let self = self, let (announcement, displayed) = try? result.get(), !displayed else {
+            guard let self = self else { return }
+            guard let (announcement, displayed) = try? result.get(), !displayed else {
                 return DDLogInfo("📣 There are no announcements to show!")
             }
             let whatsNewViewController = WhatsNewFactory.whatsNew(announcement) { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
@@ -6,6 +6,7 @@ protocol ReportListPresentable {
     var title: String { get }
     var ctaTitle: String { get }
     var onDismiss: () -> Void { get }
+    func onAppear()
 }
 
 struct ReportItem: Identifiable {
@@ -39,6 +40,7 @@ struct ReportList: View {
                 .padding(.horizontal, Layout.buttonHorizontalPadding(sizeClass))
                 .padding(.bottom, Layout.buttonVerticalPadding(sizeClass))
         }
+        .onAppear(perform: viewModel.onAppear)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -20,7 +20,7 @@ struct WhatsNewFactory {
     /// Transform Features into ReportItem models
     private static func mapFeaturesToItems(_ features: [Feature]) -> [ReportItem] {
         features.map {
-            return ReportItem(title: $0.title, subtitle: $0.subtitle, icon: icon(for: $0))
+            ReportItem(title: $0.title, subtitle: $0.subtitle, icon: icon(for: $0))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -20,15 +20,20 @@ struct WhatsNewFactory {
     /// Transform Features into ReportItem models
     private static func mapFeaturesToItems(_ features: [Feature]) -> [ReportItem] {
         features.map {
-            var icon: IconListItem.Icon?
-            if let base64String = $0.iconBase64,
-               let imageData = Data(base64Encoded: base64String),
-               let image = UIImage(data: imageData) {
-                icon = .base64(image)
-            } else if let url = URL(string: $0.iconUrl) {
-                icon = .remote(url)
-            }
-            return ReportItem(title: $0.title, subtitle: $0.subtitle, icon: icon)
+            return ReportItem(title: $0.title, subtitle: $0.subtitle, icon: icon(for: $0))
         }
+    }
+
+    /// Get IconListItem.Icon from a Feature
+    private static func icon(for feature: Feature) -> IconListItem.Icon? {
+        var icon: IconListItem.Icon?
+        if let base64String = feature.iconBase64,
+           let imageData = Data(base64Encoded: base64String),
+           let image = UIImage(data: imageData) {
+            icon = .base64(image)
+        } else if let url = URL(string: feature.iconUrl) {
+            icon = .remote(url)
+        }
+        return icon
     }
 }

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import Yosemite
+
+struct WhatsNewFactory {
+    /// Creates a What's New view controller for a given announcement
+    ///
+    /// - Parameters:
+    ///   - announcement: Announcement model
+    ///   - onDismiss: called when the CTA button is pressed, mainly for dismissing the screen
+    static func whatsNew(_ announcement: Announcement,
+                         onDismiss: @escaping () -> Void) -> UIViewController {
+
+        let items = mapFeaturesToItems(announcement.features)
+        let viewModel = WhatsNewViewModel(items: items, onDismiss: onDismiss)
+        let rootView = ReportList(viewModel: viewModel)
+        let hostingViewController = WhatsNewHostingController(rootView: rootView)
+        return hostingViewController
+    }
+
+    /// Transform Features into ReportItem models
+    private static func mapFeaturesToItems(_ features: [Feature]) -> [ReportItem] {
+        features.map {
+            var icon: IconListItem.Icon?
+            if let base64String = $0.iconBase64,
+               let imageData = Data(base64Encoded: base64String),
+               let image = UIImage(data: imageData) {
+                icon = .base64(image)
+            } else if let url = URL(string: $0.iconUrl) {
+                icon = .remote(url)
+            }
+            return ReportItem(title: $0.title, subtitle: $0.subtitle, icon: icon)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// WhatsNewHostingController wrapper to handle all the specific presentation details and trait handling
+final class WhatsNewHostingController: UIHostingController<ReportList> {
+    override init(rootView: ReportList) {
+        super.init(rootView: rootView)
+        if UIDevice.isPad() {
+            preferredContentSize = Layout.iPadContentSize
+        }
+        modalPresentationStyle = .formSheet
+    }
+
+    override var traitCollection: UITraitCollection {
+        self.presentingViewController?.traitCollection ?? .current
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Constants
+//
+private extension WhatsNewHostingController {
+    enum Layout {
+        static let iPadContentSize = CGSize(width: 360, height: 574)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
@@ -10,6 +10,7 @@ final class WhatsNewHostingController: UIHostingController<ReportList> {
         modalPresentationStyle = .formSheet
     }
 
+    /// Since preferredContentSize may be custom (in case of iPad) we must override traitCollection in order to obtain the "real" trait collection
     override var traitCollection: UITraitCollection {
         self.presentingViewController?.traitCollection ?? .current
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1112,6 +1112,7 @@
 		D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51A26DE6B5000D75B02 /* LargeTitle.swift */; };
 		D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C52526DFBBDA00D75B02 /* WhatsNewFactory.swift */; };
 		D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C52826DFBCCC00D75B02 /* WhatsNewHostingController.swift */; };
+		D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C52B26E02F2F00D75B02 /* WhatsNewFactoryTests.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
@@ -2513,6 +2514,7 @@
 		D449C51A26DE6B5000D75B02 /* LargeTitle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTitle.swift; sourceTree = "<group>"; };
 		D449C52526DFBBDA00D75B02 /* WhatsNewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewFactory.swift; sourceTree = "<group>"; };
 		D449C52826DFBCCC00D75B02 /* WhatsNewHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewHostingController.swift; sourceTree = "<group>"; };
+		D449C52B26E02F2F00D75B02 /* WhatsNewFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewFactoryTests.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
@@ -6016,6 +6018,14 @@
 			path = WhatsNew;
 			sourceTree = "<group>";
 		};
+		D449C52A26E02EFD00D75B02 /* WhatsNew */ = {
+			isa = PBXGroup;
+			children = (
+				D449C52B26E02F2F00D75B02 /* WhatsNewFactoryTests.swift */,
+			);
+			path = WhatsNew;
+			sourceTree = "<group>";
+		};
 		D8025469265517F9001B2CC1 /* CardPresentPayments */ = {
 			isa = PBXGroup;
 			children = (
@@ -6050,6 +6060,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				D449C52A26E02EFD00D75B02 /* WhatsNew */,
 				D810F8F62639EDD900437C67 /* CardPresentPayments */,
 				26FE09E224DCFE4000B9BDF5 /* inAppFeedback */,
 				57B374B3245B32EE00D58BE0 /* ReusableViews */,
@@ -7704,6 +7715,7 @@
 				0279F0E2252DC4BF0098D7DE /* ProductLoaderViewControllerModelTests.swift in Sources */,
 				4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
+				D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1110,6 +1110,8 @@
 		D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51826DE6B5000D75B02 /* ReportList.swift */; };
 		D449C51C26DE6B5000D75B02 /* IconListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51926DE6B5000D75B02 /* IconListItem.swift */; };
 		D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51A26DE6B5000D75B02 /* LargeTitle.swift */; };
+		D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C52526DFBBDA00D75B02 /* WhatsNewFactory.swift */; };
+		D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C52826DFBCCC00D75B02 /* WhatsNewHostingController.swift */; };
 		D802541F2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */; };
 		D802546B2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */; };
 		D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */; };
@@ -2509,6 +2511,8 @@
 		D449C51826DE6B5000D75B02 /* ReportList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportList.swift; sourceTree = "<group>"; };
 		D449C51926DE6B5000D75B02 /* IconListItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconListItem.swift; sourceTree = "<group>"; };
 		D449C51A26DE6B5000D75B02 /* LargeTitle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTitle.swift; sourceTree = "<group>"; };
+		D449C52526DFBBDA00D75B02 /* WhatsNewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewFactory.swift; sourceTree = "<group>"; };
+		D449C52826DFBCCC00D75B02 /* WhatsNewHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewHostingController.swift; sourceTree = "<group>"; };
 		D802541E2655137A001B2CC1 /* CardPresentModalNonRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalNonRetryableError.swift; sourceTree = "<group>"; };
 		D802546A2655180A001B2CC1 /* CardPresentModalReaderIsReadyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalReaderIsReadyTests.swift; sourceTree = "<group>"; };
 		D802547226551D0F001B2CC1 /* CardPresentModalTapCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapCardTests.swift; sourceTree = "<group>"; };
@@ -5004,6 +5008,7 @@
 				26B119B524D0B36700FED5C7 /* Survey */,
 				02817B37242B34260050AD8B /* Toolbar */,
 				02404EE52315272C00FF1170 /* Top Banner */,
+				D449C52726DFBBE000D75B02 /* WhatsNew */,
 				B56DB3CD2049BFAA00D4AA8E /* Main.storyboard */,
 				CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */,
 				D8736B5222EF4F5900A14A29 /* NotificationsBadgeController.swift */,
@@ -6000,6 +6005,15 @@
 				D41C9F2426D97D5400993558 /* IconListItem.swift */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		D449C52726DFBBE000D75B02 /* WhatsNew */ = {
+			isa = PBXGroup;
+			children = (
+				D449C52526DFBBDA00D75B02 /* WhatsNewFactory.swift */,
+				D449C52826DFBCCC00D75B02 /* WhatsNewHostingController.swift */,
+			);
+			path = WhatsNew;
 			sourceTree = "<group>";
 		};
 		D8025469265517F9001B2CC1 /* CardPresentPayments */ = {
@@ -7353,6 +7367,7 @@
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
 				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
+				D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */,
 				025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
@@ -7619,6 +7634,7 @@
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				5783FB3F25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
+				D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */,
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,
 				57A25C7625ACE9BC00A54A62 /* OrderFulfillmentUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/WhatsNew/WhatsNewViewModelTests.swift
@@ -1,7 +1,15 @@
 import XCTest
+import Yosemite
 @testable import WooCommerce
 
 class WhatsNewViewModelTests: XCTestCase {
+
+    private var storesManager: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
 
     func test_on_init_with_no_items_it_has_no_items() {
         // Arrange, Act
@@ -27,6 +35,18 @@ class WhatsNewViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.title, Expectations.title)
         XCTAssertEqual(viewModel.ctaTitle, Expectations.ctaTitle)
+    }
+
+    func test_on_appear_it_triggers_a_mark_as_displayed_action() throws {
+        // Arrange
+        let viewModel = WhatsNewViewModel(items: [], stores: storesManager, onDismiss: {})
+
+        // Act
+        viewModel.onAppear()
+
+        // Assert
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+        XCTAssertTrue(storesManager.receivedActions.first is AnnouncementsAction)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/WhatsNew/WhatsNewFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/WhatsNew/WhatsNewFactoryTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import WordPressKit
+@testable import WooCommerce
+
+final class WhatsNewFactoryTests: XCTestCase {
+
+    func test_create_whats_new_view_controller_has_expected_properties() throws {
+        // Arrange
+        let announcement = try makeWordPressAnnouncement()
+
+        // Act
+        let viewController = WhatsNewFactory.whatsNew(announcement, onDismiss: {}) as? WhatsNewHostingController
+
+        // Assert
+        XCTAssertEqual(viewController?.rootView.viewModel.items.count, 1)
+        XCTAssertEqual(viewController?.modalPresentationStyle, .formSheet)
+    }
+}
+
+// MARK: - Mocks
+//
+private extension WhatsNewFactoryTests {
+    func makeWordPressAnnouncement() throws -> WordPressKit.Announcement {
+        let jsonData = try JSONSerialization.data(withJSONObject: [
+            "appVersionName": "1",
+            "minimumAppVersion": "",
+            "maximumAppVersion": "",
+            "appVersionTargets": [],
+            "detailsUrl": "http://wordpress.org",
+            "features": [[
+                "title": "foo",
+                "subtitle": "bar",
+                "iconBase64": "",
+                "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
+            ]],
+            "announcementVersion": "2",
+            "isLocalized": true,
+            "responseLocale": "en_US"
+        ])
+
+        return try JSONDecoder().decode(Announcement.self, from: jsonData)
+    }
+}

--- a/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
@@ -5,4 +5,12 @@ public enum AnnouncementsAction: Action {
     /// Synchronizes the latest Announcements and save it on disk
     ///
     case synchronizeAnnouncements(onCompletion: (Result<Announcement, Error>) -> Void)
+
+    /// Load latest saved announcement along with a boolean indicating if it was already presented to the user on app launch
+    ///
+    case loadSavedAnnouncement(onCompletion: (Result<(Announcement, IsDisplayed), Error>) -> Void)
+
+    /// Marks the saved announcement as displayed
+    ///
+    case markSavedAnnouncementAsDisplayed(onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
+++ b/Yosemite/Yosemite/Actions/AnnouncementsAction.swift
@@ -12,5 +12,5 @@ public enum AnnouncementsAction: Action {
 
     /// Marks the saved announcement as displayed
     ///
-    case markSavedAnnouncementAsDisplayed(onCompletion: (Error?) -> Void)
+    case markSavedAnnouncementAsDisplayed(onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -78,9 +78,6 @@ public class AnnouncementsStore: Store {
 private extension AnnouncementsStore {
     /// Get Announcements from Announcements API and persist this information on disk.
     func synchronizeAnnouncements(onCompletion: @escaping (Result<Announcement, Error>) -> Void) {
-
-//        try! fileStorage.deleteFile(at: featureAnnouncementsFileURL!)
-//        return
         remote.getAnnouncements(appId: Constants.WooCommerceAppId,
                                 appVersion: appVersion,
                                 locale: Locale.current.identifier) { [weak self] result in

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -148,7 +148,7 @@ private extension AnnouncementsStore {
             let encodedObject = try JSONEncoder().encode(storedAnnouncement)
             return try JSONDecoder().decode(Announcement.self, from: encodedObject)
         } catch {
-            throw AnnouncementsStorageError.noAnnouncementSaved
+            throw AnnouncementsStorageError.invalidAnnouncement
         }
     }
 
@@ -176,7 +176,7 @@ private extension AnnouncementsStore {
         do {
             return try fileStorage.data(for: fileURL)
         } catch {
-            throw AnnouncementsStorageError.noAnnouncementSaved
+            throw AnnouncementsStorageError.invalidAnnouncement
         }
     }
 
@@ -214,7 +214,7 @@ private enum Constants {
 // MARK: - Errors
 enum AnnouncementsStorageError: Error {
     case unableToFindFileURL
-    case noAnnouncementSaved
+    case invalidAnnouncement
     case unableToSaveAnnouncement
     case announcementAlreadyExists
 }

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -198,7 +198,7 @@ private extension AnnouncementsStore {
 // MARK: - Announcement Extension
 private extension Announcement {
     func isNewCompared(to announcement: StorageAnnouncement) -> Bool {
-        appVersionName != announcement.appVersionName || announcementVersion > announcement.announcementVersion
+        appVersionName > announcement.appVersionName || announcementVersion > announcement.announcementVersion
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -141,6 +141,7 @@ private extension AnnouncementsStore {
         }
     }
 
+    /// Mark saved announcement as displayed. Returng an error in case of failure to save announcement
     func markSavedAnnouncementAsDisplayed(onCompletion: (Result<Void, Error>) -> Void) {
         guard let fileURL = featureAnnouncementsFileURL else {
             return onCompletion(.failure(AnnouncementsStorageError.unableToFindFileURL))
@@ -153,10 +154,11 @@ private extension AnnouncementsStore {
             onCompletion(.success(()))
         }
         catch {
-            onCompletion(.failure(AnnouncementsStorageError.noAnnouncementSaved))
+            onCompletion(.failure(AnnouncementsStorageError.unableToSaveAnnouncement))
         }
     }
 
+    /// Loads saved annpouncement from disk (Maps from StorageAnnouncement to Announcement)
     func savedAnnouncement() throws -> Announcement {
         guard let fileURL = featureAnnouncementsFileURL else { throw AnnouncementsStorageError.unableToFindFileURL }
         do {
@@ -189,6 +191,7 @@ private enum Constants {
 enum AnnouncementsStorageError: Error {
     case unableToFindFileURL
     case noAnnouncementSaved
+    case unableToSaveAnnouncement
     case announcementAlreadyExists
 }
 

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -122,7 +122,7 @@ private extension AnnouncementsStore {
 // MARK: - Helper functions
 private extension AnnouncementsStore {
     /// Map `WordPressKit.Announcement` to `StorageAnnouncement` model
-    func mapAnnouncementToStorageModel(_ announcement: Announcement, displayed: Bool = false) -> StorageAnnouncement {
+    func mapAnnouncementToStorageModel(_ announcement: Announcement) -> StorageAnnouncement {
         let mappedFeatures = announcement.features.map {
             StorageFeature(title: $0.title,
                            subtitle: $0.subtitle,
@@ -139,7 +139,7 @@ private extension AnnouncementsStore {
                                    isLocalized: announcement.isLocalized,
                                    responseLocale: announcement.responseLocale,
                                    features: mappedFeatures,
-                                   displayed: displayed)
+                                   displayed: false)
     }
 
     /// Map `StorageAnnouncement` to `WordPressKit.Announcement` model

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -109,7 +109,7 @@ final class AnnouncementsStoreTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(resultError, .noAnnouncementSaved)
+        XCTAssertEqual(resultError, .invalidAnnouncement)
     }
 
     func test_load_newly_saved_announcement_returns_an_announcement_not_yet_displayed() throws {

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -152,8 +152,8 @@ final class AnnouncementsStoreTests: XCTestCase {
 
         // Act
         let error: Error? = waitFor { [weak self] promise in
-            let action = AnnouncementsAction.markSavedAnnouncementAsDisplayed { error in
-                promise(error)
+            let action = AnnouncementsAction.markSavedAnnouncementAsDisplayed { result in
+                promise(result.failure)
             }
             self?.subject?.onAction(action)
         }
@@ -201,7 +201,15 @@ private extension AnnouncementsStoreTests {
     }
 
     func makeStorageAnnouncement(displayed: Bool = false) -> StorageAnnouncement {
-        StorageAnnouncement(appVersionName: "1", minimumAppVersion: "1", maximumAppVersion: "2", appVersionTargets: [], detailsUrl: "",
-                            announcementVersion: "", isLocalized: true, responseLocale: "", features: [], displayed: displayed)
+        StorageAnnouncement(appVersionName: "1",
+                            minimumAppVersion: "1",
+                            maximumAppVersion: "2",
+                            appVersionTargets: [],
+                            detailsUrl: "",
+                            announcementVersion: "",
+                            isLocalized: true,
+                            responseLocale: "",
+                            features: [],
+                            displayed: displayed)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -98,13 +98,89 @@ final class AnnouncementsStoreTests: XCTestCase {
         // Assert
         XCTAssertEqual(resultError, .announcementNotFound)
     }
+
+    func test_load_saved_announcement_without_saved_data_returns_error() {
+        // Arrange, Act
+        let resultError: AnnouncementsStorageError? = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(result.failure as? AnnouncementsStorageError)
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertEqual(resultError, .noAnnouncementSaved)
+    }
+
+    func test_load_newly_saved_announcement_returns_an_announcement_not_yet_displayed() throws {
+        //Arrange
+        try fileStorage?.write(makeStorageAnnouncement(), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
+
+        // Act
+        let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(try! result.get())
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertNotNil(announcement)
+        XCTAssertFalse(isDisplayed)
+    }
+
+    func test_load_saved_announcement_already_displayed_returns_a_displayed_announcement() throws {
+        //Arrange
+        try fileStorage?.write(makeStorageAnnouncement(displayed: true), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
+
+        // Act
+        let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(try! result.get())
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertNotNil(announcement)
+        XCTAssertTrue(isDisplayed)
+    }
+
+    func test_on_mark_announcement_as_displayed_it_updates_storage_model() throws {
+        //Arrange
+        try fileStorage?.write(makeStorageAnnouncement(displayed: false), to: try XCTUnwrap(expectedFeatureAnnouncementsFileURL))
+
+        // Act
+        let error: Error? = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.markSavedAnnouncementAsDisplayed { error in
+                promise(error)
+            }
+            self?.subject?.onAction(action)
+        }
+
+        let (announcement, isDisplayed): (WordPressKit.Announcement, Bool) = waitFor { [weak self] promise in
+            let action = AnnouncementsAction.loadSavedAnnouncement { result in
+                promise(try! result.get())
+            }
+            self?.subject?.onAction(action)
+        }
+
+        // Assert
+        XCTAssertNil(error)
+        XCTAssertNotNil(announcement)
+        XCTAssertTrue(isDisplayed)
+    }
 }
 
-// MARK: - Mocks
+// MARK: - Utils
 //
 private extension AnnouncementsStoreTests {
+    var expectedFeatureAnnouncementsFileURL: URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("feature-announcements.plist")
+    }
+
     func makeWordPressAnnouncement() throws -> WordPressKit.Announcement {
-        let announcementJson: [String: Any] = [
+        let jsonData = try JSONSerialization.data(withJSONObject: [
             "appVersionName": "1",
             "minimumAppVersion": "",
             "maximumAppVersion": "",
@@ -119,9 +195,13 @@ private extension AnnouncementsStoreTests {
             "announcementVersion": "2",
             "isLocalized": true,
             "responseLocale": "en_US"
-        ]
+        ])
 
-        let jsonData = try JSONSerialization.data(withJSONObject: announcementJson)
         return try JSONDecoder().decode(Announcement.self, from: jsonData)
+    }
+
+    func makeStorageAnnouncement(displayed: Bool = false) -> StorageAnnouncement {
+        StorageAnnouncement(appVersionName: "1", minimumAppVersion: "1", maximumAppVersion: "2", appVersionTargets: [], detailsUrl: "",
+                            announcementVersion: "", isLocalized: true, responseLocale: "", features: [], displayed: displayed)
     }
 }


### PR DESCRIPTION
Part of: #4863 

# Description 📜

This PR makes the integration between the existing logic to fetch announcements (and now mark them as displayed as well) and the SwiftUI work done in the [previous Pull Request](https://github.com/woocommerce/woocommerce-ios/pull/4899).

# Main Changes ⚙️
- Add all the fields from WordPressKit to Yosemite.Announcement so we can encode/decode as we wish
- AppCoordinator now fetches the latest announcement and displays the WhatsNewComponent on app launch
- Introduces WhatsNewFactory to wrap app the viewController/viewModel creation and UI setup for What's new component
- Add new AnnouncementAction: `markSavedAnnouncementAsDisplayed `: responsible for marking the saved announcement as `displayed`.

### Flow Diagram
This is the flow for fetching and persisting an announcement on app launch
![image](https://user-images.githubusercontent.com/997521/131747321-52022326-0888-4798-854b-0ec0bd13a233.png)

### Recordings:
| iPhone 12 Pro Max  |  iPad Pro                  |
| ------------------- | ------------------- | 
| <video src="https://user-images.githubusercontent.com/997521/131748713-cde5ec9f-5599-4f1b-9ba9-4ac772724d23.mp4"> |     <video src="https://user-images.githubusercontent.com/997521/131748755-a51afdbd-6a72-407b-b0c6-c53a9a91cb93.mov">  |

# Testing 🧑‍🔬🧪

### ⚠️ Pre-requisite ⚠️
_Please do the following change_
<img width="495" alt="image" src="https://user-images.githubusercontent.com/997521/131144031-136d2892-cb05-495a-8532-dbc924d8ee02.png">

## Scenario 1
1. Run the app
2. What's New component should be displayed upon app launch
3. Tap Continue to dismiss the modal

## Scenario 2
1. Run the app again (after seeing the What's New component once)
2. What's New component should **NOT** be displayed

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
