### PR TITLE
Shipping Labels: Create/activate new package on Add New Package screen

### DIFF
--- a/Fakes/Fakes/Fakes.generated.swift
+++ b/Fakes/Fakes/Fakes.generated.swift
@@ -1179,6 +1179,7 @@ extension ShippingLabelPredefinedOption {
     public static func fake() -> ShippingLabelPredefinedOption {
         .init(
             title: .fake(),
+            providerID: .fake(),
             predefinedPackages: .fake()
         )
     }

--- a/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/Predefined package/ShippingLabelPredefinedOption.swift
@@ -8,12 +8,16 @@ public struct ShippingLabelPredefinedOption: Equatable, GeneratedFakeable {
     /// The title of the predefined option. It works like an ID, and it is unique.
     public let title: String
 
+    /// The ID of the predefined option (shipping provider), e.g. "usps". This is required for activating predefined packages remotely.
+    public let providerID: String
+
     /// List of predefined packages
     public let predefinedPackages: [ShippingLabelPredefinedPackage]
 
 
-    public init(title: String, predefinedPackages: [ShippingLabelPredefinedPackage]) {
+    public init(title: String, providerID: String, predefinedPackages: [ShippingLabelPredefinedPackage]) {
         self.title = title
+        self.providerID = providerID
         self.predefinedPackages = predefinedPackages
     }
 }
@@ -25,12 +29,14 @@ extension ShippingLabelPredefinedOption: Decodable {
 
         let title = try container.decode(String.self, forKey: .title)
         let predefinedPackages = try container.decodeIfPresent([ShippingLabelPredefinedPackage].self, forKey: .predefinedPackages) ?? []
+        let providerID = try container.decodeIfPresent(String.self, forKey: .providerID) ?? ""
 
-        self.init(title: title, predefinedPackages: predefinedPackages)
+        self.init(title: title, providerID: providerID, predefinedPackages: predefinedPackages)
     }
 
     private enum CodingKeys: String, CodingKey {
         case title
         case predefinedPackages
+        case providerID
     }
 }

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -67,7 +67,7 @@ extension ShippingLabelPackagesResponse: Decodable {
 
                 if !activatedPredefinedPackages.isEmpty {
                     let titleOption: String = providerValueDict?["title"] as? String ?? ""
-                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: activatedPredefinedPackages)
+                    let option = ShippingLabelPredefinedOption(title: titleOption, providerID: key, predefinedPackages: activatedPredefinedPackages)
                     predefinedOptions.append(option)
                 }
 
@@ -75,7 +75,7 @@ extension ShippingLabelPackagesResponse: Decodable {
 
                 if !unactivatedPredefinedPackages.isEmpty {
                     let titleOption: String = providerValueDict?["title"] as? String ?? ""
-                    let option = ShippingLabelPredefinedOption(title: titleOption, predefinedPackages: unactivatedPredefinedPackages)
+                    let option = ShippingLabelPredefinedOption(title: titleOption, providerID: key, predefinedPackages: unactivatedPredefinedPackages)
                     unactivatedPredefinedOptions.append(option)
                 }
             })

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -335,7 +335,10 @@ private extension ShippingLabelRemote {
         static let emailReceipt = "email_receipt"
         static let async = "async"
     }
+}
 
+// MARK: Errors {
+extension ShippingLabelRemote {
     enum ShippingLabelError: Error {
         case missingPackage
     }

--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -142,11 +142,12 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
                               predefinedOption: ShippingLabelPredefinedOption?,
                               completion: @escaping (Result<Bool, Error>) -> Void) {
         do {
-            var customPackageDictionary: [String: Any] = [:]
+            var customPackageList: [[String: Any]] = []
             var predefinedOptionDictionary: [String: [String]] = [:]
 
             if let customPackage = customPackage {
-                customPackageDictionary = try customPackage.toDictionary()
+                let customPackageDictionary = try customPackage.toDictionary()
+                customPackageList = [customPackageDictionary]
             } else if let predefinedOption = predefinedOption {
                 let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
                 predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
@@ -155,7 +156,7 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
             }
 
             let parameters: [String: Any] = [
-                ParameterKey.custom: [customPackageDictionary],
+                ParameterKey.custom: customPackageList,
                 ParameterKey.predefined: predefinedOptionDictionary
             ]
             let path = Path.packages

--- a/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingLabelPackagesMapperTests.swift
@@ -72,6 +72,7 @@ private extension ShippingLabelPackagesMapperTests {
                                                                  isLetter: false,
                                                                  dimensions: "28.57 x 22.22 x 15.24")]
         let predefinedOption1 = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                              providerID: "usps",
                                                               predefinedPackages: predefinedPackages1)
 
         let predefinedPackages2 = [ShippingLabelPredefinedPackage(id: "LargePaddedPouch",
@@ -79,6 +80,7 @@ private extension ShippingLabelPackagesMapperTests {
                                                                   isLetter: true,
                                                                   dimensions: "30.22 x 35.56 x 2.54")]
         let predefinedOption2 = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              providerID: "dhlexpress",
                                                               predefinedPackages: predefinedPackages2)
 
         return [predefinedOption1, predefinedOption2]
@@ -106,7 +108,8 @@ private extension ShippingLabelPackagesMapperTests {
                                                                  isLetter: false,
                                                                  dimensions: "44.45 x 31.75 x 7.62")]
         let predefinedOption = ShippingLabelPredefinedOption(title: "DHL Express",
-                                                              predefinedPackages: predefinedPackages)
+                                                             providerID: "dhlexpress",
+                                                             predefinedPackages: predefinedPackages)
 
         return predefinedOption
     }

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -201,6 +201,44 @@ final class ShippingLabelRemoteTests: XCTestCase {
         XCTAssertTrue(successResponse)
     }
 
+    func test_createPackage_returns_success_response_with_only_custom_package() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "generic_success_data")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: ShippingLabelCustomPackage.fake(),
+                                 predefinedOption: nil) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        XCTAssertTrue(successResponse)
+    }
+
+    func test_createPackage_returns_success_response_with_only_service_package() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "packages", filename: "generic_success_data")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: nil,
+                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let successResponse = try XCTUnwrap(result.get())
+        XCTAssertTrue(successResponse)
+    }
+
     func test_createPackage_returns_error_on_failure() throws {
         // Given
         let remote = ShippingLabelRemote(network: network)
@@ -222,7 +260,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         XCTAssertEqual(result.failure as? DotcomError, expectedError)
     }
 
