### PR TITLE
Adds closures to respond to action buttons

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -1,8 +1,27 @@
 import SwiftUI
+import SafariServices
 
 /// Hosting controller wrapper for `StorePickerError`
 ///
 final class StorePickerErrorHostingController: UIHostingController<StorePickerError> {
+
+    /// Creates an `StorePickerErrorHostingController` with preconfigured button actions.
+    ///
+    static func createWithActions(presentingViewController: UIViewController) -> StorePickerErrorHostingController {
+        .init(
+            troubleshootingAction: {
+                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+                presentingViewController.present(safariViewController, animated: true)
+            },
+            contactSupportAction: {
+                ZendeskManager.shared.showNewRequestIfPossible(from: presentingViewController)
+            },
+            dismissAction: {
+                presentingViewController.dismiss(animated: true)
+            }
+        )
+    }
+
     init(troubleshootingAction: @escaping () -> Void, contactSupportAction: @escaping () -> Void, dismissAction: @escaping () -> Void) {
         super.init(rootView: StorePickerError(troubleshootingAction: troubleshootingAction,
                                               contactSupportAction: contactSupportAction,

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -3,8 +3,10 @@ import SwiftUI
 /// Hosting controller wrapper for `StorePickerError`
 ///
 final class StorePickerErrorHostingController: UIHostingController<StorePickerError> {
-    init() {
-        super.init(rootView: StorePickerError())
+    init(troubleshootingAction: @escaping () -> Void, contactSupportAction: @escaping () -> Void, dismissAction: @escaping () -> Void) {
+        super.init(rootView: StorePickerError(troubleshootingAction: troubleshootingAction,
+                                              contactSupportAction: contactSupportAction,
+                                              dismissAction: dismissAction))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -16,6 +18,19 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 /// Generic Store Picker error view that allows the user to contact support.
 ///
 struct StorePickerError: View {
+
+    /// Closure invoked when the "Troubleshooting" button is pressed
+    ///
+    let troubleshootingAction: () -> Void
+
+    /// Closure invoked when the "Contact Support" button is pressed
+    ///
+    let contactSupportAction: () -> Void
+
+    /// Closure invoked when the "Back To Sites" button is pressed
+    ///
+    let dismissAction: () -> Void
+
     var body: some View {
         VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
             // Title
@@ -32,22 +47,16 @@ struct StorePickerError: View {
 
             VStack(spacing: Layout.buttonsSpacing) {
                 // Primary Button
-                Button(Localization.troubleshoot) {
-                    print("Troubleshooting Tips tapped")
-                }
-                .buttonStyle(PrimaryButtonStyle())
+                Button(Localization.troubleshoot, action: troubleshootingAction)
+                    .buttonStyle(PrimaryButtonStyle())
 
                 // Secondary button
-                Button(Localization.contact) {
-                    print("Contact support tapped")
-                }
-                .buttonStyle(SecondaryButtonStyle())
+                Button(Localization.contact, action: contactSupportAction)
+                    .buttonStyle(SecondaryButtonStyle())
 
                 // Dismiss button
-                Button(Localization.back) {
-                    print("Back to site")
-                }
-                .buttonStyle(LinkButtonStyle())
+                Button(Localization.back, action: dismissAction)
+                    .buttonStyle(LinkButtonStyle())
             }
         }
         .padding([.leading, .trailing, .bottom])
@@ -85,14 +94,14 @@ private extension StorePickerError {
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
         VStack {
-            StorePickerError()
+            StorePickerError(troubleshootingAction: {}, contactSupportAction: {}, dismissAction: {})
         }
         .padding()
         .background(Color.gray)
         .previewLayout(.sizeThatFits)
 
         VStack {
-            StorePickerError()
+            StorePickerError(troubleshootingAction: {}, contactSupportAction: {}, dismissAction: {})
         }
         .padding()
         .background(Color.gray)


### PR DESCRIPTION
part of #4383

# Why

After #4993, this PR makes sure to add the necessary actions to make the UI useful.

- Launch the troubleshooting URL using a `SafaryViewController`
- Begin a `Zendesk` request 
- Dismiss the view controller.

Note: This VC is supposed to be presented as a modal with a custom presentation context but that will be done in the next PR, once I connect it to come from the real store picker.

# How

- Add closures on `StorePickerError` to be assigned from `StorePickerErrorHostingController`
- Added a factory function to create `StorePickerErrorHostingController` configured with propper actions.


# Demo

https://user-images.githubusercontent.com/562080/133471128-ae65fd55-1cca-44a7-a80c-22caeb2ff985.mov

# Testing Steps

In the `ViewDidLoad` of `DashboardViewController` add this code

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
    let viewController = StorePickerErrorHostingController.createWithActions(presenting: self)
    self.present(viewController, animated: true)
}
```

- See that you can navigate to troubleshooting tips and to contact support.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
