### PR TITLE
Order Editing: Adds Country Selector UI

### DIFF
--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -289,6 +289,12 @@ extension UIColor {
             return .white
         }
     }
+
+    /// SearchBar background color.
+    ///
+    static var searchBarBackground: UIColor {
+        .secondarySystemFill
+    }
 }
 
 // MARK: - UI elements.

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// `SwiftUI` wrapper for `ListSelectorViewController`
+///
+struct ListSelector<Command: ListSelectorCommand>: UIViewControllerRepresentable {
+
+    /// Command that defines cell style and provide data.
+    ///
+    let command: Command
+
+    /// Table view style.
+    ///
+    let tableStyle: UITableView.Style
+
+    /// Closure to be invoked when the view is dismissed.
+    ///
+    var onDismiss: (Command.Model?) -> Void = { _ in }
+
+    /// Creates `ViewController` with the provided parameters.
+    ///
+    func makeUIViewController(context: Context) -> ListSelectorViewController<Command, Command.Model, Command.Cell> {
+        ListSelectorViewController(command: command, tableViewStyle: tableStyle, onDismiss: onDismiss)
+    }
+
+    /// Update the `ViewController` from parent `SwiftUI` view
+    ///
+    func updateUIViewController(_ uiViewController: ListSelectorViewController<Command, Command.Model, Command.Cell>, context: Context) {
+        // No op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -4,8 +4,9 @@ import SwiftUI
 ///
 struct CountrySelector: View {
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             SearchHeader()
+                .background(Color(.listForeground))
             ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
         }
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct CountrySelector: View {
+    var body: some View {
+        ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -1,7 +1,65 @@
 import SwiftUI
 
+/// Country Selector View
+///
 struct CountrySelector: View {
     var body: some View {
-        ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
+        VStack {
+            SearchHeader()
+            ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
+        }
+        .navigationTitle(Localization.title)
+    }
+}
+
+/// Search Header View
+///
+private struct SearchHeader: View {
+    var body: some View {
+        HStack(spacing: 0) {
+            // Search Icon
+            Image(uiImage: .searchBarButtonItemImage)
+                .renderingMode(.template)
+                .resizable()
+                .frame(width: Layout.iconSize.width, height: Layout.iconSize.height)
+                .foregroundColor(Color(.listSmallIcon))
+                .padding([.leading, .trailing], Layout.internalPadding)
+
+            // TextField
+            TextField(Localization.placeholder, text: .constant(""))
+                .padding([.bottom, .top], Layout.internalPadding)
+        }
+        .background(Color(.searchBarBackground))
+        .cornerRadius(Layout.cornerRadius)
+        .padding(Layout.externalPadding)
+    }
+}
+
+// MARK: Constants
+
+private extension CountrySelector {
+    enum Localization {
+        static let title = NSLocalizedString("Country", comment: "Title to select country from the edit address screen")
+    }
+}
+
+private extension SearchHeader {
+    enum Layout {
+        static let iconSize = CGSize(width: 16, height: 16)
+        static let internalPadding: CGFloat = 8
+        static let cornerRadius: CGFloat = 10
+        static let externalPadding = EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
+    }
+
+    enum Localization {
+        static let placeholder = NSLocalizedString("Filter Countries", comment: "Placeholder on the search field to search for a specific country")
+    }
+}
+
+struct CountrySelector_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            CountrySelector()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -15,13 +15,17 @@ struct CountrySelector: View {
 /// Search Header View
 ///
 private struct SearchHeader: View {
+
+    // Tracks the scale of the view due to accessibility changes
+    @ScaledMetric var scale: CGFloat = 1
+
     var body: some View {
         HStack(spacing: 0) {
             // Search Icon
             Image(uiImage: .searchBarButtonItemImage)
                 .renderingMode(.template)
                 .resizable()
-                .frame(width: Layout.iconSize.width, height: Layout.iconSize.height)
+                .frame(width: Layout.iconSize.width * scale, height: Layout.iconSize.height * scale)
                 .foregroundColor(Color(.listSmallIcon))
                 .padding([.leading, .trailing], Layout.internalPadding)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -18,7 +18,7 @@ struct CountrySelector: View {
 private struct SearchHeader: View {
 
     // Tracks the scale of the view due to accessibility changes
-    @ScaledMetric var scale: CGFloat = 1
+    @ScaledMetric private var scale: CGFloat = 1
 
     var body: some View {
         HStack(spacing: 0) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Yosemite
+
+/// Command to be used to select a country when editing addresses.
+///
+final class CountrySelectorCommand: ListSelectorCommand {
+    /// Data to display
+    ///
+    let data: [Country]
+
+    /// Current selected country
+    ///
+    private(set) var selected: Country?
+
+    /// Navigation bar title
+    ///
+    let navigationBarTitle: String? = ""
+
+    init(countries: [Country], selected: Country?) {
+        self.data = countries
+        self.selected = selected
+    }
+
+    func handleSelectedChange(selected: Country, viewController: ViewController) {
+        self.selected = selected
+    }
+
+    func isSelected(model: Country) -> Bool {
+        model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: Country) {
+        cell.textLabel?.text = model.name
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -4,6 +4,9 @@ import Yosemite
 /// Command to be used to select a country when editing addresses.
 ///
 final class CountrySelectorCommand: ListSelectorCommand {
+    typealias Model = Country
+    typealias Cell = BasicTableViewCell
+
     /// Data to display
     ///
     let data: [Country]
@@ -16,7 +19,7 @@ final class CountrySelectorCommand: ListSelectorCommand {
     ///
     let navigationBarTitle: String? = ""
 
-    init(countries: [Country], selected: Country?) {
+    init(countries: [Country] = temporaryCountries(), selected: Country? = nil) {
         self.data = countries
         self.selected = selected
     }
@@ -31,5 +34,13 @@ final class CountrySelectorCommand: ListSelectorCommand {
 
     func configureCell(cell: BasicTableViewCell, model: Country) {
         cell.textLabel?.text = model.name
+    }
+
+    // TESTING HELPER, WILL BE REMOVED LATER.
+    private static func temporaryCountries() -> [Country] {
+        return Locale.isoRegionCodes.map { regionCode in
+            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
+            return Country(code: regionCode, name: name, states: [])
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import UIKit
 
 /// Hosting controller that wraps an `EditAddressForm`.
 ///
@@ -18,6 +19,9 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 /// Allows merchant to edit the customer provided address of an order.
 ///
 struct EditAddressForm: View {
+
+    @State var showEditCountry = false
+
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -96,7 +100,9 @@ struct EditAddressForm: View {
                     }
 
                     Group {
-                        TitleAndValueRow(title: Localization.countryField, value: Localization.placeholderSelectOption, selectable: true) { }
+                        TitleAndValueRow(title: Localization.countryField, value: Localization.placeholderSelectOption, selectable: true) {
+                            showEditCountry = true
+                        }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndValueRow(title: Localization.stateField, value: Localization.placeholderSelectOption, selectable: true) { }
@@ -115,6 +121,11 @@ struct EditAddressForm: View {
         }
         .disabled(true) // TODO: enable if there are pending changes
         )
+
+        // Go to edit country
+        NavigationLink(destination: ListSelector(command: CountrySelectorCommand(), tableStyle: .plain), isActive: $showEditCountry) {
+            EmptyView()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -20,7 +20,9 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 ///
 struct EditAddressForm: View {
 
-    @State var showEditCountry = false
+    /// Set it to `true` to present the country selector.
+    ///
+    @State var showCountrySelector = false
 
     var body: some View {
         GeometryReader { geometry in
@@ -101,7 +103,7 @@ struct EditAddressForm: View {
 
                     Group {
                         TitleAndValueRow(title: Localization.countryField, value: Localization.placeholderSelectOption, selectable: true) {
-                            showEditCountry = true
+                            showCountrySelector = true
                         }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
@@ -123,7 +125,7 @@ struct EditAddressForm: View {
         )
 
         // Go to edit country
-        NavigationLink(destination: ListSelector(command: CountrySelectorCommand(), tableStyle: .plain), isActive: $showEditCountry) {
+        NavigationLink(destination: CountrySelector(), isActive: $showCountrySelector) {
             EmptyView()
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		2662D90626E1571900E25611 /* ListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90526E1571900E25611 /* ListSelector.swift */; };
 		2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */; };
+		2662D90A26E16B3600E25611 /* CountrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90926E16B3600E25611 /* CountrySelector.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
@@ -1792,6 +1793,7 @@
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		2662D90526E1571900E25611 /* ListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelector.swift; sourceTree = "<group>"; };
 		2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorCommand.swift; sourceTree = "<group>"; };
+		2662D90926E16B3600E25611 /* CountrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelector.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4771,6 +4773,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
+				2662D90926E16B3600E25611 /* CountrySelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 			);
 			path = "Address Edit";
@@ -7532,6 +7535,7 @@
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
+				2662D90A26E16B3600E25611 /* CountrySelector.swift in Sources */,
 				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		265D909B2446657B00D66F0F /* ProductCategoryViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */; };
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		2662D90626E1571900E25611 /* ListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90526E1571900E25611 /* ListSelector.swift */; };
+		2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
@@ -1790,6 +1791,7 @@
 		265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		2662D90526E1571900E25611 /* ListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelector.swift; sourceTree = "<group>"; };
+		2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorCommand.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4769,6 +4771,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
+				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 			);
 			path = "Address Edit";
 			sourceTree = "<group>";
@@ -7191,6 +7194,7 @@
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReadersStoredList.swift in Sources */,
+				2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
 				314265AC26459F7300500598 /* CardReaderSettingsSearchingViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */; };
 		265D909B2446657B00D66F0F /* ProductCategoryViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */; };
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
+		2662D90626E1571900E25611 /* ListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90526E1571900E25611 /* ListSelector.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
@@ -1788,6 +1789,7 @@
 		265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
+		2662D90526E1571900E25611 /* ListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelector.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -3617,6 +3619,7 @@
 			isa = PBXGroup;
 			children = (
 				0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */,
+				2662D90526E1571900E25611 /* ListSelector.swift */,
 				02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */,
 				0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */,
 			);
@@ -7043,6 +7046,7 @@
 				0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */,
 				CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */,
 				E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */,
+				2662D90626E1571900E25611 /* ListSelector.swift in Sources */,
 				74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */,
 				0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */,
 				DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */,


### PR DESCRIPTION
part of #4779 

# Why

While editing an address, merchants require the ability to edit the address country.

# How

- Added a `SwiftUI` wrapper around `ListSelectorViewController`

- Created `CountrySelector` which is a view that holds the `ListSelector` + a search header.

- Added a `CountrySelectorCommand` to populate the `ListSelector`. This command is currently populated with all available Regions/Countries, this is temporary and will be replaced in a subsequent PR.

- Added navigation from `EditAddressForm` to `CountrySelector`

# Screenshots

Normal | Dark | Big
---- | ---- | ----
<img width="382" alt="normal" src="https://user-images.githubusercontent.com/562080/131930405-b6562785-3189-4af4-a83c-97a54ce7bed6.png"> | <img width="390" alt="dark" src="https://user-images.githubusercontent.com/562080/131931033-ba04f785-39fe-4504-9e20-6dd2e2d53474.png"> | <img width="377" alt="big-size" src="https://user-images.githubusercontent.com/562080/131930413-3855a655-1887-406f-bb1d-66b65234f46f.png">

# Testing Steps

- Launch the app and navigate to an order
- Tap on the edit icon from the shipping address row
- Tap on the country row
- See the list of countries.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
