### PR TITLE
[Mobile Payments] Adjust modal dimensions for iPads

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -11,6 +11,7 @@ final class CardPresentPaymentsModalViewController: UIViewController {
 
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var mainStackView: UIStackView!
+    @IBOutlet weak var bottomPaddingRegular: NSLayoutConstraint!
     @IBOutlet weak var primaryActionButtonsStackView: UIStackView!
     @IBOutlet weak var buttonsSpacer: UIView!
     @IBOutlet private weak var topTitleLabel: UILabel!
@@ -82,6 +83,7 @@ final class CardPresentPaymentsModalViewController: UIViewController {
 
         heightConstraint.priority = .required
         widthConstraint.priority = .required
+        configureSpacer()
     }
 }
 
@@ -117,8 +119,8 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleBottomLabels() {
         actionButtonsView.isHidden = true
-        buttonsSpacer.isHidden = false
         bottomLabels.isHidden = false
+        configureSpacer()
 
         styleBottomTitle()
         styleBottomSubtitle()
@@ -134,8 +136,8 @@ private extension CardPresentPaymentsModalViewController {
 
     func styleActionButtons() {
         actionButtonsView.isHidden = false
-        buttonsSpacer.isHidden = true
         bottomLabels.isHidden = true
+        configureSpacer()
 
         stylePrimaryButton()
         styleSecondaryButton()
@@ -239,7 +241,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func hideActionButtonsView() {
         actionButtonsView.isHidden = true
-        buttonsSpacer.isHidden = false
+        configureSpacer()
     }
 
     func configurePrimaryButton() {
@@ -270,6 +272,30 @@ private extension CardPresentPaymentsModalViewController {
 
         auxiliaryButton.isHidden = false
         auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
+    }
+
+    func configureSpacer() {
+        let enabled = !shouldShowActionButtons()
+
+        if isRegularClassSize {
+            buttonsSpacer.isHidden = true
+            // For iPads, instead of a flexible spacer we expand the bottom margin with an extra 127px.
+            // This would be the space equivalents to the primary and secondary buttons being visible
+            // - 32px of spacing between buttons container and the rest of the content
+            // - 40px for the primary button
+            // - 15px of spacing between buttons
+            // - 40px for the secondary button
+            bottomPaddingRegular.constant = 42 + (enabled ? 127 : 0)
+        } else {
+            // For compact screens (iPhones, or iPad in split mode), we us a flexible spacer with a low
+            // content hugging priority to ensure it takes all the available space, leaving the rest of
+            // the visible items aligned to the top of the stack view
+            buttonsSpacer.isHidden = !enabled
+        }
+    }
+
+    var isRegularClassSize: Bool {
+        traitCollection.verticalSizeClass == .regular && traitCollection.horizontalSizeClass == .regular
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -13,6 +13,7 @@
                 <outlet property="actionButtonsView" destination="10Z-y1-ZQ6" id="L1z-Zs-L2J"/>
                 <outlet property="auxiliaryButton" destination="maO-19-PuQ" id="cQA-7p-jmo"/>
                 <outlet property="bottomLabels" destination="k73-qi-GuD" id="LvQ-UE-SBc"/>
+                <outlet property="bottomPaddingRegular" destination="lVZ-pu-Fmb" id="CJM-oy-oSx"/>
                 <outlet property="bottomSubtitleLabel" destination="2Sx-5s-f7J" id="Mco-Vu-Li6"/>
                 <outlet property="bottomTitleLabel" destination="oAj-lv-0k9" id="Clc-oi-Ywf"/>
                 <outlet property="buttonsSpacer" destination="OFI-6w-cag" id="Uva-gQ-T7X"/>

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.xib
@@ -136,20 +136,57 @@
                             <constraints>
                                 <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="jIt-xb-rrN" secondAttribute="leading" id="0sg-Uf-xbd"/>
                                 <constraint firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="Nrr-ur-lj3"/>
+                                <constraint firstAttribute="width" constant="248" id="wyC-vo-Y5l"/>
                             </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="wyC-vo-Y5l"/>
+                                </mask>
+                            </variation>
+                            <variation key="heightClass=regular-widthClass=regular">
+                                <mask key="constraints">
+                                    <include reference="wyC-vo-Y5l"/>
+                                </mask>
+                            </variation>
                         </stackView>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="8Tg-Q2-wkH" secondAttribute="leading" constant="16" id="80k-pZ-tsR"/>
+                        <constraint firstAttribute="width" constant="454" id="Apy-47-NLE"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="42" id="FxC-xu-ACf"/>
                         <constraint firstAttribute="height" priority="250" constant="382" id="J6m-sz-CD5"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="8Tg-Q2-wkH" secondAttribute="top" constant="32" id="JLA-XJ-MiD"/>
-                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="lVZ-pu-Fmb"/>
+                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="16" id="bkK-x1-zVB"/>
+                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="42" id="lVZ-pu-Fmb"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="382" id="n7H-7U-izh"/>
                         <constraint firstItem="jIt-xb-rrN" firstAttribute="centerX" secondItem="8Tg-Q2-wkH" secondAttribute="centerX" id="p6Y-jJ-KuU"/>
                         <constraint firstAttribute="width" constant="280" id="uaz-2N-7M4"/>
                         <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="16" id="ufT-Yf-gsb"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="490" id="w7w-an-P9s"/>
                     </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="Apy-47-NLE"/>
+                            <exclude reference="w7w-an-P9s"/>
+                            <exclude reference="FxC-xu-ACf"/>
+                            <exclude reference="lVZ-pu-Fmb"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=regular">
+                        <mask key="constraints">
+                            <include reference="Apy-47-NLE"/>
+                            <exclude reference="n7H-7U-izh"/>
+                            <exclude reference="uaz-2N-7M4"/>
+                            <include reference="w7w-an-P9s"/>
+                            <exclude reference="80k-pZ-tsR"/>
+                            <include reference="FxC-xu-ACf"/>
+                            <exclude reference="JLA-XJ-MiD"/>
+                            <exclude reference="bkK-x1-zVB"/>
+                            <include reference="lVZ-pu-Fmb"/>
+                            <exclude reference="ufT-Yf-gsb"/>
+                        </mask>
+                    </variation>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>


### PR DESCRIPTION
Fixes #4557 

This implements the changes requested in #4557 to make the modals a bit bigger on iPads. Looking at the screens in Figma, I wasn't able to see a consistent layout (the horizontal margin of the buttons was 96, 103, or 114.25 depending on the screen), so here's how I interpreted the rules:

- The modal size is 454x490
- The vertical padding is 42px
- Instead of setting a horizontal padding, I tried to keep the content at the same size it was on the iPhone modals (280-2x16 = 248px) and make sure it's centered. This would be equivalent to a 103px horizontal padding, but it made a bit more sense to define it that way
- All these new rules apply when both the horizontal and vertical [size class](https://useyourloaf.com/blog/size-classes/) are "regular"

## To test

1. Find an order that's eligible for payments
2. Tap Collect Payment
3. Connect to a reader and go through the payment flow

The modal view controller is generic to all the payment modals, so the changes should be the same for all screens, but feel free to test as many cases as you want.

You can also check that the modals haven't changed when running on an iPhone.

![Screen Shot 2021-09-06 at 14 07 16](https://user-images.githubusercontent.com/8739/132216617-ef57a73c-9054-4ab8-b65f-c5d2bb6b7dd5.png)|![Screen Shot 2021-09-06 at 14 08 09](https://user-images.githubusercontent.com/8739/132216623-665f9289-9c48-43cb-96e7-3849179e0963.png)|![Screen Shot 2021-09-06 at 14 07 24](https://user-images.githubusercontent.com/8739/132216626-934ecabc-6768-4d4c-9cab-932b32d0f464.png)
-|-|-
![Screen Shot 2021-09-06 at 14 07 27](https://user-images.githubusercontent.com/8739/132216636-872d407c-41e7-4057-91d3-e284f9ed7ddb.png)|![Screen Shot 2021-09-06 at 14 07 33](https://user-images.githubusercontent.com/8739/132216638-f7b2b1d8-df71-4c4e-964a-d07143a3df6c.png)|![Screen Shot 2021-09-06 at 14 07 40](https://user-images.githubusercontent.com/8739/132216641-7f6f4168-c332-4c65-b7f4-65e9532bc8aa.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
