### PR TITLE
Shipping Labels: fix decimal values in different countries in custom package creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageFormViewModel.swift
@@ -68,11 +68,11 @@ final class ShippingLabelCustomPackageFormViewModel: ObservableObject {
     /// Validated custom package
     ///
     var validatedCustomPackage: ShippingLabelCustomPackage? {
-        guard isPackageValidated, let boxWeight = Double(emptyPackageWeight) else {
+        guard isPackageValidated, let boxWeight = NumberFormatter.double(from: emptyPackageWeight) else {
             return nil
         }
         let isLetter = packageType == .letter
-        let dimensions = "\(packageLength) x \(packageWidth) x \(packageHeight)"
+        let dimensions = "\(packageLength) x \(packageWidth) x \(packageHeight)".replacingOccurrences(of: ",", with: ".")
         return ShippingLabelCustomPackage(isUserDefined: true,
                                           title: packageName,
                                           isLetter: isLetter,
@@ -166,7 +166,7 @@ extension ShippingLabelCustomPackageFormViewModel {
     /// Sanitize string input to return only valid Double values
     ///
     func sanitizeNumericInput(_ value: String) -> String {
-        guard Double(value) != nil else {
+        guard NumberFormatter.double(from: value) != nil else {
             return String(value.dropLast())
         }
         return value
@@ -177,14 +177,14 @@ extension ShippingLabelCustomPackageFormViewModel {
     }
 
     private func validatePackageDimension(_ dimension: String) -> Bool {
-        guard let numericValue = Double(dimension) else {
+        guard dimension.isNotEmpty, let numericValue = NumberFormatter.double(from: dimension) else {
             return false
         }
         return numericValue > 0
     }
 
     private func validatePackageWeight(_ weight: String) -> Bool {
-        guard let numericValue = Double(weight) else {
+        guard let numericValue = NumberFormatter.double(from: weight) else {
             return false
         }
         return numericValue >= 0


### PR DESCRIPTION

## Description
While I was testing https://github.com/woocommerce/woocommerce-ios/pull/4976 before enabling the feature flag to all our users, I discovered https://github.com/woocommerce/woocommerce-ios/pull/4976#pullrequestreview-753707349 a bug about decimal values in different countries where the separator for the floating-point numbers is the comma and not the dot (like in Italy). In that case, it's impossible to edit the values in the custom package form. 

In this PR, I fixed the issue using the new extension of `NumberFormatter` introduced by @itsmeichigo previously. Plus, I make sure to send always the dot to the backend instead of a comma when we send the dimensions property.

## Testing
1. Change your device location to Italy (or another country) where the decimal separator is the comma `,`.
2. Open an order detail that is eligible for a shipping label.
3. Tap the button "Create Shipping Label.”
4. Confirm "Ship From" and "Ship To.”
5. In the package details section, tap on “Package Selected.”
6. On the Add New Package screen, create a new custom package (on the Custom Package tab).
7. Add all the info needed, and make sure you are able to insert decimal values with a comma.
7. Tap the Done button and confirm your new package is selected on the "Package Selected" screen.

Repeat the testing procedure with a country where the decimal separator is the dot `.`.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