-    func test_createPackage_returns_missingPackage_error() throws {
+    func test_createPackage_returns_missingPackage_error_with_no_packages() throws {
         // Given
         let remote = ShippingLabelRemote(network: network)
 

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -189,7 +189,9 @@ final class ShippingLabelRemoteTests: XCTestCase {
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            remote.createPackage(siteID: self.sampleSiteID, customPackage: self.sampleShippingLabelCustomPackage()) { result in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: ShippingLabelCustomPackage.fake(),
+                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
                 promise(result)
             }
         }
@@ -206,7 +208,9 @@ final class ShippingLabelRemoteTests: XCTestCase {
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in
-            remote.createPackage(siteID: self.sampleSiteID, customPackage: self.sampleShippingLabelCustomPackage()) { result in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: ShippingLabelCustomPackage.fake(),
+                                 predefinedOption: ShippingLabelPredefinedOption.fake()) { result in
                 promise(result)
             }
         }
@@ -216,6 +220,24 @@ final class ShippingLabelRemoteTests: XCTestCase {
             .unknown(code: "duplicate_custom_package_names_of_existing_packages",
                      message: "At least one of the new custom packages has the same name as existing packages.")
         XCTAssertEqual(result.failure as? DotcomError, expectedError)
+    }
+
+    func test_createPackage_returns_missingPackage_error() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.createPackage(siteID: self.sampleSiteID,
+                                 customPackage: nil,
+                                 predefinedOption: nil) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let expectedError = ShippingLabelRemote.ShippingLabelError.missingPackage
+        XCTAssertEqual(result.failure as? ShippingLabelRemote.ShippingLabelError, expectedError)
     }
 
     func test_loadCarriersAndRates_parses_success_response() throws {
@@ -469,15 +491,6 @@ private extension ShippingLabelRemoteTests {
                                     address2: "",
                                     city: "SAN FRANCISCO",
                                     postcode: "94110-4929")
-    }
-
-    func sampleShippingLabelCustomPackage() -> ShippingLabelCustomPackage {
-        return ShippingLabelCustomPackage(isUserDefined: true,
-                                          title: "Test Package",
-                                          isLetter: false,
-                                          dimensions: "10 x 10 x 10",
-                                          boxWeight: 5,
-                                          maxWeight: 1)
     }
 
     func sampleShippingLabelCarrierRate() -> ShippingLabelCarrierRate {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -42,14 +42,15 @@ struct ShippingLabelAddNewPackage: View {
                 // Done button
                 ToolbarItem(placement: .navigationBarTrailing, content: {
                     Button(action: {
-                        isSyncing = true
                         switch viewModel.selectedView {
                         case .customPackage:
                             viewModel.customPackageVM.validatePackage()
                             if viewModel.customPackageVM.validatedCustomPackage != nil {
+                                isSyncing = true
                                 viewModel.createCustomPackage()
                             }
                         case .servicePackage:
+                            isSyncing = true
                             viewModel.activateServicePackage()
                         }
                     }, label: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -61,13 +61,15 @@ struct ShippingLabelAddNewPackage: View {
                         }
                     })
                     .disabled(isSyncing)
-                    .onReceive(viewModel.$dismissView, perform: { dismiss in
-                        if dismiss {
+                    .onAppear() {
+                        // Dismiss the view after API calls are finished
+                        viewModel.$dismissView.sink { dismiss in
+                            guard dismiss else { return }
                             viewModel.dismissView = false
                             isSyncing = false
                             presentation.wrappedValue.dismiss()
-                        }
-                    })
+                        }.cancel()
+                    }
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -45,13 +45,20 @@ struct ShippingLabelAddNewPackage: View {
                         switch viewModel.selectedView {
                         case .customPackage:
                             viewModel.customPackageVM.validatePackage()
-                            if viewModel.customPackageVM.validatedCustomPackage != nil {
-                                isSyncing = true
-                                viewModel.createCustomPackage()
+                            guard viewModel.customPackageVM.validatedCustomPackage != nil else { return }
+                            isSyncing = true
+                            viewModel.createCustomPackage() { success in
+                                isSyncing = false
+                                guard success else { return }
+                                presentation.wrappedValue.dismiss()
                             }
                         case .servicePackage:
                             isSyncing = true
-                            viewModel.activateServicePackage()
+                            viewModel.activateServicePackage() { success in
+                                isSyncing = false
+                                guard success else { return }
+                                presentation.wrappedValue.dismiss()
+                            }
                         }
                     }, label: {
                         if isSyncing {
@@ -62,15 +69,6 @@ struct ShippingLabelAddNewPackage: View {
                         }
                     })
                     .disabled(isSyncing)
-                    .onAppear() {
-                        // Dismiss the view after API calls are finished
-                        viewModel.$dismissView.sink { dismiss in
-                            guard dismiss else { return }
-                            viewModel.dismissView = false
-                            isSyncing = false
-                            presentation.wrappedValue.dismiss()
-                        }.cancel()
-                    }
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -8,7 +8,12 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     private let stores: StoresManager
     private let siteID: Int64
 
+    /// Index of the selected tab
+    ///
     @Published var selectedIndex: Int
+
+    /// View for the selected tab
+    ///
     var selectedView: PackageViewType {
         PackageViewType(rawValue: selectedIndex) ?? .customPackage
     }
@@ -17,12 +22,20 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     var customPackageVM = ShippingLabelCustomPackageFormViewModel()
     lazy var servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
 
+    /// Package selected on the Custom Package tab
+    ///
     private var validatedCustomPackage: ShippingLabelCustomPackage? {
         customPackageVM.validatedCustomPackage
     }
+
+    /// Package selected on the Service Package tab
+    ///
     private var selectedServicePackage: ShippingLabelPredefinedPackage? {
         servicePackageVM.selectedPackage
     }
+
+    /// Package details fetched from the API
+    ///
     private var packagesResponse: ShippingLabelPackagesResponse?
 
     /// Completion callback
@@ -63,6 +76,8 @@ extension ShippingLabelAddNewPackageViewModel {
 
         createPackage(customPackage: newCustomPackage) { [weak self] success in
             onCompletion(success)
+
+            // On success, reset tab state and save new package details
             guard success else { return }
             self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self?.onCompletion(newCustomPackage, nil, self?.packagesResponse)
@@ -84,6 +99,8 @@ extension ShippingLabelAddNewPackageViewModel {
 
         createPackage(predefinedOption: selectedOption) { [weak self] success in
             onCompletion(success)
+
+            // On success, reset tab state and save new package details
             guard success else { return }
             self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self?.servicePackageVM.packagesResponse = self?.packagesResponse

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -19,8 +19,8 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     }
 
     // View models for child views (tabs)
-    var customPackageVM = ShippingLabelCustomPackageFormViewModel()
-    lazy var servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
+    private(set) var customPackageVM = ShippingLabelCustomPackageFormViewModel()
+    private(set) var servicePackageVM: ShippingLabelServicePackageListViewModel
 
     /// Package selected on the Custom Package tab
     ///
@@ -53,6 +53,7 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
         self.selectedIndex = selectedIndex
         self.stores = stores
         self.siteID = siteID
+        self.servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
         self.packagesResponse = packagesResponse
         self.onCompletion = onCompletion
     }
@@ -103,7 +104,7 @@ extension ShippingLabelAddNewPackageViewModel {
             // On success, reset tab state and save new package details
             guard let self = self, success else { return }
             self.customPackageVM = ShippingLabelCustomPackageFormViewModel()
-            self.servicePackageVM.packagesResponse = self.packagesResponse
+            self.servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: self.packagesResponse)
             self.onCompletion(nil, selectedServicePackage, self.packagesResponse)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -127,7 +127,7 @@ private extension ShippingLabelAddNewPackageViewModel {
                                                        customPackage: customPackage,
                                                        predefinedOption: predefinedOption) { result in
             switch result {
-            case .success(_):
+            case .success:
                 self.syncPackageDetails() { success in
                     onCompletion?(success)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -5,6 +5,9 @@ import Yosemite
 /// View model for `ShippingLabelAddNewPackage`.
 ///
 final class ShippingLabelAddNewPackageViewModel: ObservableObject {
+    private let stores: StoresManager
+    private let siteID: Int64
+
     @Published var selectedIndex: Int
     var selectedView: PackageViewType {
         PackageViewType(rawValue: selectedIndex) ?? .customPackage
@@ -12,16 +15,140 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
 
     // View models for child views (tabs)
     let customPackageVM = ShippingLabelCustomPackageFormViewModel()
-    let servicePackageVM: ShippingLabelServicePackageListViewModel
+    lazy var servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
+
+    private var validatedCustomPackage: ShippingLabelCustomPackage? {
+        customPackageVM.validatedCustomPackage
+    }
+    private var selectedServicePackage: ShippingLabelPredefinedPackage? {
+        servicePackageVM.selectedPackage
+    }
+    private var packagesResponse: ShippingLabelPackagesResponse?
+
+    @Published var dismissView = false
+    @Published var showLoadingIndicator = false
+
+    /// Completion callback
+    ///
+    typealias Completion = (_ customPackage: ShippingLabelCustomPackage? ,
+                            _ servicePackage: ShippingLabelPredefinedPackage? ,
+                            _ packagesResponse: ShippingLabelPackagesResponse?) -> Void
+    let onCompletion: Completion
 
     init(_ selectedIndex: Int = PackageViewType.customPackage.rawValue,
-         packagesResponse: ShippingLabelPackagesResponse?) {
+         stores: StoresManager = ServiceLocator.stores,
+         siteID: Int64,
+         packagesResponse: ShippingLabelPackagesResponse?,
+         onCompletion: @escaping Completion) {
         self.selectedIndex = selectedIndex
-        self.servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
+        self.stores = stores
+        self.siteID = siteID
+        self.packagesResponse = packagesResponse
+        self.onCompletion = onCompletion
     }
 
     enum PackageViewType: Int {
         case customPackage = 0
         case servicePackage = 1
+    }
+}
+
+// MARK: - Helper methods
+extension ShippingLabelAddNewPackageViewModel {
+
+    /// Creates the custom package remotely and updates the package details to select the new package
+    ///
+    func createCustomPackage() {
+        guard let newCustomPackage = validatedCustomPackage else {
+            return
+        }
+
+        let group = DispatchGroup()
+
+        group.enter()
+        showLoadingIndicator = true
+        createPackage(customPackage: newCustomPackage) { [weak self] in
+            group.enter()
+            self?.syncPackageDetails() {
+                group.leave()
+            }
+            group.leave()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            self?.showLoadingIndicator = false
+            self?.dismissView = true
+            self?.onCompletion(newCustomPackage, nil, self?.packagesResponse)
+        }
+    }
+
+    /// Activates the selected service package remotely and updates the package details to select the new package
+    ///
+    func activateServicePackage() {
+        guard let selectedServicePackage = selectedServicePackage,
+              let shippingProvider = servicePackageVM.predefinedOptions.first(where: { $0.predefinedPackages.contains(selectedServicePackage) } ) else {
+            return
+        }
+
+        let selectedOption = ShippingLabelPredefinedOption(title: shippingProvider.title,
+                                                           providerID: shippingProvider.providerID,
+                                                           predefinedPackages: [selectedServicePackage])
+
+        let group = DispatchGroup()
+
+        group.enter()
+        createPackage(predefinedOption: selectedOption) { [weak self] in
+            group.enter()
+            self?.syncPackageDetails() {
+                group.leave()
+            }
+            group.leave()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            self?.dismissView = true
+            self?.onCompletion(nil, selectedServicePackage, self?.packagesResponse)
+        }
+    }
+}
+
+// MARK: - API Requests
+private extension ShippingLabelAddNewPackageViewModel {
+
+    /// Creates a custom package or activates a predefined option remotely
+    ///
+    func createPackage(customPackage: ShippingLabelCustomPackage? = nil,
+                       predefinedOption: ShippingLabelPredefinedOption? = nil,
+                       onCompletion: (() -> Void)? = nil) {
+        guard customPackage != nil || predefinedOption != nil else {
+            return
+        }
+
+        let action = ShippingLabelAction.createPackage(siteID: siteID,
+                                                       customPackage: customPackage,
+                                                       predefinedOption: predefinedOption) { result in
+            switch result {
+            case .success(_):
+                break
+            case .failure(let error):
+                DDLogError("⛔️ Error creating package: \(error.localizedDescription)")
+            }
+            onCompletion?()
+        }
+        stores.dispatch(action)
+    }
+
+    func syncPackageDetails(onCompletion: (() -> Void)? = nil) {
+        let action = ShippingLabelAction.packagesDetails(siteID: siteID) { result in
+            switch result {
+            case .success(let value):
+                self.packagesResponse = value
+            case .failure:
+                DDLogError("⛔️ Error synchronizing package details")
+                return
+            }
+            onCompletion?()
+        }
+        stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -26,7 +26,6 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     private var packagesResponse: ShippingLabelPackagesResponse?
 
     @Published var dismissView = false
-    @Published var showLoadingIndicator = false
 
     /// Completion callback
     ///
@@ -66,7 +65,6 @@ extension ShippingLabelAddNewPackageViewModel {
         let group = DispatchGroup()
 
         group.enter()
-        showLoadingIndicator = true
         createPackage(customPackage: newCustomPackage) { [weak self] in
             group.enter()
             self?.syncPackageDetails() {
@@ -76,7 +74,6 @@ extension ShippingLabelAddNewPackageViewModel {
         }
 
         group.notify(queue: .main) { [weak self] in
-            self?.showLoadingIndicator = false
             self?.dismissView = true
             self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self?.onCompletion(newCustomPackage, nil, self?.packagesResponse)
@@ -107,7 +104,6 @@ extension ShippingLabelAddNewPackageViewModel {
         }
 
         group.notify(queue: .main) { [weak self] in
-            self?.showLoadingIndicator = false
             self?.dismissView = true
             self?.servicePackageVM.packagesResponse = self?.packagesResponse
             self?.onCompletion(nil, selectedServicePackage, self?.packagesResponse)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -14,7 +14,7 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     }
 
     // View models for child views (tabs)
-    let customPackageVM = ShippingLabelCustomPackageFormViewModel()
+    var customPackageVM = ShippingLabelCustomPackageFormViewModel()
     lazy var servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: packagesResponse)
 
     private var validatedCustomPackage: ShippingLabelCustomPackage? {
@@ -78,6 +78,7 @@ extension ShippingLabelAddNewPackageViewModel {
         group.notify(queue: .main) { [weak self] in
             self?.showLoadingIndicator = false
             self?.dismissView = true
+            self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self?.onCompletion(newCustomPackage, nil, self?.packagesResponse)
         }
     }
@@ -106,7 +107,9 @@ extension ShippingLabelAddNewPackageViewModel {
         }
 
         group.notify(queue: .main) { [weak self] in
+            self?.showLoadingIndicator = false
             self?.dismissView = true
+            self?.servicePackageVM.packagesResponse = self?.packagesResponse
             self?.onCompletion(nil, selectedServicePackage, self?.packagesResponse)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -78,9 +78,9 @@ extension ShippingLabelAddNewPackageViewModel {
             onCompletion(success)
 
             // On success, reset tab state and save new package details
-            guard success else { return }
-            self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
-            self?.onCompletion(newCustomPackage, nil, self?.packagesResponse)
+            guard let self = self, success else { return }
+            self.customPackageVM = ShippingLabelCustomPackageFormViewModel()
+            self.onCompletion(newCustomPackage, nil, self.packagesResponse)
         }
     }
 
@@ -101,10 +101,10 @@ extension ShippingLabelAddNewPackageViewModel {
             onCompletion(success)
 
             // On success, reset tab state and save new package details
-            guard success else { return }
-            self?.customPackageVM = ShippingLabelCustomPackageFormViewModel()
-            self?.servicePackageVM.packagesResponse = self?.packagesResponse
-            self?.onCompletion(nil, selectedServicePackage, self?.packagesResponse)
+            guard let self = self, success else { return }
+            self.customPackageVM = ShippingLabelCustomPackageFormViewModel()
+            self.servicePackageVM.packagesResponse = self.packagesResponse
+            self.onCompletion(nil, selectedServicePackage, self.packagesResponse)
         }
     }
 }
@@ -125,7 +125,9 @@ private extension ShippingLabelAddNewPackageViewModel {
 
         let action = ShippingLabelAction.createPackage(siteID: siteID,
                                                        customPackage: customPackage,
-                                                       predefinedOption: predefinedOption) { result in
+                                                       predefinedOption: predefinedOption) { [weak self] result in
+            guard let self = self else { return }
+
             switch result {
             case .success:
                 self.syncPackageDetails() { success in
@@ -142,7 +144,9 @@ private extension ShippingLabelAddNewPackageViewModel {
     /// Gets updated package list with new package. On completion, indicates if sync was successful.
     ///
     func syncPackageDetails(onCompletion: ((Bool) -> Void)? = nil) {
-        let action = ShippingLabelAction.packagesDetails(siteID: siteID) { result in
+        let action = ShippingLabelAction.packagesDetails(siteID: siteID) { [weak self] result in
+            guard let self = self else { return }
+
             switch result {
             case .success(let value):
                 self.packagesResponse = value

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -6,7 +6,7 @@ final class ShippingLabelServicePackageListViewModel: ObservableObject {
 
     /// The packages response fetched from API
     ///
-    @Published var packagesResponse: ShippingLabelPackagesResponse?
+    @Published private var packagesResponse: ShippingLabelPackagesResponse?
 
     /// Service packages not yet activated on the store, organized by shipping provider
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -96,7 +96,9 @@ struct ShippingLabelPackageList_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackages: [])
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         ShippingLabelPackageList(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageSelection.swift
@@ -18,10 +18,14 @@ struct ShippingLabelPackageSelection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackages: [])
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         let viewModelWithoutPackages = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: nil,
-                                                             selectedPackages: [])
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         ShippingLabelPackageSelection(viewModel: viewModelWithPackages)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -6,14 +6,8 @@ struct ShippingLabelPackageDetails: View {
     @State private var showingPackageSelection = false
     @Environment(\.presentationMode) var presentation
 
-    /// Completion callback
-    ///
-    typealias Completion = (_ packagesResponse: ShippingLabelPackagesResponse?, _ selectedPackages: [ShippingLabelPackageAttributes]) -> Void
-    private let onCompletion: Completion
-
-    init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {
+    init(viewModel: ShippingLabelPackageDetailsViewModel) {
         self.viewModel = viewModel
-        onCompletion = completion
         ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "packages_started"])
     }
 
@@ -82,7 +76,7 @@ struct ShippingLabelPackageDetails: View {
         .navigationBarItems(trailing: Button(action: {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
                                            withProperties: ["state": "packages_selected"])
-            onCompletion(viewModel.packagesResponse, viewModel.selectedPackagesDetails)
+            viewModel.savePackageSelection()
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)
@@ -117,15 +111,15 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
 
         let viewModel = ShippingLabelPackageDetailsViewModel(order: ShippingLabelPackageDetailsViewModel.sampleOrder(),
                                                              packagesResponse: ShippingLabelPackageDetailsViewModel.samplePackageDetails(),
-                                                             selectedPackages: [])
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { _, _ in
-        })
+        ShippingLabelPackageDetails(viewModel: viewModel)
         .environment(\.colorScheme, .light)
         .previewDisplayName("Light")
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { _, _ in
-        })
+        ShippingLabelPackageDetails(viewModel: viewModel)
         .environment(\.colorScheme, .dark)
         .previewDisplayName("Dark")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetails.swift
@@ -8,7 +8,7 @@ struct ShippingLabelPackageDetails: View {
 
     /// Completion callback
     ///
-    typealias Completion = (_ selectedPackageID: String?, _ totalPackageWeight: String?) -> Void
+    typealias Completion = (_ packagesResponse: ShippingLabelPackagesResponse?, _ selectedPackageID: String?, _ totalPackageWeight: String?) -> Void
     private let onCompletion: Completion
 
     init(viewModel: ShippingLabelPackageDetailsViewModel, completion: @escaping Completion) {
@@ -82,7 +82,7 @@ struct ShippingLabelPackageDetails: View {
         .navigationBarItems(trailing: Button(action: {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow,
                                            withProperties: ["state": "packages_selected"])
-            onCompletion(viewModel.selectedPackageID, viewModel.totalWeight)
+            onCompletion(viewModel.packagesResponse, viewModel.selectedPackageID, viewModel.totalWeight)
             presentation.wrappedValue.dismiss()
         }, label: {
             Text(Localization.doneButton)
@@ -120,12 +120,12 @@ struct ShippingLabelPackageDetails_Previews: PreviewProvider {
                                                              selectedPackageID: nil,
                                                              totalWeight: nil)
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (selectedPackageID, totalPackageWeight) in
+        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (_, _, _) in
         })
         .environment(\.colorScheme, .light)
         .previewDisplayName("Light")
 
-        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (selectedPackageID, totalPackageWeight) in
+        ShippingLabelPackageDetails(viewModel: viewModel, completion: { (_, _, _) in
         })
         .environment(\.colorScheme, .dark)
         .previewDisplayName("Dark")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -85,7 +85,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
 
     lazy var addNewPackageViewModel = ShippingLabelAddNewPackageViewModel(siteID: order.siteID,
                                                                           packagesResponse: packagesResponse,
-                                                                          onCompletion: { (customPackage, predefinedOption, packagesResponse) in
+                                                                          onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
+                                                                            guard let self = self else { return }
                                                                             self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                                                           })
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -83,7 +83,11 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         return customPackages.count > 0
     }
 
-    lazy var addNewPackageViewModel: ShippingLabelAddNewPackageViewModel = ShippingLabelAddNewPackageViewModel(packagesResponse: packagesResponse)
+    lazy var addNewPackageViewModel = ShippingLabelAddNewPackageViewModel(siteID: order.siteID,
+                                                                          packagesResponse: packagesResponse,
+                                                                          onCompletion: { (customPackage, predefinedOption, packagesResponse) in
+                                                                            self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
+                                                                          })
 
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
@@ -323,6 +327,25 @@ extension ShippingLabelPackageDetailsViewModel {
         }
         didSelectPackage(selectedPackageID)
         confirmPackageSelection()
+    }
+
+    /// Selects a newly created custom package or newly activated service package and adds it to the package list
+    ///
+    func handleNewPackage(_ customPackage: ShippingLabelCustomPackage?,
+                          _ servicePackage: ShippingLabelPredefinedPackage?,
+                          _ packagesResponse: ShippingLabelPackagesResponse?) {
+        guard let packagesResponse = packagesResponse else {
+            return
+        }
+
+        self.packagesResponse = packagesResponse
+
+        if let customPackage = customPackage {
+            selectCustomPackage(customPackage.title)
+        }
+        else if let servicePackage = servicePackage {
+            selectPredefinedPackage(servicePackage.id)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -529,6 +529,7 @@ extension ShippingLabelPackageDetailsViewModel {
                                                                  isLetter: false,
                                                                  dimensions: "28.57 x 22.22 x 15.24")]
         let predefinedOption1 = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                              providerID: "usps",
                                                               predefinedPackages: predefinedPackages1)
 
         let predefinedPackages2 = [ShippingLabelPredefinedPackage(id: "LargePaddedPouch",
@@ -536,6 +537,7 @@ extension ShippingLabelPackageDetailsViewModel {
                                                                   isLetter: true,
                                                                   dimensions: "30.22 x 35.56 x 2.54")]
         let predefinedOption2 = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              providerID: "dhlexpress",
                                                               predefinedPackages: predefinedPackages2)
 
         return [predefinedOption1, predefinedOption2]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -100,13 +100,23 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
                                                                             self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                                                           })
 
+    /// Completion callback after package details are synced from remote
+    ///
+    private let onPackageSyncCompletion: (_ packagesResponse: ShippingLabelPackagesResponse?) -> Void
+
+    /// Completion callback after selected package is saved
+    ///
+    private let onPackageSaveCompletion: (_ selectedPackages: [ShippingLabelPackageAttributes]) -> Void
+
     init(order: Order,
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackages: [ShippingLabelPackageAttributes],
          formatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         weightUnit: String? = ServiceLocator.shippingSettingsService.weightUnit) {
+         weightUnit: String? = ServiceLocator.shippingSettingsService.weightUnit,
+         onPackageSyncCompletion: @escaping (_ packagesResponse: ShippingLabelPackagesResponse?) -> Void,
+         onPackageSaveCompletion: @escaping (_ selectedPackages: [ShippingLabelPackageAttributes]) -> Void) {
         self.order = order
         self.orderItems = order.items
         self.currency = order.currency
@@ -116,6 +126,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
         self.weightUnit = weightUnit
         self.packagesResponse = packagesResponse
         self.selectedPackageID = selectedPackages.first?.packageID // TODO-4599: fix this
+        self.onPackageSyncCompletion = onPackageSyncCompletion
+        self.onPackageSaveCompletion = onPackageSaveCompletion
 
         configureResultsControllers()
         setDefaultPackage()
@@ -278,6 +290,10 @@ extension ShippingLabelPackageDetailsViewModel {
     func isPackageDetailsDoneButtonEnabled() -> Bool {
         return !selectedPackageID.isNilOrEmpty && totalWeight.isNotEmpty && Double(totalWeight) != 0 && Double(totalWeight) != nil
     }
+
+    func savePackageSelection() {
+        onPackageSaveCompletion(selectedPackagesDetails)
+    }
 }
 
 // MARK: - Package Selection
@@ -356,6 +372,8 @@ extension ShippingLabelPackageDetailsViewModel {
         else if let servicePackage = servicePackage {
             selectPredefinedPackage(servicePackage.id)
         }
+
+        onPackageSyncCompletion(packagesResponse)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -419,10 +419,14 @@ private extension ShippingLabelFormViewController {
     func displayPackageDetailsVC(inputPackages: [ShippingLabelPackageAttributes]) {
         let vm = ShippingLabelPackageDetailsViewModel(order: viewModel.order,
                                                       packagesResponse: viewModel.packagesResponse,
-                                                      selectedPackages: inputPackages)
-        let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] (packagesResponse, selectedPackages) in
-            self?.viewModel.handlePackageDetailsValueChanges(packagesResponse: packagesResponse, details: selectedPackages)
-        }
+                                                      selectedPackages: inputPackages,
+                                                      onPackageSyncCompletion: { [weak self] (packagesResponse) in
+                                                        self?.viewModel.handleNewPackagesResponse(packagesResponse: packagesResponse)
+                                                      },
+                                                      onPackageSaveCompletion: { [weak self] (selectedPackages) in
+                                                        self?.viewModel.handlePackageDetailsValueChanges(details: selectedPackages)
+                                                      })
+        let packageDetails = ShippingLabelPackageDetails(viewModel: vm)
 
         let hostingVC = UIHostingController(rootView: packageDetails)
         navigationController?.show(hostingVC, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -422,8 +422,10 @@ private extension ShippingLabelFormViewController {
                                                       packagesResponse: viewModel.packagesResponse,
                                                       selectedPackageID: selectedPackageID,
                                                       totalWeight: totalPackageWeight)
-        let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] (selectedPackageID, totalPackageWeight) in
-            self?.viewModel.handlePackageDetailsValueChanges(selectedPackageID: selectedPackageID, totalPackageWeight: totalPackageWeight)
+        let packageDetails = ShippingLabelPackageDetails(viewModel: vm) { [weak self] (packagesResponse, selectedPackageID, totalPackageWeight) in
+            self?.viewModel.handlePackageDetailsValueChanges(packagesResponse: packagesResponse,
+                                                             selectedPackageID: selectedPackageID,
+                                                             totalPackageWeight: totalPackageWeight)
         }
 
         let hostingVC = UIHostingController(rootView: packageDetails)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -200,8 +200,11 @@ final class ShippingLabelFormViewModel {
         }
     }
 
-    func handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse?, details: [ShippingLabelPackageAttributes]) {
+    func handleNewPackagesResponse(packagesResponse: ShippingLabelPackagesResponse?) {
         self.packagesResponse = packagesResponse
+    }
+
+    func handlePackageDetailsValueChanges(details: [ShippingLabelPackageAttributes]) {
         self.selectedPackagesDetails = details
 
         guard details.isNotEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -196,7 +196,8 @@ final class ShippingLabelFormViewModel {
         }
     }
 
-    func handlePackageDetailsValueChanges(selectedPackageID: String?, totalPackageWeight: String?) {
+    func handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse?, selectedPackageID: String?, totalPackageWeight: String?) {
+        self.packagesResponse = packagesResponse
         self.selectedPackageID = selectedPackageID
         self.totalPackageWeight = totalPackageWeight
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -965,6 +965,7 @@
 		CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */; };
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
+		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
@@ -2389,6 +2390,7 @@
 		CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndToggleRow.swift; sourceTree = "<group>"; };
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
+		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
@@ -4167,6 +4169,7 @@
 				45AF9DA9265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift */,
 				CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */,
 				CCCC5B1226CC2B9F0034FB63 /* ShippingLabelCustomPackageFormViewModelTests.swift */,
+				CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */,
 			);
 			path = "Create Shipping Label";
 			sourceTree = "<group>";
@@ -7805,6 +7808,7 @@
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,
+				CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				0215C6FC2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift in Sources */,
 				265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddNewPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddNewPackageViewModelTests.swift
@@ -15,6 +15,7 @@ class ShippingLabelAddNewPackageViewModelTests: XCTestCase {
                                                             onCompletion: {_, _, _ in })
 
         // Given a validated custom package
+        viewModel.customPackageVM.packageType = .letter
         viewModel.customPackageVM.packageName = "Test Package"
         viewModel.customPackageVM.packageHeight = "1"
         viewModel.customPackageVM.packageWidth = "1"
@@ -37,6 +38,12 @@ class ShippingLabelAddNewPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(viewModel.customPackageVM.validatedCustomPackage)
+        XCTAssertEqual(viewModel.customPackageVM.packageType, .box)
+        XCTAssertEqual(viewModel.customPackageVM.packageName, "")
+        XCTAssertEqual(viewModel.customPackageVM.packageHeight, "")
+        XCTAssertEqual(viewModel.customPackageVM.packageWidth, "")
+        XCTAssertEqual(viewModel.customPackageVM.packageLength, "")
+        XCTAssertEqual(viewModel.customPackageVM.emptyPackageWeight, "")
     }
 
     func test_activateServicePackage_resets_child_view_models_on_success() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddNewPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddNewPackageViewModelTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Yosemite
+@testable import WooCommerce
+
+class ShippingLabelAddNewPackageViewModelTests: XCTestCase {
+
+    private let sampleSiteID = 12345
+
+    func test_createCustomPackage_resets_child_view_models_on_success() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ShippingLabelAddNewPackageViewModel(stores: stores,
+                                                            siteID: 12345,
+                                                            packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                            onCompletion: {_, _, _ in })
+
+        // Given a validated custom package
+        viewModel.customPackageVM.packageName = "Test Package"
+        viewModel.customPackageVM.packageHeight = "1"
+        viewModel.customPackageVM.packageWidth = "1"
+        viewModel.customPackageVM.packageLength = "1"
+        viewModel.customPackageVM.emptyPackageWeight = "1"
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .createPackage(_, _, _, onCompletion):
+                onCompletion(.success(true))
+            case let .packagesDetails(_, onCompletion):
+                onCompletion(.success(ShippingLabelPackagesResponse.fake()))
+            default:
+                break
+            }
+        }
+
+        viewModel.createCustomPackage(onCompletion: { _ in })
+
+        // Then
+        XCTAssertNil(viewModel.customPackageVM.validatedCustomPackage)
+    }
+
+    func test_activateServicePackage_resets_child_view_models_on_success() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ShippingLabelAddNewPackageViewModel(stores: stores,
+                                                            siteID: 12345,
+                                                            packagesResponse: Mocks.packagesResponse,
+                                                            onCompletion: {_, _, _ in })
+
+        // Given changes to child view models
+        viewModel.customPackageVM.packageName = "Test Package"
+        viewModel.servicePackageVM.selectedPackage = Mocks.predefinedPackage
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .createPackage(_, _, _, onCompletion):
+                onCompletion(.success(true))
+            case let .packagesDetails(_, onCompletion):
+                onCompletion(.success(ShippingLabelPackagesResponse.fake()))
+            default:
+                break
+            }
+        }
+
+        viewModel.activateServicePackage(onCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.customPackageVM.packageName, "")
+        XCTAssertNotEqual(viewModel.servicePackageVM.selectedPackage, Mocks.predefinedPackage)
+        XCTAssertFalse(viewModel.servicePackageVM.predefinedOptions.contains(Mocks.predefinedOption))
+    }
+}
+
+extension ShippingLabelAddNewPackageViewModelTests {
+    enum Mocks {
+        static let predefinedPackage = ShippingLabelPredefinedPackage(id: "small_flat_box",
+                                                                      title: "Small Flat Rate Box",
+                                                                      isLetter: false,
+                                                                      dimensions: "21.91 x 13.65 x 4.13")
+        static let predefinedOption = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                                    providerID: "usps",
+                                                                    predefinedPackages: [predefinedPackage])
+        static let packagesResponse = ShippingLabelPackagesResponse(storeOptions: ShippingLabelStoreOptions.fake(),
+                                                                    customPackages: [ShippingLabelCustomPackage.fake()],
+                                                                    predefinedOptions: [],
+                                                                    unactivatedPredefinedOptions: [predefinedOption])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -169,13 +169,17 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
                                                                     destinationAddress: nil)
+        let expectedPackageResponse = ShippingLabelPackagesResponse.fake()
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: expectedPackageResponse,
+                                                                    selectedPackageID: expectedPackageID,
+                                                                    totalPackageWeight: expectedPackageWeight)
 
         // Then
+        XCTAssertEqual(shippingLabelFormViewModel.packagesResponse, expectedPackageResponse)
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackageID, expectedPackageID)
         XCTAssertEqual(shippingLabelFormViewModel.totalPackageWeight, expectedPackageWeight)
     }
@@ -197,7 +201,9 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                                    selectedPackageID: expectedPackageID,
+                                                                    totalPackageWeight: expectedPackageWeight)
 
         // Then
         XCTAssertNil(shippingLabelFormViewModel.selectedRate)
@@ -229,7 +235,9 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: expectedPackageWeight)
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                                    selectedPackageID: expectedPackageID,
+                                                                    totalPackageWeight: expectedPackageWeight)
 
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, expectedPackageID)
@@ -865,7 +873,9 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        viewModel.handlePackageDetailsValueChanges(selectedPackageID: expectedPackageID, totalPackageWeight: "55")
+        viewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                   selectedPackageID: expectedPackageID,
+                                                   totalPackageWeight: "55")
 
         // Then
         let defaultForms = viewModel.customsForms

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -164,21 +164,33 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(row?.displayMode, .disabled)
     }
 
-    func test_handlePackageDetailsValueChanges_returns_updated_data() {
+    func test_handleNewPackagesResponse_returns_updated_data() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
                                                                     destinationAddress: nil)
         let expectedPackageResponse = ShippingLabelPackagesResponse.fake()
+
+        // When
+        shippingLabelFormViewModel.handleNewPackagesResponse(packagesResponse: expectedPackageResponse)
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.packagesResponse, expectedPackageResponse)
+    }
+
+    func test_handlePackageDetailsValueChanges_returns_updated_data() {
+        // Given
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
         let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: expectedPackageResponse, details: [selectedPackage])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
-        XCTAssertEqual(shippingLabelFormViewModel.packagesResponse, expectedPackageResponse)
         XCTAssertEqual(shippingLabelFormViewModel.selectedPackagesDetails, [selectedPackage])
     }
 
@@ -200,7 +212,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(), details: [selectedPackage])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         XCTAssertNil(shippingLabelFormViewModel.selectedRate)
@@ -233,7 +245,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
         // When
