### PR TITLE
Order Editing: State Selector UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,18 +1,36 @@
 import Combine
+import SwiftUI
 
 /// View Model for the `CountrySelector` view.
 ///
-final class CountrySelectorViewModel: ObservableObject {
+final class CountrySelectorViewModel: FilterListSelectorViewModelable, ObservableObject {
 
     /// Current search term entered by the user.
     /// Each update will trigger an update to the `command` that contains the country data.
-    @Published var searchTerm = "" {
+    var searchTerm: String = "" {
         didSet {
             command.filterCountries(term: searchTerm)
+            objectWillChange.send()
         }
     }
 
     /// Command that powers the `ListSelector` view.
     ///
     let command = CountrySelectorCommand()
+
+    /// Navigation title
+    ///
+    let navigationTitle = Localization.title
+
+    /// Filter text field placeholder
+    ///
+    let filterPlaceholder = Localization.placeholder
+}
+
+// MARK: Constants
+private extension CountrySelectorViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("Country", comment: "Title to select country from the edit address screen")
+        static let placeholder = NSLocalizedString("Filter Countries", comment: "Placeholder on the search field to search for a specific country")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -24,6 +24,10 @@ struct EditAddressForm: View {
     ///
     @State var showCountrySelector = false
 
+    /// Set it to `true` to present the state selector.
+    ///
+    @State var showStateSelector = false
+
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -107,7 +111,9 @@ struct EditAddressForm: View {
                         }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
-                        TitleAndValueRow(title: Localization.stateField, value: Localization.placeholderSelectOption, selectable: true) { }
+                        TitleAndValueRow(title: Localization.stateField, value: Localization.placeholderSelectOption, selectable: true) {
+                            showStateSelector = true
+                        }
                     }
                 }
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -125,8 +131,14 @@ struct EditAddressForm: View {
         )
 
         // Go to edit country
-        // TODO: Move `CountrySelectorViewModel` to the VM when it exists.
-        NavigationLink(destination: FilterListCountrySelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
+        // TODO: Move `CountrySelectorViewModel` creation to the VM when it exists.
+        NavigationLink(destination: FilterListSelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
+            EmptyView()
+        }
+
+        // Go to edit state
+        // TODO: Move `StateSelectorViewModel` creation to the VM when it exists.
+        NavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
             EmptyView()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -126,7 +126,7 @@ struct EditAddressForm: View {
 
         // Go to edit country
         // TODO: Move `CountrySelectorViewModel` to the VM when it exists.
-        NavigationLink(destination: CountrySelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
+        NavigationLink(destination: FilterListCountrySelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
             EmptyView()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// Country Selector View
+/// Filterable List Selector View/
 ///
-struct CountrySelector: View {
+struct FilterListCountrySelector: View {
 
     /// View model to drive the view content
     ///
@@ -52,7 +52,7 @@ private struct SearchHeader: View {
 
 // MARK: Constants
 
-private extension CountrySelector {
+private extension FilterListCountrySelector {
     enum Localization {
         static let title = NSLocalizedString("Country", comment: "Title to select country from the edit address screen")
     }
@@ -74,7 +74,7 @@ private extension SearchHeader {
 struct CountrySelector_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            CountrySelector(viewModel: CountrySelectorViewModel())
+            FilterListCountrySelector(viewModel: CountrySelectorViewModel())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
@@ -1,21 +1,42 @@
 import SwiftUI
 
+protocol FilterListSelectorViewModelable: ObservableObject {
+
+    associatedtype Command: ListSelectorCommand
+
+    /// Binding variable for the filter search term
+    ///
+    var searchTerm: Binding<String> { get set }
+
+    /// Command to provide data and cell configuration
+    ///
+    var command: Command { get }
+
+    /// View title in a navigation context
+    ///
+    var navigationTitle: String { get }
+
+    /// Placeholder for the filter text field
+    ///
+    var filterPlaceholder: String { get }
+}
+
 /// Filterable List Selector View/
 ///
-struct FilterListCountrySelector: View {
+struct FilterListCountrySelector<ViewModel: FilterListSelectorViewModelable>: View {
 
     /// View model to drive the view content
     ///
-    @ObservedObject private(set) var viewModel: CountrySelectorViewModel
+    @ObservedObject private(set) var viewModel: ViewModel
 
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader(filterText: $viewModel.searchTerm)
+            SearchHeader(filterText: viewModel.searchTerm, filterPlaceholder: viewModel.filterPlaceholder)
                 .background(Color(.listForeground))
 
             ListSelector(command: viewModel.command, tableStyle: .plain)
         }
-        .navigationTitle(Localization.title)
+        .navigationTitle(viewModel.navigationTitle)
     }
 }
 
@@ -30,6 +51,10 @@ private struct SearchHeader: View {
     ///
     @Binding var filterText: String
 
+    /// Placeholder for the filter text field
+    ///
+    let filterPlaceholder: String
+
     var body: some View {
         HStack(spacing: 0) {
             // Search Icon
@@ -41,7 +66,7 @@ private struct SearchHeader: View {
                 .padding([.leading, .trailing], Layout.internalPadding)
 
             // TextField
-            TextField(Localization.placeholder, text: $filterText)
+            TextField(filterPlaceholder, text: $filterText)
                 .padding([.bottom, .top], Layout.internalPadding)
         }
         .background(Color(.searchBarBackground))
@@ -52,22 +77,12 @@ private struct SearchHeader: View {
 
 // MARK: Constants
 
-private extension FilterListCountrySelector {
-    enum Localization {
-        static let title = NSLocalizedString("Country", comment: "Title to select country from the edit address screen")
-    }
-}
-
 private extension SearchHeader {
     enum Layout {
         static let iconSize = CGSize(width: 16, height: 16)
         static let internalPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 10
         static let externalPadding = EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
-    }
-
-    enum Localization {
-        static let placeholder = NSLocalizedString("Filter Countries", comment: "Placeholder on the search field to search for a specific country")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListCountrySelector.swift
@@ -6,7 +6,7 @@ protocol FilterListSelectorViewModelable: ObservableObject {
 
     /// Binding variable for the filter search term
     ///
-    var searchTerm: Binding<String> { get set }
+    var searchTerm: String { get set }
 
     /// Command to provide data and cell configuration
     ///
@@ -31,7 +31,7 @@ struct FilterListCountrySelector<ViewModel: FilterListSelectorViewModelable>: Vi
 
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader(filterText: viewModel.searchTerm, filterPlaceholder: viewModel.filterPlaceholder)
+            SearchHeader(filterText: $viewModel.searchTerm, filterPlaceholder: viewModel.filterPlaceholder)
                 .background(Color(.listForeground))
 
             ListSelector(command: viewModel.command, tableStyle: .plain)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -21,9 +21,9 @@ protocol FilterListSelectorViewModelable: ObservableObject {
     var filterPlaceholder: String { get }
 }
 
-/// Filterable List Selector View/
+/// Filterable List Selector View
 ///
-struct FilterListCountrySelector<ViewModel: FilterListSelectorViewModelable>: View {
+struct FilterListSelector<ViewModel: FilterListSelectorViewModelable>: View {
 
     /// View model to drive the view content
     ///
@@ -86,10 +86,10 @@ private extension SearchHeader {
     }
 }
 
-struct CountrySelector_Previews: PreviewProvider {
+struct FilterListSelector_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            FilterListCountrySelector(viewModel: CountrySelectorViewModel())
+            FilterListSelector(viewModel: CountrySelectorViewModel())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Yosemite
+
+/// Command to be used to select a state when editing addresses.
+///
+final class StateSelectorCommand: ListSelectorCommand {
+    typealias Model = StateOfACountry
+    typealias Cell = BasicTableViewCell
+
+    /// Original array of countries.
+    ///
+    private let states: [StateOfACountry]
+
+    /// Data to display
+    ///
+    private(set) var data: [StateOfACountry]
+
+    /// Current selected country
+    ///
+    private(set) var selected: StateOfACountry?
+
+    /// Navigation bar title
+    ///
+    let navigationBarTitle: String? = ""
+
+    init(states: [StateOfACountry] = temporaryStates, selected: StateOfACountry? = nil) {
+        self.states = states
+        self.data = states
+        self.selected = selected
+    }
+
+    func handleSelectedChange(selected: StateOfACountry, viewController: ViewController) {
+        self.selected = selected
+    }
+
+    func isSelected(model: StateOfACountry) -> Bool {
+        model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: StateOfACountry) {
+        cell.textLabel?.text = model.name
+    }
+
+    /// Filter available states that contains a given search term.
+    ///
+    func filterStates(term: String) {
+        guard term.isNotEmpty else {
+            return data = states
+        }
+
+        data = states.filter { $0.name.localizedCaseInsensitiveContains(term) }
+    }
+}
+
+// MARK: Temporary Methods
+extension StateSelectorCommand {
+
+    // Supported states will come from the view model later.
+    //
+    private static let temporaryStates: [StateOfACountry] = {
+        return Locale.isoRegionCodes.map { regionCode in
+            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
+            return StateOfACountry(code: regionCode, name: name)
+        }
+    }()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
@@ -1,0 +1,36 @@
+import Combine
+import SwiftUI
+
+/// View Model for the `StateSelector` view.
+///
+final class StateSelectorViewModel: FilterListSelectorViewModelable, ObservableObject {
+
+    /// Current search term entered by the user.
+    /// Each update will trigger an update to the `command` that contains the state data.
+    var searchTerm: String = "" {
+        didSet {
+            command.filterStates(term: searchTerm)
+            objectWillChange.send()
+        }
+    }
+
+    /// Command that powers the `ListSelector` view.
+    ///
+    let command = StateSelectorCommand()
+
+    /// Navigation title
+    ///
+    let navigationTitle = Localization.title
+
+    /// Filter text field placeholder
+    ///
+    let filterPlaceholder = Localization.placeholder
+}
+
+// MARK: Constants
+private extension StateSelectorViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("State", comment: "Title to select state from the edit address screen")
+        static let placeholder = NSLocalizedString("Filter States", comment: "Placeholder on the search field to search for a specific state")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -444,6 +444,8 @@
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
 		26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */; };
+		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
+		26C6E8E826E6B6AC00C7BB0F /* StateSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
@@ -1843,6 +1845,8 @@
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModelTests.swift; sourceTree = "<group>"; };
+		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
+		26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorCommand.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
@@ -4815,6 +4819,8 @@
 				2662D90926E16B3600E25611 /* FilterListSelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 				26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */,
+				26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */,
+				26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */,
 			);
 			path = "Address Edit";
 			sourceTree = "<group>";
@@ -7348,6 +7354,7 @@
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
+				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
@@ -7451,6 +7458,7 @@
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
+				26C6E8E826E6B6AC00C7BB0F /* StateSelectorCommand.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		2662D90626E1571900E25611 /* ListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90526E1571900E25611 /* ListSelector.swift */; };
 		2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */; };
-		2662D90A26E16B3600E25611 /* CountrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90926E16B3600E25611 /* CountrySelector.swift */; };
+		2662D90A26E16B3600E25611 /* FilterListCountrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
@@ -1804,7 +1804,7 @@
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		2662D90526E1571900E25611 /* ListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelector.swift; sourceTree = "<group>"; };
 		2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorCommand.swift; sourceTree = "<group>"; };
-		2662D90926E16B3600E25611 /* CountrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelector.swift; sourceTree = "<group>"; };
+		2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListCountrySelector.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4812,7 +4812,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
-				2662D90926E16B3600E25611 /* CountrySelector.swift */,
+				2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 				26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */,
 			);
@@ -7607,7 +7607,7 @@
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
-				2662D90A26E16B3600E25611 /* CountrySelector.swift in Sources */,
+				2662D90A26E16B3600E25611 /* FilterListCountrySelector.swift in Sources */,
 				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		2662D90626E1571900E25611 /* ListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90526E1571900E25611 /* ListSelector.swift */; };
 		2662D90826E15D6E00E25611 /* CountrySelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */; };
-		2662D90A26E16B3600E25611 /* FilterListCountrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */; };
+		2662D90A26E16B3600E25611 /* FilterListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2662D90926E16B3600E25611 /* FilterListSelector.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
@@ -1804,7 +1804,7 @@
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		2662D90526E1571900E25611 /* ListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelector.swift; sourceTree = "<group>"; };
 		2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorCommand.swift; sourceTree = "<group>"; };
-		2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListCountrySelector.swift; sourceTree = "<group>"; };
+		2662D90926E16B3600E25611 /* FilterListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListSelector.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
@@ -4812,7 +4812,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
-				2662D90926E16B3600E25611 /* FilterListCountrySelector.swift */,
+				2662D90926E16B3600E25611 /* FilterListSelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 				26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */,
 			);
@@ -7607,7 +7607,7 @@
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
-				2662D90A26E16B3600E25611 /* FilterListCountrySelector.swift in Sources */,
+				2662D90A26E16B3600E25611 /* FilterListSelector.swift in Sources */,
 				314265B12645A07800500598 /* CardReaderSettingsConnectedViewController.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,


### PR DESCRIPTION
closes #4779

# Why

This PR adds a navigation link from the `AddressForm` screen to the `StateSelector` screen to continue adding more functionality to the edit a shipping address.

# How

- Refactor `CountryListSelector` to receive a generic `ViewModel` protocol instead of a specific `CountrySelectorViewModel`

- Created `StateSelectorViewModel` and `StateSelectorCommand` 

- Added a navigation link from  `AddressForm` screen to the `ListSelector` view with the `StateSelectorViewModel` value.

# Demo

https://user-images.githubusercontent.com/562080/132261022-8ee00ddc-f323-4533-9e6a-b183907c44f5.mov

# Testing Steps

- Navigate to an order and tap on the shipping address edit icon.
- Tap in the "select country" row and see that everything works as expected
- Go back and tap in the "select state" row and see that everything works as expected.

Note: States, for now, are just a copy of countries content. real values will be fetched in #4780 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
