### PR TITLE
Adds Store picker error modal UI

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+/// Hosting controller wrapper for `StorePickerError`
+///
+final class StorePickerErrorHostingController: UIHostingController<StorePickerError> {
+    init() {
+        super.init(rootView: StorePickerError())
+    }
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
 /// Generic Store Picker error view that allows the user to contact support.
 ///
 struct StorePickerError: View {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -17,7 +17,7 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 ///
 struct StorePickerError: View {
     var body: some View {
-        VStack(alignment: .center, spacing: 30) {
+        VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
             // Title
             Text(Localization.title)
                 .headlineStyle()
@@ -29,27 +29,29 @@ struct StorePickerError: View {
             Text(Localization.body)
                 .bodyStyle()
 
-            // Primary Button
-            Button(Localization.troubleshoot) {
-                print("Troubleshooting Tips tapped")
-            }
-            .buttonStyle(PrimaryButtonStyle())
+            VStack(spacing: Layout.buttonsSpacing) {
+                // Primary Button
+                Button(Localization.troubleshoot) {
+                    print("Troubleshooting Tips tapped")
+                }
+                .buttonStyle(PrimaryButtonStyle())
 
-            // Secondary button
-            Button(Localization.contact) {
-                print("Contact support tapped")
-            }
-            .buttonStyle(SecondaryButtonStyle())
+                // Secondary button
+                Button(Localization.contact) {
+                    print("Contact support tapped")
+                }
+                .buttonStyle(SecondaryButtonStyle())
 
-            // Dismiss button
-            Button(Localization.back) {
-                print("Back to site")
+                // Dismiss button
+                Button(Localization.back) {
+                    print("Back to site")
+                }
+                .buttonStyle(LinkButtonStyle())
             }
-            .buttonStyle(LinkButtonStyle())
         }
         .padding()
         .background(Color(.basicBackground))
-        .cornerRadius(10)
+        .cornerRadius(Layout.rounderCorners)
     }
 }
 
@@ -66,6 +68,12 @@ private extension StorePickerError {
                                                comment: "Text for the button to contact support from the store picker error screen")
         static let back = NSLocalizedString("Back to Sites",
                                             comment: "Text for the button to dismiss the store picker error screen")
+    }
+
+    enum Layout {
+        static let rounderCorners: CGFloat = 10
+        static let mainVerticalSpacing: CGFloat = 25
+        static let buttonsSpacing: CGFloat = 15
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -47,9 +47,9 @@ struct StorePickerError: View {
             }
             .buttonStyle(LinkButtonStyle())
         }
+        .padding()
         .background(Color(.basicBackground))
         .cornerRadius(10)
-        .padding()
     }
 }
 
@@ -73,7 +73,11 @@ private extension StorePickerError {
 
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
-        StorePickerError()
-            .previewLayout(.sizeThatFits)
+        VStack {
+            StorePickerError()
+        }
+        .padding()
+        .background(Color.gray)
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -27,6 +27,7 @@ struct StorePickerError: View {
 
             // Body text
             Text(Localization.body)
+                .multilineTextAlignment(.center)
                 .bodyStyle()
 
             VStack(spacing: Layout.buttonsSpacing) {
@@ -49,7 +50,8 @@ struct StorePickerError: View {
                 .buttonStyle(LinkButtonStyle())
             }
         }
-        .padding()
+        .padding([.leading, .trailing, .bottom])
+        .padding(.top, Layout.topPadding)
         .background(Color(.basicBackground))
         .cornerRadius(Layout.rounderCorners)
     }
@@ -74,6 +76,7 @@ private extension StorePickerError {
         static let rounderCorners: CGFloat = 10
         static let mainVerticalSpacing: CGFloat = 25
         static let buttonsSpacing: CGFloat = 15
+        static let topPadding: CGFloat = 30
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -52,7 +52,7 @@ struct StorePickerError: View {
         }
         .padding([.leading, .trailing, .bottom])
         .padding(.top, Layout.topPadding)
-        .background(Color(.basicBackground))
+        .background(Color(.tertiarySystemBackground))
         .cornerRadius(Layout.rounderCorners)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -17,38 +17,55 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 ///
 struct StorePickerError: View {
     var body: some View {
-        VStack(alignment: .center) {
+        VStack(alignment: .center, spacing: 30) {
             // Title
-            Text("We couldn't load your site")
+            Text(Localization.title)
                 .headlineStyle()
 
             // Main image
             Image(uiImage: .errorImage)
 
             // Body text
-            Text("Please try again or reach out to us and we'll be happy to assist you!")
+            Text(Localization.body)
                 .bodyStyle()
 
             // Primary Button
-            Button("Read our Troubleshooting Tips") {
+            Button(Localization.troubleshoot) {
                 print("Troubleshooting Tips tapped")
             }
             .buttonStyle(PrimaryButtonStyle())
 
             // Secondary button
-            Button("Contact Support") {
+            Button(Localization.contact) {
                 print("Contact support tapped")
             }
             .buttonStyle(SecondaryButtonStyle())
 
             // Dismiss button
-            Button("Back to Sites") {
+            Button(Localization.back) {
                 print("Back to site")
             }
             .buttonStyle(LinkButtonStyle())
         }
         .background(Color(.basicBackground))
+        .cornerRadius(10)
         .padding()
+    }
+}
+
+// MARK: Constant
+
+private extension StorePickerError {
+    enum Localization {
+        static let title = NSLocalizedString("We couldn't load your site", comment: "Title for the default store picker error screen")
+        static let body = NSLocalizedString("Please try again or reach out to us and we'll be happy to assist you!",
+                                            comment: "Body text for the default store picker error screen")
+        static let troubleshoot = NSLocalizedString("Read our Troubleshooting Tips",
+                                                    comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
+        static let contact = NSLocalizedString("Contact Support",
+                                               comment: "Text for the button to contact support from the store picker error screen")
+        static let back = NSLocalizedString("Back to Sites",
+                                            comment: "Text for the button to dismiss the store picker error screen")
     }
 }
 
@@ -57,6 +74,6 @@ struct StorePickerError: View {
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
         StorePickerError()
-            .previewLayout(.fixed(width: 414, height: 768))
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -90,5 +90,13 @@ struct StorePickerError_Preview: PreviewProvider {
         .padding()
         .background(Color.gray)
         .previewLayout(.sizeThatFits)
+
+        VStack {
+            StorePickerError()
+        }
+        .padding()
+        .background(Color.gray)
+        .environment(\.colorScheme, .dark)
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -6,6 +6,7 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     init() {
         super.init(rootView: StorePickerError())
     }
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -46,6 +47,8 @@ struct StorePickerError: View {
             }
             .buttonStyle(LinkButtonStyle())
         }
+        .background(Color(.basicBackground))
+        .padding()
     }
 }
 
@@ -54,5 +57,6 @@ struct StorePickerError: View {
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
         StorePickerError()
+            .previewLayout(.fixed(width: 414, height: 768))
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Generic Store Picker error view that allows the user to contact support.
+///
+struct StorePickerError: View {
+    var body: some View {
+        VStack(alignment: .center) {
+            // Title
+            Text("We couldn't load your site")
+                .headlineStyle()
+
+            // Main image
+            Image(uiImage: .errorImage)
+
+            // Body text
+            Text("Please try again or reach out to us and we'll be happy to assist you!")
+                .bodyStyle()
+
+            // Primary Button
+            Button("Read our Troubleshooting Tips") {
+                print("Troubleshooting Tips tapped")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            // Secondary button
+            Button("Contact Support") {
+                print("Contact support tapped")
+            }
+            .buttonStyle(SecondaryButtonStyle())
+
+            // Dismiss button
+            Button("Back to Sites") {
+                print("Back to site")
+            }
+            .buttonStyle(LinkButtonStyle())
+        }
+    }
+}
+
+// MARK: Previews
+
+struct StorePickerError_Preview: PreviewProvider {
+    static var previews: some View {
+        StorePickerError()
+    }
+}

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -423,7 +423,8 @@ private extension StorePickerViewController {
         RequirementsChecker.checkMinimumWooVersion(for: siteID) { [weak self] result in
             switch result {
             case .success(.validWCVersion):
-                self?.updateUIForValidSite()
+                //self?.updateUIForValidSite()
+                self?.updateUIForEmptyOrErroredSite(named: siteName, with: siteID)
             case .success(.invalidWCVersion):
                 self?.updateUIForInvalidSite(named: siteName)
             case .failure:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -423,8 +423,7 @@ private extension StorePickerViewController {
         RequirementsChecker.checkMinimumWooVersion(for: siteID) { [weak self] result in
             switch result {
             case .success(.validWCVersion):
-                //self?.updateUIForValidSite()
-                self?.updateUIForEmptyOrErroredSite(named: siteName, with: siteID)
+                self?.updateUIForValidSite()
             case .success(.invalidWCVersion):
                 self?.updateUIForInvalidSite(named: siteName)
             case .failure:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
+		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263E38462641FF3400260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; };
@@ -1812,6 +1813,7 @@
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
+		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
@@ -5357,6 +5359,7 @@
 				B5D1AFC520BC7B7300DB0E8C /* StorePickerViewController.swift */,
 				B5D1AFC720BC7B9600DB0E8C /* StorePickerViewController.xib */,
 				74460D4122289C7A00D7316A /* StorePickerCoordinator.swift */,
+				262C922026F1370000011F92 /* StorePickerError.swift */,
 				45527A402472C6160078D609 /* SwitchStoreUseCase.swift */,
 				45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */,
 			);
@@ -7807,6 +7810,7 @@
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,
 				57A25C7625ACE9BC00A54A62 /* OrderFulfillmentUseCase.swift in Sources */,
+				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,


### PR DESCRIPTION
part of #4383 

# Why

For HACK Week, I'm working on improving the error shown when a merchant can't select a store.
Currently, it is just a notice and we will turn it into a modal popover.
This PR just adds the UI.

Note: Accessibility will be tackled later.

# How

- Added a `SwiftUI` view with the required components & Styles
- Added a hosting view controller so it can be presented later from the store picker view controller.

# Screenshots

Light | Dark
--- | ---
<img width="463" alt="Screen Shot 2021-09-14 at 8 16 34 PM" src="https://user-images.githubusercontent.com/562080/133440549-2c6b83d0-6503-43b0-9042-91a51ebf86e3.png"> | <img width="442" alt="Screen Shot 2021-09-15 at 8 12 57 AM" src="https://user-images.githubusercontent.com/562080/133440556-3173a87d-977c-4e75-84d2-289ef5ed21a3.png">

# Testing Steps
- In Xcode go to the `StorePickerError` file
- See the view rendered in the Preview Provider.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
