### PR TITLE
[Mobile Payments] Update turn-on-your-reader prompt to avoid unwanted power off

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -47,7 +47,7 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let instruction = NSLocalizedString(
-            "Press the power button of your reader until you see a flashing blue light",
+            "To turn on your card reader, briefly press its power button",
             comment: "Label within the modal dialog that appears when searching for a card reader"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -47,7 +47,7 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let instruction = NSLocalizedString(
-            "To turn on your card reader, briefly press its power button",
+            "To turn on your card reader, briefly press its power button. When powered on, the power LED will blink blue.",
             comment: "Label within the modal dialog that appears when searching for a card reader"
         )
 


### PR DESCRIPTION
Closes #4668 

Changes:
- Updates the prompt displayed when searching for readers to avoid suggesting the user hold down the button for an extended period (which may result in powering off a reader during discovery)

Related Android issue:


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
