### PR TITLE
[Mobile Payments] [Several Readers Found] Remove several-readers-found feature flag and launch for all users

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -19,8 +19,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .cardPresentSeveralReadersFound:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .whatsNewOnWooCommerce:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -42,10 +42,6 @@ enum FeatureFlag: Int {
     ///
     case orderEditing
 
-    /// Card-Present Payments Several Readers Found
-    ///
-    case cardPresentSeveralReadersFound
-
     /// Display "What's new on WooCommerce" on App Launch and App Settings
     ///
     case whatsNewOnWooCommerce

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -183,10 +183,6 @@ private extension CardReaderConnectionController {
     /// single reader found UI for this particular discovery)
     ///
     func updateShowSeveralFoundReaders() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.cardPresentSeveralReadersFound) else {
-            return
-        }
-
         if foundReaders.containsMoreThanOne {
             showSeveralFoundReaders = true
         }


### PR DESCRIPTION
Closes #4333 

Changes:
- This is the last PR in the series of PRs that brings the "Several Readers Found" flow to life
- It simple removes the feature flag for the several-readers-found feature so that this feature launches for all users

To test:
- Ensure you can continue to discover just one reader or multiple readers in settings or collect payment flows
- Ensure all unit tests pass

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
