### PR TITLE
Shipping Labels: Update purchase form view model to support multi-package

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A structure to hold the basic details for a selected package on Package Details screen of Shipping Label purchase flow.
 ///
-struct ShippingLabelPackageInfo: Hashable, Equatable {
+struct ShippingLabelPackageAttributes: Hashable, Equatable {
 
     /// ID of the selected package.
     let packageID: String

--- a/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
@@ -3,7 +3,13 @@ import Foundation
 /// A structure to hold the basic details for a selected package on Package Details screen of Shipping Label purchase flow.
 ///
 struct ShippingLabelPackageInfo: Hashable {
+
+    /// ID of the selected package.
     let packageID: String
+
+    /// Total weight of the package in string value.
     let totalWeight: String
+
+    /// List of product or variation IDs for items in the package.
     let productIDs: [Int64]
 }

--- a/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// A structure to hold the basic details for a selected package on Package Details screen of Shipping Label purchase flow.
+///
+struct ShippingLabelPackageInfo: Hashable {
+    let packageID: String
+    let totalWeight: String
+    let productIDs: [Int64]
+}

--- a/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageInfo.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A structure to hold the basic details for a selected package on Package Details screen of Shipping Label purchase flow.
 ///
-struct ShippingLabelPackageInfo: Hashable {
+struct ShippingLabelPackageInfo: Hashable, Equatable {
 
     /// ID of the selected package.
     let packageID: String

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -96,8 +96,7 @@ struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil)
+                                                             selectedPackageDetails: [:])
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -96,7 +96,7 @@ struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageDetails: [:])
+                                                             selectedPackageListDetails: [:])
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -96,7 +96,7 @@ struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageListDetails: [:])
+                                                             selectedPackages: [])
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -18,12 +18,10 @@ struct ShippingLabelPackageSelection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil)
+                                                             selectedPackageDetails: [:])
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: nil,
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil)
+                                                             selectedPackageDetails: [:])
 
         ShippingLabelPackageSelection(viewModel: viewModelWithPackages)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -18,10 +18,10 @@ struct ShippingLabelPackageSelection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageDetails: [:])
+                                                             selectedPackageListDetails: [:])
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: nil,
-                                                             selectedPackageDetails: [:])
+                                                             selectedPackageListDetails: [:])
 
         ShippingLabelPackageSelection(viewModel: viewModelWithPackages)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -18,10 +18,10 @@ struct ShippingLabelPackageSelection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageListDetails: [:])
