### PR TITLE
Order Editing: Show a loading placeholders while countries are being synced.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Shimmer
 
 protocol FilterListSelectorViewModelable: ObservableObject {
 
@@ -19,6 +20,10 @@ protocol FilterListSelectorViewModelable: ObservableObject {
     /// Placeholder for the filter text field
     ///
     var filterPlaceholder: String { get }
+
+    /// Value to indicate if the views should be redacted
+    ///
+    var showPlaceholders: Bool { get }
 }
 
 /// Filterable List Selector View
@@ -37,6 +42,8 @@ struct FilterListSelector<ViewModel: FilterListSelectorViewModelable>: View {
             ListSelector(command: viewModel.command, tableStyle: .plain)
         }
         .navigationTitle(viewModel.navigationTitle)
+        .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
+        .shimmering(active: viewModel.showPlaceholders)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
@@ -25,6 +25,10 @@ final class StateSelectorViewModel: FilterListSelectorViewModelable, ObservableO
     /// Filter text field placeholder
     ///
     let filterPlaceholder = Localization.placeholder
+
+    /// States do not require data loading
+    ///
+    let showPlaceholders = false
 }
 
 // MARK: Constants


### PR DESCRIPTION
part of #4780

# Why

As countries can be synced from a remote source, it's necessary to show some ghost/loading content while the sync finishes.

# How

- Update `FilterListSelector` to show a redacted + shimmer effect when the view model mandates it.

- Update `CountrySelectorViewModel` to provide a property `showPlaceholders` that indicates if we need to show gosht/loading content or not. 
This is achieved by streamlining two publishers into the variable, `syncCountriesTrigger` and `makeSyncCountriesFuture`
The idea is to maintain all state mutations within the same chain of publishers, so it's clear how the `showPlaceholders` property acquired their values.

# Demo
https://user-images.githubusercontent.com/562080/132597469-1ed59178-5bb3-4a0b-9f08-6631fb012542.mov

# Testing Steps

- Log out from the app to clear the storage
- Login and navigate to an order
- Tap on the shipping address edit button
- Tap on the "Select Country" row
- See some redacted views with a shimmering effect while the content is synced.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
