### PR TITLE
Order Edit: Fix shipping address row background

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,7 +44,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="pQe-4r-eVj" firstAttribute="leading" secondItem="9Pw-dA-pUx" secondAttribute="leading" id="0bW-hT-8M3"/>
                                             <constraint firstAttribute="bottom" secondItem="KJW-Ch-VgS" secondAttribute="bottom" id="1PF-9c-iAk"/>
@@ -89,9 +88,4 @@
             <point key="canvasLocation" x="34" y="114"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
# Why

In a recent PR https://github.com/woocommerce/woocommerce-ios/pull/4869 we introduced edit indicators in the shipping address row and by accident we introduced a small glitch in dark mode.

<img width="379" alt="error" src="https://user-images.githubusercontent.com/562080/131931889-da6cf446-8cef-40ad-8fa5-d52170e07700.png">


# How

The fix is to set one of the subviews in from that cell to have transparent background, so it doesn't mess with the cell background color.

# Screenshots

<img width="378" alt="good" src="https://user-images.githubusercontent.com/562080/131931945-c3f0022d-9f03-4b88-8729-cdb08c35db43.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
