### PR TITLE
[What's New Component] Add WhatsNewOnWooCommerce feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -21,6 +21,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .cardPresentSeveralReadersFound:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .whatsNewOnWooCommerce:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -45,4 +45,8 @@ enum FeatureFlag: Int {
     /// Card-Present Payments Several Readers Found
     ///
     case cardPresentSeveralReadersFound
+
+    /// Display "What's new on WooCommerce" on App Launch and App Settings
+    ///
+    case whatsNewOnWooCommerce
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -62,6 +62,7 @@ private extension AppCoordinator {
     /// Displays the What's New Screen.
     ///
     func showWhatsNewIfNeeded() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.whatsNewOnWooCommerce) else { return }
         // TODO: Check the saved Announcement App Version in order to display or not the what's new component
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { _ in }))
     }


### PR DESCRIPTION
### Description 📜 
We must be able to turn the What's New on WooCommerce feature according to a feature flag until we finish its development.

### Main Changes ⚙️
- Add new FeatureFlag `.whatsNewOnWooCommerce` and check for it being enabled before fetching the service right away on app launch

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