+                                                             selectedPackages: [])
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: nil,
-                                                             selectedPackageListDetails: [:])
+                                                             selectedPackages: [])
 
         ShippingLabelPackageSelection(viewModel: viewModelWithPackages)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -82,7 +82,7 @@ struct ShippingLabelPackageDetails: View {
         .navigationBarItems(trailing: Button(action: {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
                                            withProperties: ["state": "packages_selected"])
-            onCompletion(viewModel.selectedPackageListDetails)
+            onCompletion(viewModel.selectedPackagesDetails)
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageDetails: View {
 
     /// Completion callback
     ///
-    typealias Completion = (_ selectedPackageListDetails: [String: String]) -> Void
+    typealias Completion = (_ selectedPackages: [ShippingLabelPackageInfo]) -> Void
     private let onCompletion: Completion
 
     init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {
@@ -117,7 +117,7 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageListDetails: [:])
+                                                             selectedPackages: [])
 
         ShippingLabelPackageDetails(viewModel: viewModel, completion: { _ in
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageDetails: View {
 
     /// Completion callback
     ///
-    typealias Completion = (_ selectedPackages: [ShippingLabelPackageInfo]) -> Void
+    typealias Completion = (_ selectedPackages: [ShippingLabelPackageAttributes]) -> Void
     private let onCompletion: Completion
 
     init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageDetails: View {
 
     /// Completion callback
     ///
-    typealias Completion = (_ selectedPackageID: String?, _ totalPackageWeight: String?) -> Void
+    typealias Completion = (_ selectedPackageDetails: [String: String]) -> Void
     private let onCompletion: Completion
 
     init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {
@@ -82,7 +82,7 @@ struct ShippingLabelPackageDetails: View {
         .navigationBarItems(trailing: Button(action: {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
                                            withProperties: ["state": "packages_selected"])
-            onCompletion(viewModel.selectedPackageID, viewModel.totalWeight)
+            onCompletion(viewModel.selectedPackageDetails)
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)
@@ -117,15 +117,14 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil)
+                                                             selectedPackageDetails: [:])
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (selectedPackageID, totalPackageWeight) in
+        ShippingLabelPackageDetails(viewModel: viewModel, completion: { _ in
         })
         .environment(\.colorScheme, .light)
         .previewDisplayName("Light")
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (selectedPackageID, totalPackageWeight) in
+        ShippingLabelPackageDetails(viewModel: viewModel, completion: { _ in
         })
         .environment(\.colorScheme, .dark)
         .previewDisplayName("Dark")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageDetails: View {
 
     /// Completion callback
     ///
-    typealias Completion = (_ selectedPackageDetails: [String: String]) -> Void
+    typealias Completion = (_ selectedPackageListDetails: [String: String]) -> Void
     private let onCompletion: Completion
 
     init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {
@@ -82,7 +82,7 @@ struct ShippingLabelPackageDetails: View {
         .navigationBarItems(trailing: Button(action: {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
                                            withProperties: ["state": "packages_selected"])
-            onCompletion(viewModel.selectedPackageDetails)
+            onCompletion(viewModel.selectedPackageListDetails)
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)
@@ -117,7 +117,7 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackageDetails: [:])
+                                                             selectedPackageListDetails: [:])
 
         ShippingLabelPackageDetails(viewModel: viewModel, completion: { _ in
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -56,6 +56,16 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     @Published var selectedPackageID: String?
 
+    /// List of selected package IDs and their weights.
+    /// TODO-4599: update this to properly support multi-package.
+    ///
+    var selectedPackageDetails: [String: String] {
+        guard let id = selectedPackageID, totalWeight.isNotEmpty else {
+            return [:]
+        }
+        return [id: totalWeight]
+    }
+    
     /// The title of the selected package, if any.
     ///
     var selectedPackageName: String {
@@ -85,8 +95,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
-         selectedPackageID: String?,
-         totalWeight: String?,
+         selectedPackageDetails: [String: String],
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -99,14 +108,14 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.storageManager = storageManager
         self.weightUnit = weightUnit
         self.packagesResponse = packagesResponse
-        self.selectedPackageID = selectedPackageID
+        self.selectedPackageID = selectedPackageDetails.first?.key // TODO-4599: fix this
 
         configureResultsControllers()
         setDefaultPackage()
         syncProducts()
         syncProductVariations()
         configureItemRows()
-        configureTotalWeights(initialTotalWeight: totalWeight)
+        configureTotalWeights(initialTotalWeight: selectedPackageDetails.first?.value) // TODO-4599: fix this
     }
 
     /// Observe changes in products and variations to update item rows.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -56,14 +56,14 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     ///
     @Published var selectedPackageID: String?
 
-    /// List of selected package IDs and their weights.
+    /// List of selected package with basic info.
     /// TODO-4599: update this to properly support multi-package.
     ///
-    var selectedPackageListDetails: [String: String] {
+    var selectedPackageListDetails: [ShippingLabelPackageInfo] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {
-            return [:]
+            return []
         }
-        return [id: totalWeight]
+        return [ShippingLabelPackageInfo(packageID: id, totalWeight: totalWeight, productIDs: orderItems.map { $0.productOrVariationID })]
     }
 
     /// The title of the selected package, if any.
@@ -95,7 +95,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
-         selectedPackageListDetails: [String: String],
+         selectedPackages: [ShippingLabelPackageInfo],
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -108,14 +108,14 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.storageManager = storageManager
         self.weightUnit = weightUnit
         self.packagesResponse = packagesResponse
-        self.selectedPackageID = selectedPackageListDetails.first?.key // TODO-4599: fix this
+        self.selectedPackageID = selectedPackages.first?.packageID // TODO-4599: fix this
 
         configureResultsControllers()
         setDefaultPackage()
         syncProducts()
         syncProductVariations()
         configureItemRows()
-        configureTotalWeights(initialTotalWeight: selectedPackageListDetails.first?.value) // TODO-4599: fix this
+        configureTotalWeights(initialTotalWeight: selectedPackages.first?.totalWeight) // TODO-4599: fix this
     }
 
     /// Observe changes in products and variations to update item rows.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -65,7 +65,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         }
         return [id: totalWeight]
     }
-    
+
     /// The title of the selected package, if any.
     ///
     var selectedPackageName: String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -59,11 +59,11 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// List of selected package with basic info.
     /// TODO-4599: update this to properly support multi-package.
     ///
-    var selectedPackagesDetails: [ShippingLabelPackageInfo] {
+    var selectedPackagesDetails: [ShippingLabelPackageAttributes] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {
             return []
         }
-        return [ShippingLabelPackageInfo(packageID: id, totalWeight: totalWeight, productIDs: orderItems.map { $0.productOrVariationID })]
+        return [ShippingLabelPackageAttributes(packageID: id, totalWeight: totalWeight, productIDs: orderItems.map { $0.productOrVariationID })]
     }
 
     /// The title of the selected package, if any.
@@ -95,7 +95,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
-         selectedPackages: [ShippingLabelPackageInfo],
+         selectedPackages: [ShippingLabelPackageAttributes],
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -59,7 +59,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// List of selected package with basic info.
     /// TODO-4599: update this to properly support multi-package.
     ///
-    var selectedPackageListDetails: [ShippingLabelPackageInfo] {
+    var selectedPackagesDetails: [ShippingLabelPackageInfo] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {
             return []
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -59,7 +59,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     /// List of selected package IDs and their weights.
     /// TODO-4599: update this to properly support multi-package.
     ///
-    var selectedPackageDetails: [String: String] {
+    var selectedPackageListDetails: [String: String] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {
             return [:]
         }
@@ -95,7 +95,7 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
-         selectedPackageDetails: [String: String],
+         selectedPackageListDetails: [String: String],
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -108,14 +108,14 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.storageManager = storageManager
         self.weightUnit = weightUnit
         self.packagesResponse = packagesResponse
-        self.selectedPackageID = selectedPackageDetails.first?.key // TODO-4599: fix this
+        self.selectedPackageID = selectedPackageListDetails.first?.key // TODO-4599: fix this
 
         configureResultsControllers()
         setDefaultPackage()
         syncProducts()
         syncProductVariations()
         configureItemRows()
-        configureTotalWeights(initialTotalWeight: selectedPackageDetails.first?.value) // TODO-4599: fix this
+        configureTotalWeights(initialTotalWeight: selectedPackageListDetails.first?.value) // TODO-4599: fix this
     }
 
     /// Observe changes in products and variations to update item rows.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -416,7 +416,7 @@ private extension ShippingLabelFormViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func displayPackageDetailsVC(inputPackages: [ShippingLabelPackageInfo]) {
+    func displayPackageDetailsVC(inputPackages: [ShippingLabelPackageAttributes]) {
         let vm = ShippingLabelPackageDetailsViewModel(order: viewModel.order,
                                                       packagesResponse: viewModel.packagesResponse,
                                                       selectedPackages: inputPackages)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -159,7 +159,7 @@ extension ShippingLabelFormViewController: UITableViewDelegate {
         case Row(type: .shipTo, dataState: .validated, displayMode: .editable):
             displayEditAddressFormVC(address: viewModel.destinationAddress, validationError: nil, type: .destination)
         case Row(type: .packageDetails, dataState: .validated, displayMode: .editable):
-            displayPackageDetailsVC(selectedPackageListDetails: viewModel.selectedPackageListDetails)
+            displayPackageDetailsVC(inputPackages: viewModel.selectedPackagesDetails)
         case Row(type: .customs, dataState: .validated, displayMode: .editable):
             displayCustomsFormListVC(customsForms: viewModel.customsForms)
         case Row(type: .shippingCarrierAndRates, dataState: .validated, displayMode: .editable):
@@ -277,7 +277,8 @@ private extension ShippingLabelFormViewController {
                        title: Localization.packageDetailsCellTitle,
                        body: viewModel.getPackageDetailsBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            self?.displayPackageDetailsVC(selectedPackageListDetails: self?.viewModel.selectedPackageListDetails ?? [:])
+            guard let self = self else { return }
+            self.displayPackageDetailsVC(inputPackages: self.viewModel.selectedPackagesDetails)
         }
     }
 
@@ -415,10 +416,10 @@ private extension ShippingLabelFormViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func displayPackageDetailsVC(selectedPackageListDetails: [String: String]) {
+    func displayPackageDetailsVC(inputPackages: [ShippingLabelPackageInfo]) {
         let vm = ShippingLabelPackageDetailsViewModel(order: viewModel.order,
                                                       packagesResponse: viewModel.packagesResponse,
-                                                      selectedPackageListDetails: viewModel.selectedPackageListDetails)
+                                                      selectedPackages: inputPackages)
         let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] selectedPackages in
             self?.viewModel.handlePackageDetailsValueChanges(details: selectedPackages)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -498,9 +498,10 @@ private extension ShippingLabelFormViewController {
 
     /// Removes the Shipping Label Form from the navigation stack and displays the Print Shipping Label screen.
     /// This prevents navigating back to the purchase form after successfully purchasing the label.
+    /// TODO-4599: Update for multi-package support
     ///
     func displayPrintShippingLabelVC() {
-        guard let purchasedShippingLabel = viewModel.purchasedShippingLabel,
+        guard let purchasedShippingLabel = viewModel.purchasedShippingLabels.first,
               let navigationController = navigationController else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -159,8 +159,7 @@ extension ShippingLabelFormViewController: UITableViewDelegate {
         case Row(type: .shipTo, dataState: .validated, displayMode: .editable):
             displayEditAddressFormVC(address: viewModel.destinationAddress, validationError: nil, type: .destination)
         case Row(type: .packageDetails, dataState: .validated, displayMode: .editable):
-            displayPackageDetailsVC(selectedPackageID: viewModel.selectedPackageID,
-                                    totalPackageWeight: viewModel.totalPackageWeight)
+            displayPackageDetailsVC(selectedPackageDetails: viewModel.selectedPackageDetails)
         case Row(type: .customs, dataState: .validated, displayMode: .editable):
             displayCustomsFormListVC(customsForms: viewModel.customsForms)
         case Row(type: .shippingCarrierAndRates, dataState: .validated, displayMode: .editable):
@@ -278,8 +277,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.packageDetailsCellTitle,
                        body: viewModel.getPackageDetailsBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            self?.displayPackageDetailsVC(selectedPackageID: self?.viewModel.selectedPackageID,
-                                          totalPackageWeight: self?.viewModel.totalPackageWeight)
+            self?.displayPackageDetailsVC(selectedPackageDetails: self?.viewModel.selectedPackageDetails ?? [:])
         }
     }
 
@@ -417,13 +415,12 @@ private extension ShippingLabelFormViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func displayPackageDetailsVC(selectedPackageID: String?, totalPackageWeight: String?) {
+    func displayPackageDetailsVC(selectedPackageDetails: [String: String]) {
         let vm = ShippingLabelPackageDetailsViewModel(order: viewModel.order,
                                                       packagesResponse: viewModel.packagesResponse,
-                                                      selectedPackageID: selectedPackageID,
-                                                      totalWeight: totalPackageWeight)
-        let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] (selectedPackageID, totalPackageWeight) in
-            self?.viewModel.handlePackageDetailsValueChanges(selectedPackageID: selectedPackageID, totalPackageWeight: totalPackageWeight)
+                                                      selectedPackageDetails: viewModel.selectedPackageDetails)
+        let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] selectedPackages in
+            self?.viewModel.handlePackageDetailsValueChanges(details: selectedPackages)
         }
 
         let hostingVC = UIHostingController(rootView: packageDetails)
@@ -451,14 +448,14 @@ private extension ShippingLabelFormViewController {
                                    selectedAdultSignatureRate: ShippingLabelCarrierRate?) {
         guard let originAddress = viewModel.originAddress,
               let destinationAddress = viewModel.destinationAddress,
-              let selectedPackage = viewModel.selectedPackage else {
+              viewModel.selectedPackages.isNotEmpty else {
             return
         }
 
         let vm = ShippingLabelCarriersViewModel(order: viewModel.order,
                                                 originAddress: originAddress,
                                                 destinationAddress: destinationAddress,
-                                                packages: [selectedPackage],
+                                                packages: viewModel.selectedPackages,
                                                 selectedRate: selectedRate,
                                                 selectedSignatureRate: selectedSignatureRate,
                                                 selectedAdultSignatureRate: selectedAdultSignatureRate)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -159,7 +159,7 @@ extension ShippingLabelFormViewController: UITableViewDelegate {
         case Row(type: .shipTo, dataState: .validated, displayMode: .editable):
             displayEditAddressFormVC(address: viewModel.destinationAddress, validationError: nil, type: .destination)
         case Row(type: .packageDetails, dataState: .validated, displayMode: .editable):
-            displayPackageDetailsVC(selectedPackageDetails: viewModel.selectedPackageDetails)
+            displayPackageDetailsVC(selectedPackageListDetails: viewModel.selectedPackageListDetails)
         case Row(type: .customs, dataState: .validated, displayMode: .editable):
             displayCustomsFormListVC(customsForms: viewModel.customsForms)
         case Row(type: .shippingCarrierAndRates, dataState: .validated, displayMode: .editable):
@@ -277,7 +277,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.packageDetailsCellTitle,
                        body: viewModel.getPackageDetailsBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            self?.displayPackageDetailsVC(selectedPackageDetails: self?.viewModel.selectedPackageDetails ?? [:])
+            self?.displayPackageDetailsVC(selectedPackageListDetails: self?.viewModel.selectedPackageListDetails ?? [:])
         }
     }
 
@@ -415,10 +415,10 @@ private extension ShippingLabelFormViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func displayPackageDetailsVC(selectedPackageDetails: [String: String]) {
+    func displayPackageDetailsVC(selectedPackageListDetails: [String: String]) {
         let vm = ShippingLabelPackageDetailsViewModel(order: viewModel.order,
                                                       packagesResponse: viewModel.packagesResponse,
-                                                      selectedPackageDetails: viewModel.selectedPackageDetails)
+                                                      selectedPackageListDetails: viewModel.selectedPackageListDetails)
         let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] selectedPackages in
             self?.viewModel.handlePackageDetailsValueChanges(details: selectedPackages)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -35,7 +35,7 @@ final class ShippingLabelFormViewModel {
 
     /// Selected packages configured from Package Details form.
     ///
-    private(set) var selectedPackagesDetails: [ShippingLabelPackageInfo] = []
+    private(set) var selectedPackagesDetails: [ShippingLabelPackageAttributes] = []
 
     /// Customs forms
     ///
@@ -200,7 +200,7 @@ final class ShippingLabelFormViewModel {
         }
     }
 
-    func handlePackageDetailsValueChanges(details: [ShippingLabelPackageInfo]) {
+    func handlePackageDetailsValueChanges(details: [ShippingLabelPackageAttributes]) {
         self.selectedPackagesDetails = details
 
         guard details.isNotEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -600,7 +600,7 @@ private extension ShippingLabelFormViewModel {
     /// When multi-package support is available, we should create separate form for each package ID.
     ///
     private func createDefaultCustomsFormsIfNeeded() -> [ShippingLabelCustomsForm] {
-        guard customsFormRequired, !selectedPackagesDetails.isEmpty else {
+        guard customsFormRequired, selectedPackagesDetails.isNotEmpty else {
             return []
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -35,7 +35,7 @@ final class ShippingLabelFormViewModel {
 
     /// Selected packages by ID and their weights in string values.
     ///
-    private(set) var selectedPackageDetails: [String: String] = [:]
+    private(set) var selectedPackageListDetails: [String: String] = [:]
 
     /// Customs forms
     ///
@@ -51,7 +51,7 @@ final class ShippingLabelFormViewModel {
             return []
         }
 
-        return selectedPackageDetails.compactMap { selectedPackageID, weightString -> ShippingLabelPackageSelected? in
+        return selectedPackageListDetails.compactMap { selectedPackageID, weightString -> ShippingLabelPackageSelected? in
             let weight = Double(weightString) ?? .zero
 
             if let customPackage = packagesResponse.customPackages.first(where: { $0.title == selectedPackageID }) {
@@ -201,7 +201,7 @@ final class ShippingLabelFormViewModel {
     }
 
     func handlePackageDetailsValueChanges(details: [String: String]) {
-        self.selectedPackageDetails = details
+        self.selectedPackageListDetails = details
 
         guard !details.isEmpty else {
             updateRowState(type: .packageDetails, dataState: .pending, displayMode: .editable)
@@ -275,7 +275,7 @@ final class ShippingLabelFormViewModel {
     ///
     func getPackageDetailsBody() -> String {
         guard let packagesResponse = packagesResponse,
-              let selectedPackage = selectedPackageDetails.first else {
+              let selectedPackage = selectedPackageListDetails.first else {
             return Localization.packageDetailsPlaceholder
         }
 
@@ -600,11 +600,11 @@ private extension ShippingLabelFormViewModel {
     /// When multi-package support is available, we should create separate form for each package ID.
     ///
     private func createDefaultCustomsFormsIfNeeded() -> [ShippingLabelCustomsForm] {
-        guard customsFormRequired, !selectedPackageDetails.isEmpty else {
+        guard customsFormRequired, !selectedPackageListDetails.isEmpty else {
             return []
         }
         
-        return selectedPackageDetails.keys.map { packageID -> ShippingLabelCustomsForm in
+        return selectedPackageListDetails.keys.map { packageID -> ShippingLabelCustomsForm in
             let packageName: String = {
                 guard let response = packagesResponse else {
                     return ""

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -603,7 +603,7 @@ private extension ShippingLabelFormViewModel {
         guard customsFormRequired, !selectedPackageListDetails.isEmpty else {
             return []
         }
-        
+
         return selectedPackageListDetails.keys.map { packageID -> ShippingLabelCustomsForm in
             let packageName: String = {
                 guard let response = packagesResponse else {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1282,7 +1282,7 @@
 		DEC2962526C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */; };
 		DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */; };
 		DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962826C20ECB005A056B /* CollapsibleView.swift */; };
-		DEDB886B26E8531E00981595 /* ShippingLabelPackageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */; };
+		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2694,7 +2694,7 @@
 		DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModel.swift; sourceTree = "<group>"; };
 		DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelCustomsForm+Localization.swift"; sourceTree = "<group>"; };
 		DEC2962826C20ECB005A056B /* CollapsibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleView.swift; sourceTree = "<group>"; };
-		DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageInfo.swift; sourceTree = "<group>"; };
+		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5120,7 +5120,7 @@
 				D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */,
 				FEDD70AE26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift */,
 				E1C5E78326C2B8E8008D4C47 /* Site+Woo.swift */,
-				DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */,
+				DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7361,7 +7361,7 @@
 				02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */,
-				DEDB886B26E8531E00981595 /* ShippingLabelPackageInfo.swift in Sources */,
+				DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1282,6 +1282,7 @@
 		DEC2962526C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */; };
 		DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */; };
 		DEC2962926C20ECB005A056B /* CollapsibleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962826C20ECB005A056B /* CollapsibleView.swift */; };
+		DEDB886B26E8531E00981595 /* ShippingLabelPackageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -2693,6 +2694,7 @@
 		DEC2962426C122DF005A056B /* ShippingLabelCustomsFormInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModel.swift; sourceTree = "<group>"; };
 		DEC2962626C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelCustomsForm+Localization.swift"; sourceTree = "<group>"; };
 		DEC2962826C20ECB005A056B /* CollapsibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleView.swift; sourceTree = "<group>"; };
+		DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageInfo.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5118,6 +5120,7 @@
 				D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */,
 				FEDD70AE26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift */,
 				E1C5E78326C2B8E8008D4C47 /* Site+Woo.swift */,
+				DEDB886A26E8531E00981595 /* ShippingLabelPackageInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7358,6 +7361,7 @@
 				02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				3142663F2645E2AB00500598 /* CardReaderSettingsViewModelPresenter.swift in Sources */,
+				DEDB886B26E8531E00981595 /* ShippingLabelPackageInfo.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				45DB70602614C7E80064A6CF /* ShippingLabelPackageDetailsResultsControllers.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -171,7 +171,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         // When
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
@@ -187,7 +187,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
@@ -216,7 +216,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -867,7 +867,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: "55", productIDs: [expectedProductID])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", productIDs: [expectedProductID])
         viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -176,7 +176,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
 
         // Then
-        XCTAssertEqual(shippingLabelFormViewModel.selectedPackageDetails, [expectedPackageID: expectedPackageWeight])
+        XCTAssertEqual(shippingLabelFormViewModel.selectedPackageListDetails, [expectedPackageID: expectedPackageWeight])
     }
 
     func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -171,12 +171,13 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
+        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
-        XCTAssertEqual(shippingLabelFormViewModel.selectedPackageListDetails, [expectedPackageID: expectedPackageWeight])
+        XCTAssertEqual(shippingLabelFormViewModel.selectedPackagesDetails, [selectedPackage])
     }
 
     func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {
@@ -186,6 +187,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
+        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
@@ -196,7 +198,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         XCTAssertNil(shippingLabelFormViewModel.selectedRate)
@@ -214,6 +216,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
+        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -228,7 +231,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, expectedPackageID)
@@ -864,7 +867,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        viewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: "55"])
+        let selectedPackage = ShippingLabelPackageInfo(packageID: expectedPackageID, totalWeight: "55", productIDs: [expectedProductID])
+        viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         let defaultForms = viewModel.customsForms

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -173,11 +173,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let expectedPackageWeight = "55"
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
 
         // Then
-        XCTAssertEqual(shippingLabelFormViewModel.selectedPackageID, expectedPackageID)
-        XCTAssertEqual(shippingLabelFormViewModel.totalPackageWeight, expectedPackageWeight)
+        XCTAssertEqual(shippingLabelFormViewModel.selectedPackageDetails, [expectedPackageID: expectedPackageWeight])
     }
 
     func test_handlePackageDetailsValueChanges_reset_carrier_and_rates_selection() {
@@ -197,7 +196,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
 
         // Then
         XCTAssertNil(shippingLabelFormViewModel.selectedRate)
@@ -229,7 +228,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: expectedPackageWeight])
 
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, expectedPackageID)
@@ -865,7 +864,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        viewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: "55")
+        viewModel.handlePackageDetailsValueChanges(details: [expectedPackageID: "55"])
 
         // Then
         let defaultForms = viewModel.customsForms

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -311,7 +311,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                             productVariationID: 49,
                                             attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
 
-        let selectedPackages = [ShippingLabelPackageInfo(packageID: "Box", totalWeight: "30", productIDs: [1, 33, 23, 49])]
+        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Box", totalWeight: "30", productIDs: [1, 33, 23, 49])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
                                                              selectedPackages: selectedPackages,
@@ -364,7 +364,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         // When
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
-        let selectedPackages = [ShippingLabelPackageInfo(packageID: "Package", totalWeight: "500", productIDs: [1])]
+        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Package", totalWeight: "500", productIDs: [1])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
                                                              selectedPackages: selectedPackages,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -35,7 +35,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager)
 
@@ -64,7 +64,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -104,7 +104,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -134,7 +134,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -157,7 +157,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -175,7 +175,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -196,7 +196,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -219,7 +219,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -275,7 +275,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -314,7 +314,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: ["Box": "30"],
+                                                             selectedPackageListDetails: ["Box": "30"],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -340,7 +340,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -367,7 +367,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: ["Test": "500"],
+                                                             selectedPackageListDetails: ["Test": "500"],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -394,7 +394,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageDetails: [:],
+                                                             selectedPackageListDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -424,28 +424,28 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // When
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                             packagesResponse: nil,
-                                                                            selectedPackageDetails: [:],
+                                                                            selectedPackageListDetails: [:],
                                                                             formatter: currencyFormatter,
                                                                             stores: stores,
                                                                             storageManager: storageManager,
                                                                             weightUnit: "kg")
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                          packagesResponse: mockPackageResponse(),
-                                                                         selectedPackageDetails: [:],
+                                                                         selectedPackageListDetails: [:],
                                                                          formatter: currencyFormatter,
                                                                          stores: stores,
                                                                          storageManager: storageManager,
                                                                          weightUnit: "kg")
         let viewModelWithCustomPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: true, withPredefined: false),
-                                                                               selectedPackageDetails: [:],
+                                                                               selectedPackageListDetails: [:],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,
                                                                                weightUnit: "kg")
         let viewModelWithPredefinedPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: false, withPredefined: true),
-                                                                               selectedPackageDetails: [:],
+                                                                               selectedPackageListDetails: [:],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -35,8 +35,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager)
 
@@ -65,8 +64,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -106,8 +104,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -137,8 +134,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -161,8 +157,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -180,8 +175,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -202,8 +196,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: "Box",
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -226,8 +219,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: "Box",
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -283,12 +275,12 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: "Box",
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
-
+        viewModel.didSelectPackage("Box")
+        viewModel.confirmPackageSelection()
 
         // Then
         XCTAssertEqual(viewModel.totalWeight, "72.88")
@@ -322,8 +314,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: "30",
+                                                             selectedPackageDetails: ["Box": "30"],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -349,8 +340,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -377,8 +367,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: "500",
+                                                             selectedPackageDetails: ["Test": "500"],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -405,8 +394,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageID: nil,
-                                                             totalWeight: nil,
+                                                             selectedPackageDetails: [:],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -436,32 +424,28 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // When
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                             packagesResponse: nil,
-                                                                            selectedPackageID: nil,
-                                                                            totalWeight: nil,
+                                                                            selectedPackageDetails: [:],
                                                                             formatter: currencyFormatter,
                                                                             stores: stores,
                                                                             storageManager: storageManager,
                                                                             weightUnit: "kg")
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                          packagesResponse: mockPackageResponse(),
-                                                                         selectedPackageID: nil,
-                                                                         totalWeight: nil,
+                                                                         selectedPackageDetails: [:],
                                                                          formatter: currencyFormatter,
                                                                          stores: stores,
                                                                          storageManager: storageManager,
                                                                          weightUnit: "kg")
         let viewModelWithCustomPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: true, withPredefined: false),
-                                                                               selectedPackageID: nil,
-                                                                               totalWeight: nil,
+                                                                               selectedPackageDetails: [:],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,
                                                                                weightUnit: "kg")
         let viewModelWithPredefinedPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: false, withPredefined: true),
-                                                                               selectedPackageID: nil,
-                                                                               totalWeight: nil,
+                                                                               selectedPackageDetails: [:],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -35,7 +35,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager)
 
@@ -64,7 +64,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -104,7 +104,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -134,7 +134,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -157,7 +157,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -175,7 +175,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
@@ -196,7 +196,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -219,7 +219,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -275,7 +275,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -311,10 +311,10 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                             productVariationID: 49,
                                             attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
 
-
+        let selectedPackages = [ShippingLabelPackageInfo(packageID: "Box", totalWeight: "30", productIDs: [1, 33, 23, 49])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: ["Box": "30"],
+                                                             selectedPackages: selectedPackages,
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -340,7 +340,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -364,10 +364,10 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         // When
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
-
+        let selectedPackages = [ShippingLabelPackageInfo(packageID: "Package", totalWeight: "500", productIDs: [1])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: ["Test": "500"],
+                                                             selectedPackages: selectedPackages,
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -394,7 +394,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
-                                                             selectedPackageListDetails: [:],
+                                                             selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
                                                              weightUnit: "kg")
@@ -424,28 +424,28 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         // When
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                             packagesResponse: nil,
-                                                                            selectedPackageListDetails: [:],
+                                                                            selectedPackages: [],
                                                                             formatter: currencyFormatter,
                                                                             stores: stores,
                                                                             storageManager: storageManager,
                                                                             weightUnit: "kg")
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                          packagesResponse: mockPackageResponse(),
-                                                                         selectedPackageListDetails: [:],
+                                                                         selectedPackages: [],
                                                                          formatter: currencyFormatter,
                                                                          stores: stores,
                                                                          storageManager: storageManager,
                                                                          weightUnit: "kg")
         let viewModelWithCustomPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: true, withPredefined: false),
-                                                                               selectedPackageListDetails: [:],
+                                                                               selectedPackages: [],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,
                                                                                weightUnit: "kg")
         let viewModelWithPredefinedPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: false, withPredefined: true),
-                                                                               selectedPackageListDetails: [:],
+                                                                               selectedPackages: [],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,


### PR DESCRIPTION
Part of #4599

# Description
To prepare for updates of the purchase form fields to support multi-package, I think it's best to first update the form view model. This PR aims to replace the single selected package ID and weight with a list of basic package details. This also leads to updates in the view controller and package details.

# Changes
## ShippingLabelFormViewModel
- Replaced `selectedPackageID` and `totalPackageWeight` with `selectedPackagesDetails`. This is a list with of a new model `ShippingLabelPackageInfo` with basic details: package ID, total weight and product ID list. Note: I'm not quite happy with the naming of the model and the variable so any suggestion for renaming is appreciated!
- Replaced `selectedPackage` with `selectedPackages` array and updated its calculated value to prepare appropriate model for each package ID.
- Updated other parts relating to selected packages: handling package selection, setting up default customs forms, purchasing label.

## ShippingLabelFormViewController & ShippingLabelPackageDetails
- Updated input and output of `ShippingLabelPackageDetails` to use the selected package list details.

## ShippingLabelPackageDetailsViewModel
- Updated initializer with new parameter `selectedPackages`. 
- Added temporary updates to support the new parameter. These should be fixed in the next PR to properly support multiple packages.

# Testing
With the changes in place, it is expected that configuring package details should still work properly as before. Fetching carriers and purchasing label should also work as before.

1. Make sure that your test store has installed WCShip plugin and configured packages including DHL packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Open an order detail that is eligible for the shipping label.
3. Configure Ship To and Ship From.
4. Configure Package Details: select any package and / or update package weight manually and tap Done. Notice that the details are displayed correctly on the purchase form.
5. Tap Package Details again, notice that correct package and weight are displayed.
6. Tap Carrier and Rates, notice that carrier list can still be fetched for the package if the details are appropriate.
7. Proceed through Payment Method and purchase the label. The purchase should still succeed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
