### PR TITLE
Remove double order_status_change event when completing an order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -531,13 +531,6 @@ private extension OrderDetailsViewController {
         let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel) { [weak self] in
             guard let self = self else { return }
-            ServiceLocator.analytics.track(
-                .orderStatusChange,
-                withProperties: [
-                    "id": self.viewModel.order.orderID,
-                    "from": self.viewModel.order.status.rawValue,
-                    "to": OrderStatusEnum.completed.rawValue
-                ])
             let fulfillmentProcess = self.viewModel.markCompleted()
             let presenter = OrderFulfillmentNoticePresenter()
             presenter.present(process: fulfillmentProcess)


### PR DESCRIPTION
# Why

@astralbodies noticed that since August there is a spike in the number of the "order_status_change" recorded events.

It seems like when we bring back `ReviewOrderViewController` we also added an unnecessary track for when the order is marked as completed. 

This event is already being fired by the `OrderFulfillmentUseCase` which is triggered within the view model `markCompleted()` method.

# How

Delete the unnecessary event track.

# Test

- Navigate to a processing order 
- Mark an order as completed by tapping the "Mark as completed" button
- See in the device logs that only one `order_status_change` event is being fired.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
