### PR TITLE
Order Editing: Select & update country when editing Shipping Address

### DIFF
--- a/WooCommerce/Classes/Tools/Binding.swift
+++ b/WooCommerce/Classes/Tools/Binding.swift
@@ -1,0 +1,6 @@
+import struct SwiftUI.Binding
+
+/// `Binding` resides inside `SwiftUI`.
+/// This alias allows us to use it inside view models to communicate with `SwiftUI` views without having the import the module on each file.
+///
+typealias Binding = SwiftUI.Binding

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Yosemite
 
+import struct SwiftUI.Binding
+
 /// Command to be used to select a country when editing addresses.
 ///
 final class CountrySelectorCommand: ObservableListSelectorCommand {
@@ -17,16 +19,16 @@ final class CountrySelectorCommand: ObservableListSelectorCommand {
 
     /// Current selected country
     ///
-    private(set) var selected: Country?
+    @Binding private(set) var selected: Country?
 
     /// Navigation bar title
     ///
     let navigationBarTitle: String? = ""
 
-    init(countries: [Country], selected: Country? = nil) {
+    init(countries: [Country], selected: Binding<Country?>) {
         self.countries = countries
         self.data = countries
-        self.selected = selected
+        self._selected = selected
     }
 
     func handleSelectedChange(selected: Country, viewController: ViewController) {
@@ -34,7 +36,7 @@ final class CountrySelectorCommand: ObservableListSelectorCommand {
     }
 
     func isSelected(model: Country) -> Bool {
-        model == selected
+        model.code == selected?.code // I'm only comparing country codes because states can be unsorted
     }
 
     func configureCell(cell: BasicTableViewCell, model: Country) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorCommand.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Yosemite
 
-import struct SwiftUI.Binding
-
 /// Command to be used to select a country when editing addresses.
 ///
 final class CountrySelectorCommand: ObservableListSelectorCommand {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -27,13 +27,18 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     ///
     let filterPlaceholder = Localization.placeholder
 
-    /// Current `SiteID`, needed to sync countries from a remote source.
+    /// Subscriptions store
     ///
-    private let siteID: Int64
+    private var subscriptions = Set<AnyCancellable>()
 
-    init(siteID: Int64, countries: [Country]) {
-        self.siteID = siteID
-        self.command = CountrySelectorCommand(countries: countries)
+    init(countries: [Country], selected: CurrentValueSubject<Country?, Never>) {
+        self.command = CountrySelectorCommand(countries: countries, selected: selected.value)
+
+        /// Bind selected country to the provided selected subject
+        ///
+        command.$selected.sink { country in
+            selected.send(country)
+        }.store(in: &subscriptions)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -27,10 +27,6 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     ///
     let filterPlaceholder = Localization.placeholder
 
-    /// Subscriptions store
-    ///
-    private var subscriptions = Set<AnyCancellable>()
-
     init(countries: [Country], selected: Binding<Country?>) {
         self.command = CountrySelectorCommand(countries: countries, selected: selected)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import SwiftUI
 import Yosemite
+import struct SwiftUI.Binding
 import protocol Storage.StorageManagerType
 
 /// View Model for the `CountrySelector` view.
@@ -31,14 +32,8 @@ final class CountrySelectorViewModel: FilterListSelectorViewModelable, Observabl
     ///
     private var subscriptions = Set<AnyCancellable>()
 
-    init(countries: [Country], selected: CurrentValueSubject<Country?, Never>) {
-        self.command = CountrySelectorCommand(countries: countries, selected: selected.value)
-
-        /// Bind selected country to the provided selected subject
-        ///
-        command.$selected.sink { country in
-            selected.send(country)
-        }.store(in: &subscriptions)
+    init(countries: [Country], selected: Binding<Country?>) {
+        self.command = CountrySelectorCommand(countries: countries, selected: selected)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,7 +1,6 @@
 import Combine
 import SwiftUI
 import Yosemite
-import struct SwiftUI.Binding
 import protocol Storage.StorageManagerType
 
 /// View Model for the `CountrySelector` view.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -112,7 +112,7 @@ struct EditAddressForm: View {
                     }
 
                     Group {
-                        TitleAndValueRow(title: Localization.countryField, value: Localization.placeholderSelectOption, selectable: true) {
+                        TitleAndValueRow(title: Localization.countryField, value: viewModel.fields.country, selectable: true) {
                             showCountrySelector = true
                         }
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -1,7 +1,6 @@
 import Yosemite
 import Storage
 import Combine
-import struct SwiftUI.Binding
 
 final class EditAddressFormViewModel: ObservableObject {
     /// Current site ID

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
+		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
@@ -1803,6 +1804,7 @@
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
+		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
@@ -5003,6 +5005,7 @@
 				B5D6DC53214802740003E48A /* SyncCoordinator.swift */,
 				CE22709E2293052700C0626C /* WebviewHelper.swift */,
 				45D685FD23D0FB25005F87D0 /* Throttler.swift */,
+				262C921E26EEF8B100011F92 /* Binding.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -7500,6 +7503,7 @@
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,
 				B5D1AFB820BC510200DB0E8C /* UIImage+Woo.swift in Sources */,
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
+				262C921F26EEF8B100011F92 /* Binding.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
 				CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -2,23 +2,23 @@ import XCTest
 import Yosemite
 import TestKit
 import Combine
+import struct SwiftUI.Binding
 @testable import WooCommerce
 
 final class CountrySelectorViewModelTests: XCTestCase {
 
-    let selectedSubject = CurrentValueSubject<Country?, Never>(nil)
     var subscriptions = Set<AnyCancellable>()
 
     override func setUp () {
         super.setUp()
 
-        selectedSubject.value = nil
         subscriptions.removeAll()
     }
 
     func test_filter_countries_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+        let binding = Binding<Country?>(get: { nil }, set: { _ in })
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: binding)
 
         // When
         viewModel.searchTerm = "Co"
@@ -43,7 +43,8 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_filter_countries_with_uppercase_letters_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+        let binding = Binding<Country?>(get: { nil }, set: { _ in })
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: binding)
 
         // When
         viewModel.searchTerm = "CO"
@@ -68,7 +69,8 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_cleaning_search_terms_return_all_countries() {
         // Given
-        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+        let binding = Binding<Country?>(get: { nil }, set: { _ in })
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: binding)
         let totalNumberOfCountries = viewModel.command.data.count
 
         // When
@@ -82,27 +84,28 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_providing_a_selected_country_is_reflected_on_command() {
         // Given
-        let country = Self.sampleCountries[0]
-        selectedSubject.value = country
+        let binding = Binding<Country?>(get: { Self.sampleCountries[0] }, set: { _ in })
 
         // When
-        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: binding)
 
         // Then
-        XCTAssertEqual(viewModel.command.selected, country)
+        XCTAssertEqual(viewModel.command.selected, binding.wrappedValue)
     }
 
-    func test_selecting_country_via_command_updates_subject() {
+    func test_selecting_country_via_command_updates_binding() {
         // Given
-        let country = Self.sampleCountries[0]
-        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+        let expectedCountry = Self.sampleCountries[0]
+        var selectedCountry: Country? = nil
+        let binding = Binding<Country?>(get: { selectedCountry }, set: { selectedCountry = $0 })
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: binding)
 
         // When
         let viewController = ListSelectorViewController(command: viewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
-        viewModel.command.handleSelectedChange(selected: country, viewController: viewController)
+        viewModel.command.handleSelectedChange(selected: expectedCountry, viewController: viewController)
 
         // Then
-        XCTAssertEqual(selectedSubject.value, country)
+        XCTAssertEqual(selectedCountry, expectedCountry)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -1,19 +1,24 @@
 import XCTest
 import Yosemite
 import TestKit
+import Combine
 @testable import WooCommerce
 
 final class CountrySelectorViewModelTests: XCTestCase {
 
-    let sampleSiteID: Int64 = 123
+    let selectedSubject = CurrentValueSubject<Country?, Never>(nil)
+    var subscriptions = Set<AnyCancellable>()
 
     override func setUp () {
         super.setUp()
+
+        selectedSubject.value = nil
+        subscriptions.removeAll()
     }
 
     func test_filter_countries_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
 
         // When
         viewModel.searchTerm = "Co"
@@ -38,7 +43,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_filter_countries_with_uppercase_letters_return_expected_results() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
 
         // When
         viewModel.searchTerm = "CO"
@@ -63,7 +68,7 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
     func test_cleaning_search_terms_return_all_countries() {
         // Given
-        let viewModel = CountrySelectorViewModel(siteID: sampleSiteID, countries: Self.sampleCountries)
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
         let totalNumberOfCountries = viewModel.command.data.count
 
         // When
@@ -73,6 +78,31 @@ final class CountrySelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.command.data.count, totalNumberOfCountries)
+    }
+
+    func test_providing_a_selected_country_is_reflected_on_command() {
+        // Given
+        let country = Self.sampleCountries[0]
+        selectedSubject.value = country
+
+        // When
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+
+        // Then
+        XCTAssertEqual(viewModel.command.selected, country)
+    }
+
+    func test_selecting_country_via_command_updates_subject() {
+        // Given
+        let country = Self.sampleCountries[0]
+        let viewModel = CountrySelectorViewModel(countries: Self.sampleCountries, selected: selectedSubject)
+
+        // When
+        let viewController = ListSelectorViewController(command: viewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        viewModel.command.handleSelectedChange(selected: country, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(selectedSubject.value, country)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/CountrySelector/CountrySelectorViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import Yosemite
 import TestKit
 import Combine
-import struct SwiftUI.Binding
 @testable import WooCommerce
 
 final class CountrySelectorViewModelTests: XCTestCase {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -18,14 +18,14 @@ final class EditAddressFormViewModelTests: XCTestCase {
         super.setUp()
 
         testingStorage.reset()
+        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
+
         testingStores.reset()
         subscriptions.removeAll()
     }
 
     func test_creating_with_address_prefills_fields_with_correct_data() {
         // Given
-        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
-
         let address = sampleAddress()
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
 
@@ -54,7 +54,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_updating_fields_enables_done_button() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
@@ -68,7 +68,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_updating_fields_back_to_original_values_disables_done_button() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
@@ -84,7 +84,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
     func test_creating_without_address_disables_done_button() {
         // Given
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: nil)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: nil, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -96,7 +96,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_creating_with_address_with_empty_nullable_fields_disables_done_button() {
         // Given
         let address = sampleAddressWithEmptyNullableFields()
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -108,7 +108,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_loading_indicator_gets_enabled_during_network_request() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -121,7 +121,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address)
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: address, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -137,6 +137,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
     func test_starting_view_model_without_stored_countries_fetches_them_remotely() {
         // Given
+        testingStorage.reset()
         let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: sampleAddress(), storageManager: testingStorage, stores: testingStores)
 
         // When
@@ -157,13 +158,15 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
     func test_syncing_countries_correctly_sets_showPlaceholders_properties() {
         // Given
-        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: sampleAddress(), storageManager: testingStorage, stores: testingStores)
+        testingStorage.reset()
         testingStores.whenReceivingAction(ofType: DataAction.self) { action in
             switch action {
             case .synchronizeCountries(_, let completion):
                 completion(.success([])) // Sending an empty because we don't really care about countries on this test.
             }
         }
+
+        let viewModel = EditAddressFormViewModel(siteID: sampleSiteID, address: sampleAddress(), storageManager: testingStorage, stores: testingStores)
 
         // When
         let showPlaceholdersStates: [Bool] = waitFor { promise in
@@ -184,7 +187,6 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
     func test_selecting_country_updates_country_field() {
         // Given
-        testingStorage.insertSampleCountries(readOnlyCountries: Self.sampleCountries)
         let newCountry = Self.sampleCountries[0]
 
         let address = sampleAddress()


### PR DESCRIPTION
part of #4780 

# Why

After moving the country synchronization to the EditAddress screen on #4967 now it's time to reflect on the `EditAddress` screen when a new country is selected.

# How

- Expose the `Binding` type to be used in the `WooCommerce` target without having to import `SwiftUI`. Similar to how [`Published` is exposed](https://developer.apple.com/documentation/foundation/published). 

- Expose a binding variable all the way from `CountrySelectorCommand` to the `EditAddressForm`. When this binding is assigned the fields property is repopulated and the trailing button recalculated. I tested several approaches to accomplish this(completion blocks, inout variables, subjects) but this binding approach was the simples and the one that looks cleaner!

- Create a `selectedCountry` published variable to track the latest selected country. This publisher is updated at startup with the initial value from the original address.

# Known Problems

- Everytime a country is selected the view is poped. Fixed in https://github.com/woocommerce/woocommerce-ios/pull/4981
- The "Select Country" row should render the country name in body style. https://github.com/woocommerce/woocommerce-ios/projects/39#card-68560797

# Demo

https://user-images.githubusercontent.com/562080/133095408-eeeacc39-635f-47b0-80df-dfb4aa59db22.mov

# Testing Steps

- Navigate to an order and edit its shipping address
- See that the the "select country" row now has the country name on it
- Select a new country
- See that the country name updates and the done button becomes enabled


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
