### PR TITLE
Shipping Labels: Display error when package creation fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/PackageCreationError+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/PackageCreationError+UI.swift
@@ -1,0 +1,29 @@
+import Yosemite
+
+extension PackageCreationError {
+    var alertTitle: String {
+        switch self {
+        case .duplicatePackageNames, .duplicateNamesByCarrier, .duplicateCustomPackageNames, .duplicatePredefinedPackageNames:
+            return NSLocalizedString("Invalid Package Name",
+                                     comment: "The title of the alert when there is an error with the package name")
+        case .unknown:
+            return NSLocalizedString("Cannot add package",
+                                     comment: "The title of the alert when there is a generic error adding the package")
+        }
+    }
+}
+
+extension PackageCreationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .duplicatePackageNames, .duplicateCustomPackageNames:
+            return NSLocalizedString("The new custom package name is not unique.",
+                                     comment: "The message of the alert when another custom package has the same name")
+        case .duplicateNamesByCarrier, .duplicatePredefinedPackageNames:
+            return NSLocalizedString("The new service package name is not unique.",
+                                     comment: "The message of the alert when another service package has the same name")
+        case .unknown:
+            return NSLocalizedString("Unexpected error", comment: "The message of the alert when there is an unexpected error adding the package")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -77,8 +77,9 @@ struct ShippingLabelAddNewPackage: View {
                     })
                     .disabled(isSyncing)
                     .alert(isPresented: $showingAddPackageError, content: {
-                        Alert(title: Text(Localization.errorAlertTitle),
-                              message: Text(Localization.errorAlertMessage))
+                        let title = viewModel.error?.alertTitle ?? Localization.errorAlertTitle
+                        let message = viewModel.error?.errorDescription ?? Localization.errorAlertMessage
+                        return Alert(title: Text(title), message: Text(message))
                     })
                 })
             }
@@ -92,10 +93,9 @@ private extension ShippingLabelAddNewPackage {
         static let customPackage = NSLocalizedString("Custom Package", comment: "Custom Package menu in Shipping Label Add New Package flow")
         static let servicePackage = NSLocalizedString("Service Package", comment: "Service Package menu in Shipping Label Add New Package flow")
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Add New Package screen in Shipping Label flow")
-        static let errorAlertTitle = NSLocalizedString("Cannot add package",
-                                                       comment: "Title of the alert when there is a failure adding a package in the Shipping Label flow")
+        static let errorAlertTitle = NSLocalizedString("Cannot add package", comment: "The title of the alert when there is a generic error adding the package")
         static let errorAlertMessage = NSLocalizedString("Unexpected error",
-                                                         comment: "Message of the alert when there is a failure adding a package in the Shipping Label flow")
+                                                         comment: "The message of the alert when there is an unexpected error adding the package")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackage.swift
@@ -4,7 +4,8 @@ import Yosemite
 struct ShippingLabelAddNewPackage: View {
     @ObservedObject var viewModel: ShippingLabelAddNewPackageViewModel
     @Environment(\.presentationMode) var presentation
-    @State var isSyncing = false
+    @State private var isSyncing = false
+    @State private var showingAddPackageError = false
 
     var body: some View {
         GeometryReader { geometry in
@@ -49,14 +50,20 @@ struct ShippingLabelAddNewPackage: View {
                             isSyncing = true
                             viewModel.createCustomPackage() { success in
                                 isSyncing = false
-                                guard success else { return }
+                                guard success else {
+                                    showingAddPackageError = true
+                                    return
+                                }
                                 presentation.wrappedValue.dismiss()
                             }
                         case .servicePackage:
                             isSyncing = true
                             viewModel.activateServicePackage() { success in
                                 isSyncing = false
-                                guard success else { return }
+                                guard success else {
+                                    showingAddPackageError = true
+                                    return
+                                }
                                 presentation.wrappedValue.dismiss()
                             }
                         }
@@ -69,6 +76,10 @@ struct ShippingLabelAddNewPackage: View {
                         }
                     })
                     .disabled(isSyncing)
+                    .alert(isPresented: $showingAddPackageError, content: {
+                        Alert(title: Text(Localization.errorAlertTitle),
+                              message: Text(Localization.errorAlertMessage))
+                    })
                 })
             }
         }
