### PR TITLE
[Mobile Payments] Don't allow mobile payments in orders with subscriptions

### DIFF
--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -8,6 +8,7 @@ public enum ProductType: Codable, Hashable, GeneratedFakeable {
     case grouped
     case affiliate
     case variable
+    case subscription
     case custom(String) // in case there are extensions modifying product types
 }
 
@@ -28,6 +29,8 @@ extension ProductType: RawRepresentable {
             self = .affiliate
         case Keys.variable:
             self = .variable
+        case Keys.subscription:
+            self = .subscription
         default:
             self = .custom(rawValue)
         }
@@ -41,6 +44,7 @@ extension ProductType: RawRepresentable {
         case .grouped:              return Keys.grouped
         case .affiliate:            return Keys.affiliate
         case .variable:             return Keys.variable
+        case .subscription:         return Keys.subscription
         case .custom(let payload):  return payload
         }
     }
@@ -57,6 +61,8 @@ extension ProductType: RawRepresentable {
             return NSLocalizedString("External/Affiliate", comment: "Display label for affiliate product type.")
         case .variable:
             return NSLocalizedString("Variable", comment: "Display label for variable product type.")
+        case .subscription:
+            return NSLocalizedString("Subscription", comment: "Display label for subscription product type.")
         case .custom(let payload):
             return payload // unable to localize at runtime.
         }
@@ -67,8 +73,9 @@ extension ProductType: RawRepresentable {
 /// Enum containing the 'Known' ProductType Keys
 ///
 private enum Keys {
-    static let simple    = "simple"
-    static let grouped   = "grouped"
-    static let affiliate = "external"
-    static let variable  = "variable"
+    static let simple       = "simple"
+    static let grouped      = "grouped"
+    static let affiliate    = "external"
+    static let variable     = "variable"
+    static let subscription = "subscription"
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -48,7 +48,8 @@ final class OrderDetailsDataSource: NSObject {
         return isOrderAmountEligibleForCardPayment() &&
             isOrderStatusEligibleForCardPayment() &&
             isOrderPaymentMethodEligibleForCardPayment() &&
-            hasCardPresentEligiblePaymentGatewayAccount()
+            hasCardPresentEligiblePaymentGatewayAccount() &&
+            !orderContainsAnySubscription()
     }
 
     /// Whether the button to create shipping labels should be visible.
@@ -1477,6 +1478,12 @@ private extension OrderDetailsDataSource {
 
     func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {
         resultsControllers.paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
+    }
+
+    func orderContainsAnySubscription() -> Bool {
+        order.items.contains { item in
+            lookUpProduct(by: item.productID)?.productType == .subscription
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -121,6 +121,10 @@ public enum BottomSheetProductType: Hashable {
             self = .affiliate
         case .grouped:
             self = .grouped
+        case .subscription:
+            // We need to be aware of subscriptions for Payments
+            // but we don't handle them in the UI yet
+            self = .custom("subscription")
         case .custom(let string):
             self = .custom(string)
         }


### PR DESCRIPTION
Fixes #4426 

To match what we do on Android, this prevents orders with any subscription to show the option to collect payment.

## To test

From the web:

1. Ensure your site has the Subscriptions extension added
2. Add a product with type subscription. Make sure you don't have a free trial, or the order will be marked as completed
3. Go to WooCommerce > Settings > Subscriptions and make sure "Accept Manual Renewals" is enabled. Otherwise, you won't be able to select Cash on Delivery as the payment method
4. Make an order for that product, using Cash on Delivery as the payment method

From the app:

1. Find the order in the orders tab, make sure the Collect Payment button doesn't show
2. Check that the Collect Payment button shows in other orders that don't have a subscription

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
