### PR TITLE
[Mobile Payments] Make sure cancelling search gets a chance to actually cancel search

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -14,6 +14,24 @@ final class CardReaderSettingsSearchingViewController: UIViewController, CardRea
     ///
     private var viewModel: CardReaderSettingsSearchingViewModel?
 
+    /// Connection Controller (helps connect readers)
+    ///
+    private lazy var connectionController: CardReaderConnectionController? = {
+        guard let siteID = viewModel?.siteID else {
+            return nil
+        }
+
+        guard let knownReadersProvider = viewModel?.knownReadersProvider else {
+            return nil
+        }
+
+        return CardReaderConnectionController(
+            forSiteID: siteID,
+            knownReadersProvider: knownReadersProvider,
+            alertsProvider: CardReaderSettingsAlerts()
+        )
+    }()
+
     /// Table Sections to be rendered
     ///
     private var sections = [Section]()
@@ -225,21 +243,7 @@ private extension CardReaderSettingsSearchingViewController {
 //
 private extension CardReaderSettingsSearchingViewController {
     func searchAndConnect() {
-        guard let siteID = viewModel?.siteID else {
-            return
-        }
-
-        guard let knownReadersProvider = viewModel?.knownReadersProvider else {
-            return
-        }
-
-        let connectionController = CardReaderConnectionController(
-            forSiteID: siteID,
-            knownReadersProvider: knownReadersProvider,
-            alertsProvider: CardReaderSettingsAlerts()
-        )
-
-        connectionController.searchAndConnect(from: self) { _ in
+        connectionController?.searchAndConnect(from: self) { _ in
             /// No need for logic here. Once connected, the connected reader will publish
             /// through the `cardReaderAvailableSubscription`
         }


### PR DESCRIPTION
Fixes #4653
Fixes #4651 

Changes:
- Our cancellation closures weren't getting a chance to fire because the connection controller was being de-initialized too soon.
- This change promotes the connection controller to a lazy class var - this way it will be initialized if the user initiates a search, and it won't be de-initialized until the instantiator (the searching view controller) is done with its work
- This also avoids an "SDK" warning that can happen if you begin search again after a cancel that doesn't really cancel

Props @designsimply for finding these first

To test:
- Toggle on simulated readers, if desired, in the Run Scheme
- Begin search for a reader
- Cancel the search
- Wait 10 seconds to make sure the search really stopped
- Begin search for a reader
- Make sure you don't get the "The system is busy..." error
- Tap "Keep Searching" to decline each found reader
- Eventually you'll get to cancel the search once all your readers have been exhausted
- Wait 10 seconds to make sure the search really stopped

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
