### PR TITLE
[Mobile Payments] Modal UI fixes

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingToReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingToReader.swift
@@ -34,13 +34,13 @@ final class CardPresentModalConnectingToReader: CardPresentPaymentsModalViewMode
 private extension CardPresentModalConnectingToReader {
     enum Localization {
         static let title = NSLocalizedString(
-            "Scanning for reader",
-            comment: "Title label for modal dialog that appears when searching for a card reader"
+            "Connecting reader",
+            comment: "Title label for modal dialog that appears when connecting to a card reader"
         )
 
         static let instruction = NSLocalizedString(
             "Please wait...",
-            comment: "Label within the modal dialog that appears when searching for a card reader"
+            comment: "Label within the modal dialog that appears when connecting to a card reader"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingToReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingToReader.swift
@@ -34,7 +34,7 @@ final class CardPresentModalConnectingToReader: CardPresentPaymentsModalViewMode
 private extension CardPresentModalConnectingToReader {
     enum Localization {
         static let title = NSLocalizedString(
-            "Connecting reader",
+            "Connecting to reader",
             comment: "Title label for modal dialog that appears when connecting to a card reader"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalFoundReader.swift
@@ -35,9 +35,7 @@ final class CardPresentModalFoundReader: CardPresentPaymentsModalViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        viewController?.dismiss(animated: true, completion: { [weak self] in
-            self?.connectAction()
-        })
+        connectAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -12,6 +12,7 @@ final class CardPresentPaymentsModalViewController: UIViewController {
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var mainStackView: UIStackView!
     @IBOutlet weak var primaryActionButtonsStackView: UIStackView!
+    @IBOutlet weak var buttonsSpacer: UIView!
     @IBOutlet private weak var topTitleLabel: UILabel!
     @IBOutlet private weak var topSubtitleLabel: UILabel!
     @IBOutlet private weak var bottomTitleLabel: UILabel!
@@ -116,6 +117,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleBottomLabels() {
         actionButtonsView.isHidden = true
+        buttonsSpacer.isHidden = false
         bottomLabels.isHidden = false
 
         styleBottomTitle()
@@ -132,6 +134,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleActionButtons() {
         actionButtonsView.isHidden = false
+        buttonsSpacer.isHidden = true
         bottomLabels.isHidden = true
 
         stylePrimaryButton()
@@ -236,6 +239,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func hideActionButtonsView() {
         actionButtonsView.isHidden = true
+        buttonsSpacer.isHidden = false
     }
 
     func configurePrimaryButton() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -107,7 +107,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleTopTitle() {
-        topTitleLabel.applyHeadlineStyle()
+        topTitleLabel.applyBodyStyle()
     }
 
     func styleTopSubtitle() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -79,8 +79,8 @@ final class CardPresentPaymentsModalViewController: UIViewController {
             widthConstraint.constant = Constants.modalWidth
         }
 
-        heightConstraint.priority = .defaultHigh
-        widthConstraint.priority = .defaultHigh
+        heightConstraint.priority = .required
+        widthConstraint.priority = .required
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -123,7 +123,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleBottomTitle() {
-        bottomTitleLabel.applyBodyStyle()
+        bottomTitleLabel.applySubheadlineStyle()
     }
 
     func styleBottomSubtitle() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -34,13 +34,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="67" y="196.5" width="280" height="513"/>
+                    <rect key="frame" x="67" y="204.5" width="280" height="497"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="20" y="32" width="240" height="449"/>
+                            <rect key="frame" x="16" y="32" width="248" height="449"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
-                                    <rect key="frame" x="99.5" y="0.0" width="41.5" height="49"/>
+                                    <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -57,10 +57,10 @@
                                     </subviews>
                                 </stackView>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                                    <rect key="frame" x="53" y="81" width="134" height="117"/>
+                                    <rect key="frame" x="57" y="81" width="134" height="117"/>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
-                                    <rect key="frame" x="99.5" y="230" width="41.5" height="57"/>
+                                    <rect key="frame" x="103.5" y="230" width="41.5" height="57"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -77,7 +77,7 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="319" width="240" height="130"/>
+                                    <rect key="frame" x="4" y="319" width="240" height="130"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
                                             <rect key="frame" x="0.0" y="0.0" width="240" height="130"/>
@@ -132,14 +132,14 @@
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="20" id="80k-pZ-tsR"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="16" id="80k-pZ-tsR"/>
                         <constraint firstAttribute="height" priority="250" constant="382" id="J6m-sz-CD5"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
-                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="32" id="lVZ-pu-Fmb"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="lVZ-pu-Fmb"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="382" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
                         <constraint firstAttribute="width" constant="280" id="uaz-2N-7M4"/>
-                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="20" id="ufT-Yf-gsb"/>
+                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="16" id="ufT-Yf-gsb"/>
                     </constraints>
                 </view>
             </subviews>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -35,21 +35,21 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="67" y="195.5" width="280" height="515"/>
+                    <rect key="frame" x="67" y="198" width="280" height="510"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="16" y="32" width="248" height="467"/>
+                            <rect key="frame" x="16" y="32" width="248" height="462"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
+                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aVs-Lf-QTr">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aVs-Lf-QTr">
                                             <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -63,13 +63,13 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
                                     <rect key="frame" x="103.5" y="230" width="41.5" height="43"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Sx-5s-f7J">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Sx-5s-f7J">
                                             <rect key="frame" x="0.0" y="22.5" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -81,16 +81,16 @@
                                     <rect key="frame" x="4" y="305" width="240" height="0.0"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="337" width="248" height="130"/>
+                                <view contentMode="scaleToFill" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
+                                    <rect key="frame" x="0.0" y="337" width="248" height="125"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
-                                            <rect key="frame" x="0.0" y="0.0" width="248" height="130"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="248" height="125"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
                                                     <rect key="frame" x="0.0" y="0.0" width="248" height="95"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
                                                             <rect key="frame" x="0.0" y="0.0" width="248" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
@@ -103,7 +103,7 @@
                                                                 <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                                                             </userDefinedRuntimeAttributes>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
                                                             <rect key="frame" x="0.0" y="55" width="248" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
@@ -118,8 +118,8 @@
                                                         </button>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="95" width="248" height="35"/>
+                                                <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
+                                                    <rect key="frame" x="0.0" y="95" width="248" height="30"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -34,10 +34,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="67" y="204.5" width="280" height="497"/>
+                    <rect key="frame" x="67" y="211.5" width="280" height="483"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="16" y="32" width="248" height="449"/>
+                            <rect key="frame" x="16" y="32" width="248" height="435"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
@@ -59,8 +59,8 @@
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
                                     <rect key="frame" x="57" y="81" width="134" height="117"/>
                                 </imageView>
-                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
-                                    <rect key="frame" x="103.5" y="230" width="41.5" height="57"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
+                                    <rect key="frame" x="103.5" y="230" width="41.5" height="43"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -69,7 +69,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Sx-5s-f7J">
-                                            <rect key="frame" x="0.0" y="36.5" width="41.5" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="22.5" width="41.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -77,16 +77,16 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="4" y="319" width="240" height="130"/>
+                                    <rect key="frame" x="0.0" y="305" width="248" height="130"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
-                                            <rect key="frame" x="0.0" y="0.0" width="240" height="130"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="248" height="130"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="100"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
+                                                    <rect key="frame" x="0.0" y="0.0" width="248" height="95"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
-                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="40"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="248" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
                                                             </constraints>
@@ -99,7 +99,7 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </button>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
-                                                            <rect key="frame" x="0.0" y="60" width="240" height="40"/>
+                                                            <rect key="frame" x="0.0" y="55" width="248" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
                                                             </constraints>
@@ -114,7 +114,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="100" width="240" height="30"/>
+                                                    <rect key="frame" x="0.0" y="95" width="248" height="35"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>
@@ -128,6 +128,10 @@
                                     </constraints>
                                 </view>
                             </subviews>
+                            <constraints>
+                                <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leading" id="0sg-Uf-xbd"/>
+                                <constraint firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="Nrr-ur-lj3"/>
+                            </constraints>
                         </stackView>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -135,7 +139,7 @@
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="16" id="80k-pZ-tsR"/>
                         <constraint firstAttribute="height" priority="250" constant="382" id="J6m-sz-CD5"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
-                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="lVZ-pu-Fmb"/>
+                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="lVZ-pu-Fmb"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="382" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
                         <constraint firstAttribute="width" constant="280" id="uaz-2N-7M4"/>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -34,13 +34,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="31" y="186.5" width="352" height="533"/>
+                    <rect key="frame" x="67" y="196.5" width="280" height="513"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="20" y="32" width="312" height="469"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
+                            <rect key="frame" x="20" y="32" width="240" height="449"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
-                                    <rect key="frame" x="135.5" y="0.0" width="41.5" height="49"/>
+                                    <rect key="frame" x="99.5" y="0.0" width="41.5" height="49"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oDv-zz-CTp">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -57,10 +57,10 @@
                                     </subviews>
                                 </stackView>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="woo-celebration" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                                    <rect key="frame" x="89" y="81" width="134" height="117"/>
+                                    <rect key="frame" x="53" y="81" width="134" height="117"/>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k73-qi-GuD">
-                                    <rect key="frame" x="135.5" y="230" width="41.5" height="57"/>
+                                    <rect key="frame" x="99.5" y="230" width="41.5" height="57"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAj-lv-0k9">
                                             <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -77,16 +77,16 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="319" width="312" height="150"/>
+                                    <rect key="frame" x="0.0" y="319" width="240" height="130"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
-                                            <rect key="frame" x="0.0" y="0.0" width="312" height="150"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="240" height="130"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                                                    <rect key="frame" x="0.0" y="0.0" width="312" height="100"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="100"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
-                                                            <rect key="frame" x="0.0" y="0.0" width="312" height="40"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="Gcd-Af-CS9"/>
                                                             </constraints>
@@ -99,7 +99,7 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </button>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
-                                                            <rect key="frame" x="0.0" y="60" width="312" height="40"/>
+                                                            <rect key="frame" x="0.0" y="60" width="240" height="40"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="40" id="ju1-aE-m26"/>
                                                             </constraints>
@@ -114,7 +114,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="100" width="312" height="50"/>
+                                                    <rect key="frame" x="0.0" y="100" width="240" height="30"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>
@@ -133,12 +133,12 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="20" id="80k-pZ-tsR"/>
+                        <constraint firstAttribute="height" priority="250" constant="382" id="J6m-sz-CD5"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
-                        <constraint firstItem="jIt-xb-rrN" firstAttribute="height" secondItem="8Tg-Q2-wkH" secondAttribute="height" constant="-64" id="VJR-wO-lUP"/>
-                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="32" id="lVZ-pu-Fmb"/>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="250" constant="382" id="n7H-7U-izh"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="32" id="lVZ-pu-Fmb"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="382" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
-                        <constraint firstAttribute="width" priority="250" constant="280" id="uaz-2N-7M4"/>
+                        <constraint firstAttribute="width" constant="280" id="uaz-2N-7M4"/>
                         <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="20" id="ufT-Yf-gsb"/>
                     </constraints>
                 </view>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -15,6 +15,7 @@
                 <outlet property="bottomLabels" destination="k73-qi-GuD" id="LvQ-UE-SBc"/>
                 <outlet property="bottomSubtitleLabel" destination="2Sx-5s-f7J" id="Mco-Vu-Li6"/>
                 <outlet property="bottomTitleLabel" destination="oAj-lv-0k9" id="Clc-oi-Ywf"/>
+                <outlet property="buttonsSpacer" destination="OFI-6w-cag" id="Uva-gQ-T7X"/>
                 <outlet property="containerView" destination="8Tg-Q2-wkH" id="0n7-5Q-edX"/>
                 <outlet property="heightConstraint" destination="n7H-7U-izh" id="cbE-Eb-VuR"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
@@ -34,10 +35,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Tg-Q2-wkH" userLabel="WrapperView">
-                    <rect key="frame" x="67" y="211.5" width="280" height="483"/>
+                    <rect key="frame" x="67" y="195.5" width="280" height="515"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                            <rect key="frame" x="16" y="32" width="248" height="435"/>
+                            <rect key="frame" x="16" y="32" width="248" height="467"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Q0r-qo-iZS">
                                     <rect key="frame" x="103.5" y="0.0" width="41.5" height="49"/>
@@ -76,8 +77,12 @@
                                         </label>
                                     </subviews>
                                 </stackView>
+                                <view contentMode="scaleToFill" verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="OFI-6w-cag" userLabel="Buttons Spacer">
+                                    <rect key="frame" x="4" y="305" width="240" height="0.0"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                                    <rect key="frame" x="0.0" y="305" width="248" height="130"/>
+                                    <rect key="frame" x="0.0" y="337" width="248" height="130"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
                                             <rect key="frame" x="0.0" y="0.0" width="248" height="130"/>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -84,7 +84,7 @@
                                 <view contentMode="scaleToFill" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
                                     <rect key="frame" x="0.0" y="337" width="248" height="125"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="o73-de-cj4">
                                             <rect key="frame" x="0.0" y="0.0" width="248" height="125"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
@@ -119,7 +119,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="maO-19-PuQ">
-                                                    <rect key="frame" x="0.0" y="95" width="248" height="30"/>
+                                                    <rect key="frame" x="0.0" y="101" width="248" height="24"/>
                                                     <state key="normal" title="Button"/>
                                                 </button>
                                             </subviews>


### PR DESCRIPTION
Fixes #4550 

This the requests from #4550. I've been fighting auto layout for a couple days already and was about to give up on some of the things, so I decided to put up a PR with the things I managed to fix. As I was writing up descriptions of the remaining issues I kept finding new solutions 😅 

## What's fixed

- Modal shown when connecting to reader has "Connecting to reader" in the title instead of "Scanning for reader"
- Modal shown when connecting to reader is displayed when manually connecting as well as when we auto connect
- Modals are always 280px wide and at least 382px high
- The top title on the modal uses the `body` font style
- The bottom title on the modal uses the `subheadline` font style
- Modals have 16px padding on all edges except the top one, which has 32px
- Adjusted spacing between bottom labels
- Adjusted spacing between buttons
- Adjusted layout so top title aligns to top, buttons align to bottom, and the rest of the content is evenly distributed between top labels, image, bottom labels, and buttons. Also, when there are no buttons, I added a spacer to the bottom, so that all the content is aligned to top 

Note that the spacing between the bottom labels in the "Insert Card" screen seems wrong. On Figma, I see a 2px space between labels, which is the spacing I set on Xcode, but the result is visually different. On Figma, both text boxes are 20px high and include some whitespace, on iOS the boxes are 18px and 15.67px respectively with the default font, so I could account for the difference and add an extra 6px of spacing, but I'm not sure if that would be what's expected with dynamic text.

Figma|Xcode|Runtime
-|-|-
![Screen Shot 2021-09-03 at 10 25 27](https://user-images.githubusercontent.com/8739/131974880-069338ec-2cf0-470d-b9af-9fb9ebae4911.png)|![Screen Shot 2021-09-03 at 10 25 53](https://user-images.githubusercontent.com/8739/131974954-d8a478ee-7df6-4237-a154-0bd7c5582e3a.png)|![Screen Shot 2021-09-03 at 10 30 42](https://user-images.githubusercontent.com/8739/131975599-a645f761-5281-4965-9471-bbed10500ec9.png)

## How it's fixed

I thought I'd leave a few notes, because reviewing diffs of XIB files is an exercise in decryption (even I'm having trouble remembering what I've changed exactly) 😩 

The behavior we want is that the top item (top labels) stick to the top, and the bottom item (buttons) sticks to the bottom. A stack view with a `fill` distribution won't do this by default and distribute the space evenly among all children, and these will typically be vertically centered in the available space. After a lot of trying, I adjusted the hugging priority to required (1000) in all the items I did not want to expand (top labels and their container, buttons and their container). For the bottom labels I see now that I left the priority at high (750), but I guess the behavior would be the same, as the rest of the items have a lower priority. The image and container for the bottom labels have low (250) priority, so they're the ones which will grow to fill the available space.

When there are no buttons at the bottom, it looks like the designs want the content gravitating towards the top, so I added a spacer view that's only visible when the buttons are not, and it has the lowest hugging priority (1). So if this spacer is visible, it will take any available extra space before any other view can grow.

I know I had to adjust something to make the buttons grow to the full width, but I can't find it in the diff now 😬 

Besides this, I added a bunch of Xcode labels for views, because it was impossible to understand the existing constraints otherwise (too many things named `StackView`)

## Screenshots

### Searching for reader

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131972058-25ba220d-229d-45d5-a0f7-279057ff288c.png" width="375">|<img src="https://user-images.githubusercontent.com/28450084/124573583-fb001e80-de49-11eb-8393-22ab48c10b9e.png" width="375">

### Connect to reader

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131972091-bca7ff40-e750-4554-a48d-6c50bd7f797d.png" width="375">|<img src="https://user-images.githubusercontent.com/28450084/124574020-59c59800-de4a-11eb-9a21-3be0029ea761.png" width="375">

### Connecting to reader

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131972128-3bdae3d7-4de8-4cdc-94b9-3a99b78d2da2.png" width="375">|<img src="https://user-images.githubusercontent.com/8739/131972204-2290fc4d-f09e-4af1-a066-929c1f51d489.png" width="375">

### Insert card

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131972231-b7416cee-511e-4f99-ba76-61d3b119a040.png" width="375">|<img src="https://user-images.githubusercontent.com/8739/131966470-5c171387-2886-49f8-a6da-545c06e49645.png" width="375">

### Remove card

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131972276-310348ed-9f61-4ad5-9880-5a0ecc49a42a.png" width="375">|<img src="https://user-images.githubusercontent.com/8739/131973122-285fd3c5-8d36-41f1-b687-5221c05c8254.png" width="375">

### Payment completed

Screenshots | Designs
------------ | -------------
<img src="https://user-images.githubusercontent.com/8739/131974109-b6eb3bc6-c44f-42b3-b48e-0f7c27ef232b.png" width="375">|<img src="https://user-images.githubusercontent.com/8739/131972643-28b3ef3d-6bad-4d2e-a779-426712397356.png" width="375">

## To test

Using a store with payments available, and a reader that's not "known" (if necessary, go to Settings > In-Person Payments > Manage Card Reader and Connect then Disconnect manually):

1. Make sure your reader is turned off
2. Find an order that can be paid in person, tap on Collect payment
3. See **Scanning for reader** screen and make sure it matches the design
4. Turn on your reader
5. See **Connect to reader** screen and make sure it matches the design
6. Tap on Connect to reader
7. See **Connecting to reader** screen and make sure it matches the design
8. See **Insert Card** screen and make sure it matches the design
9. Tap your card to pay
10. See **Remove Card** screen and make sure it matches the design
11. See **Payment Completed** screen and make sure it matches the design

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