@@ -81,6 +92,10 @@ private extension ShippingLabelAddNewPackage {
         static let customPackage = NSLocalizedString("Custom Package", comment: "Custom Package menu in Shipping Label Add New Package flow")
         static let servicePackage = NSLocalizedString("Service Package", comment: "Service Package menu in Shipping Label Add New Package flow")
         static let doneButton = NSLocalizedString("Done", comment: "Done navigation button in the Add New Package screen in Shipping Label flow")
+        static let errorAlertTitle = NSLocalizedString("Cannot add package",
+                                                       comment: "Title of the alert when there is a failure adding a package in the Shipping Label flow")
+        static let errorAlertMessage = NSLocalizedString("Unexpected error",
+                                                         comment: "Message of the alert when there is a failure adding a package in the Shipping Label flow")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -38,6 +38,10 @@ final class ShippingLabelAddNewPackageViewModel: ObservableObject {
     ///
     private var packagesResponse: ShippingLabelPackagesResponse?
 
+    /// Error if package creation fails
+    ///
+    private(set) var error: PackageCreationError?
+
     /// Completion callback
     ///
     typealias Completion = (_ customPackage: ShippingLabelCustomPackage? ,
@@ -135,6 +139,7 @@ private extension ShippingLabelAddNewPackageViewModel {
                     onCompletion?(success)
                 }
             case .failure(let error):
+                self.error = error
                 DDLogError("⛔️ Error creating package: \(error.localizedDescription)")
                 onCompletion?(false)
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -970,6 +970,7 @@
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */; };
+		CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */; };
 		CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC69236126010946002FB669 /* LoginProloguePages.swift */; };
 		CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
@@ -2400,6 +2401,7 @@
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC593A6626EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModelTests.swift; sourceTree = "<group>"; };
+		CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PackageCreationError+UI.swift"; sourceTree = "<group>"; };
 		CC69236126010946002FB669 /* LoginProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePages.swift; sourceTree = "<group>"; };
 		CC6923AB26010D8D002FB669 /* LoginProloguePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProloguePageViewController.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
@@ -5368,6 +5370,7 @@
 				CC254F3726C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift */,
 				CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */,
 				CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */,
+				CC593A6A26EA640800EF0E04 /* PackageCreationError+UI.swift */,
 			);
 			path = "Package Creation";
 			sourceTree = "<group>";
@@ -7771,6 +7774,7 @@
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				D8B4D5EE26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift in Sources */,
+				CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */,
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,
 				2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */,
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -46,7 +46,7 @@ public enum ShippingLabelAction: Action {
     case createPackage(siteID: Int64,
                        customPackage: ShippingLabelCustomPackage? = nil,
                        predefinedOption: ShippingLabelPredefinedOption? = nil,
-                       completion: (Result<Bool, Error>) -> Void)
+                       completion: (Result<Bool, PackageCreationError>) -> Void)
 
     /// Fetch list of shipping carriers and their rates
     ///

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -514,7 +514,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<Bool, Error> = waitFor { promise in
+        let result: Result<Bool, PackageCreationError> = waitFor { promise in
             let action = ShippingLabelAction.createPackage(siteID: self.sampleSiteID, customPackage: self.sampleShippingLabelCustomPackage()) { result in
                 promise(result)
             }
@@ -534,7 +534,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
         // When
-        let result: Result<Bool, Error> = waitFor { promise in
+        let result: Result<Bool, PackageCreationError> = waitFor { promise in
             let action = ShippingLabelAction.createPackage(siteID: self.sampleSiteID, customPackage: self.sampleShippingLabelCustomPackage()) { result in
                 promise(result)
             }
@@ -542,8 +542,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         }
 
         // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssertEqual(error as? NetworkError, expectedError)
+        XCTAssertTrue(result.isFailure)
     }
 
     // MARK: `loadCarriersAndRates`


### PR DESCRIPTION
Part of: #4745 
⚠️ Merge after #4950 ⚠️ 

## Description

In the Shipping Label creation flow, if adding a new package fails we now display an alert with an error message to the user. This will show a specific error if there is a problem with the package itself (e.g. a custom package with a non-unique name) or a generic error for other problems (e.g. a network error).

For now, I used an alert because our other reusable components ( notice, error banner) aren't readily available to use with SwiftUI views. This feels like an acceptable compromise for now, to be able to release this feature sooner, and we can replace the alert with a different component later. @woocommerce/mobile-designers If you have a different perspective on that, please let me know!

## Changes

* Adds `PackageCreationError` to handle the expected errors when creating packages. In the UI layer, these errors are mapped to localized strings that match our UI (where only one package is created at a time).
* Adds an alert to `ShippingLabelAddNewPackage` that is displayed when adding a new package fails, with the errors from `PackageCreationError`.

Package name error|Generic error
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-09 at 18 40 55](https://user-images.githubusercontent.com/8658164/132736508-ae0405b9-6da7-4f70-bfc6-e3307511f884.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-09 at 18 41 06](https://user-images.githubusercontent.com/8658164/132736515-32f5c1d0-de35-428b-869e-dfb8c6593bb7.png)


## Testing

1. Make sure you have configured the WooCommerce WCShip plugin.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. If you already have existing packages on your store, you will see the Package Selected screen. Tap on "Create new package" at the bottom of the screen.
8. On the Add New Package screen, fill in the Custom Package form — to make sure an error is triggered, give your package the same name as a custom package that already exists on your store.
9. Tap the Done button. (You can also trigger an error by disabling your network connection before tapping Done.)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
