### PR TITLE
Shipping Labels: Additional unit tests for package creation

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1006,6 +1006,27 @@ extension ShippingLabelCustomsForm.Item {
     }
 }
 
+extension ShippingLabelPackagesResponse {
+    public func copy(
+        storeOptions: CopiableProp<ShippingLabelStoreOptions> = .copy,
+        customPackages: CopiableProp<[ShippingLabelCustomPackage]> = .copy,
+        predefinedOptions: CopiableProp<[ShippingLabelPredefinedOption]> = .copy,
+        unactivatedPredefinedOptions: CopiableProp<[ShippingLabelPredefinedOption]> = .copy
+    ) -> ShippingLabelPackagesResponse {
+        let storeOptions = storeOptions ?? self.storeOptions
+        let customPackages = customPackages ?? self.customPackages
+        let predefinedOptions = predefinedOptions ?? self.predefinedOptions
+        let unactivatedPredefinedOptions = unactivatedPredefinedOptions ?? self.unactivatedPredefinedOptions
+
+        return ShippingLabelPackagesResponse(
+            storeOptions: storeOptions,
+            customPackages: customPackages,
+            predefinedOptions: predefinedOptions,
+            unactivatedPredefinedOptions: unactivatedPredefinedOptions
+        )
+    }
+}
+
 extension ShippingLabelPaymentMethod {
     public func copy(
         paymentMethodID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a list of Shipping Label Packages (custom and predefined).
 ///
-public struct ShippingLabelPackagesResponse: Equatable, GeneratedFakeable {
+public struct ShippingLabelPackagesResponse: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// The options of the store, like currency symbol and origin country.
     public let storeOptions: ShippingLabelStoreOptions

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -457,6 +457,45 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModelWithCustomPackages.hasCustomOrPredefinedPackages)
         XCTAssertTrue(viewModelWithPredefinedPackages.hasCustomOrPredefinedPackages)
     }
+
+    func test_handleNewPackage_returns_updated_data_with_custom_package() {
+        // Given
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(), packagesResponse: ShippingLabelPackagesResponse.fake(), selectedPackages: [])
+        let expectedCustomPackage = ShippingLabelCustomPackage(isUserDefined: true,
+                                                               title: "Box",
+                                                               isLetter: true,
+                                                               dimensions: "3 x 10 x 4",
+                                                               boxWeight: 10,
+                                                               maxWeight: 11)
+        let expectedPackagesResponse = ShippingLabelPackagesResponse.fake().copy(customPackages: [expectedCustomPackage])
+
+        // When
+        viewModel.handleNewPackage(expectedCustomPackage, nil, expectedPackagesResponse)
+
+        // Then
+        XCTAssertEqual(viewModel.packagesResponse, expectedPackagesResponse)
+        XCTAssertEqual(viewModel.selectedCustomPackage, expectedCustomPackage)
+    }
+
+    func test_handleNewPackage_returns_updated_data_with_service_package() {
+        // Given
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(), packagesResponse: ShippingLabelPackagesResponse.fake(), selectedPackages: [])
+        let expectedPredefinedPackage = ShippingLabelPredefinedPackage(id: "package-1",
+                                                                       title: "Small",
+                                                                       isLetter: true,
+                                                                       dimensions: "3 x 4 x 5")
+        let expectedPredefinedOption = ShippingLabelPredefinedOption(title: "USPS",
+                                                                     providerID: "usps",
+                                                                     predefinedPackages: [expectedPredefinedPackage])
+        let expectedPackagesResponse = ShippingLabelPackagesResponse.fake().copy(predefinedOptions: [expectedPredefinedOption])
+
+        // When
+        viewModel.handleNewPackage(nil, expectedPredefinedPackage, expectedPackagesResponse)
+
+        // Then
+        XCTAssertEqual(viewModel.packagesResponse, expectedPackagesResponse)
+        XCTAssertEqual(viewModel.selectedPredefinedPackage, expectedPredefinedPackage)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Part of: #4745
⚠️ Merge after #4950 ⚠️ 

## Description

These are additional unit tests related to the changes in #4950.

## Changes

* Adds `copy()` method for `ShippingLabelPackagesResponse`, to help with unit testing.
* Adds tests for the `handleNewPackage` method in the `ShippingLabelPackageDetails` view model, to confirm it is updated with the new `packagesResponse` and selected package.

## Testing

* Confirm tests make sense and pass in CI.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
