### PR TITLE
Tests: Add missing arguments to fix build failure

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -494,7 +494,11 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
     func test_handleNewPackage_returns_updated_data_with_custom_package() {
         // Given
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(), packagesResponse: ShippingLabelPackagesResponse.fake(), selectedPackages: [])
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(),
+                                                             packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         let expectedCustomPackage = ShippingLabelCustomPackage(isUserDefined: true,
                                                                title: "Box",
                                                                isLetter: true,
@@ -513,7 +517,11 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
     func test_handleNewPackage_returns_updated_data_with_service_package() {
         // Given
-        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(), packagesResponse: ShippingLabelPackagesResponse.fake(), selectedPackages: [])
+        let viewModel = ShippingLabelPackageDetailsViewModel(order: Order.fake(),
+                                                             packagesResponse: ShippingLabelPackagesResponse.fake(),
+                                                             selectedPackages: [],
+                                                             onPackageSyncCompletion: { _ in },
+                                                             onPackageSaveCompletion: { _ in })
         let expectedPredefinedPackage = ShippingLabelPredefinedPackage(id: "package-1",
                                                                        title: "Small",
                                                                        isLetter: true,


### PR DESCRIPTION
## Description

A conflict between #4950 and #4963 wasn't caught before merging to `develop`, causing tests to fail due to build errors. This resolves the build failure.

## Changes

Adds missing parameters to tests in `ShippingLabelPackageDetailsViewModelTests`.

## Testing

Confirm tests pass in CI.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
