### PR TITLE
[Mobile Payments] Set eligibility for In-Person Payments based also on currency: USD

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -46,6 +46,7 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var isEligibleForCardPresentPayment: Bool {
         return isOrderAmountEligibleForCardPayment() &&
+            isOrderCurrencyEligibleForCardPayment() &&
             isOrderStatusEligibleForCardPayment() &&
             isOrderPaymentMethodEligibleForCardPayment() &&
             hasCardPresentEligiblePaymentGatewayAccount() &&
@@ -1465,6 +1466,10 @@ private extension OrderDetailsDataSource {
         // * in general, all orders where we might want to capture a payment for less than the total order amount
         let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
         return !paymentViewModel.hasBeenPartiallyCharged
+    }
+
+    func isOrderCurrencyEligibleForCardPayment() -> Bool {
+        CurrencySettings.CurrencyCode(rawValue: order.currency) == .USD
     }
 
     func isOrderStatusEligibleForCardPayment() -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -259,6 +259,50 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
     }
 
+    func test_collect_payment_button_is_visible_if_order_is_eligible_and_currency_is_usd() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, currency: "usd", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_not_visible_if_order_currency_is_not_usd() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .processing, currency: "cad", datePaid: .some(nil), total: "100", paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
     func test_create_shipping_label_button_is_visible_for_eligible_order_with_no_labels() throws {
         // Given
         let order = makeOrder()


### PR DESCRIPTION
Closes: #4926 

As discussed in pdfdoF-6f, we want to make sure that we take currency into account for eligibility for In-Person Payments.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/132037986-62d517b5-be1b-4db0-bda6-b795901986b4.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/132037989-0e355af8-8ee1-4a7f-910c-ae23c16cc4e2.png" width="350"/> |


## Changes
* Verify that the order currency is USD
* Add tests

## How to test
* Navigate to an order eligible for In-Person Payments. If the order currency is USD, the "Collect Payment" button should be visible. If the order currency is not USD, the "Collect Payment" button should not be visible.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
