### PR TITLE
Order Editing: Fix issue where country state is persisted across navigations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -136,13 +136,13 @@ struct EditAddressForm: View {
         .disabled(!viewModel.isDoneButtonEnabled))
 
         // Go to edit country
-        NavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
+        LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
             EmptyView()
         }
 
         // Go to edit state
         // TODO: Move `StateSelectorViewModel` creation to the VM when it exists.
-        NavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
+        LazyNavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
             EmptyView()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// `NavigationLink` wrapper that instantiates  the `DestinationView`  when the navigation occurs.
+///
+struct LazyNavigationLink<Destination: View, Label: View>: View {
+
+    /// Destination view builder
+    ///
+    private let destination: () -> Destination
+
+    /// Set it to `true` to proceed with the desired navigation. Set it to `false` to remove the view from the navigation context.
+    ///
+    @Binding var isActive: Bool
+
+    /// `NavigationLink` label
+    ///
+    private let label: () -> Label
+
+    /// Creates a navigation link that creates and presents the destination view when active.
+    /// - Parameters:
+    ///   - destination: A view for the navigation link to present.
+    ///   - isActive: A binding to a Boolean value that indicates whether `destination` is currently presented.
+    ///   - label: A view builder to produce a label describing the `destination` to present.
+    init(destination: @autoclosure @escaping () -> Destination, isActive: Binding<Bool>, label: @escaping () -> Label) {
+        self.destination = destination
+        self._isActive = isActive
+        self.label = label
+    }
+
+    var body: some View {
+        NavigationLink(destination: LazyView(destination), isActive: $isActive, label: label)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyView.swift
@@ -9,14 +9,16 @@ struct LazyView<Wrapped: View>: View {
     ///
     private let wrapped: () -> Wrapped
 
-    /// Stores the function as a closure using the `@autoclosure` attribute.
-    ///
+    /// Creates a wrapper for a view to be instantiated lazily.
+    /// - Parameters:
+    ///   - wrapped: View builder function.
     init(_ wrapped: @autoclosure @escaping () -> Wrapped) {
         self.wrapped = wrapped
     }
 
-    /// Receives the builder closure.
-    ///
+    /// Creates a wrapper for a view to be instantiated lazily.
+    /// - Parameters:
+    ///   - wrapped: View builder closure.
     init(_ wrapped: @escaping () -> Wrapped) {
         self.wrapped = wrapped
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Lazily loads a `View` using a closure as a builder function.
+/// Useful for cases when it's not desired to load the `View` at the view definition time. EG: `NavigationLink`
+///
+struct LazyView<Wrapped: View>: View {
+
+    /// Builder closure
+    ///
+    private let wrapped: () -> Wrapped
+
+    /// Stores the function as a closure using the `@autoclosure` attribute.
+    ///
+    init(_ wrapped: @autoclosure @escaping () -> Wrapped) {
+        self.wrapped = wrapped
+    }
+
+    /// Receives the builder closure.
+    ///
+    init(_ wrapped: @escaping () -> Wrapped) {
+        self.wrapped = wrapped
+    }
+
+    var  body: Wrapped {
+        wrapped()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 		26C6E8E426E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */; };
 		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
 		26C6E8E826E6B6AC00C7BB0F /* StateSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */; };
+		26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E926E8FD3900C7BB0F /* LazyView.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
@@ -1849,6 +1850,7 @@
 		26C6E8E326E2D87C00C7BB0F /* CountrySelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModelTests.swift; sourceTree = "<group>"; };
 		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorCommand.swift; sourceTree = "<group>"; };
+		26C6E8E926E8FD3900C7BB0F /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
@@ -4365,6 +4367,7 @@
 				E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */,
 				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
 				DEE6437726D8DAD900888A75 /* InProgressView.swift */,
+				26C6E8E926E8FD3900C7BB0F /* LazyView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7409,6 +7412,7 @@
 				4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */,
 				CE1F512B206985DF00C6C810 /* PaddedLabel.swift in Sources */,
 				26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */,
+				26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */,
 				7421344A210A323C00C13890 /* WooAnalyticsStat.swift in Sources */,
 				02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */,
 				02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
 		26C6E8E826E6B6AC00C7BB0F /* StateSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */; };
 		26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E926E8FD3900C7BB0F /* LazyView.swift */; };
+		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
@@ -1851,6 +1852,7 @@
 		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E726E6B6AC00C7BB0F /* StateSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorCommand.swift; sourceTree = "<group>"; };
 		26C6E8E926E8FD3900C7BB0F /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
+		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
@@ -4368,6 +4370,7 @@
 				DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */,
 				DEE6437726D8DAD900888A75 /* InProgressView.swift */,
 				26C6E8E926E8FD3900C7BB0F /* LazyView.swift */,
+				26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -7193,6 +7196,7 @@
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditAddressForm.swift in Sources */,
+				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,


### PR DESCRIPTION
part of #4780

# Why

While implementing #4949 I noticed that we had a problem where the "filter search term" was persisted when navigating multiple times to the country selector.

After some investigation, it seems that the `NavigationLink` destination view is instantiated when the `NavigationLink` is defined and it is never deallocated but re-used in future navigations. 

ref: https://twitter.com/chriseidhof/status/1144242544680849410

# How

To solve this problem, I've introduced two utility views.

- `LazyView`: As a wrapper that makes use of the `@autoclosure` attribute to convert the view creation function into a closure to be executed when the body is rendered.

- `LazyNavigationLink`: As a `NavigationLink` wrapper that wraps the "Destination View" inside a `LazyView`

# Demo

### Before
https://user-images.githubusercontent.com/562080/132533608-3cf6ef3a-5998-43d6-ba25-63c03bac3704.mov

### After
https://user-images.githubusercontent.com/562080/132533622-3f7cb1ff-ee7b-49df-8a04-a5b7f364f0f7.mov

# Testing Steps

- Navigate to an order and tap on the shipping address edit icon
- Tap on the "Select Country" row
- Filter some countries
- Navigate back and tap on the "Select Country" row again.
- See that the search term is not persisted.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
