### PR TITLE
Order Editing: Fixes auto pop issue when selecting a country

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -147,6 +147,17 @@ struct EditAddressForm: View {
         LazyNavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
             EmptyView()
         }
+
+        ///
+        /// iOS 14.5 has a bug where
+        /// Pushing a view while having "exactly two" navigation links makes the pushed view to be popped when the initial view changes its state.
+        /// EG: AddressForm -> CountrySelector -> Country is selected -> AddressForm updates country -> CountrySelector is popped automatically.
+        /// Adding an extra and useless navigation link fixes the problem but throws a warning in the console.
+        /// Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279
+        ///
+        NavigationLink(destination: EmptyView()) {
+            EmptyView()
+        }
     }
 
     /// Decides if the navigation trailing item should be a done button or a loading indicator.


### PR DESCRIPTION
part of #4780 

# Why

On #4980 I spotted an issue where the country selector screen is instantly popped after selecting a country.

Upon investigation, it seems to be a bug on `iOS 14.5` where if we have "exactly two" navigation links and one of those destinations triggers a mutation on the first screen, the view will be popped.

A quick(and ugly) fix is to create an empty navigation link.

I also tried having one navigation link and figure out the destination at runtime, and while this worked the code necessary to accomplish it was not trivial, therefore I decided to go for the quick hack. 🤷‍♂️ 

Ref: https://forums.swift.org/t/14-5-beta3-navigationlink-unexpected-pop/45279

# Demo

### Before

https://user-images.githubusercontent.com/562080/133114649-f5ba9db8-eaf8-4aa7-bfef-6086ea473ef1.mov

### After

https://user-images.githubusercontent.com/562080/133114680-c7ca1bb6-f4e5-4e24-9d5a-102fd7b0c7a1.mov



# Testing Steps

- Navigate to an order and edit its shipping address
- Select a new country
- See that the view is not popped automatically.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