-        shippingLabelFormViewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(), details: [selectedPackage])
+        shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, expectedPackageID)
@@ -870,7 +882,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
         let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", productIDs: [expectedProductID])
-        viewModel.handlePackageDetailsValueChanges(packagesResponse: ShippingLabelPackagesResponse.fake(), details: [selectedPackage])
+        viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         let defaultForms = viewModel.customsForms

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -37,7 +37,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              packagesResponse: mockPackageResponse(),
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
-                                                             storageManager: storageManager)
+                                                             storageManager: storageManager,
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.itemsRows.count, 0)
@@ -67,7 +69,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         XCTAssertEqual(viewModel.itemsRows.count, 0)
 
         // When
@@ -108,7 +112,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
 
         XCTAssertNil(viewModel.selectedCustomPackage)
@@ -138,7 +144,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         XCTAssertNil(viewModel.selectedCustomPackage)
         XCTAssertNil(viewModel.selectedPredefinedPackage)
@@ -161,7 +169,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
 
         // Then
@@ -179,7 +189,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              formatter: currencyFormatter,
                                                              stores: stores,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.selectedPackageID, "package-1")
@@ -199,7 +211,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // When
         viewModel.selectedPackageID = "sample-package"
@@ -222,7 +236,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // When
         viewModel.selectedPackageID = "sample-package"
