### PR TITLE
Add/Edit Products: product image stops loading on product image upload error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.6
 -----
-- [*] Fix: when product image upload fails, the image cell stop loading.
+- [*] Fix: when product image upload fails, the image cell stop loading. [https://github.com/woocommerce/woocommerce-ios/pull/4989]
 
 7.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.6
 -----
-
+- [*] Fix: when product image upload fails, the image cell stop loading.
 
 7.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -122,9 +122,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 self.displayErrorAlert(title: title, message: message)
             }
 
-            if productImageStatuses.hasPendingUpload {
-                self.onImageStatusesUpdated(statuses: productImageStatuses)
-            }
+            self.onImageStatusesUpdated(statuses: productImageStatuses)
 
             self.viewModel.updateImages(productImageStatuses.images)
         }


### PR DESCRIPTION
Fixes #3134 

Previously, when product image upload fails, the image cell still stays in the loading state.

## Testing
1. Go to the Products tab
2. Add or edit a product
3. Tap on the "+" cell or any image cell in the images header
4. Tap "Add Photos"
5. Choose a photo or take one with camera, and quickly switch to offline mode --> after a bit, an error alert is shown and the image cell should stop the loading state.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
