### PR TITLE
Shipping Labels: Fix incorrect phone validation for non-US country and add instant local validation on value changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -142,16 +142,20 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func registerTableViewCells() {
-            tableView.registerNib(for: TitleAndTextFieldTableViewCell.self)
-            tableView.registerNib(for: BasicTableViewCell.self)
+        tableView.registerNib(for: TitleAndTextFieldTableViewCell.self)
+        tableView.registerNib(for: BasicTableViewCell.self)
     }
 
     func observeViewModel() {
-        viewModel.onChange = { [weak self] in
+        viewModel.onChange = { [weak self] focusedIndex in
             guard let self = self else { return }
             self.configureNavigationBar()
             self.updateTopBannerView()
             self.tableView.reloadData()
+            if let index = focusedIndex,
+               let cell = self.tableView.cellForRow(at: IndexPath(row: index, section: 0)) as? TitleAndTextFieldTableViewCell {
+                cell.textFieldBecomeFirstResponder()
+            }
         }
     }
 
@@ -459,8 +463,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { _ in
-        }
+                                                                     textFieldAlignment: .leading) { _ in }
         cell.configure(viewModel: cellViewModel)
         cell.enableTextField(viewModel.statesOfSelectedCountry.isEmpty)
     }
@@ -471,8 +474,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.countryFieldPlaceholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { _ in
-        }
+                                                                     textFieldAlignment: .leading) { _ in }
         cell.configure(viewModel: cellViewModel)
         cell.enableTextField(false)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -25,15 +25,16 @@ final class ShippingLabelAddressFormViewModel {
     private let stores: StoresManager
 
     /// Closure to notify the `ViewController` when the view model properties change.
+    /// Accepts optional index for row to be focused after reloading the table view.
     ///
-    var onChange: (() -> (Void))?
+    var onChange: ((_ focusedRowIndex: Int?) -> (Void))?
 
     /// Current `ViewModel` state.
     ///
     private var state: State = State() {
         didSet {
             updateSections()
-            onChange?()
+            onChange?(nil)
         }
     }
 
@@ -106,10 +107,14 @@ final class ShippingLabelAddressFormViewModel {
         case .state:
             address = address?.copy(state: newValue)
         case .country:
-            address = address?.copy(country: newValue)
+            address = address?.copy(country: newValue, state: "")
         default:
             return
         }
+
+        updateSections()
+        let index: Int? = sections.first?.rows.firstIndex(where: { $0 == row })
+        onChange?(index)
     }
 
     func updateSections() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -181,21 +181,36 @@ extension ShippingLabelAddressFormViewModel {
         case invalidPhoneNumber
     }
 
-    /// Validates phone number for origin address.
+    /// Validates phone number for the address.
     /// This take into account whether phone is not empty,
     /// has length 10 with additional "1" area code for US.
-    ///
-    /// Note: This logic may need to be updated if there is a need for validating other cases.
     ///
     private var isPhoneNumberValid: Bool {
         guard let phone = address?.phone, phone.isNotEmpty else {
             return false
+        }
+        guard address?.country == "US" else {
+            return true
         }
         if phone.hasPrefix("1") {
             return phone.count == 11
         } else {
             return phone.count == 10
         }
+    }
+
+    private var phoneValidationError: ValidationError? {
+        guard let addressToBeValidated = address else {
+            return nil
+        }
+        if phoneNumberRequired {
+            if addressToBeValidated.phone.isEmpty {
+                return .missingPhoneNumber
+            } else if !isPhoneNumberValid {
+                return .invalidPhoneNumber
+            }
+        }
+        return nil
     }
 
     private func validateAddressLocally() -> [ValidationError] {
@@ -220,12 +235,8 @@ extension ShippingLabelAddressFormViewModel {
             if addressToBeValidated.country.isEmpty {
                 errors.append(.country)
             }
-            if phoneNumberRequired {
-                if addressToBeValidated.phone.isEmpty {
-                    errors.append(.missingPhoneNumber)
-                } else if !isPhoneNumberValid {
-                    errors.append(.invalidPhoneNumber)
-                }
+            if let error = phoneValidationError {
+                errors.append(error)
             }
         }
 


### PR DESCRIPTION
Fixes #4971 

# Description
This PR fixes issues in Edit Address screen validation:
- Required 10-digit number is only required for US.
- Address state of country is cleared when switching country.
- Validation error messages are updated instantly on value changes. Text field focus states are kept even after validation rows are updated.

# Changes
- View model: 
   - Updates `onChange` closure to accepts optional index for focused row.
   - Updates `handleAddressValueChanges` to reset state of country when country is updated.
   - Updates `handleAddressValueChanges` to do local validation and update table view rows.
   - Checks for country code US before proceeding to check for 10-digit phone number.
- View controller:
   -  Update `observeViewModel` to focus on the specified row after reloading table view.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
