### PR TITLE
[Mobile Payments] Improved error modal

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -306,7 +306,7 @@ updating the application or using a different reader
             return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
                                      comment: "Error message when the card reader session has timed out.")
         case .internalServiceError:
-            return NSLocalizedString("The system experienced an unexpected internal error - please try again",
+            return NSLocalizedString("Sorry, this payment couldn’t be processed",
                                      comment: "Error message when the card reader service experiences an unexpected internal service error.")
         }
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -3,9 +3,6 @@ import UIKit
 /// Modal presented on error
 final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
-    /// Amount charged
-    private let amount: String
-
     /// The error returned by the stack
     private let error: Error
 
@@ -17,9 +14,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let topTitle: String = Localization.paymentFailed
 
-    var topSubtitle: String? {
-        amount
-    }
+    var topSubtitle: String? = nil
 
     let image: UIImage = .paymentErrorImage
 
@@ -35,8 +30,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = nil
 
-    init(amount: String, error: Error, primaryAction: @escaping () -> Void) {
-        self.amount = amount
+    init(error: Error, primaryAction: @escaping () -> Void) {
         self.error = error
         self.primaryAction = primaryAction
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -60,12 +60,12 @@ private extension CardPresentModalError {
         )
 
         static let tryAgain = NSLocalizedString(
-            "Try collecting payment again",
+            "Try Collecting Again",
             comment: "Button to try to collect a payment again. Presented to users after a collecting a payment fails"
         )
 
         static let noThanks = NSLocalizedString(
-            "No thanks",
+            "Back to Order",
             comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails"
         )
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -3,9 +3,6 @@ import UIKit
 /// Modal presented when the payment has been collected successfully
 final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
-    /// Amount charged
-    private let amount: String
-
     /// Closure to execute when primary button is tapped
     private let printReceiptAction: () -> Void
 
@@ -18,9 +15,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let topTitle: String = Localization.paymentSuccessful
 
-    var topSubtitle: String? {
-        amount
-    }
+    var topSubtitle: String? = nil
 
     let image: UIImage = .celebrationImage
 
@@ -34,8 +29,7 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = nil
 
-    init(amount: String, printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
-        self.amount = amount
+    init(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
         self.emailReceiptAction = emailReceipt
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -75,7 +75,7 @@ private extension CardPresentModalSuccess {
         )
 
         static let noThanks = NSLocalizedString(
-            "No thanks",
+            "Back to Order",
             comment: "Button to dismiss modal overlay. Presented to users after a payment has been successfully collected"
         )
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -3,9 +3,6 @@ import UIKit
 /// Modal presented when the payment has been collected successfully
 final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewModel {
 
-    /// Amount charged
-    private let amount: String
-
     /// Closure to execute when primary button is tapped
     private let printReceiptAction: () -> Void
 
@@ -14,9 +11,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let topTitle: String = Localization.paymentSuccessful
 
-    var topSubtitle: String? {
-        amount
-    }
+    var topSubtitle: String? = nil
 
     let image: UIImage = .celebrationImage
 
@@ -30,8 +25,7 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
 
     let bottomSubtitle: String? = nil
 
-    init(amount: String, printReceipt: @escaping () -> Void) {
-        self.amount = amount
+    init(printReceipt: @escaping () -> Void) {
         self.printReceiptAction = printReceipt
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -61,7 +61,7 @@ private extension CardPresentModalSuccessWithoutEmail {
         )
 
         static let noThanks = NSLocalizedString(
-            "No thanks",
+            "Back to Order",
             comment: "Button to dismiss modal overlay. Presented to users after a payment has been successfully collected"
         )
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -103,9 +103,9 @@ private extension OrderDetailsPaymentAlerts {
 
     func successViewModel(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(amount: amount, printReceipt: printReceipt, emailReceipt: emailReceipt)
+            return CardPresentModalSuccess(printReceipt: printReceipt, emailReceipt: emailReceipt)
         } else {
-            return CardPresentModalSuccessWithoutEmail(amount: amount, printReceipt: printReceipt)
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -69,7 +69,7 @@ final class OrderDetailsPaymentAlerts {
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void) {
-        let viewModel = errorViewModel(amount: amount, error: error, tryAgain: tryAgain)
+        let viewModel = errorViewModel(error: error, tryAgain: tryAgain)
         presentViewModel(viewModel: viewModel)
     }
 
@@ -109,8 +109,8 @@ private extension OrderDetailsPaymentAlerts {
         }
     }
 
-    func errorViewModel(amount: String, error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalError(amount: amount, error: error, primaryAction: tryAgain)
+    func errorViewModel(error: Error, tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalError(error: error, primaryAction: tryAgain)
     }
 
     func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalErrorTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalErrorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalError(amount: Expectations.amount, error: Expectations.error, primaryAction: closures.primaryAction())
+        viewModel = CardPresentModalError(error: Expectations.error, primaryAction: closures.primaryAction())
     }
 
     override func tearDown() {
@@ -25,8 +25,8 @@ final class CardPresentModalErrorTests: XCTestCase {
         XCTAssertNotNil(viewModel.topTitle)
     }
 
-    func test_topSubtitle_provides_expected_title() {
-        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
     }
 
     func test_primary_button_title_is_not_nil() {
@@ -49,7 +49,6 @@ final class CardPresentModalErrorTests: XCTestCase {
 
 private extension CardPresentModalErrorTests {
     enum Expectations {
-        static let amount = "amount"
         static let image = UIImage.paymentErrorImage
         static let error = MockError()
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalSuccessTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccess(amount: Expectations.amount, printReceipt: closures.printReceipt(), emailReceipt: closures.emailReceipt())
+        viewModel = CardPresentModalSuccess(printReceipt: closures.printReceipt(), emailReceipt: closures.emailReceipt())
     }
 
     override func tearDown() {
@@ -25,8 +25,8 @@ final class CardPresentModalSuccessTests: XCTestCase {
         XCTAssertNotNil(viewModel.topTitle)
     }
 
-    func test_topSubtitle_provides_expected_title() {
-        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
     }
 
     func test_primary_button_title_is_not_nil() {
@@ -65,7 +65,6 @@ final class CardPresentModalSuccessTests: XCTestCase {
 
 private extension CardPresentModalSuccessTests {
     enum Expectations {
-        static var amount = "amount"
         static var image = UIImage.celebrationImage
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmailTests.swift
@@ -8,7 +8,7 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
     override func setUp() {
         super.setUp()
         closures = Closures()
-        viewModel = CardPresentModalSuccessWithoutEmail(amount: Expectations.amount, printReceipt: closures.printReceipt())
+        viewModel = CardPresentModalSuccessWithoutEmail(printReceipt: closures.printReceipt())
     }
 
     override func tearDown() {
@@ -25,8 +25,8 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
         XCTAssertNotNil(viewModel.topTitle)
     }
 
-    func test_topSubtitle_provides_expected_title() {
-        XCTAssertEqual(viewModel.topSubtitle, Expectations.amount)
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
     }
 
     func test_primary_button_title_is_not_nil() {
@@ -59,7 +59,6 @@ final class CardPresentModalSuccessWithoutEmailTests: XCTestCase {
 
 private extension CardPresentModalSuccessWithoutEmailTests {
     enum Expectations {
-        static var amount = "amount"
         static var image = UIImage.celebrationImage
     }
 }


### PR DESCRIPTION
Fixes #4551 

This addresses the UI requests in #4551:

- Updated copy for the generic error message
- Remove order amount
- Update copy on the buttons

Before|After
-|-
![Screen Shot 2021-09-06 at 13 16 01](https://user-images.githubusercontent.com/8739/132209508-73466e6d-db53-4641-bbf1-a646ba18cc3c.png)|![Screen Shot 2021-09-06 at 13 14 07](https://user-images.githubusercontent.com/8739/132209501-d4d17f34-25aa-4c6d-9039-1390149309fb.png)

I've also removed the amount and update the button copy on the success screens, prompted by https://github.com/woocommerce/woocommerce-ios/pull/4919#issuecomment-913623633

Before|After
-|-
![Screen Shot 2021-09-06 at 16 19 03](https://user-images.githubusercontent.com/8739/132230993-b2f36a6d-81e6-440d-8e70-54c1a9f0968e.png)|![Screen Shot 2021-09-06 at 16 21 54](https://user-images.githubusercontent.com/8739/132231217-8348b1d9-f67b-4a05-a81f-475d5c8d796d.png)


## To test

I've forced a generic error by replacing the implementation of `StripeCardReaderService.createPaymentIntent(_:)` with:

```swift
func createPaymentIntent(_ parameters: PaymentIntentParameters) -> Future<StripeTerminal.PaymentIntent, Error> {
    return Future() { [weak self] promise in
        return promise(.failure(CardReaderServiceError.intentCreation(underlyingError: .internalServiceError)))
    }
}
```

Then:

1. Find an order eligible for payment
2. Tap on Collect Payment
3. Connect to the reader if necessary
4. Tap the card to pay
5. See the error message

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
