### PR TITLE
Replace htmlToAttributedString with a markdown variant

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Down",
+        "repositoryURL": "https://github.com/johnxnguyen/Down",
+        "state": {
+          "branch": null,
+          "revision": "f34b166be1f1db4aa8f573067e901d72f2a6be57",
+          "version": "0.11.0"
+        }
+      },
+      {
         "package": "Embassy",
         "repositoryURL": "https://github.com/envoy/Embassy",
         "state": {

--- a/WooCommerce/Classes/Extensions/NSAttributedString+Markdown.swift
+++ b/WooCommerce/Classes/Extensions/NSAttributedString+Markdown.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Down
+
+extension NSAttributedString {
+    convenience init(markdown: String) throws {
+        self.init(attributedString: try Down(markdownString: markdown).toAttributedString())
+    }
+}

--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -4,30 +4,6 @@ import Foundation
 /// String: HTML Stripping
 ///
 extension String {
-
-    /// Convert HTML to an attributed string
-    ///
-    /// This method uses `NSAttributedString.init(data:options:documentAttributes:)` with a documentType value of html.
-    /// Internally it uses WebKit so it should only be called from the main thread.
-    ///
-    /// Even then, the implementation seems to suspend the execution while WebKit is loading and might continue processing other events in the run loop.
-    ///
-    /// See [#4527](https://github.com/woocommerce/woocommerce-ios/pull/4527) for an example of the problems this can cause.
-    ///
-    var htmlToAttributedString: NSAttributedString {
-        precondition(Thread.isMainThread, "htmlToAttributedString should only be called from the main thread")
-        guard let data = data(using: .utf8) else { return NSAttributedString() }
-        do {
-            return try NSAttributedString(data: data,
-                                          options: [.documentType: NSAttributedString.DocumentType.html,
-                                                    .characterEncoding: String.Encoding.utf8.rawValue],
-                                          documentAttributes: nil)
-        } catch {
-            DDLogError("Error: unable to convert HTML data to an attributed string")
-            return NSAttributedString()
-        }
-    }
-
     /// Removed all tags in the form of `<*>`.
     ///
     var removedHTMLTags: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -392,7 +392,7 @@ private extension CardReaderSettingsSearchingViewController {
 
         static let learnMore: NSAttributedString = {
             let learnMoreText = NSLocalizedString(
-                "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
+                "[Learn more](https://woocommerce.com/payments) about accepting payments with your mobile device and ordering card readers",
                 comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
             )
 
@@ -401,8 +401,7 @@ private extension CardReaderSettingsSearchingViewController {
                 .foregroundColor: UIColor.textSubtle
             ]
 
-            let learnMoreAttrText = NSMutableAttributedString()
-            learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
+            let learnMoreAttrText = try! NSMutableAttributedString(markdown: learnMoreText)
             let range = NSRange(location: 0, length: learnMoreAttrText.length)
             learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -38,7 +38,7 @@ private enum Localization {
 
     static let learnMore: NSAttributedString = {
         let learnMoreText = NSLocalizedString(
-            "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
+            "[Learn more](https://woocommerce.com/payments) about accepting payments with your mobile device and ordering card readers",
             comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
         )
 
@@ -47,8 +47,7 @@ private enum Localization {
             .foregroundColor: UIColor.textSubtle
         ]
 
-        let learnMoreAttrText = NSMutableAttributedString()
-        learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
+        let learnMoreAttrText = try! NSMutableAttributedString(markdown: learnMoreText)
         let range = NSRange(location: 0, length: learnMoreAttrText.length)
         learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -758,16 +758,15 @@ private extension SettingsViewController {
     /// (which contains a link to the "Work with us" URL)
     ///
     var hiringAttributedText: NSAttributedString {
-        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "It reads 'Made with love by Automattic. We’re hiring!'. Place \'We’re hiring!' between `<a>` and `</a>`"
+        let hiringText = NSLocalizedString("Made with love by Automattic. [We’re hiring!](https://automattic.com/work-with-us/)",
+                                           comment: "It reads 'Made with love by Automattic. Markdown"
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,
             .foregroundColor: UIColor.textSubtle
         ]
 
-        let hiringAttrText = NSMutableAttributedString()
-        hiringAttrText.append(hiringText.htmlToAttributedString)
+        let hiringAttrText = try! NSMutableAttributedString(markdown: hiringText)
         let range = NSRange(location: 0, length: hiringAttrText.length)
         hiringAttrText.addAttributes(hiringAttributes, range: range)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -70,7 +70,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .renderedIf(!viewModel.hasValidHSTariffNumber)
 
                 VStack(spacing: 0) {
-                    LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreHSTariffText)
+                    LearnMoreRow(localizedMarkdownString: Localization.learnMoreHSTariffText)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -184,7 +184,7 @@ private extension ShippingLabelCustomsFormItemDetails {
         static let hsTariffNumberError = NSLocalizedString("HS Tariff Number must be 6 digits long",
                                                            comment: "Validation error for HS Tariff Number row in Customs screen of Shipping Label flow")
         static let learnMoreHSTariffText = NSLocalizedString(
-            "<a href=\"https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29\">Learn more</a> " +
+            "[Learn more](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29) " +
                 "about HS Tariff Number",
             comment: "A label prompting users to learn more about HS Tariff Number with an embedded hyperlink in Customs screen of Shipping Label flow")
         static let weightTitle = NSLocalizedString("Weight (%1$@ per unit)",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -142,7 +142,7 @@ struct ShippingLabelCustomsFormInput: View {
             }
             .renderedIf(validationErrorMessageForITNRow.isNotEmpty)
 
-            LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreITNText)
+            LearnMoreRow(localizedMarkdownString: Localization.learnMoreITNText)
         }
     }
 
@@ -199,8 +199,7 @@ private extension ShippingLabelCustomsFormInput {
                                                                         "Customs screen of Shipping Label flow")
         static let itnInvalidFormat = NSLocalizedString("Invalid ITN format",
                                                         comment: "Error message for invalid format of ITN in Customs screen of Shipping Label flow")
-        static let learnMoreITNText = NSLocalizedString("<a href=\"https://pe.usps.com/text/imm/immc5_010.htm\">" +
-                                                            "Learn more</a> about Internal Transaction Number",
+        static let learnMoreITNText = NSLocalizedString("[Learn more](https://pe.usps.com/text/imm/immc5_010.htm) about Internal Transaction Number",
                                                         comment: "A label prompting users to learn more about internal " +
                                                             "transaction number with an embedded hyperlink")
         static let packageContentSection = NSLocalizedString("Package Content",

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -213,8 +213,8 @@ struct AttributedText_Previews: PreviewProvider {
         VStack {
             Link("Default Link", destination: URL(string: "https://woocommerce.com/")!)
             Text("Default Text")
-            AttributedText("AttributedText <a href=\"https://woocommerce.com/\">with a link</a>".htmlToAttributedString)
-            AttributedText("Custom AttributedText <a href=\"https://woocommerce.com/\">with a link</a>".htmlToAttributedString)
+            AttributedText(try! NSAttributedString(markdown: "AttributedText [with a link](https://woocommerce.com/)"))
+            AttributedText(try! NSAttributedString(markdown: "Custom AttributedText [with a link](https://woocommerce.com/)"))
                 .font(.footnote)
                 .attributedTextForegroundColor(.gray)
                 .attributedTextLinkColor(.pink)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct LearnMoreRow: View {
-    let localizedStringWithHyperlink: String
+    let localizedMarkdownString: String
     @State private var learnMoreURL: URL? = nil
 
     var body: some View {
@@ -20,8 +20,7 @@ struct LearnMoreRow: View {
             .underlineStyle: 0
         ]
 
-        let learnMoreAttrText = NSMutableAttributedString()
-        learnMoreAttrText.append(localizedStringWithHyperlink.htmlToAttributedString)
+        let learnMoreAttrText = try! NSMutableAttributedString(markdown: localizedMarkdownString)
         let range = NSRange(location: 0, length: learnMoreAttrText.length)
         learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
 
@@ -38,6 +37,6 @@ private extension LearnMoreRow {
 
 struct LearnMoreRow_Previews: PreviewProvider {
     static var previews: some View {
-        LearnMoreRow(localizedStringWithHyperlink: "<a href=\"https://pe.usps.com/text/imm/immc5_010.htm\">Learn more</a> about Internal Transaction Number")
+        LearnMoreRow(localizedMarkdownString: "[Learn more](https://pe.usps.com/text/imm/immc5_010.htm about Internal Transaction Number")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1310,6 +1310,8 @@
 		E1D4E84526776AD900256B83 /* HeadlineTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1D4E84226776A6A00256B83 /* HeadlineTableViewCell.xib */; };
 		E1ED16E4266E10A10037B8DB /* ApplicationLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */; };
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
+		E1FBF69526E2290500B16840 /* Down in Frameworks */ = {isa = PBXBuildFile; productRef = E1FBF69426E2290500B16840 /* Down */; };
+		E1FBF69726E2291C00B16840 /* NSAttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FBF69626E2291C00B16840 /* NSAttributedString+Markdown.swift */; };
 		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
 		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
@@ -2715,6 +2717,7 @@
 		E1D4E84326776A6A00256B83 /* HeadlineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineTableViewCell.swift; sourceTree = "<group>"; };
 		E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModel.swift; sourceTree = "<group>"; };
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
+		E1FBF69626E2291C00B16840 /* NSAttributedString+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Markdown.swift"; sourceTree = "<group>"; };
 		F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetaFeaturesScreen.swift; sourceTree = "<group>"; };
 		F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		F93E8E5724087FE10057FF21 /* ProductsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsScreen.swift; sourceTree = "<group>"; };
@@ -2761,6 +2764,7 @@
 			files = (
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
+				E1FBF69526E2290500B16840 /* Down in Frameworks */,
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
@@ -5641,6 +5645,7 @@
 				DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */,
 				DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */,
 				DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */,
+				E1FBF69626E2291C00B16840 /* NSAttributedString+Markdown.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6444,6 +6449,7 @@
 			packageProductDependencies = (
 				263E37E02641AD8300260D3B /* Codegen */,
 				45455E312657C3F300BBB0C4 /* Shimmer */,
+				E1FBF69426E2290500B16840 /* Down */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -6600,6 +6606,7 @@
 				45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
+				E1FBF69326E2290500B16840 /* XCRemoteSwiftPackageReference "Down" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -7492,6 +7499,7 @@
 				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
+				E1FBF69726E2291C00B16840 /* NSAttributedString+Markdown.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
 				45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */,
@@ -8760,6 +8768,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		E1FBF69326E2290500B16840 /* XCRemoteSwiftPackageReference "Down" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/johnxnguyen/Down";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.11.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -8804,6 +8820,11 @@
 		57150E0E24F462C200E81611 /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
+		};
+		E1FBF69426E2290500B16840 /* Down */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1FBF69326E2290500B16840 /* XCRemoteSwiftPackageReference "Down" */;
+			productName = Down;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
As I found out in #4527, using the HTML parser included with `NSAttributedString` can have concurrency issues. Since iOS 15 will start supporting [Markdown in AttributedString](https://developer.apple.com/documentation/foundation/attributedstring/) and SwiftUI views, it seems like a better choice

See discussion in paNNhX-gK-p2. Note that this is untested. For now, I'm uploading this as an example of the approach.

One issue I've noticed is that the default attributes might be different, as the vertical alignment has changed:

Markdown|HTML
-|-
![Screen Shot 2021-09-03 at 12 19 59](https://user-images.githubusercontent.com/8739/131990493-0bc0e3d8-13b9-458d-a25b-8dda86b3bbf9.png)|![Screen Shot 2021-09-03 at 12 23 19](https://user-images.githubusercontent.com/8739/131990728-6d851a34-8e8c-48f7-a58d-deb464ecbd49.png)


Markdown:

```
Learn more{
    NSColor = "<UIDynamicSystemColor: 0x28032ac40; name = secondaryLabelColor>";
    NSFont = "<UICTFont: 0x125520e40> font-family: \"UICTFontTextStyleFootnote\"; font-weight: normal; font-style: normal; font-size: 13.00pt";
    NSKern = 0;
    NSLink = "https://woocommerce.com/payments";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 12, ParagraphSpacingBefore 0, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n), DefaultTabInterval 36, Blocks (\n), Lists (\n), BaseWritingDirection 0, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0";
    NSStrokeColor = "kCGColorSpaceModelRGB 0 0 0.933333 1 ";
    NSStrokeWidth = 0;
    NSUnderline = 1;
} about accepting payments with your mobile device and ordering card readers
{
    NSColor = "<UIDynamicSystemColor: 0x28032ac40; name = secondaryLabelColor>";
    NSFont = "<UICTFont: 0x125520e40> font-family: \"UICTFontTextStyleFootnote\"; font-weight: normal; font-style: normal; font-size: 13.00pt";
    NSKern = 0;
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 12, ParagraphSpacingBefore 0, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n), DefaultTabInterval 36, Blocks (\n), Lists (\n), BaseWritingDirection 0, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0";
    NSStrokeColor = "kCGColorSpaceModelRGB 0 0 0 1 ";
    NSStrokeWidth = 0;
}
```

HTML:

```
Learn more{
    NSColor = "<UIDynamicSystemColor: 0x2827b2340; name = secondaryLabelColor>";
    NSFont = "<UICTFont: 0x13e909b90> font-family: \"UICTFontTextStyleFootnote\"; font-weight: normal; font-style: normal; font-size: 13.00pt";
    NSKern = 0;
    NSLink = "https://woocommerce.com/payments";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 0, ParagraphSpacingBefore 0, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n), DefaultTabInterval 36, Blocks (\n), Lists (\n), BaseWritingDirection 0, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0";
    NSStrokeColor = "kCGColorSpaceModelRGB 0 0 0.933333 1 ";
    NSStrokeWidth = 0;
    NSUnderline = 1;
} about accepting payments with your mobile device and ordering card readers{
    NSColor = "<UIDynamicSystemColor: 0x2827b2340; name = secondaryLabelColor>";
    NSFont = "<UICTFont: 0x13e909b90> font-family: \"UICTFontTextStyleFootnote\"; font-weight: normal; font-style: normal; font-size: 13.00pt";
    NSKern = 0;
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 0, ParagraphSpacingBefore 0, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n), DefaultTabInterval 36, Blocks (\n), Lists (\n), BaseWritingDirection 0, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0";
    NSStrokeColor = "kCGColorSpaceModelRGB 0 0 0 1 ";
    NSStrokeWidth = 0;
}
```

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
