### PR TITLE
Issue 4854: Order Details titles should be title case

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.1)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -244,6 +245,9 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.12.2)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.2-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -328,6 +332,7 @@ GEM
     xctest_list (1.2.1)
 
 PLATFORMS
+  -darwin-20
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,6 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.1)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -245,9 +244,6 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.12.2)
-      mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
     nokogiri (1.12.2-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -332,7 +328,6 @@ GEM
     xctest_list (1.2.1)
 
 PLATFORMS
-  -darwin-20
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -781,15 +781,9 @@ private extension OrderDetailsDataSource {
     private func configureShippingAddress(cell: CustomerInfoTableViewCell) {
         let shippingAddress = order.shippingAddress
 
-        cell.title = NSLocalizedString("Shipping details",
-                                       comment: "Shipping title for customer info cell")
+        cell.title = Title.shippingAddress
         cell.name = shippingAddress?.fullNameWithCompany
-        cell.address = shippingAddress?.formattedPostalAddress ??
-            NSLocalizedString(
-                "No address specified.",
-                comment: "Order details > customer info > shipping details. " +
-                "This is where the address would normally display."
-        )
+        cell.address = shippingAddress?.formattedPostalAddress ?? Title.shippingAddressEmptyAction
 
         cell.onEditTapped = orderEditingEnabled ? { [weak self] in
             self?.onCellAction?(.editShippingAddress, nil)
@@ -1221,6 +1215,8 @@ extension OrderDetailsDataSource {
         static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
         static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
         static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
+        static let shippingAddress = NSLocalizedString("Shipping Details",
+                                                       comment: "Shipping title for customer info cell")
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
@@ -1242,6 +1238,10 @@ extension OrderDetailsDataSource {
             NSLocalizedString("Don’t know how to print from your mobile device?",
                               comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
                                 "a shipping label on the mobile device.")
+        static let shippingAddressEmptyAction =
+            NSLocalizedString("No address specified.",
+                              comment: "Order details > customer info > shipping details. " +
+                                "This is where the address would normally display.")
     }
 
     enum Footer {


### PR DESCRIPTION
Fixes #4854 

## Description
The title string "Shipping details" should be title case. This change fixes the casing, to make it consistent with the rest of the titles on the Order Details screen. 

Additionally, I've moved the relevant localizable strings to the Localization enum.

## Testing
On a store with an order, navigate to `Orders > Order #x` and scroll down to the `Shipping Details` section.
![Shipping Details](https://user-images.githubusercontent.com/2472348/133250314-53ef8a86-5238-42d3-aaf7-baa63d1ac7f7.jpg)





Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
