### PR TITLE
Order Editing: Sync countries on EditAddressForm

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -9,7 +9,7 @@ final class CountrySelectorCommand: ObservableListSelectorCommand {
 
     /// Original array of countries.
     ///
-    private var countries: [Country]
+    private let countries: [Country]
 
     /// Data to display
     ///
@@ -39,13 +39,6 @@ final class CountrySelectorCommand: ObservableListSelectorCommand {
 
     func configureCell(cell: BasicTableViewCell, model: Country) {
         cell.textLabel?.text = model.name
-    }
-
-    /// Resets countries data.
-    ///
-    func resetCountries(_ countries: [Country]) {
-        self.countries = countries
-        self.data = countries
     }
 
     /// Filter available countries that contains a given search term.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -15,10 +15,6 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
         }
     }
 
-    /// Define if the view should show placeholders instead of the real elements.
-    ///
-    @Published private(set) var showPlaceholders: Bool = false
-
     /// Command that powers the `ListSelector` view.
     ///
     let command = CountrySelectorCommand(countries: [])
@@ -31,93 +27,12 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     ///
     let filterPlaceholder = Localization.placeholder
 
-    /// ResultsController for stored countries.
-    ///
-    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
-        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
-        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
-    }()
-
-    /// Trigger to sync countries.
-    ///
-    private let syncCountriesTrigger = PassthroughSubject<Void, Never>()
-
-    /// Storage to fetch countries
-    ///
-    private let storageManager: StorageManagerType
-
-    /// Stores to sync countries
-    ///
-    private let stores: StoresManager
-
     /// Current `SiteID`, needed to sync countries from a remote source.
     ///
     private let siteID: Int64
 
