### PR TITLE
Shipping Labels: Ensure Add New Package view retains state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -4,6 +4,7 @@ import Yosemite
 struct ShippingLabelAddNewPackage: View {
     @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
     @StateObject private var customPackageVM = ShippingLabelCustomPackageFormViewModel()
+    @StateObject private var servicePackageVM = ShippingLabelServicePackageListViewModel()
     let packagesResponse: ShippingLabelPackagesResponse?
 
     var body: some View {
@@ -21,7 +22,10 @@ struct ShippingLabelAddNewPackage: View {
                     case .customPackage:
                         ShippingLabelCustomPackageForm(viewModel: customPackageVM, safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        ShippingLabelServicePackageList(packagesResponse: packagesResponse, geometry: geometry)
+                        ShippingLabelServicePackageList(viewModel: servicePackageVM, geometry: geometry)
+                            .onAppear() {
+                                servicePackageVM.packagesResponse = packagesResponse
+                            }
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct ShippingLabelAddNewPackage: View {
     @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
+    @StateObject private var customPackageVM = ShippingLabelCustomPackageFormViewModel()
     let packagesResponse: ShippingLabelPackagesResponse?
 
     var body: some View {
@@ -18,7 +19,7 @@ struct ShippingLabelAddNewPackage: View {
                 ScrollView {
                     switch viewModel.selectedView {
                     case .customPackage:
-                        ShippingLabelCustomPackageForm(safeAreaInsets: geometry.safeAreaInsets)
+                        ShippingLabelCustomPackageForm(viewModel: customPackageVM, safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
                         ShippingLabelServicePackageList(packagesResponse: packagesResponse, geometry: geometry)
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Yosemite
 
 struct ShippingLabelAddNewPackage: View {
-    @StateObject var viewModel: ShippingLabelAddNewPackageViewModel
+    @ObservedObject var viewModel: ShippingLabelAddNewPackageViewModel
 
     var body: some View {
         GeometryReader { geometry in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -4,8 +4,11 @@ import Yosemite
 struct ShippingLabelAddNewPackage: View {
     @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
     @StateObject private var customPackageVM = ShippingLabelCustomPackageFormViewModel()
-    @StateObject private var servicePackageVM = ShippingLabelServicePackageListViewModel()
-    let packagesResponse: ShippingLabelPackagesResponse?
+    @StateObject private var servicePackageVM: ShippingLabelServicePackageListViewModel
+
+    init(packagesResponse: ShippingLabelPackagesResponse?) {
+        _servicePackageVM = StateObject(wrappedValue: ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse))
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -23,9 +26,6 @@ struct ShippingLabelAddNewPackage: View {
                         ShippingLabelCustomPackageForm(viewModel: customPackageVM, safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
                         ShippingLabelServicePackageList(viewModel: servicePackageVM, geometry: geometry)
-                            .onAppear() {
-                                servicePackageVM.packagesResponse = packagesResponse
-                            }
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -2,13 +2,7 @@ import SwiftUI
 import Yosemite
 
 struct ShippingLabelAddNewPackage: View {
-    @StateObject private var viewModel = ShippingLabelAddNewPackageViewModel()
-    @StateObject private var customPackageVM = ShippingLabelCustomPackageFormViewModel()
-    @StateObject private var servicePackageVM: ShippingLabelServicePackageListViewModel
-
-    init(packagesResponse: ShippingLabelPackagesResponse?) {
-        _servicePackageVM = StateObject(wrappedValue: ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse))
-    }
+    @StateObject var viewModel: ShippingLabelAddNewPackageViewModel
 
     var body: some View {
         GeometryReader { geometry in
@@ -23,9 +17,9 @@ struct ShippingLabelAddNewPackage: View {
                 ScrollView {
                     switch viewModel.selectedView {
                     case .customPackage:
-                        ShippingLabelCustomPackageForm(viewModel: customPackageVM, safeAreaInsets: geometry.safeAreaInsets)
+                        ShippingLabelCustomPackageForm(viewModel: viewModel.customPackageVM, safeAreaInsets: geometry.safeAreaInsets)
                     case .servicePackage:
-                        ShippingLabelServicePackageList(viewModel: servicePackageVM, geometry: geometry)
+                        ShippingLabelServicePackageList(viewModel: viewModel.servicePackageVM, geometry: geometry)
                     }
                 }
                  .background(Color(.listBackground).ignoresSafeArea(.container, edges: .bottom))
@@ -47,6 +41,8 @@ private extension ShippingLabelAddNewPackage {
 
 struct ShippingLabelAddNewPackage_Previews: PreviewProvider {
     static var previews: some View {
-        ShippingLabelAddNewPackage(packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+        let viewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails())
+
+        ShippingLabelAddNewPackage(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SwiftUI
+import Yosemite
 
 /// View model for `ShippingLabelAddNewPackage`.
 ///
@@ -9,8 +10,14 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
         PackageViewType(rawValue: selectedIndex) ?? .customPackage
     }
 
-    init(_ selectedIndex: Int = PackageViewType.customPackage.rawValue) {
+    // View models for child views (tabs)
+    let customPackageVM = ShippingLabelCustomPackageFormViewModel()
+    let servicePackageVM: ShippingLabelServicePackageListViewModel
+
+    init(_ selectedIndex: Int = PackageViewType.customPackage.rawValue,
+         packagesResponse: ShippingLabelPackagesResponse?) {
         self.selectedIndex = selectedIndex
+        self.servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
     }
 
     enum PackageViewType: Int {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -3,15 +3,10 @@ import Combine
 
 /// Form to create a new custom package to use with shipping labels.
 struct ShippingLabelCustomPackageForm: View {
-    private let safeAreaInsets: EdgeInsets
-
     @Environment(\.presentationMode) var presentation
-    @StateObject private var viewModel = ShippingLabelCustomPackageFormViewModel()
+    @ObservedObject var viewModel: ShippingLabelCustomPackageFormViewModel
     @State private var showingPackageTypes = false
-
-    init(safeAreaInsets: EdgeInsets) {
-        self.safeAreaInsets = safeAreaInsets
-    }
+    let safeAreaInsets: EdgeInsets
 
     var body: some View {
         VStack(spacing: Constants.verticalSpacing) {
@@ -207,7 +202,9 @@ private extension ShippingLabelCustomPackageForm {
 
 struct ShippingLabelAddCustomPackage_Previews: PreviewProvider {
     static var previews: some View {
-        ShippingLabelCustomPackageForm(safeAreaInsets: .zero)
+        let viewModel = ShippingLabelCustomPackageFormViewModel()
+
+        ShippingLabelCustomPackageForm(viewModel: viewModel, safeAreaInsets: .zero)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -3,15 +3,11 @@ import Yosemite
 
 struct ShippingLabelServicePackageList: View {
     @Environment(\.presentationMode) var presentation
-    @StateObject var viewModel = ShippingLabelServicePackageListViewModel()
-    let packagesResponse: ShippingLabelPackagesResponse?
+    @ObservedObject var viewModel: ShippingLabelServicePackageListViewModel
     let geometry: GeometryProxy
 
     var body: some View {
         servicePackageListView
-            .onAppear(perform: {
-                viewModel.packagesResponse = packagesResponse
-            })
             .background(Color(.listBackground))
             .minimalNavigationBarBackButton()
     }
@@ -91,14 +87,17 @@ private extension ShippingLabelServicePackageList {
 
 struct ShippingLabelServicePackageList_Previews: PreviewProvider {
     static var previews: some View {
-        let packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
+        let viewModel = ShippingLabelServicePackageListViewModel()
 
         GeometryReader { geometry in
-            ShippingLabelServicePackageList(packagesResponse: packagesResponse, geometry: geometry)
+            ShippingLabelServicePackageList(viewModel: viewModel, geometry: geometry)
+                .onAppear() {
+                    viewModel.packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
+                }
         }
 
         GeometryReader { geometry in
-            ShippingLabelServicePackageList(packagesResponse: nil, geometry: geometry)
+            ShippingLabelServicePackageList(viewModel: viewModel, geometry: geometry)
                 .previewDisplayName("Empty State")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageList.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 struct ShippingLabelServicePackageList: View {
     @Environment(\.presentationMode) var presentation
@@ -87,17 +86,16 @@ private extension ShippingLabelServicePackageList {
 
 struct ShippingLabelServicePackageList_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ShippingLabelServicePackageListViewModel()
+        let packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
+        let populatedViewModel = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
+        let emptyViewModel = ShippingLabelServicePackageListViewModel(packagesResponse: nil)
 
         GeometryReader { geometry in
-            ShippingLabelServicePackageList(viewModel: viewModel, geometry: geometry)
-                .onAppear() {
-                    viewModel.packagesResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
-                }
+            ShippingLabelServicePackageList(viewModel: populatedViewModel, geometry: geometry)
         }
 
         GeometryReader { geometry in
-            ShippingLabelServicePackageList(viewModel: viewModel, geometry: geometry)
+            ShippingLabelServicePackageList(viewModel: emptyViewModel, geometry: geometry)
                 .previewDisplayName("Empty State")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -23,4 +23,8 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
     var shouldShowEmptyState: Bool {
         predefinedOptions.isEmpty
     }
+
+    init(packagesResponse: ShippingLabelPackagesResponse?) {
+        self.packagesResponse = packagesResponse
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -62,8 +62,7 @@ struct ShippingLabelPackageList: View {
                 }))
 
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages) {
-                    let viewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: viewModel.packagesResponse)
-                    NavigationLink(destination: ShippingLabelAddNewPackage(viewModel: viewModel),
+                    NavigationLink(destination: ShippingLabelAddNewPackage(viewModel: viewModel.addNewPackageViewModel),
                                    isActive: $isShowingNewPackageCreation) {
                         EmptyView()
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -62,7 +62,8 @@ struct ShippingLabelPackageList: View {
                 }))
 
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.shippingLabelsAddCustomPackages) {
-                    NavigationLink(destination: ShippingLabelAddNewPackage(packagesResponse: viewModel.packagesResponse),
+                    let viewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: viewModel.packagesResponse)
+                    NavigationLink(destination: ShippingLabelAddNewPackage(viewModel: viewModel),
                                    isActive: $isShowingNewPackageCreation) {
                         EmptyView()
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -8,7 +8,8 @@ struct ShippingLabelPackageSelection: View {
             if viewModel.hasCustomOrPredefinedPackages {
                 ShippingLabelPackageList(viewModel: viewModel)
             } else {
-                ShippingLabelAddNewPackage(packagesResponse: viewModel.packagesResponse)
+                let viewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: viewModel.packagesResponse)
+                ShippingLabelAddNewPackage(viewModel: viewModel)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -8,8 +8,7 @@ struct ShippingLabelPackageSelection: View {
             if viewModel.hasCustomOrPredefinedPackages {
                 ShippingLabelPackageList(viewModel: viewModel)
             } else {
-                let viewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: viewModel.packagesResponse)
-                ShippingLabelAddNewPackage(viewModel: viewModel)
+                ShippingLabelAddNewPackage(viewModel: viewModel.addNewPackageViewModel)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -83,6 +83,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         return customPackages.count > 0
     }
 
+    lazy var addNewPackageViewModel: ShippingLabelAddNewPackageViewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: packagesResponse)
+
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackageID: String?,


### PR DESCRIPTION
Part of: #4743 / #4744

## Description

In https://github.com/woocommerce/woocommerce-ios/pull/4882#discussion_r698176446 @itsmeichigo noted that switching between tabs on the Add New Package screen in the Shipping Label flow caused the tabs to lose state. (The Custom Package tab lost any data entered in the form, and the Service Package tab lost its package selection.)

This fixes the way those views and their view models are initialized so that they retain state. You should now be able to perform any action on those screens (e.g. switch tabs, rotate the device) and the changes on each tab will be retained.

~Note: I didn't intentionally address the issue reported in #4913, where the modal closes when rotating the device from portrait to landscape. However, in testing I found it is no longer an issue as of these changes.~ → As noted in the discussion below, this is still an issue.

## Changes

* Initializes the custom package and service package view models as `StateObject`s in the `ShippingLabelAddNewPackage` view. This ensures that each view model only has a single instance, even if the views are redrawn.
* Removes the use of `onAppear` to set the value of `packagesResponse` in the service package view model (since that is called every time the view is redrawn), and uses `StateObject(wrappedValue:)` to initialize that view model instead. Although the [Apple documentation](https://developer.apple.com/documentation/swiftui/stateobject/init(wrappedvalue:)) says not to call this initializer directly, the SwiftUI digital lounge at WWDC21 [clarified that this is an acceptable use](https://swiftui-lab.com/random-lessons/#data-10).

**State retained when switching tabs**

<img src="https://user-images.githubusercontent.com/8658164/131921665-33b30d7e-d086-4d73-91f6-2c77bf208d70.gif" width="300px">


**Modal stays open when rotating device**

<img src="https://user-images.githubusercontent.com/8658164/131921427-14b3ff31-4892-4564-b1ef-9b23bf50429c.gif" width="300px">


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin, and you have one or more packages set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap the “Create new package” button at the bottom of the screen.
8. On the Add New Package screen, switch between the "Custom Package" and "Service Package" tabs. Enter custom package details in the form and select a service package from the list, and confirm your changes are retained as you switch between tabs or rotate your device.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
