### PR TITLE
[Mobile Payments] Display connecting-to-reader failures

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
@@ -1,0 +1,62 @@
+import UIKit
+import Yosemite
+
+/// Modal presented when an error occurs while connecting to a reader
+///
+final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel {
+    private let continueSearchAction: () -> Void
+    private let cancelSearchAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedTopInfo
+    let actionsMode: PaymentsModalActionsMode = .twoAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.tryAgain
+
+    let secondaryButtonTitle: String? = Localization.cancel
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    init(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        self.continueSearchAction = continueSearch
+        self.cancelSearchAction = cancelSearch
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        continueSearchAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        cancelSearchAction()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalConnectingFailed {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "We couldn't connect your reader",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails"
+        )
+
+        static let tryAgain = NSLocalizedString(
+            "Try again",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This allows the search to continue."
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This also cancels searching."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -20,6 +20,10 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: connectingToReader())
     }
 
+    func connectingFailed(from: UIViewController, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
+    }
+
     func foundReader(from: UIViewController,
                      name: String,
                      connect: @escaping () -> Void,
@@ -55,6 +59,10 @@ private extension CardReaderSettingsAlerts {
 
     func connectingToReader() -> CardPresentPaymentsModalViewModel {
         CardPresentModalConnectingToReader()
+    }
+
+    func connectingFailed(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
     func foundReader(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -26,6 +26,13 @@ protocol CardReaderSettingsAlertsProvider {
     ///
     func connectingToReader(from: UIViewController)
 
+    /// Defines an alert indicating connecting failed. The user may continue the search
+    /// or cancel
+    ///
+    func connectingFailed(from: UIViewController,
+                          continueSearch: @escaping () -> Void,
+                          cancelSearch: @escaping () -> Void)
+
     /// Dismisses any alert being presented
     ///
     func dismiss()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -500,6 +500,8 @@
 		3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */; };
 		3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */; };
 		3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */; };
+		31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AD0B1026E9575F000B6391 /* CardPresentModalConnectingFailed.swift */; };
+		31AD0B1326E95998000B6391 /* CardPresentModalConnectingFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AD0B1226E95998000B6391 /* CardPresentModalConnectingFailedTests.swift */; };
 		31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */; };
 		31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */; };
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */; };
@@ -1904,6 +1906,8 @@
 		3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentRetryableError.swift; sourceTree = "<group>"; };
 		3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalRetryableErrorTests.swift; sourceTree = "<group>"; };
 		3198A1E72694DC7200597213 /* MockKnownReadersProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKnownReadersProvider.swift; sourceTree = "<group>"; };
+		31AD0B1026E9575F000B6391 /* CardPresentModalConnectingFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailed.swift; sourceTree = "<group>"; };
+		31AD0B1226E95998000B6391 /* CardPresentModalConnectingFailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedTests.swift; sourceTree = "<group>"; };
 		31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalFoundReader.swift; sourceTree = "<group>"; };
 		31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingToReader.swift; sourceTree = "<group>"; };
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsSearchingViewModel.swift; sourceTree = "<group>"; };
@@ -6113,6 +6117,7 @@
 				E17E3BFA266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift */,
 				E17E3BF8266917C10009D977 /* CardPresentModalScanningFailedTests.swift */,
 				3190D61C26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift */,
+				31AD0B1226E95998000B6391 /* CardPresentModalConnectingFailedTests.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -6217,6 +6222,7 @@
 				3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */,
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
 				31B05522264B3C8900134D87 /* CardPresentModalConnectingToReader.swift */,
+				31AD0B1026E9575F000B6391 /* CardPresentModalConnectingFailed.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
 			);
@@ -7115,6 +7121,7 @@
 				77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
+				31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */,
 				576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */,
 				CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */,
 				45DB6D972632CF9300E83C1A /* ActivityIndicator.swift in Sources */,
@@ -7993,6 +8000,7 @@
 				DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */,
 				0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