-    init(siteID: Int64, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64) {
         self.siteID = siteID
-        self.storageManager = storageManager
-        self.stores = stores
-        bindSyncTrigger()
-        bindStoredCountries()
-    }
-}
-
-// MARK: Helpers
-private extension CountrySelectorViewModel {
-    /// Fetches & Binds countries from storage, If there are no stored countries, trigger a sync request.
-    ///
-    func bindStoredCountries() {
-
-        // Bind stored countries & command
-        countriesResultsController.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
-            self.command.resetCountries(self.countriesResultsController.fetchedObjects)
-        }
-
-        // Initial fetch
-        try? countriesResultsController.performFetch()
-
-        // Trigger a sync request if there are no countries.
-        guard !countriesResultsController.isEmpty else {
-            return syncCountriesTrigger.send()
-        }
-
-        // Reset countries with fetched
-        command.resetCountries(countriesResultsController.fetchedObjects)
-    }
-
-    /// Sync countries when requested. Defines the `showPlaceholderState` value depending if countries are being synced or not.
-    ///
-    func bindSyncTrigger() {
-        syncCountriesTrigger
-            .handleEvents(receiveOutput: { // Set `showPlaceholders` to `true` before initiating sync.
-                self.showPlaceholders = true // I could not find a way to assign this using combine operators. :-(
-            })
-            .map { // Sync countries
-                self.makeSyncCountriesFuture()
-                    .replaceError(with: ()) // TODO: Handle errors
-            }
-            .switchToLatest()
-            .map { _ in // Set `showPlaceholders` to `false` after sync is done.
-                false
-            }
-            .assign(to: &$showPlaceholders)
-    }
-
-    /// Creates a publisher that syncs countries into our storage layer.
-    ///
-    func makeSyncCountriesFuture() -> AnyPublisher<Void, Error> {
-        Future<Void, Error> { [weak self] promise in
-            guard let self = self else { return }
-
-            let action = DataAction.synchronizeCountries(siteID: self.siteID) { result in
-                let newResult = result.map { _ in } // Hides the result success type because we don't need it.
-                promise(newResult)
-            }
-            self.stores.dispatch(action)
-        }
-        .eraseToAnyPublisher()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -17,7 +17,7 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
 
     /// Command that powers the `ListSelector` view.
     ///
-    let command = CountrySelectorCommand(countries: [])
+    let command: CountrySelectorCommand
 
     /// Navigation title
     ///
@@ -31,8 +31,9 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     ///
     private let siteID: Int64
 
-    init(siteID: Int64) {
+    init(siteID: Int64, countries: [Country]) {
         self.siteID = siteID
+        self.command = CountrySelectorCommand(countries: countries)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -136,6 +136,9 @@ struct EditAddressForm: View {
         .disabled(!viewModel.isDoneButtonEnabled))
         .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
         .shimmering(active: viewModel.showPlaceholders)
+        .onAppear {
+            viewModel.onLoadTrigger.send()
+        }
 
         // Go to edit country
         LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -134,6 +134,8 @@ struct EditAddressForm: View {
             // TODO: save changes
         }
         .disabled(!viewModel.isDoneButtonEnabled))
+        .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
+        .shimmering(active: viewModel.showPlaceholders)
 
         // Go to edit country
         LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -1,4 +1,6 @@
 import Yosemite
+import Storage
+import Combine
 
 final class EditAddressFormViewModel: ObservableObject {
 
@@ -6,9 +8,30 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     private let siteID: Int64
 
-    init(siteID: Int64, address: Address?) {
+    /// ResultsController for stored countries.
+    ///
+    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
+        let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
+        return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
+    }()
+
+    /// Trigger to sync countries.
+    ///
+    private let syncCountriesTrigger = PassthroughSubject<Void, Never>()
+
+    /// Storage to fetch countries
+    ///
+    private let storageManager: StorageManagerType
+
+    /// Stores to sync countries
+    ///
+    private let stores: StoresManager
+
+    init(siteID: Int64, address: Address?, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.originalAddress = address ?? .empty
+        self.storageManager = storageManager
+        self.stores = stores
         updateFieldsWithOriginalAddress()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -84,7 +84,7 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Creates a view model to be used when selecting a country
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {
-        CountrySelectorViewModel(siteID: siteID)
+        CountrySelectorViewModel(siteID: siteID, countries: countriesResultsController.fetchedObjects)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -27,19 +27,32 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
+    /// Store for publishers subscriptions
+    ///
+    private var subscriptions = Set<AnyCancellable>()
+
+
     init(siteID: Int64, address: Address?, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.originalAddress = address ?? .empty
         self.storageManager = storageManager
         self.stores = stores
         updateFieldsWithOriginalAddress()
-        bindSyncTrigger()
-        fetchStoredCountriesAndTriggerSyncIfNeeded()
+
+        // Listen only to the first emitted event.
+        onLoadTrigger.first().sink {
+            self.bindSyncTrigger()
+            self.fetchStoredCountriesAndTriggerSyncIfNeeded()
+        }.store(in: &subscriptions)
     }
 
     /// Original `Address` model.
     ///
     private let originalAddress: Address
+
+    /// Trigger to perform any one time setups.
+    ///
+    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
     // MARK: User Fields
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -33,6 +33,7 @@ final class EditAddressFormViewModel: ObservableObject {
         self.storageManager = storageManager
         self.stores = stores
         updateFieldsWithOriginalAddress()
+        fetchStoredCountriesAndTriggerSyncIfNeeded()
     }
 
     /// Original `Address` model.
@@ -97,5 +98,18 @@ private extension EditAddressFormViewModel {
                 country: originalAddress.country, // TODO: replace with local value
                 phone: phone.isEmpty ? nil : phone,
                 email: email.isEmpty ? nil : email)
+    }
+
+
+    /// Fetches countries from storage, If there are no stored countries, trigger a sync request.
+    ///
+    func fetchStoredCountriesAndTriggerSyncIfNeeded() {
+        // Initial fetch
+        try? countriesResultsController.performFetch()
+
+        // Trigger a sync request if there are no countries.
+        guard !countriesResultsController.isEmpty else {
+            return syncCountriesTrigger.send()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -33,6 +33,7 @@ final class EditAddressFormViewModel: ObservableObject {
         self.storageManager = storageManager
         self.stores = stores
         updateFieldsWithOriginalAddress()
+        bindSyncTrigger()
         fetchStoredCountriesAndTriggerSyncIfNeeded()
     }
 
@@ -56,6 +57,10 @@ final class EditAddressFormViewModel: ObservableObject {
     @Published var postcode: String = ""
 
     // MARK: Navigation and utility
+
+    /// Define if the view should show placeholders instead of the real elements.
+    ///
+    @Published private(set) var showPlaceholders: Bool = false
 
     /// Return `true` if the done button should be enabled.
     ///
@@ -111,5 +116,38 @@ private extension EditAddressFormViewModel {
         guard !countriesResultsController.isEmpty else {
             return syncCountriesTrigger.send()
         }
+    }
+
+    /// Sync countries when requested. Defines the `showPlaceholderState` value depending if countries are being synced or not.
+    ///
+    func bindSyncTrigger() {
+        syncCountriesTrigger
+            .handleEvents(receiveOutput: { // Set `showPlaceholders` to `true` before initiating sync.
+                self.showPlaceholders = true // I could not find a way to assign this using combine operators. :-(
+            })
+            .map { // Sync countries
+                self.makeSyncCountriesFuture()
+                    .replaceError(with: ()) // TODO: Handle errors
+            }
+            .switchToLatest()
+            .map { _ in // Set `showPlaceholders` to `false` after sync is done.
+                false
+            }
+            .assign(to: &$showPlaceholders)
+    }
+
+    /// Creates a publisher that syncs countries into our storage layer.
+    ///
+    func makeSyncCountriesFuture() -> AnyPublisher<Void, Error> {
+        Future<Void, Error> { [weak self] promise in
+            guard let self = self else { return }
+
+            let action = DataAction.synchronizeCountries(siteID: self.siteID) { result in
+                let newResult = result.map { _ in } // Hides the result success type because we don't need it.
+                promise(newResult)
+            }
+            self.stores.dispatch(action)
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -20,10 +20,6 @@ protocol FilterListSelectorViewModelable: ObservableObject {
     /// Placeholder for the filter text field
     ///
     var filterPlaceholder: String { get }
-
-    /// Value to indicate if the views should be redacted
-    ///
-    var showPlaceholders: Bool { get }
 }
 
 /// Filterable List Selector View
@@ -42,8 +38,6 @@ struct FilterListSelector<ViewModel: FilterListSelectorViewModelable>: View {
             ListSelector(command: viewModel.command, tableStyle: .plain)
         }
         .navigationTitle(viewModel.navigationTitle)
-        .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
-        .shimmering(active: viewModel.showPlaceholders)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
@@ -25,10 +25,6 @@ final class StateSelectorViewModel: FilterListSelectorViewModelable, ObservableO
     /// Filter text field placeholder
     ///
     let filterPlaceholder = Localization.placeholder
-
-    /// States do not require data loading
-    ///
-    let showPlaceholders = false
 }
 
 // MARK: Constants

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -6,18 +6,14 @@ import TestKit
 final class CountrySelectorViewModelTests: XCTestCase {
 
     let sampleSiteID: Int64 = 123
-    let testingStorage = MockStorageManager()
 
     override func setUp () {
         super.setUp()
-
-        testingStorage.reset()
-        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
     }
 
     func test_filter_countries_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
 
         // When
         viewModel.searchTerm = "Co"
@@ -42,7 +38,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_filter_countries_with_uppercase_letters_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
 
         // When
         viewModel.searchTerm = "CO"
@@ -67,7 +63,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_cleaning_search_terms_return_all_countries() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, storageManager: testingStorage)
+        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
         let totalNumberOfCountries = viewModel.command.data.count
 
         // When
@@ -78,28 +74,6 @@ final class CountrySelectorViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.command.data.count, totalNumberOfCountries)
     }
-
-    func test_starting_view_model_without_stored_countries_fetches_them_remotely() {
-        // Given
-        testingStorage.reset()
-        let testingStores = MockStoresManager(sessionManager: .testingInstance)
-
-
-        // When
-        let countriesFetched: Bool = waitFor { promise in
-            testingStores.whenReceivingAction(ofType: DataAction.self) { action in
-                switch action {
-                case .synchronizeCountries:
-                    promise(true)
-                }
-            }
-
-            _ = CountrySelectorViewModel(siteID: self.sampleSiteID, storageManager: self.testingStorage, stores: testingStores)
-        }
-
-        // Then
-        XCTAssertTrue(countriesFetched)
-    }
 }
 
 // MARK: Helpers
@@ -108,6 +82,8 @@ private extension CountrySelectorViewModelTests {
         return Locale.isoRegionCodes.map { regionCode in
             let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
             return Country(code: regionCode, name: name, states: [])
+        }.sorted { a, b in
+            a.name <= b.name
         }
     }()
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -1,11 +1,26 @@
 import XCTest
 import Yosemite
 import TestKit
+import Combine
 @testable import WooCommerce
 
 final class EditAddressFormViewModelTests: XCTestCase {
 
     let sampleSiteID: Int64 = 123
+
+    let testingStorage = MockStorageManager()
+
+    let testingStores = MockStoresManager(sessionManager: .testingInstance)
+
+    var subscriptions = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+
+        testingStorage.reset()
+        testingStores.reset()
+        subscriptions.removeAll()
+    }
 
     func test_creating_with_address_prefills_fields_with_correct_data() {
         // Given
@@ -71,6 +86,53 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isDoneButtonEnabled)
+    }
+
+    func test_starting_view_model_without_stored_countries_fetches_them_remotely() {
+        // Given
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: sampleAddress(), storageManager: testingStorage, stores: testingStores)
+
+        // When
+        let countriesFetched: Bool = waitFor { promise in
+            self.testingStores.whenReceivingAction(ofType: DataAction.self) { action in
+                switch action {
+                case .synchronizeCountries:
+                    promise(true)
+                }
+            }
+
+            viewModel.onLoadTrigger.send()
+        }
+
+        // Then
+        XCTAssertTrue(countriesFetched)
+    }
+
+    func test_syncing_countries_correctly_sets_showPlaceholders_properties() {
+        // Given
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: sampleAddress(), storageManager: testingStorage, stores: testingStores)
+        testingStores.whenReceivingAction(ofType: DataAction.self) { action in
+            switch action {
+            case .synchronizeCountries(_, let completion):
+                completion(.success([])) // Sending an empty because we don't really care about countries on this test.
+            }
+        }
+
+        // When
+        let showPlaceholdersStates: [Bool] = waitFor { promise in
+            viewModel.$showPlaceholders
+                .dropFirst() // Drop initial value
+                .collect(2)  // Expect two state changes
+                .sink { emittedValues in
+                    promise(emittedValues)
+                }
+                .store(in: &self.subscriptions)
+
+            viewModel.onLoadTrigger.send()
+        }
+
+        // Then
+        assertEqual(showPlaceholdersStates, [true, false]) // true: showPlaceholders, false: hide placeholders
     }
 }
 


### PR DESCRIPTION
part of #4798

# Why 

In a previous PR, I have added the ability to sync countries in the country selector screen. 
To not replicate the same logic on the state selector screen this PR moves that sync logic from `CountrySelectorViewModel` to `EditAddressFormViewModel` so it can be reused when pushing the state selector screen.

# How

- Move all country syncing code from `CountrySelectorViewModel` to `EditAddressFormViewModel`.

- Remove code from `CountrySelectedCommand` that allowed consumers to modify the countries list, as these are now provided on the init and not asynchronously.

- In `EditAddressFormViewModel` I'm experimenting with a way to perform actions only one. In the view, we only have the `onAppear()` modifier but this is invoked every time the screen is presented, similar to `viewWillAppear`. To overcome this I'm using a publisher to act as a trigger for the actions that we need to be performed only once, like data fetching. This is needed in order to not perform any side effect on `previews` and to allow for easier testing.

# Demo

https://user-images.githubusercontent.com/562080/132762354-c4cd0418-b4a0-4925-88dc-b34e616879cb.mov


# Testing Steps

- Log out from the app to clear the storage
- Login and navigate to an order
- Tap on the shipping address edit button
- See the loading effect in the screen
- Tap on the "Select Country" row
- See the country selector screen

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
