### PR TITLE
Shipping Labels: Add Tracks analytics for package creation flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -233,6 +233,9 @@ public enum WooAnalyticsStat: String {
     case shippingLabelAddressSuggestionsEditSelectedAddressButtonTapped = "shipping_label_address_suggestions_edit_selected_address_button_tapped"
     case shippingLabelAddressValidationFailed = "shipping_label_address_validation_failed"
     case shippingLabelAddressValidationSucceeded = "shipping_label_address_validation_succeeded"
+    case shippingLabelAddPackageTapped = "shipping_label_add_package_tapped"
+    case shippingLabelPackageAddedSuccessfully = "shipping_label_package_added_successfully"
+    case shippingLabelAddPackageFailed = "shipping_label_add_package_failed"
 
     // MARK: Receipt Events
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -135,11 +135,25 @@ private extension ShippingLabelAddNewPackageViewModel {
 
             switch result {
             case .success:
+                if customPackage != nil {
+                    ServiceLocator.analytics.track(.shippingLabelPackageAddedSuccessfully, withProperties: ["type": "custom"])
+                }
+                if predefinedOption != nil {
+                    ServiceLocator.analytics.track(.shippingLabelPackageAddedSuccessfully, withProperties: ["type": "predefined"])
+                }
                 self.syncPackageDetails() { success in
                     onCompletion?(success)
                 }
             case .failure(let error):
                 self.error = error
+                if customPackage != nil {
+                    ServiceLocator.analytics.track(.shippingLabelAddPackageFailed, withProperties: ["type": "custom",
+                                                                                                    "error": error.localizedDescription])
+                }
+                if predefinedOption != nil {
+                    ServiceLocator.analytics.track(.shippingLabelAddPackageFailed, withProperties: ["type": "predefined",
+                                                                                                    "error": error.localizedDescription])
+                }
                 DDLogError("⛔️ Error creating package: \(error.localizedDescription)")
                 onCompletion?(false)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageList.swift
@@ -70,6 +70,7 @@ struct ShippingLabelPackageList: View {
                                      title: Localization.createPackageButton,
                                      image: .plusImage,
                                      onButtonTapped: {
+                                        ServiceLocator.analytics.track(.shippingLabelAddPackageTapped)
                                         self.isShowingNewPackageCreation = true
                                      })
                 }


### PR DESCRIPTION
Part of: #3909 
⚠️ This PR relies on changes in #4950 and #4964. Wait to merge after those PRs ⚠️ 

## Description

This PR adds the Tracks events for the package creation flow.

## Events included

- [ ] `shipping_label_add_package_tapped`: When the "Create new package" button the package list is tapped.
- [ ] `shipping_label_package_added_successfully`: When a custom or service package is added successfully. Includes a custom property for the type of package (`custom` or `predefined`).
- [ ] `shipping_label_add_package_failed`: When adding a custom or service package fails. Includes a custom property for the type of package (`custom` or `predefined`) and the error message.

## Testing

1. Make sure you have configured the WooCommerce WCShip plugin with at least one package already set up in WP Admin under WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Launch the app in debug mode (so the feature flag is enabled).
3. Open an order detail that is eligible for the shipping label.
4. Tap the button "Create Shipping Label.”
5. Confirm "Ship From" and "Ship To.”
6. In the package details section, tap on “Package Selected.”
7. On the Package Selected screen, tap on "Create new package" at the bottom of the screen. Confirm the `shipping_label_add_package_tapped` event is fired.
8. On the Add New Package screen, fill in the Custom Package form and tap Done. Confirm the `shipping_label_package_added_successfully` event is fired with the `custom` type.
9. Tap on "Create new package" and fill in the Custom Package form again with the same package name you used before. Confirm the `shipping_label_add_package_failed` event is fired with the `custom` type and error message.
10. Tap on "Create new package" and select the Service Package tab. Select a package and tap Done. Confirm `shipping_label_package_added_successfully` is fired with the `predefined` type.
11. Tap on "Create new package" and select the Service Package tab. Select a package and disable your network connection before you tap Done. Confirm `shipping_label_add_package_failed` is fired with the `predefined` type and error message.


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
