### PR TITLE
Order Editing: Add save action on Edit Address form + refactor changes detection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -150,7 +150,9 @@ struct EditAddressForm: View {
         switch viewModel.navigationTrailingItem {
         case .done(let enabled):
             Button(Localization.done) {
-                // TODO: update remote address
+                viewModel.updateRemoteAddress(onFinish: { success in
+                    // TODO: dismiss on success
+                })
             }
             .disabled(!enabled)
         case .loading:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -130,10 +130,7 @@ struct EditAddressForm: View {
         }
         .navigationTitle(Localization.shippingTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarItems(trailing: Button(Localization.done) {
-            // TODO: save changes
-        }
-        .disabled(!viewModel.isDoneButtonEnabled))
+        .navigationBarItems(trailing: navigationBarTrailingItem())
 
         // Go to edit country
         LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createCountryViewModel()), isActive: $showCountrySelector) {
@@ -144,6 +141,20 @@ struct EditAddressForm: View {
         // TODO: Move `StateSelectorViewModel` creation to the VM when it exists.
         LazyNavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
             EmptyView()
+        }
+    }
+
+    /// Decides if the navigation trailing item should be a done button or a loading indicator.
+    ///
+    @ViewBuilder private func navigationBarTrailingItem() -> some View {
+        switch viewModel.navigationTrailingItem {
+        case .done(let enabled):
+            Button(Localization.done) {
+                // TODO: update remote address
+            }
+            .disabled(!enabled)
+        case .loading:
+            ProgressView()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -42,28 +42,28 @@ struct EditAddressForm: View {
                 VStack(spacing: 0) {
                     TitleAndTextFieldRow(title: Localization.firstNameField,
                                          placeholder: "",
-                                         text: $viewModel.firstName,
+                                         text: $viewModel.fields.firstName,
                                          symbol: nil,
                                          keyboardType: .default)
                     Divider()
                         .padding(.leading, Constants.dividerPadding)
                     TitleAndTextFieldRow(title: Localization.lastNameField,
                                          placeholder: "",
-                                         text: $viewModel.lastName,
+                                         text: $viewModel.fields.lastName,
                                          symbol: nil,
                                          keyboardType: .default)
                     Divider()
                         .padding(.leading, Constants.dividerPadding)
                     TitleAndTextFieldRow(title: Localization.emailField,
                                          placeholder: "",
-                                         text: $viewModel.email,
+                                         text: $viewModel.fields.email,
                                          symbol: nil,
                                          keyboardType: .emailAddress)
                     Divider()
                         .padding(.leading, Constants.dividerPadding)
                     TitleAndTextFieldRow(title: Localization.phoneField,
                                          placeholder: "",
-                                         text: $viewModel.phone,
+                                         text: $viewModel.fields.phone,
                                          symbol: nil,
                                          keyboardType: .phonePad)
                 }
@@ -76,35 +76,35 @@ struct EditAddressForm: View {
                     Group {
                         TitleAndTextFieldRow(title: Localization.companyField,
                                              placeholder: Localization.placeholderOptional,
-                                             text: $viewModel.company,
+                                             text: $viewModel.fields.company,
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.address1Field,
                                              placeholder: "",
-                                             text: $viewModel.address1,
+                                             text: $viewModel.fields.address1,
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.address2Field,
                                              placeholder: "Optional",
-                                             text: $viewModel.address2,
+                                             text: $viewModel.fields.address2,
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.cityField,
                                              placeholder: "",
-                                             text: $viewModel.city,
+                                             text: $viewModel.fields.city,
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
                         TitleAndTextFieldRow(title: Localization.postcodeField,
                                              placeholder: "",
-                                             text: $viewModel.postcode,
+                                             text: $viewModel.fields.postcode,
                                              symbol: nil,
                                              keyboardType: .default)
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -18,17 +18,13 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     private let originalAddress: Address
 
-    /// Tracks if a network request is being performed.
-    ///
-    private let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
-
-    // MARK: Form Fields
-
     /// Address form fields
     ///
     @Published var fields = FormFields()
 
-    // MARK: Navigation and utility
+    /// Tracks if a network request is being performed.
+    ///
+    private let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
 
     /// Active navigation bar trailing item.
     /// Defaults to a disabled done button.
@@ -46,10 +42,6 @@ final class EditAddressFormViewModel: ObservableObject {
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
         // TODO: perform network request
         // TODO: add success/failure notice
-
-        // To corroborate that the fields are getting updated
-        print("Address to update: \(fields)")
-
         performingNetworkRequest.send(true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
             self?.performingNetworkRequest.send(false)
@@ -85,7 +77,6 @@ private extension EditAddressFormViewModel {
             .assign(to: &$navigationTrailingItem)
     }
 }
-
 
 extension EditAddressFormViewModel {
     /// Type to hold values from all the form fields 
@@ -125,15 +116,15 @@ extension EditAddressFormViewModel {
         func toAddress() -> Address {
             Address(firstName: firstName,
                     lastName: lastName,
-                    company: company,
+                    company: company.isEmpty ? nil : company,
                     address1: address1,
-                    address2: address2,
+                    address2: address2.isEmpty ? nil : address2,
                     city: city,
                     state: state,
                     postcode: postcode,
                     country: country,
-                    phone: phone,
-                    email: email)
+                    phone: phone.isEmpty ? nil : phone,
+                    email: email.isEmpty ? nil : email)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -55,6 +55,18 @@ final class EditAddressFormViewModel: ObservableObject {
     func createCountryViewModel() -> CountrySelectorViewModel {
         CountrySelectorViewModel(siteID: siteID)
     }
+
+    /// Update the address remotely and invoke a completion block when finished
+    ///
+    func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
+        // TODO: perform network request
+        // TODO: add success/failure notice
+        performingNetworkRequest.send(true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            self?.performingNetworkRequest.send(false)
+            onFinish(true)
+        }
+    }
 }
 
 extension EditAddressFormViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -45,12 +45,6 @@ final class EditAddressFormViewModel: ObservableObject {
 
     // MARK: Navigation and utility
 
-    /// Return `true` if the done button should be enabled.
-    ///
-    var isDoneButtonEnabled: Bool {
-        return originalAddress != updatedAddress
-    }
-
     /// Active navigation bar trailing item.
     /// Defaults to a disabled done button.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -57,29 +57,8 @@ extension EditAddressFormViewModel {
         case done(enabled: Bool)
         case loading
     }
-}
 
-private extension EditAddressFormViewModel {
-    func updateFieldsWithOriginalAddress() {
-        fields.update(from: originalAddress)
-    }
-
-    /// Calculates what navigation trailing item should be shown depending on our internal state.
-    ///
-    func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest($fields, performingNetworkRequest)
-            .map { [originalAddress] fields, performingNetworkRequest -> NavigationItem in
-                guard !performingNetworkRequest else {
-                    return .loading
-                }
-                return .done(enabled: originalAddress != fields.toAddress())
-            }
-            .assign(to: &$navigationTrailingItem)
-    }
-}
-
-extension EditAddressFormViewModel {
-    /// Type to hold values from all the form fields 
+    /// Type to hold values from all the form fields
     ///
     struct FormFields {
         // MARK: User Fields
@@ -126,5 +105,24 @@ extension EditAddressFormViewModel {
                     phone: phone.isEmpty ? nil : phone,
                     email: email.isEmpty ? nil : email)
         }
+    }
+}
+
+private extension EditAddressFormViewModel {
+    func updateFieldsWithOriginalAddress() {
+        fields.update(from: originalAddress)
+    }
+
+    /// Calculates what navigation trailing item should be shown depending on our internal state.
+    ///
+    func bindNavigationTrailingItemPublisher() {
+        Publishers.CombineLatest($fields, performingNetworkRequest)
+            .map { [originalAddress] fields, performingNetworkRequest -> NavigationItem in
+                guard !performingNetworkRequest else {
+                    return .loading
+                }
+                return .done(enabled: originalAddress != fields.toAddress())
+            }
+            .assign(to: &$navigationTrailingItem)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -24,27 +24,27 @@ final class EditAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.city, address.city)
         XCTAssertEqual(viewModel.postcode, address.postcode)
 
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
 
     func test_updating_fields_enables_done_button() {
         // Given
         let address = sampleAddress()
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
         viewModel.firstName = "John"
 
         // Then
-        XCTAssertTrue(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
     }
 
     func test_updating_fields_back_to_original_values_disables_done_button() {
         // Given
         let address = sampleAddress()
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
         viewModel.firstName = "John"
@@ -53,7 +53,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
         viewModel.lastName = "Appleseed"
 
         // Then
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
 
     func test_creating_without_address_disables_done_button() {
@@ -61,7 +61,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: nil)
 
         // Then
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
 
     func test_creating_with_address_with_empty_nullable_fields_disables_done_button() {
@@ -70,7 +70,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
 
         // Then
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
+        XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -72,6 +72,34 @@ final class EditAddressFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
+
+    func test_loading_indicator_gets_enabled_during_network_request() {
+        // Given
+        let address = sampleAddress()
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+
+        // When
+        viewModel.updateRemoteAddress { _ in }
+
+        // Then
+        assertEqual(viewModel.navigationTrailingItem, .loading)
+    }
+
+    func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
+        // Given
+        let address = sampleAddress()
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+
+        // When
+        let navigationItem = waitFor { promise in
+            viewModel.updateRemoteAddress { _ in
+                promise(viewModel.navigationTrailingItem)
+            }
+        }
+
+        // Then
+        assertEqual(navigationItem, .done(enabled: false))
+    }
 }
 
 private extension EditAddressFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -13,16 +13,16 @@ final class EditAddressFormViewModelTests: XCTestCase {
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
 
         // Then
-        XCTAssertEqual(viewModel.firstName, address.firstName)
-        XCTAssertEqual(viewModel.lastName, address.lastName)
-        XCTAssertEqual(viewModel.email, address.email ?? "")
-        XCTAssertEqual(viewModel.phone, address.phone ?? "")
+        XCTAssertEqual(viewModel.fields.firstName, address.firstName)
+        XCTAssertEqual(viewModel.fields.lastName, address.lastName)
+        XCTAssertEqual(viewModel.fields.email, address.email ?? "")
+        XCTAssertEqual(viewModel.fields.phone, address.phone ?? "")
 
-        XCTAssertEqual(viewModel.company, address.company ?? "")
-        XCTAssertEqual(viewModel.address1, address.address1)
-        XCTAssertEqual(viewModel.address2, address.address2 ?? "")
-        XCTAssertEqual(viewModel.city, address.city)
-        XCTAssertEqual(viewModel.postcode, address.postcode)
+        XCTAssertEqual(viewModel.fields.company, address.company ?? "")
+        XCTAssertEqual(viewModel.fields.address1, address.address1)
+        XCTAssertEqual(viewModel.fields.address2, address.address2 ?? "")
+        XCTAssertEqual(viewModel.fields.city, address.city)
+        XCTAssertEqual(viewModel.fields.postcode, address.postcode)
 
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
@@ -34,7 +34,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
-        viewModel.firstName = "John"
+        viewModel.fields.firstName = "John"
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: true))
@@ -47,10 +47,10 @@ final class EditAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
-        viewModel.firstName = "John"
-        viewModel.lastName = "Ipsum"
-        viewModel.firstName = "Johnny"
-        viewModel.lastName = "Appleseed"
+        viewModel.fields.firstName = "John"
+        viewModel.fields.lastName = "Ipsum"
+        viewModel.fields.firstName = "Johnny"
+        viewModel.fields.lastName = "Appleseed"
 
         // Then
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/4778, https://github.com/woocommerce/woocommerce-ios/issues/4783

## Description

This PR adds save action on edit address form with simulated progress.

### Technical Details

Network action and navbar item logic are straightforward and taken mostly from `EditCustomerNote`.
Complex part was refactoring to have all fields connected through Combine to `updatedAddress` and then to `navigationTrailingItem`. Apart from ugly `CombineLatest` syntax final solution worked well in my tests.

## Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/132768993-706fa164-7bc8-42fb-b99e-9b2f6d06d60d.png">

## Testing

1. Open existing order details and tap edit button for shipping address
2. Observe correct address data in form (except State and Country)
3. Try updating any fields
4. Check that "Done" button in navbar is enabled if there are any unsaved changes
5. Tap "Done" button and observe loading indicator (simulated 3s action)
6. Revert fields to original data
7. Check that "Done" button is disabled

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
