### PR TITLE
Shipping Labels: Add empty state screen to Service Packages list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -20,7 +20,7 @@ struct ShippingLabelAddNewPackage: View {
                     case .customPackage:
                         ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        ShippingLabelServicePackageList(packagesResponse: packagesResponse, safeAreaInsets: geometry.safeAreaInsets)
+                        ShippingLabelServicePackageList(packagesResponse: packagesResponse, geometry: geometry)
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -8,6 +8,31 @@ struct ShippingLabelServicePackageList: View {
     let safeAreaInsets: EdgeInsets
 
     var body: some View {
+        servicePackageListView
+            .onAppear(perform: {
+                viewModel.packagesResponse = packagesResponse
+            })
+            .background(Color(.listBackground))
+            .minimalNavigationBarBackButton()
+    }
+
+    @ViewBuilder
+    private var servicePackageListView: some View {
+        if viewModel.shouldShowEmptyState {
+            emptyList
+        } else {
+            populatedList
+        }
+    }
+
+    private var emptyList: some View {
+        VStack(alignment: .center) {
+            EmptyState(title: Localization.emptyStateMessage, image: .waitingForCustomersImage)
+                .frame(maxHeight: .infinity)
+        }
+    }
+
+    private var populatedList: some View {
         LazyVStack(spacing: 0) {
             ListHeaderView(text: Localization.servicePackageHeader, alignment: .left)
                 .padding(.horizontal, insets: safeAreaInsets)
@@ -34,12 +59,7 @@ struct ShippingLabelServicePackageList: View {
                 }
             }
         }
-        .onAppear(perform: {
-            viewModel.packagesResponse = packagesResponse
-        })
-        .background(Color(.listBackground))
         .ignoresSafeArea(.container, edges: .horizontal)
-        .minimalNavigationBarBackButton()
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing, content: {
                 Button(Localization.doneButton, action: {
@@ -56,7 +76,10 @@ private extension ShippingLabelServicePackageList {
         static let servicePackageHeader = NSLocalizedString(
             "Set up the package you'll be using to ship your products. We'll save it for future orders.",
             comment: "Header text on Add New Service Package screen in Shipping Label flow")
-        static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Custom Package screen in Shipping Label flow")
+        static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Service Package screen in Shipping Label flow")
+        static let emptyStateMessage = NSLocalizedString(
+            "All available packages have been activated",
+            comment: "Message displayed when there are no packages to display in the Add New Service Package screen in Shipping Label flow")
     }
 
     enum Constants {
@@ -70,6 +93,8 @@ struct ShippingLabelServicePackageList_Previews: PreviewProvider {
         let packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
 
         ShippingLabelServicePackageList(packagesResponse: packagesResponse, safeAreaInsets: .zero)
-            .previewLayout(.sizeThatFits)
+
+        ShippingLabelServicePackageList(packagesResponse: nil, safeAreaInsets: .zero)
+            .previewDisplayName("Empty State")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -5,7 +5,7 @@ struct ShippingLabelServicePackageList: View {
     @Environment(\.presentationMode) var presentation
     @StateObject var viewModel = ShippingLabelServicePackageListViewModel()
     let packagesResponse: ShippingLabelPackagesResponse?
-    let safeAreaInsets: EdgeInsets
+    let geometry: GeometryProxy
 
     var body: some View {
         servicePackageListView
@@ -28,21 +28,21 @@ struct ShippingLabelServicePackageList: View {
     private var emptyList: some View {
         VStack(alignment: .center) {
             EmptyState(title: Localization.emptyStateMessage, image: .waitingForCustomersImage)
-                .frame(maxHeight: .infinity)
+                .frame(idealHeight: geometry.size.height)
         }
     }
 
     private var populatedList: some View {
         LazyVStack(spacing: 0) {
             ListHeaderView(text: Localization.servicePackageHeader, alignment: .left)
-                .padding(.horizontal, insets: safeAreaInsets)
+                .padding(.horizontal, insets: geometry.safeAreaInsets)
 
             /// Packages
             ///
             ForEach(viewModel.predefinedOptions, id: \.title) { option in
 
                 ListHeaderView(text: option.title.uppercased(), alignment: .left)
-                    .padding(.horizontal, insets: safeAreaInsets)
+                    .padding(.horizontal, insets: geometry.safeAreaInsets)
                 ForEach(option.predefinedPackages) { package in
                     let selected = package == viewModel.selectedPackage
                     SelectableItemRow(title: package.title,
@@ -51,10 +51,10 @@ struct ShippingLabelServicePackageList: View {
                         .onTapGesture {
                             viewModel.selectedPackage = package
                         }
-                        .padding(.horizontal, insets: safeAreaInsets)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                         .background(Color(.systemBackground))
                     Divider()
-                        .padding(.horizontal, insets: safeAreaInsets)
+                        .padding(.horizontal, insets: geometry.safeAreaInsets)
                         .padding(.leading, Constants.dividerPadding)
                 }
             }
@@ -92,9 +92,13 @@ struct ShippingLabelServicePackageList_Previews: PreviewProvider {
     static var previews: some View {
         let packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
 
-        ShippingLabelServicePackageList(packagesResponse: packagesResponse, safeAreaInsets: .zero)
+        GeometryReader { geometry in
+            ShippingLabelServicePackageList(packagesResponse: packagesResponse, geometry: geometry)
+        }
 
-        ShippingLabelServicePackageList(packagesResponse: nil, safeAreaInsets: .zero)
-            .previewDisplayName("Empty State")
+        GeometryReader { geometry in
+            ShippingLabelServicePackageList(packagesResponse: nil, geometry: geometry)
+                .previewDisplayName("Empty State")
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -19,4 +19,8 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
     var dimensionUnit: String {
         packagesResponse?.storeOptions.dimensionUnit ?? ""
     }
+
+    var shouldShowEmptyState: Bool {
+        predefinedOptions.isEmpty
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct EmptyState: View {
 
     @State var title: String
-    @State var description: String
+    @State var description: String?
     @State var image: UIImage?
 
     var body: some View {
@@ -17,10 +17,12 @@ struct EmptyState: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: Constants.width)
             }
-            Text(description)
-                .multilineTextAlignment(.center)
-                .bodyStyle()
-                .fixedSize(horizontal: false, vertical: true)
+            if let description = description {
+                Text(description)
+                    .multilineTextAlignment(.center)
+                    .bodyStyle()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, Constants.horizontalSpacing)


### PR DESCRIPTION
Part of: #4744 

## Description

In the shipping label creation flow, this adds an empty state screen to the Add New Package > Service Package tab. When all service packages are activated on the store, this empty state screen will appear.

This matches the empty state screen as implemented on Android in https://github.com/woocommerce/woocommerce-android/pull/4471.

## Changes

* Makes the description string optional in the reusable `EmptyState` component, so this empty state screen can be displayed with just a title and image.
* Refactors the `ShippingLabelServicePackageList` view so the empty state view and the populated list view are defined separately and displayed based on whether the list of unactivated predefined options is empty. The `GeometryProxy` is passed from the parent view so the empty state view can be vertically centered in the parent scroll view.

Light|Dark
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-01 at 23 58 45](https://user-images.githubusercontent.com/8658164/131821549-ca7e5531-4bc8-49cf-8c6a-1fdc6dfeb33c.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 01 17](https://user-images.githubusercontent.com/8658164/131821553-89b89710-2fbd-4b9d-83f6-9af13dba0551.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin
2. In WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping, select "Add Package" and then "Service Package" and enable **all** of the service packages.
3. Launch the app in debug mode (so the feature flag is enabled).
4. Open an order detail that is eligible for the shipping label.
5. Tap the button "Create Shipping Label.”
6. Confirm "Ship From" and "Ship To.”
7. In the package details section, tap on “Package Selected.”
8. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
9. On the Add New Package screen, select "Service Package" and confirm you see the expected empty state view.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
