### PR TITLE
[What's New Component] Add What's New on WooCommerce to app settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -99,7 +99,7 @@ final class SettingsViewController: UIViewController {
         })
 
         loadPaymentGatewayAccounts()
-
+        loadWhatsNewOnWooCommerce()
         configureNavigation()
         configureMainView()
         configureTableView()
@@ -240,7 +240,6 @@ private extension SettingsViewController {
     func refreshViewContent() {
         updateSites()
         checkAvailabilityForPayments()
-        loadWhatsNewOnWooCommerce()
         configureSections()
         tableView.reloadData()
     }


### PR DESCRIPTION
Part of: #4863 

## Description 📜
Add What's New on WooCommerce to the app settings.
This feature is currently under a feature flag! 🏁

## Main Changes ⚙️ 
- Add a new row in the "About the App" section (if the Feature Flag is on)
- Navigate to What's new on WooCommerce

## Evidences 📱

|           iPhone        |           iPad            |
|------------------|------------------|
| <video src="https://user-images.githubusercontent.com/997521/132043911-90607bc2-1759-4856-8b8a-7396a8c75fe1.mp4  ">            |      <video src="https://user-images.githubusercontent.com/997521/132044225-75e227c0-a6f9-421f-b4e0-e6290c6e2f0c.mp4"> |



## How to test 🧪🧑‍🔬
_Please do the following change_
<img width="495" alt="image" src="https://user-images.githubusercontent.com/997521/131144031-136d2892-cb05-495a-8532-dbc924d8ee02.png">

### Scenario
1. Run the app
2. Go to settings
3. "Tap on What's New on WooCommerce"
4. What's New Component should be displayed

## Sidenote:
- Currently, if there are no announcements to show, the tap on "What's New in WooCommerce" will do nothing. cc @Ecarrion 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
