### PR TITLE
Order Editing: Add filter functionality to Country Selector UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
@@ -25,6 +25,6 @@ struct ListSelector<Command: ListSelectorCommand>: UIViewControllerRepresentable
     /// Update the `ViewController` from parent `SwiftUI` view
     ///
     func updateUIViewController(_ uiViewController: ListSelectorViewController<Command, Command.Model, Command.Cell>, context: Context) {
-        // No op
+        uiViewController.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -4,14 +4,16 @@ import SwiftUI
 ///
 struct CountrySelector: View {
 
-    // Temporary store for the filter search term, to be moved to VM later.
-    @State var filterText = ""
+    /// View model to drive the view content
+    ///
+    @ObservedObject private(set) var viewModel: CountrySelectorViewModel
 
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader(filterText: $filterText)
+            SearchHeader(filterText: $viewModel.searchTerm)
                 .background(Color(.listForeground))
-            ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
+
+            ListSelector(command: viewModel.command, tableStyle: .plain)
         }
         .navigationTitle(Localization.title)
     }
@@ -72,7 +74,7 @@ private extension SearchHeader {
 struct CountrySelector_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            CountrySelector()
+            CountrySelector(viewModel: CountrySelectorViewModel())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelector.swift
@@ -3,9 +3,13 @@ import SwiftUI
 /// Country Selector View
 ///
 struct CountrySelector: View {
+
+    // Temporary store for the filter search term, to be moved to VM later.
+    @State var filterText = ""
+
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader()
+            SearchHeader(filterText: $filterText)
                 .background(Color(.listForeground))
             ListSelector(command: CountrySelectorCommand(), tableStyle: .plain)
         }
@@ -20,6 +24,10 @@ private struct SearchHeader: View {
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
 
+    /// Filter search term
+    ///
+    @Binding var filterText: String
+
     var body: some View {
         HStack(spacing: 0) {
             // Search Icon
@@ -31,7 +39,7 @@ private struct SearchHeader: View {
                 .padding([.leading, .trailing], Layout.internalPadding)
 
             // TextField
-            TextField(Localization.placeholder, text: .constant(""))
+            TextField(Localization.placeholder, text: $filterText)
                 .padding([.bottom, .top], Layout.internalPadding)
         }
         .background(Color(.searchBarBackground))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -48,7 +48,7 @@ final class CountrySelectorCommand: ListSelectorCommand {
             return data = countries
         }
 
-        data = countries.filter { $0.name.contains(term) }
+        data = countries.filter { $0.name.localizedCaseInsensitiveContains(term) }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -7,9 +7,13 @@ final class CountrySelectorCommand: ListSelectorCommand {
     typealias Model = Country
     typealias Cell = BasicTableViewCell
 
+    /// Original array of countries.
+    ///
+    private let countries: [Country]
+
     /// Data to display
     ///
-    let data: [Country]
+    private(set) var data: [Country]
 
     /// Current selected country
     ///
@@ -19,7 +23,8 @@ final class CountrySelectorCommand: ListSelectorCommand {
     ///
     let navigationBarTitle: String? = ""
 
-    init(countries: [Country] = temporaryCountries(), selected: Country? = nil) {
+    init(countries: [Country] = temporaryCountries, selected: Country? = nil) {
+        self.countries = countries
         self.data = countries
         self.selected = selected
     }
@@ -36,11 +41,26 @@ final class CountrySelectorCommand: ListSelectorCommand {
         cell.textLabel?.text = model.name
     }
 
-    // TESTING HELPER, WILL BE REMOVED LATER.
-    private static func temporaryCountries() -> [Country] {
+    /// Filter available countries that contains a given search term.
+    ///
+    func filterCountries(term: String) {
+        guard term.isNotEmpty else {
+            return data = countries
+        }
+
+        data = countries.filter { $0.name.contains(term) }
+    }
+}
+
+// MARK: Temporary Methods
+extension CountrySelectorCommand {
+
+    // Supported countries will come from the view model later.
+    //
+    private static let temporaryCountries: [Country] = {
         return Locale.isoRegionCodes.map { regionCode in
             let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
             return Country(code: regionCode, name: name, states: [])
         }
-    }
+    }()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,0 +1,18 @@
+import Combine
+
+/// View Model for the `CountrySelector` view.
+///
+final class CountrySelectorViewModel: ObservableObject {
+
+    /// Current search term entered by the user.
+    /// Each update will trigger an update to the `command` that contains the country data.
+    @Published var searchTerm = "" {
+        didSet {
+            command.filterCountries(term: searchTerm)
+        }
+    }
+
+    /// Command that powers the `ListSelector` view.
+    ///
+    let command = CountrySelectorCommand()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -125,7 +125,8 @@ struct EditAddressForm: View {
         )
 
         // Go to edit country
-        NavigationLink(destination: CountrySelector(), isActive: $showCountrySelector) {
+        // TODO: Move `CountrySelectorViewModel` to the VM when it exists.
+        NavigationLink(destination: CountrySelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
             EmptyView()
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
+		26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
@@ -1838,6 +1839,7 @@
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
+		26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModelTests.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
@@ -3869,6 +3871,22 @@
 			path = Survey;
 			sourceTree = "<group>";
 		};
+		26C6E8E126E2D85300C7BB0F /* Addresses */ = {
+			isa = PBXGroup;
+			children = (
+				26C6E8E226E2D85300C7BB0F /* CountrySelector */,
+			);
+			path = Addresses;
+			sourceTree = "<group>";
+		};
+		26C6E8E226E2D85300C7BB0F /* CountrySelector */ = {
+			isa = PBXGroup;
+			children = (
+				26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */,
+			);
+			path = CountrySelector;
+			sourceTree = "<group>";
+		};
 		26E1BEC7251BE50C0096D0A1 /* Issue Refunds */ = {
 			isa = PBXGroup;
 			children = (
@@ -4507,6 +4525,7 @@
 				57F2C6CA246DEBBF0074063B /* Order Summary Section */,
 				0277AE99256CA86D00F45C4A /* Shipping Labels */,
 				268EC46226D3F9A800716F5C /* Customer Note */,
+				26C6E8E126E2D85300C7BB0F /* Addresses */,
 				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 				578195FB25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift */,
 			);
@@ -7787,6 +7806,7 @@
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
+				26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */,
 				3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
+		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
@@ -1836,6 +1837,7 @@
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
+		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
@@ -4787,6 +4789,7 @@
 				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
 				2662D90926E16B3600E25611 /* CountrySelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
+				26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */,
 			);
 			path = "Address Edit";
 			sourceTree = "<group>";
@@ -7037,6 +7040,7 @@
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
 				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
+				26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
 				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Yosemite
+import TestKit
+@testable import WooCommerce
+
+final class CountrySelectorViewModelTests: XCTestCase {
+
+    func test_filter_countries_return_expected_results() {
+        // Given
+        let viewModel = CountrySelectorViewModel()
+
+        // When
+        viewModel.searchTerm = "Co"
+        let countries = viewModel.command.data.map { $0.name }
+        // Then
+        assertEqual(countries, [
+            "Cocos (Keeling) Islands",
+            "Congo - Kinshasa",
+            "Congo - Brazzaville",
+            "Cook Islands",
+            "Colombia",
+            "Costa Rica",
+            "Comoros",
+            "Morocco",
+            "Monaco",
+            "Mexico",
+            "Puerto Rico",
+            "Turks & Caicos Islands"
+        ])
+    }
+
+    func test_filter_countries_with_uppercase_letters_return_expected_results() {
+        // Given
+        let viewModel = CountrySelectorViewModel()
+
+        // When
+        viewModel.searchTerm = "CO"
+        let countries = viewModel.command.data.map { $0.name }
+        // Then
+        assertEqual(countries, [
+            "Cocos (Keeling) Islands",
+            "Congo - Kinshasa",
+            "Congo - Brazzaville",
+            "Cook Islands",
+            "Colombia",
+            "Costa Rica",
+            "Comoros",
+            "Morocco",
+            "Monaco",
+            "Mexico",
+            "Puerto Rico",
+            "Turks & Caicos Islands"
+        ])
+    }
+
+    func test_cleaning_search_terms_return_all_countries() {
+        // Given
+        let viewModel = CountrySelectorViewModel()
+        let totalNumberOfCountries = viewModel.command.data.count
+
+        // When
+        viewModel.searchTerm = "CO"
+        XCTAssertNotEqual(viewModel.command.data.count, totalNumberOfCountries)
+        viewModel.searchTerm = ""
+
+        // Then
+        XCTAssertEqual(viewModel.command.data.count, totalNumberOfCountries)
+    }
+}


### PR DESCRIPTION
# Why

The previous PR added the country selector UI #4917, this PR wires that UI so that the search term entered by the user actually filters the content on the list.

# How

- Updated `ListSelector` view wrapper to reload the table view data each time SwiftUI is updating the underlying view.

- Update `CountrySelectorCommand` to allow filtering its data using an insensitive case contains.

- Added `CountrySelectorViewModel`. Right now it serves as a store for the search term and the command. Updating the search term also updates the command.


# Demo

https://user-images.githubusercontent.com/562080/132072251-ced378b8-f173-45f2-9840-bc8fface60cd.mov

# Testing Steps

- Launch the app and navigate to an order.
- Tap on the shipping address edit icon.
- Tap on the country row
- Search for countries/regions by entering a filter search term.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
