### PR TITLE
[Mobile Payments] [Several Readers Found] Fix dark mode button color

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabelAndButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabelAndButtonTableViewCell.swift
@@ -6,4 +6,15 @@ final class LabelAndButtonTableViewCell: UITableViewCell {
 
     // TODO: Private outlets, configure method
     // TODO: Button completion
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureButton()
+    }
+}
+
+private extension LabelAndButtonTableViewCell {
+    func configureButton() {
+        button.tintColor = .accent
+    }
 }


### PR DESCRIPTION
Related Issue: #4333 

Feedback from @Garance91540 : https://github.com/woocommerce/woocommerce-ios/pull/4910#issuecomment-913624400

Before... After

<img src="https://user-images.githubusercontent.com/1595739/132760449-139dbf71-d4ca-41f5-aa89-6e6ebd7dc382.PNG" width=40% />&nbsp;<img src="https://user-images.githubusercontent.com/1595739/132760465-3bcc38e0-715b-42f1-a66d-cd92326d4749.PNG" width=40% />

Light mode unchanged

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
