### PR TITLE
[Mobile Payments] [Several Readers Found] Add top and bottom constraints to cells

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ActivitySpinnerAndLabelTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ActivitySpinnerAndLabelTableViewCell.xib
@@ -22,7 +22,7 @@
                         </constraints>
                     </activityIndicatorView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RCi-ON-QWU">
-                        <rect key="frame" x="52" y="15" width="346" height="14.5"/>
+                        <rect key="frame" x="52" y="15" width="346" height="14"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -31,7 +31,9 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="zyy-o9-EPH" firstAttribute="leading" secondItem="Qaq-rR-9Pm" secondAttribute="leading" constant="16" id="ALB-ix-29j"/>
+                    <constraint firstAttribute="bottom" secondItem="RCi-ON-QWU" secondAttribute="bottom" constant="15" id="G5b-pm-fUa"/>
                     <constraint firstItem="zyy-o9-EPH" firstAttribute="centerY" secondItem="Qaq-rR-9Pm" secondAttribute="centerY" id="YIm-45-WDs"/>
+                    <constraint firstItem="RCi-ON-QWU" firstAttribute="top" secondItem="Qaq-rR-9Pm" secondAttribute="top" constant="15" id="Zup-29-caz"/>
                     <constraint firstItem="RCi-ON-QWU" firstAttribute="leading" secondItem="zyy-o9-EPH" secondAttribute="trailing" constant="16" id="cce-a7-oH8"/>
                     <constraint firstItem="RCi-ON-QWU" firstAttribute="centerY" secondItem="Qaq-rR-9Pm" secondAttribute="centerY" id="hZI-6i-3kM"/>
                     <constraint firstAttribute="trailing" secondItem="RCi-ON-QWU" secondAttribute="trailing" constant="16" id="vXP-RA-5EA"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabelAndButtonTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabelAndButtonTableViewCell.xib
@@ -17,7 +17,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OhL-hX-qBu">
-                        <rect key="frame" x="16" y="15" width="31" height="14.5"/>
+                        <rect key="frame" x="16" y="15" width="31" height="14"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -32,7 +32,9 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="OhL-hX-qBu" firstAttribute="leading" secondItem="nm8-P2-HxZ" secondAttribute="leading" constant="16" id="32z-8n-hEN"/>
+                    <constraint firstItem="OhL-hX-qBu" firstAttribute="top" secondItem="nm8-P2-HxZ" secondAttribute="top" constant="15" id="DLB-5E-lIY"/>
                     <constraint firstAttribute="trailing" secondItem="NUH-Od-3Cg" secondAttribute="trailing" constant="16" id="Iby-g6-rYk"/>
+                    <constraint firstAttribute="bottom" secondItem="OhL-hX-qBu" secondAttribute="bottom" constant="15" id="NGj-xH-YOe"/>
                     <constraint firstItem="NUH-Od-3Cg" firstAttribute="centerY" secondItem="nm8-P2-HxZ" secondAttribute="centerY" id="pX6-Nb-5k7"/>
                     <constraint firstItem="OhL-hX-qBu" firstAttribute="centerY" secondItem="nm8-P2-HxZ" secondAttribute="centerY" id="xxB-it-osD"/>
                 </constraints>


### PR DESCRIPTION
Related issue: #4333 

I noticed the following warning during testing today that I had missed earlier:

> 2021-09-09 13:37:20.876481-0700 WooCommerce[10741:7768697] [Warning] Warning once only: Detected a case where constraints ambiguously suggest a height of zero for a table view cell's content view. We're considering the collapse unintentional and using standard height instead. Cell: <WooCommerce.LabelAndButtonTableViewCell: 0x10d7f9c90; baseClass = UITableViewCell; frame = (0 0; 490 44); clipsToBounds = YES; autoresize = W; layer = <CALayer: 0x2822345e0>>

This PR resolves that warning (and a similar warning for the `ActivitySpinnerAndLabelTableViewCell`

No visual change is introduced.

To test, you can wait for #4931 to be merged, or you can add this to`CardReaderConnectionController` `searchAndConnect` and then navigate to Settings (Gear) > In-Person Payments > Manage Card Readers > Connect Card Reader

```
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -101,7 +101,10 @@ final class CardReaderConnectionController {
 
         self.fromController = from
         self.onCompletion = onCompletion
-        self.state = .initializing
+        self.state = .idle
+
+        let controller = SeveralReadersFoundViewController()
+        from?.present(controller, animated: true)
     }
 }
```

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