@@ -278,7 +294,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         viewModel.didSelectPackage("Box")
         viewModel.confirmPackageSelection()
 
@@ -317,7 +335,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: selectedPackages,
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         XCTAssertEqual(viewModel.totalWeight, "30")
 
         // Then
@@ -343,7 +363,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.totalWeight, "120.0")
@@ -370,7 +392,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: selectedPackages,
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.totalWeight, "500")
@@ -397,7 +421,9 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                              selectedPackages: [],
                                                              formatter: currencyFormatter,
                                                              storageManager: storageManager,
-                                                             weightUnit: "kg")
+                                                             weightUnit: "kg",
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.totalWeight, "120.0")
@@ -428,28 +454,36 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                                                             formatter: currencyFormatter,
                                                                             stores: stores,
                                                                             storageManager: storageManager,
-                                                                            weightUnit: "kg")
+                                                                            weightUnit: "kg",
+                                                                            onPackageSyncCompletion: { _ in },
+                                                                            onPackageSaveCompletion: { _ in })
         let viewModelWithPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                          packagesResponse: mockPackageResponse(),
                                                                          selectedPackages: [],
                                                                          formatter: currencyFormatter,
                                                                          stores: stores,
                                                                          storageManager: storageManager,
-                                                                         weightUnit: "kg")
+                                                                         weightUnit: "kg",
+                                                                         onPackageSyncCompletion: { _ in },
+                                                                         onPackageSaveCompletion: { _ in })
         let viewModelWithCustomPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: true, withPredefined: false),
                                                                                selectedPackages: [],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,
