### PR TITLE
Tests: Add missing parameter to fix build tests failure

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackageItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackageItemViewModelTests.swift
@@ -98,14 +98,16 @@ private extension ShippingLabelPackageItemViewModelTests {
                                        boxWeight: 7,
                                        maxWeight: 10)]
 
-        let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS", predefinedPackages: [ShippingLabelPredefinedPackage(id: "package-1",
-                                                                                                                                  title: "Small",
-                                                                                                                                  isLetter: true,
-                                                                                                                                  dimensions: "3 x 4 x 5"),
-                                                                                                   ShippingLabelPredefinedPackage(id: "package-2",
-                                                                                                                                  title: "Big",
-                                                                                                                                  isLetter: true,
-                                                                                                                                  dimensions: "5 x 7 x 9")])]
+        let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS",
+                                                               providerID: "USPS",
+                                                               predefinedPackages: [ShippingLabelPredefinedPackage(id: "package-1",
+                                                                                                                   title: "Small",
+                                                                                                                   isLetter: true,
+                                                                                                                   dimensions: "3 x 4 x 5"),
+                                                                                    ShippingLabelPredefinedPackage(id: "package-2",
+                                                                                                                   title: "Big",
+                                                                                                                   isLetter: true,
+                                                                                                                   dimensions: "5 x 7 x 9")])]
 
         let packagesResponse = ShippingLabelPackagesResponse(storeOptions: storeOptions,
                                                              customPackages: withCustom ? customPackages : [],


### PR DESCRIPTION
# Description
A missing parameter was not caught in #4961 leading to failure to build tests on develop.

# Changes
Add missing `providerID` parameter in mocked predefined packages in `ShippingLabelPackageItemViewModelTests`.

# Testing
Please make sure that CI passes before the merge.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
