### PR TITLE
4890 Center empty state in space below top banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -98,6 +98,21 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     /// Used to present the Contact Support dialog if the `Config` is `.withSupportRequest`.
     private let zendeskManager: ZendeskManagerProtocol
 
+    /// Used to pin the stackView to the center of the visible area in the contact view,
+    /// taking account of the banner view when it's shown.
+    private lazy var visiblyCenteredLayoutGuide: UILayoutGuide = {
+        let centerGuide = UILayoutGuide()
+        contentView.addLayoutGuide(centerGuide)
+        let topConstraint = centerGuide.topAnchor.constraint(equalTo: contentView.topAnchor)
+        topConstraint.priority = UILayoutPriority(250)
+        NSLayoutConstraint.activate([
+            topConstraint,
+            centerGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            centerGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            centerGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
+        return centerGuide
+    }()
+
     /// Top banner that shows an error if there is a problem loading reviews data
     ///
     private lazy var topBannerView: TopBannerView = {
@@ -129,6 +144,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 
         view.backgroundColor = style.backgroundColor
         contentView.backgroundColor = style.backgroundColor
+        NSLayoutConstraint.activate([stackView.centerYAnchor.constraint(equalTo: visiblyCenteredLayoutGuide.centerYAnchor)])
 
         messageLabel.applySecondaryTitleStyle()
         detailsLabel.applySecondaryBodyStyle()
@@ -241,7 +257,8 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
             topBannerView.leadingAnchor.constraint(equalTo: contentView.safeLeadingAnchor),
             topBannerView.trailingAnchor.constraint(equalTo: contentView.safeTrailingAnchor),
             topBannerView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            topBannerView.bottomAnchor.constraint(lessThanOrEqualTo: stackView.topAnchor, constant: -16)
+            topBannerView.bottomAnchor.constraint(lessThanOrEqualTo: stackView.topAnchor, constant: -16),
+            visiblyCenteredLayoutGuide.topAnchor.constraint(equalTo: topBannerView.bottomAnchor)
         ])
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -33,7 +33,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Usx-wg-Fgl">
-                                    <rect key="frame" x="58" y="168.5" width="298" height="481.5"/>
+                                    <rect key="frame" x="58" y="185.5" width="298" height="447"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We're sorry, we couldn't find results for &quot;adidas&quot;" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h54-zO-thf">
                                             <rect key="frame" x="0.0" y="0.0" width="298" height="41"/>
@@ -45,14 +45,14 @@
                                             <rect key="frame" x="31" y="73" width="236" height="206"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iFj-AP-WfL">
-                                            <rect key="frame" x="1.5" y="311" width="295" height="108.5"/>
+                                            <rect key="frame" x="0.0" y="311" width="298" height="74"/>
                                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MHH-Z6-FbG" userLabel="Action Button">
-                                            <rect key="frame" x="35" y="451.5" width="228" height="30"/>
+                                            <rect key="frame" x="35" y="417" width="228" height="30"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="228" id="ytx-Jd-N6j"/>
                                             </constraints>
@@ -69,7 +69,7 @@
                                 <constraint firstAttribute="trailing" secondItem="Usx-wg-Fgl" secondAttribute="trailing" constant="58" id="Ard-YP-Eb1"/>
                                 <constraint firstItem="Usx-wg-Fgl" firstAttribute="leading" secondItem="nZ1-Qr-0N4" secondAttribute="leading" constant="58" id="F8T-gj-c3S"/>
                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Usx-wg-Fgl" secondAttribute="bottom" constant="8" id="ItW-Oe-98H"/>
-                                <constraint firstItem="Usx-wg-Fgl" firstAttribute="centerY" secondItem="nZ1-Qr-0N4" secondAttribute="centerY" id="Qwk-Qs-WXi"/>
+                                <constraint firstItem="Usx-wg-Fgl" firstAttribute="centerY" secondItem="nZ1-Qr-0N4" secondAttribute="centerY" placeholder="YES" id="Qwk-Qs-WXi"/>
                                 <constraint firstItem="Usx-wg-Fgl" firstAttribute="top" relation="greaterThanOrEqual" secondItem="nZ1-Qr-0N4" secondAttribute="top" constant="8" id="Z5f-Ai-Dxe"/>
                             </constraints>
                         </view>


### PR DESCRIPTION
Fixes #4900 

## Description
When the error view top banner showed on a screen with the EmptyStateViewController, the centering of the empty state stack view was still based on the total content view, rather than the visable space between the top banner and the bottom of the content view.

## Changes
This change provides a layout guide for the vertical center of the visible area, updated when the top banner is shown, expanded, or hidden. The empty state stack view has a centerY constraint equal to this guide's centerY anchor.

The >= 16 constraints for the top and bottom remain because of the keyboard centering adjustments, which come in to play on empty search results screens. Without these, a keyboard showing notification can push the empty state views outside the bounds of the content view and overlapping other views.

## Testing

### Reproduction
These steps were taken from #4407 via #4900.

1. Build and run a fresh install of the app (to begin without any cached data).
2. Log in to the app.
3. Disconnect your internet connection. (This is so you will trigger a sync error; you can also disrupt your store's Jetpack connection for a more realistic scenario.)
4. Select Orders tab.
5. Notice the error banner appears at the top of the Orders empty state screen on both the "Processing" and "All Orders" tabs.
6. Tap the expand button. The empty state will now remain vertically centered.

Before | After
-------|-------
![Before](https://user-images.githubusercontent.com/2472348/133592647-dfb3307d-6d9f-4e7e-8d57-0ca4b8f23d62.gif) | ![After](https://user-images.githubusercontent.com/2472348/133593073-21c42db5-d861-459d-abca-0584e501b3df.gif)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