+				31AD0B1326E95998000B6391 /* CardPresentModalConnectingFailedTests.swift in Sources */,
 				E16715CD2666543000326230 /* CardPresentModalSuccessWithoutEmailTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -10,6 +10,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
     private var readerUpdateAvailable: Bool
     private var failReaderUpdateCheck: Bool
     private var failUpdate: Bool
+    private var failConnection: Bool
 
     init(connectedReaders: [CardReader],
          discoveredReader: CardReader? = nil,
@@ -17,7 +18,8 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
          failDiscovery: Bool = false,
          readerUpdateAvailable: Bool = false,
          failReaderUpdateCheck: Bool = false,
-         failUpdate: Bool = false
+         failUpdate: Bool = false,
+         failConnection: Bool = false
     ) {
         self.connectedReaders = connectedReaders
         self.discoveredReader = discoveredReader
@@ -25,6 +27,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
         self.readerUpdateAvailable = readerUpdateAvailable
         self.failReaderUpdateCheck = failReaderUpdateCheck
         self.failUpdate = failUpdate
+        self.failConnection = failConnection
         super.init(sessionManager: sessionManager)
     }
 
@@ -50,6 +53,10 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
             }
             onReaderDiscovered([discoveredReader])
         case .connect(let reader, let onCompletion):
+            guard !failConnection else {
+                onCompletion(Result.failure(MockErrors.connectionFailure))
+                return
+            }
             onCompletion(Result.success(reader))
         case .cancelCardReaderDiscovery(let onCompletion):
             onCompletion(Result.success(()))
@@ -81,6 +88,7 @@ extension MockCardPresentPaymentsStoresManager {
         case discoveryFailure
         case readerUpdateCheckFailure
         case readerUpdateFailure
+        case connectionFailure
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -7,17 +7,29 @@ enum MockCardReaderSettingsAlertsMode {
     case closeScanFailure
     case continueSearching
     case connectFoundReader
+    case continueSearchingAfterConnectionFailure
+    case cancelSearchingAfterConnectionFailure
 }
 
 final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     private var mode: MockCardReaderSettingsAlertsMode
+    private var didPresentFoundReader: Bool
 
     init(mode: MockCardReaderSettingsAlertsMode) {
         self.mode = mode
+        self.didPresentFoundReader = false
     }
     func scanningForReader(from: UIViewController, cancel: @escaping () -> Void) {
         if mode == .cancelScanning {
             cancel()
+        }
+
+        if mode == .continueSearchingAfterConnectionFailure {
+            /// If we've already presented a found reader once before, cancel this second search
+            ///
+            if didPresentFoundReader {
+                cancel()
+            }
         }
     }
 
@@ -28,11 +40,13 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func foundReader(from: UIViewController, name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) {
+        didPresentFoundReader = true
+
         if mode == .continueSearching {
             continueSearch()
         }
 
-        if mode == .connectFoundReader {
+        if mode == .connectFoundReader || mode == .cancelSearchingAfterConnectionFailure || mode == .continueSearchingAfterConnectionFailure {
             connect()
         }
     }
@@ -42,7 +56,13 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailed(from: UIViewController, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
-        // GNDN
+        if mode == .continueSearchingAfterConnectionFailure {
+            continueSearch()
+        }
+
+        if mode == .cancelSearchingAfterConnectionFailure {
+            cancelSearch()
+        }
     }
 
     func dismiss() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -41,6 +41,10 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         // GNDN
     }
 
+    func connectingFailed(from: UIViewController, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        // GNDN
+    }
+
     func dismiss() {
         // GNDN
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentModalConnectingFailedTests: XCTestCase {
+    private var viewModel: CardPresentModalConnectingFailed!
+    private var closures: Closures!
+
+    override func setUp() {
+        super.setUp()
+        closures = Closures()
+        viewModel = CardPresentModalConnectingFailed(
+            continueSearch: closures.continueSearch(),
+            cancelSearch: closures.cancelSearch()
+        )
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        closures = nil
+        super.tearDown()
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        XCTAssertEqual(viewModel.image, Expectations.image)
+    }
+
+    func test_topTitle_is_not_nil() {
+        XCTAssertNotNil(viewModel.topTitle)
+    }
+
+    func test_topSubtitle_is_nil() {
+        XCTAssertNil(viewModel.topSubtitle)
+    }
+
+    func test_primary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_not_nil() {
+        XCTAssertNotNil(viewModel.secondaryButtonTitle)
+    }
+
+    func test_bottom_title_is_nil() {
+        XCTAssertNil(viewModel.bottomTitle)
+    }
+
+    func test_bottom_subTitle_is_nil() {
+        XCTAssertNil(viewModel.bottomSubtitle)
+    }
+}
+
+private extension CardPresentModalConnectingFailedTests {
+    enum Expectations {
+        static let image = UIImage.paymentErrorImage
+    }
+}
+
+private final class Closures {
+    var didTapContinueSearch = false
+    var didTapCancelSearch = false
+
+    func continueSearch() -> () -> Void {
+        return {[weak self] in
+            self?.didTapContinueSearch = true
+        }
+    }
+
+    func cancelSearch() -> () -> Void {
+        return {[weak self] in
+            self?.didTapCancelSearch = true
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -134,4 +134,73 @@ class CardReaderConnectionControllerTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_user_can_cancel_search_after_connection_error() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let discoveredReader = MockCardReader.bbposChipper2XBT()
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReader: discoveredReader,
+            sessionManager: SessionManager.testingInstance,
+            failConnection: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+        let mockPresentingViewController = UIViewController()
+        let mockKnownReadersProvider = MockKnownReadersProvider(knownReaders: [])
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelSearchingAfterConnectionFailure)
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            knownReadersProvider: mockKnownReadersProvider,
+            alertsProvider: mockAlerts
+        )
+
+        // When
+        controller.searchAndConnect(from: mockPresentingViewController) { result in
+            XCTAssertTrue(result.isSuccess)
+            if case .success(let connected) = result {
+                XCTAssertFalse(connected)
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_user_can_continue_search_after_connection_error() {
+        // Given
+        let expectation = self.expectation(description: #function)
+
+        let discoveredReader = MockCardReader.bbposChipper2XBT()
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReader: discoveredReader,
+            sessionManager: SessionManager.testingInstance,
+            failConnection: true
+        )
+        ServiceLocator.setStores(mockStoresManager)
+        let mockPresentingViewController = UIViewController()
+        let mockKnownReadersProvider = MockKnownReadersProvider(knownReaders: [])
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .continueSearchingAfterConnectionFailure)
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            knownReadersProvider: mockKnownReadersProvider,
+            alertsProvider: mockAlerts
+        )
+
+        // When
+        controller.searchAndConnect(from: mockPresentingViewController) { result in
+            XCTAssertTrue(result.isSuccess)
+            if case .success(let connected) = result {
+                XCTAssertFalse(connected)
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }


### PR DESCRIPTION
Partially addresses #4947 
Closes #4923 

To test:
- Tap on Settings
- Tap on In-Person Payments, then Manage card reader
- When the Connect your card reader view appears, tap on Connect Card Reader
- The “Scanning for reader” modal should appear
- Power on a reader at this point
- (If the reader has previously connected, it will autoconnect. You’ll need to disconnect it and repeat the process)
- When the “Do you want to connect to reader xxx” modal appears, power off the reader by holding its power button down at least 5 seconds
- Tap on “Connect to Reader”
- The “Connecting to reader” modal will display
- After about 10 seconds, the “We couldn’t connect your reader” modal will display
- Tap “Cancel”
- You should be back on the Connect your card reader view now
- Tap on Connect Card Reader
- The Scaning for reader modal should display
- Power on the reader
- The Do you want to connect to reader xxx” modal should appear
- power off the reader by holding its power button down at least 5 seconds
- Tap on “Connect to Reader”
- The “Connecting to reader” modal will display
- After about 10 seconds, the “We couldn’t connect your reader” modal will display
- Tap on “Try Again”
- The “Scanning for reader” modal should return
- Power on your reader
- NOTE: There is a bug here. The reader won’t be found. It looks like it may be a problem with the Stripe SDK: https://github.com/stripe/stripe-terminal-ios/issues/104#issuecomment-916285167 - The workaround follows:

- Cancel the Scanning for reader modal
- Tap on Connect Card Reader
- The Do you want to connect to reader xxx” modal should appear
- Tap on “Connect to Reader”
- The reader should now connect successfully

Screenshots:

<img src="https://user-images.githubusercontent.com/1595739/132595349-c2b90f54-031e-4b4d-a7df-6a1fe384bf49.PNG" width=50% />

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
