### PR TITLE
Don't request line_items in the order list

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -133,7 +133,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let paymentMethodID = try container.decode(String.self, forKey: .paymentMethodID)
         let paymentMethodTitle = try container.decode(String.self, forKey: .paymentMethodTitle)
 
-        let items = try? container.decode([OrderItem].self, forKey: .items)
+        let items = try? container.decodeIfPresent([OrderItem].self, forKey: .items) ?? []
 
         let shippingAddress = try? container.decode(Address.self, forKey: .shippingAddress)
         let billingAddress = try? container.decode(Address.self, forKey: .billingAddress)

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -60,7 +60,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 totalTax: String,
                 paymentMethodID: String,
                 paymentMethodTitle: String,
-                items: [OrderItem],
+                items: [OrderItem]?,
                 billingAddress: Address?,
                 shippingAddress: Address?,
                 shippingLines: [ShippingLine],
@@ -91,7 +91,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.paymentMethodID = paymentMethodID
         self.paymentMethodTitle = paymentMethodTitle
 
-        self.items = items
+        self.items = items ?? []
         self.billingAddress = billingAddress
         self.shippingAddress = shippingAddress
         self.shippingLines = shippingLines
@@ -133,7 +133,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         let paymentMethodID = try container.decode(String.self, forKey: .paymentMethodID)
         let paymentMethodTitle = try container.decode(String.self, forKey: .paymentMethodTitle)
 
-        let items = try container.decode([OrderItem].self, forKey: .items)
+        let items = try? container.decode([OrderItem].self, forKey: .items)
 
         let shippingAddress = try? container.decode(Address.self, forKey: .shippingAddress)
         let billingAddress = try? container.decode(Address.self, forKey: .billingAddress)

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -28,7 +28,7 @@ public class OrdersRemote: Remote {
                 ParameterKeys.page: String(pageNumber),
                 ParameterKeys.perPage: String(pageSize),
                 ParameterKeys.statusKey: statusKey ?? Defaults.statusAny,
-                ParameterKeys.fields: ParameterValues.fieldValues,
+                ParameterKeys.fields: ParameterValues.listFieldValues,
             ]
 
             if let before = before {
@@ -54,7 +54,7 @@ public class OrdersRemote: Remote {
     ///
     public func loadOrder(for siteID: Int64, orderID: Int64, completion: @escaping (Order?, Error?) -> Void) {
         let parameters = [
-            ParameterKeys.fields: ParameterValues.fieldValues
+            ParameterKeys.fields: ParameterValues.singleOrderFieldValues
         ]
 
         let path = "\(Constants.ordersPath)/\(orderID)"
@@ -98,7 +98,7 @@ public class OrdersRemote: Remote {
             ParameterKeys.page: String(pageNumber),
             ParameterKeys.perPage: String(pageSize),
             ParameterKeys.statusKey: Defaults.statusAny,
-            ParameterKeys.fields: ParameterValues.fieldValues
+            ParameterKeys.fields: ParameterValues.listFieldValues
         ]
 
         let path = Constants.ordersPath
@@ -199,11 +199,16 @@ public extension OrdersRemote {
     }
 
     enum ParameterValues {
-        static let fieldValues: String = """
+        static let listFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
-            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,line_items,shipping,\
+            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,shipping,\
             billing,coupon_lines,shipping_lines,refunds,fee_lines
             """
+        static let singleOrderFieldValues: String = """
+            id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
+            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,shipping,\
+            billing,coupon_lines,shipping_lines,refunds,fee_lines,line_items
+        """
     }
 
     /// Order fields supported for update

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -201,8 +201,8 @@ public extension OrdersRemote {
     enum ParameterValues {
         static let listFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
-            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,shipping,\
-            billing,coupon_lines,shipping_lines,refunds,fee_lines
+            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,\
+            coupon_lines,shipping_lines,refunds,fee_lines
             """
         static let singleOrderFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -199,6 +199,7 @@ public extension OrdersRemote {
     }
 
     enum ParameterValues {
+        // Same as singleOrderFieldValues except we exclude the line_items and shipping fields
         static let listFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
             discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,\

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -202,7 +202,7 @@ public extension OrdersRemote {
         static let listFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
             discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method,payment_method_title,\
-            coupon_lines,shipping_lines,refunds,fee_lines
+            billing,coupon_lines,shipping_lines,refunds,fee_lines
             """
         static let singleOrderFieldValues: String = """
             id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -68,6 +68,10 @@ struct OrdersUpsertUseCase {
         let siteID = readOnlyOrder.siteID
         let orderID = readOnlyOrder.orderID
 
+        guard readOnlyOrder.items.count > 0 else {
+            return
+        }
+
         // Upsert the items from the read-only order
         for readOnlyItem in readOnlyOrder.items {
             if let existingStorageItem = storage.loadOrderItem(siteID: siteID, orderID: orderID, itemID: readOnlyItem.itemID) {


### PR DESCRIPTION
In the order list view, we don't show details about the individual
products in the order. Requesting full details about all the products
can have a significant impact on performance.

Here we differentiate between fields we need for single orders and a
list of orders. For now the only difference is that single orders do
load the line items.