-                                                                               weightUnit: "kg")
+                                                                               weightUnit: "kg",
+                                                                               onPackageSyncCompletion: { _ in },
+                                                                               onPackageSaveCompletion: { _ in })
         let viewModelWithPredefinedPackages = ShippingLabelPackageDetailsViewModel(order: order,
                                                                                packagesResponse: mockPackageResponse(withCustom: false, withPredefined: true),
                                                                                selectedPackages: [],
                                                                                formatter: currencyFormatter,
                                                                                stores: stores,
                                                                                storageManager: storageManager,
-                                                                               weightUnit: "kg")
+                                                                               weightUnit: "kg",
+                                                                               onPackageSyncCompletion: { _ in },
+                                                                               onPackageSaveCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModelWithoutPackages.hasCustomOrPredefinedPackages)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -521,14 +521,16 @@ private extension ShippingLabelPackageDetailsViewModelTests {
                                        boxWeight: 7,
                                        maxWeight: 10)]
 
-        let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS", predefinedPackages: [ShippingLabelPredefinedPackage(id: "package-1",
-                                                                                                                                  title: "Small",
-                                                                                                                                  isLetter: true,
-                                                                                                                                  dimensions: "3 x 4 x 5"),
-                                                                                                   ShippingLabelPredefinedPackage(id: "package-2",
-                                                                                                                                  title: "Big",
-                                                                                                                                  isLetter: true,
-                                                                                                                                  dimensions: "5 x 7 x 9")])]
+        let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS",
+                                                               providerID: "usps",
+                                                               predefinedPackages: [ShippingLabelPredefinedPackage(id: "package-1",
+                                                                                                                   title: "Small",
+                                                                                                                   isLetter: true,
+                                                                                                                   dimensions: "3 x 4 x 5"),
+                                                                                    ShippingLabelPredefinedPackage(id: "package-2",
+                                                                                                                   title: "Big",
+                                                                                                                   isLetter: true,
+                                                                                                                   dimensions: "5 x 7 x 9")])]
 
         let packagesResponse = ShippingLabelPackagesResponse(storeOptions: storeOptions,
                                                              customPackages: withCustom ? customPackages : [],

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -44,7 +44,8 @@ public enum ShippingLabelAction: Action {
     /// Creates a custom package with provided package details.
     ///
     case createPackage(siteID: Int64,
-                       customPackage: ShippingLabelCustomPackage,
+                       customPackage: ShippingLabelCustomPackage? = nil,
+                       predefinedOption: ShippingLabelPredefinedOption? = nil,
                        completion: (Result<Bool, Error>) -> Void)
 
     /// Fetch list of shipping carriers and their rates

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -56,8 +56,8 @@ public final class ShippingLabelStore: Store {
                                      canCreateCustomsForm: canCreateCustomsForm,
                                      canCreatePackage: canCreatePackage,
                                      onCompletion: onCompletion)
-        case .createPackage(let siteID, let customPackage, let completion):
-            createPackage(siteID: siteID, customPackage: customPackage, completion: completion)
+        case .createPackage(let siteID, let customPackage, let predefinedOption, let completion):
+            createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption, completion: completion)
         case .loadCarriersAndRates(let siteID, let orderID, let originAddress, let destinationAddress, let packages, let completion):
             loadCarriersAndRates(siteID: siteID,
                                  orderID: orderID,
@@ -169,9 +169,10 @@ private extension ShippingLabelStore {
     }
 
     func createPackage(siteID: Int64,
-                       customPackage: ShippingLabelCustomPackage,
+                       customPackage: ShippingLabelCustomPackage?,
+                       predefinedOption: ShippingLabelPredefinedOption?,
                        completion: @escaping (Result<Bool, Error>) -> Void) {
-        remote.createPackage(siteID: siteID, customPackage: customPackage, completion: completion)
+        remote.createPackage(siteID: siteID, customPackage: customPackage, predefinedOption: predefinedOption, completion: completion)
     }
 
     func loadCarriersAndRates(siteID: Int64,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -277,7 +277,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
     func createPackage(siteID: Int64,
                        customPackage: ShippingLabelCustomPackage?,
-                       servicePackages: [String: [String]]?,
+                       predefinedOption: ShippingLabelPredefinedOption?,
                        completion: @escaping (Result<Bool, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -275,7 +275,10 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
         }
     }
 
-    func createPackage(siteID: Int64, customPackage: ShippingLabelCustomPackage, completion: @escaping (Result<Bool, Error>) -> Void) {
+    func createPackage(siteID: Int64,
+                       customPackage: ShippingLabelCustomPackage?,
+                       servicePackages: [String: [String]]?,
+                       completion: @escaping (Result<Bool, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -958,6 +958,7 @@ private extension ShippingLabelStoreTests {
                                                                  isLetter: false,
                                                                  dimensions: "28.57 x 22.22 x 15.24")]
         let predefinedOption1 = ShippingLabelPredefinedOption(title: "USPS Priority Mail Flat Rate Boxes",
+                                                              providerID: "usps",
                                                               predefinedPackages: predefinedPackages1)
 
         let predefinedPackages2 = [ShippingLabelPredefinedPackage(id: "LargePaddedPouch",
@@ -965,6 +966,7 @@ private extension ShippingLabelStoreTests {
                                                                   isLetter: true,
                                                                   dimensions: "30.22 x 35.56 x 2.54")]
         let predefinedOption2 = ShippingLabelPredefinedOption(title: "DHL Express",
+                                                              providerID: "dhlexpress",
                                                               predefinedPackages: predefinedPackages2)
 
         return [predefinedOption1, predefinedOption2]


### PR DESCRIPTION
Part of: #4745

## Description

This makes the Done button functional on the Add New Package screen in the shipping labels flow.

When the Done button is tapped, the new custom or service package is created/activated remotely and the screen is dismissed. The new package is selected for the shipping label and is listed in the Package Selected screen (the screen before the Add New Package screen if the store has existing packages).

Note: If the API calls fail, the Add New Package screen is not dismissed. However, this PR does not include any user-facing error messaging. We should show a notice if there is an error, but it may take some work to get the notice presenter working with SwiftUI so I haven't included that here.

## Changes

Networking:

* Updates the `createPackage` endpoint in `ShippingLabelRemote` to support activating a service package.
* Updates the models for `ShippingLabelPackagesResponse` and `ShippingLabelPredefinedOption` to save the provider ID (e.g. "usps" or "dhlexpress") for predefined options. This is used by the `createPackage` endpoint when activating a service package.
* Updates the Fakes and unit tests with those changes.

Yosemite:

* Updates the Shipping Label Store and Action to support the changes to the `createPackage` endpoint.

UI:

* Makes the Done button functional in `ShippingLabelAddNewPackage`:
   * Uses the state property `isSyncing` to display an activity indicator and disable the done button while the API calls are in progress.
   * If the API calls are successful, it dismisses the view.
* Adds helpers to `ShippingLabelAddNewPackageViewModel` for the Done button actions (`createCustomPackage` and `activateServicePackage`). It gets the new custom/service package from the child view, creates/activates the package remotely, syncs the package list from remote, and passes the new package and updated package list back to the Package List / Package Details.

<img src="https://user-images.githubusercontent.com/8658164/132456658-1f7f9aeb-1383-4716-afeb-5850b522a18e.gif" width="300px">


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. If you already have existing packages on your store, you will see the Package Selected screen. Tap on "Create new package" at the bottom of the screen.
8. On the Add New Package screen, fill in the Custom Package form or select a Service Package.
9. Tap the Done button and notice there is an activity indicator and the button is disabled, and when it finishes you are taken back to the previous screen where the new package is selected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
