### PR TITLE
Order Editing: Display supported countries on  Country List Selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 
+/// Protocol required to re-render the view when the command updates any of it's content.
+///
+protocol ObservableCommand: ListSelectorCommand, ObservableObject {}
+
 /// `SwiftUI` wrapper for `ListSelectorViewController`
 ///
-struct ListSelector<Command: ListSelectorCommand>: UIViewControllerRepresentable {
+struct ListSelector<Command: ObservableCommand>: UIViewControllerRepresentable {
 
     /// Command that defines cell style and provide data.
     ///
-    let command: Command
+    @ObservedObject var command: Command
 
     /// Table view style.
     ///

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelector.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 /// Protocol required to re-render the view when the command updates any of it's content.
 ///
-protocol ObservableCommand: ListSelectorCommand, ObservableObject {}
+protocol ObservableListSelectorCommand: ListSelectorCommand, ObservableObject {}
 
 /// `SwiftUI` wrapper for `ListSelectorViewController`
 ///
-struct ListSelector<Command: ObservableCommand>: UIViewControllerRepresentable {
+struct ListSelector<Command: ObservableListSelectorCommand>: UIViewControllerRepresentable {
 
     /// Command that defines cell style and provide data.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Command to be used to select a country when editing addresses.
 ///
-final class CountrySelectorCommand: ObservableCommand {
+final class CountrySelectorCommand: ObservableListSelectorCommand {
     typealias Model = Country
     typealias Cell = BasicTableViewCell
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -23,7 +23,7 @@ final class CountrySelectorCommand: ListSelectorCommand {
     ///
     let navigationBarTitle: String? = ""
 
-    init(countries: [Country] = temporaryCountries, selected: Country? = nil) {
+    init(countries: [Country], selected: Country? = nil) {
         self.countries = countries
         self.data = countries
         self.selected = selected
@@ -50,17 +50,4 @@ final class CountrySelectorCommand: ListSelectorCommand {
 
         data = countries.filter { $0.name.localizedCaseInsensitiveContains(term) }
     }
-}
-
-// MARK: Temporary Methods
-extension CountrySelectorCommand {
-
-    // Supported countries will come from the view model later.
-    //
-    private static let temporaryCountries: [Country] = {
-        return Locale.isoRegionCodes.map { regionCode in
-            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
-            return Country(code: regionCode, name: name, states: [])
-        }
-    }()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -3,17 +3,17 @@ import Yosemite
 
 /// Command to be used to select a country when editing addresses.
 ///
-final class CountrySelectorCommand: ListSelectorCommand {
+final class CountrySelectorCommand: ListSelectorCommand, ObservableObject {
     typealias Model = Country
     typealias Cell = BasicTableViewCell
 
     /// Original array of countries.
     ///
-    private let countries: [Country]
+    private var countries: [Country]
 
     /// Data to display
     ///
-    private(set) var data: [Country]
+    @Published private(set) var data: [Country]
 
     /// Current selected country
     ///
@@ -39,6 +39,13 @@ final class CountrySelectorCommand: ListSelectorCommand {
 
     func configureCell(cell: BasicTableViewCell, model: Country) {
         cell.textLabel?.text = model.name
+    }
+
+    /// Resets countries data.
+    ///
+    func resetCountries(_ countries: [Country]) {
+        self.countries = countries
+        self.data = countries
     }
 
     /// Filter available countries that contains a given search term.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Command to be used to select a country when editing addresses.
 ///
-final class CountrySelectorCommand: ListSelectorCommand, ObservableObject {
+final class CountrySelectorCommand: ObservableCommand {
     typealias Model = Country
     typealias Cell = BasicTableViewCell
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -17,14 +17,7 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
 
     /// Command that powers the `ListSelector` view.
     ///
-    private(set) var command = CountrySelectorCommand(countries: [])
-
-    /// ResultsController for stored countries.
-    ///
-    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
-        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
-    }()
+    let command = CountrySelectorCommand(countries: [])
 
     /// Navigation title
     ///
@@ -33,6 +26,13 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     /// Filter text field placeholder
     ///
     let filterPlaceholder = Localization.placeholder
+
+    /// ResultsController for stored countries.
+    ///
+    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
+        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
+        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
+    }()
 
     /// Storage to fetch countries
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -17,7 +17,7 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
 
     /// Command that powers the `ListSelector` view.
     ///
-    @Published private(set) var command = CountrySelectorCommand(countries: [])
+    private(set) var command = CountrySelectorCommand(countries: [])
 
     /// ResultsController for stored countries.
     ///
@@ -68,8 +68,10 @@ private extension CountrySelectorViewModel {
         // Initial fetch
         try? countriesResultsController.performFetch()
 
-        // Sync countries if needed
-        if countriesResultsController.isEmpty {
+        // Reset countries with fetched data or sync countries if needed.
+        if !countriesResultsController.isEmpty {
+            command.resetCountries(countriesResultsController.fetchedObjects)
+        } else {
             let action = DataAction.synchronizeCountries(siteID: siteID, onCompletion: { _ in })
             stores.dispatch(action)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -12,17 +12,12 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     var searchTerm: String = "" {
         didSet {
             command.filterCountries(term: searchTerm)
-            objectWillChange.send()
         }
     }
 
     /// Command that powers the `ListSelector` view.
     ///
-    private(set) var command = CountrySelectorCommand(countries: []) {
-        didSet {
-            objectWillChange.send()
-        }
-    }
+    @Published private(set) var command = CountrySelectorCommand(countries: [])
 
     /// ResultsController for stored countries.
     ///
@@ -67,7 +62,7 @@ private extension CountrySelectorViewModel {
         // Bind stored countries & command
         countriesResultsController.onDidChangeContent = { [weak self] in
             guard let self = self else { return }
-            self.command = CountrySelectorCommand(countries: self.countriesResultsController.fetchedObjects)
+            self.command.resetCountries(self.countriesResultsController.fetchedObjects)
         }
 
         // Initial fetch

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,5 +1,7 @@
 import Combine
 import SwiftUI
+import Yosemite
+import protocol Storage.StorageManagerType
 
 /// View Model for the `CountrySelector` view.
 ///
@@ -14,6 +16,18 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
         }
     }
 
+    /// ResultsController for stored countries, updates command with new content.
+    ///
+    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
+        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
+        let resultsController = ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
+
+        resultsController.onDidChangeContent = {
+            // TODO: Update command
+        }
+        return resultsController
+    }()
+
     /// Command that powers the `ListSelector` view.
     ///
     let command = CountrySelectorCommand()
@@ -25,6 +39,14 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     /// Filter text field placeholder
     ///
     let filterPlaceholder = Localization.placeholder
+
+    /// Storage to fetch Countries
+    ///
+    private let storageManager: StorageManagerType
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.storageManager = storageManager
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -136,8 +136,7 @@ struct EditAddressForm: View {
         .disabled(!viewModel.isDoneButtonEnabled))
 
         // Go to edit country
-        // TODO: Move `CountrySelectorViewModel` creation to the VM when it exists.
-        NavigationLink(destination: FilterListSelector(viewModel: CountrySelectorViewModel()), isActive: $showCountrySelector) {
+        NavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
             EmptyView()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -190,13 +190,13 @@ struct EditAddressForm_Previews: PreviewProvider {
                                        company: nil,
                                        address1: "234 70th Street",
                                        address2: nil,
-                                       city: "Niagara Falls",
+                                       city: "Niagara Fallsgs",
                                        state: "NY",
                                        postcode: "14304",
                                        country: "US",
                                        phone: "333-333-3333",
                                        email: "scrambled@scrambled.com")
-    static let sampleViewModel = EditAddressFormViewModel(address: sampleAddress)
+    static let sampleViewModel = EditAddressFormViewModel(siteID: 123, address: sampleAddress)
 
     static var previews: some View {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -190,7 +190,7 @@ struct EditAddressForm_Previews: PreviewProvider {
                                        company: nil,
                                        address1: "234 70th Street",
                                        address2: nil,
-                                       city: "Niagara Fallsgs",
+                                       city: "Niagara Falls",
                                        state: "NY",
                                        postcode: "14304",
                                        country: "US",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -2,7 +2,12 @@ import Yosemite
 
 final class EditAddressFormViewModel: ObservableObject {
 
-    init(address: Address?) {
+    /// Current site ID
+    ///
+    private let siteID: Int64
+
+    init(siteID: Int64, address: Address?) {
+        self.siteID = siteID
         self.originalAddress = address ?? .empty
         updateFieldsWithOriginalAddress()
     }
@@ -37,7 +42,7 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Creates a view model to be used when selecting a country
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {
-        CountrySelectorViewModel()
+        CountrySelectorViewModel(siteID: siteID)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -33,6 +33,12 @@ final class EditAddressFormViewModel: ObservableObject {
     var isDoneButtonEnabled: Bool {
         return originalAddress != addressFromFields
     }
+
+    /// Creates a view model to be used when selecting a country
+    ///
+    func createCountryViewModel() -> CountrySelectorViewModel {
+        CountrySelectorViewModel()
+    }
 }
 
 private extension EditAddressFormViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -85,11 +85,3 @@ private extension SearchHeader {
         static let externalPadding = EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
     }
 }
-
-struct FilterListSelector_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            FilterListSelector(viewModel: CountrySelectorViewModel())
-        }
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 protocol FilterListSelectorViewModelable: ObservableObject {
 
-    associatedtype Command: ObservableCommand
+    associatedtype Command: ObservableListSelectorCommand
 
     /// Binding variable for the filter search term
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 protocol FilterListSelectorViewModelable: ObservableObject {
 
-    associatedtype Command: ListSelectorCommand
+    associatedtype Command: ObservableCommand
 
     /// Binding variable for the filter search term
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Command to be used to select a state when editing addresses.
 ///
-final class StateSelectorCommand: ListSelectorCommand {
+final class StateSelectorCommand: ObservableCommand {
     typealias Model = StateOfACountry
     typealias Cell = BasicTableViewCell
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Command to be used to select a state when editing addresses.
 ///
-final class StateSelectorCommand: ObservableCommand {
+final class StateSelectorCommand: ObservableListSelectorCommand {
     typealias Model = StateOfACountry
     typealias Cell = BasicTableViewCell
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -661,7 +661,7 @@ private extension OrderDetailsViewController {
     }
 
     func editShippingAddressTapped() {
-        let viewModel = EditAddressFormViewModel(address: viewModel.order.shippingAddress)
+        let viewModel = EditAddressFormViewModel(siteID: viewModel.order.siteID, address: viewModel.order.shippingAddress)
         let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
         show(editAddressViewController, sender: self)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -47,7 +47,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
         // When
         viewModel.searchTerm = "CO"
         let countries = viewModel.command.data.map { $0.name }
-        
+
         // Then
         assertEqual(countries, [
             "Cocos (Keeling) Islands",
@@ -77,6 +77,28 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.command.data.count, totalNumberOfCountries)
+    }
+
+    func test_starting_view_model_without_stored_countries_fetches_them_remotely() {
+        // Given
+        testingStorage.reset()
+        let testingStores = MockStoresManager(sessionManager: .testingInstance)
+
+
+        // When
+        let countriesFetched: Bool = waitFor { promise in
+            testingStores.whenReceivingAction(ofType: DataAction.self) { action in
+                switch action {
+                case .synchronizeCountries:
+                    promise(true)
+                }
+            }
+
+            _ = CountrySelectorViewModel(siteID: self.sampleSiteID, storageManager: self.testingStorage, stores: testingStores)
+        }
+
+        // Then
+        XCTAssertTrue(countriesFetched)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -5,25 +5,36 @@ import TestKit
 
 final class CountrySelectorViewModelTests: XCTestCase {
 
+    let sampleSiteID: Int64 = 123
+    let testingStorage = MockStorageManager()
+
+    override func setUp () {
+        super.setUp()
+
+        testingStorage.reset()
+        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
+    }
+
     func test_filter_countries_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel()
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
 
         // When
         viewModel.searchTerm = "Co"
         let countries = viewModel.command.data.map { $0.name }
+
         // Then
         assertEqual(countries, [
             "Cocos (Keeling) Islands",
-            "Congo - Kinshasa",
-            "Congo - Brazzaville",
-            "Cook Islands",
             "Colombia",
-            "Costa Rica",
             "Comoros",
-            "Morocco",
-            "Monaco",
+            "Congo - Brazzaville",
+            "Congo - Kinshasa",
+            "Cook Islands",
+            "Costa Rica",
             "Mexico",
+            "Monaco",
+            "Morocco",
             "Puerto Rico",
             "Turks & Caicos Islands"
         ])
@@ -31,23 +42,24 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_filter_countries_with_uppercase_letters_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel()
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
 
         // When
         viewModel.searchTerm = "CO"
         let countries = viewModel.command.data.map { $0.name }
+        
         // Then
         assertEqual(countries, [
             "Cocos (Keeling) Islands",
-            "Congo - Kinshasa",
-            "Congo - Brazzaville",
-            "Cook Islands",
             "Colombia",
-            "Costa Rica",
             "Comoros",
-            "Morocco",
-            "Monaco",
+            "Congo - Brazzaville",
+            "Congo - Kinshasa",
+            "Cook Islands",
+            "Costa Rica",
             "Mexico",
+            "Monaco",
+            "Morocco",
             "Puerto Rico",
             "Turks & Caicos Islands"
         ])
@@ -55,7 +67,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_cleaning_search_terms_return_all_countries() {
         // Given
-        let viewModel = CountrySelectorViewModel()
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
         let totalNumberOfCountries = viewModel.command.data.count
 
         // When
@@ -66,4 +78,14 @@ final class CountrySelectorViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.command.data.count, totalNumberOfCountries)
     }
+}
+
+// MARK: Helpers
+private extension CountrySelectorViewModelTests {
+    static let sampleCountries: [Country] = {
+        return Locale.isoRegionCodes.map { regionCode in
+            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
+            return Country(code: regionCode, name: name, states: [])
+        }
+    }()
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -5,10 +5,12 @@ import TestKit
 
 final class EditAddressFormViewModelTests: XCTestCase {
 
+    let sampleSiteID: Int64 = 123
+
     func test_creating_with_address_prefills_fields_with_correct_data() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
 
         // Then
         XCTAssertEqual(viewModel.firstName, address.firstName)
@@ -28,7 +30,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_updating_fields_enables_done_button() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
         XCTAssertFalse(viewModel.isDoneButtonEnabled)
 
         // When
@@ -41,7 +43,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_updating_fields_back_to_original_values_disables_done_button() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
         XCTAssertFalse(viewModel.isDoneButtonEnabled)
 
         // When
@@ -56,7 +58,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
     func test_creating_without_address_disables_done_button() {
         // Given
-        let viewModel = EditAddressFormViewModel(address: nil)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: nil)
 
         // Then
         XCTAssertFalse(viewModel.isDoneButtonEnabled)
@@ -65,7 +67,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_creating_with_address_with_empty_nullable_fields_disables_done_button() {
         // Given
         let address = sampleAddressWithEmptyNullableFields()
-        let viewModel = EditAddressFormViewModel(address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
 
         // Then
         XCTAssertFalse(viewModel.isDoneButtonEnabled)

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -150,4 +150,16 @@ extension MockStorageManager {
 
         return newSetting
     }
+
+    /// Inserts new sample countries into the specified context.
+    ///
+    @discardableResult
+    func insertSampleCountries(readOnlyCountries: [Country]) -> [StorageCountry] {
+        let storedCountries: [StorageCountry] = readOnlyCountries.map { readOnlyCountry in
+            let newCountry = viewStorage.insertNewObject(ofType: StorageCountry.self)
+            newCountry.update(with: readOnlyCountry)
+            return newCountry
+        }
+        return storedCountries
+    }
 }


### PR DESCRIPTION
part of #4780

# Why

Country Selector UI was introduced in #4779 by showing a list of hardcoded countries. This PR refactors the `ViewModel` in order to show the WC-supported countries that exist in our `CoreData` store.

Additionally, if the `ViewModel` detects that no country is stored, it will proceed to sync them from a remote source.

# How

- Update `CountrySelectorCommand` so it it's internal data(countries) can be modified. This also forced me to make the command an `ObservableObject` so the `ListSelector` view can render new content when the command data changes.

- Update `CountrySelectorViewModel` to query countries from a `ResultsController`. If we detect that there are no countries stored, then sync them via the `syncCountries` Data Action.

# Demo

https://user-images.githubusercontent.com/562080/132451857-5956a05b-b52f-4b26-82e3-7f6eb45f2070.mov


# Testing Steps

- Logout & login to guarantee a fresh store
- Navigate to an order and tap on the shipping address edit icon
- Tap on "select country" row.
- See that the correct countries are being displayed.

# Known issues & Next PRs

- Add a loading state while the VM is syncing countries
- Search term is persisted between navigations 
- Render currently selected country

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
