### PR TITLE
Accessibility labels on edit icons in Order Details

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -382,6 +382,10 @@ private extension OrderDetailsDataSource {
         cell.onEditTapped = { [weak self] in
             self?.onCellAction?(.editCustomerNote, nil)
         }
+
+        cell.editButtonAccessibilityLabel = NSLocalizedString(
+            "Update Note",
+            comment: "Accessibility Label for the edit button to change the Customer Provided Note in Order Details")
     }
 
     private func configureBillingDetail(cell: WooBasicTableViewCell) {
@@ -788,6 +792,10 @@ private extension OrderDetailsDataSource {
         cell.onEditTapped = orderEditingEnabled ? { [weak self] in
             self?.onCellAction?(.editShippingAddress, nil)
         } : nil
+
+        cell.editButtonAccessibilityLabel = NSLocalizedString(
+            "Update Address",
+            comment: "Accessibility Label for the edit button to change the Customer Shipping Address in Order Details")
     }
 
     private func configureShippingMethod(cell: CustomerNoteTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.swift
@@ -56,6 +56,17 @@ class CustomerInfoTableViewCell: UITableViewCell {
         }
     }
 
+    /// Accessibility label to be used on the edit button, when shown
+    ///
+    var editButtonAccessibilityLabel: String? {
+        get {
+            editButton.accessibilityLabel
+        }
+        set {
+            editButton.accessibilityLabel = newValue
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -69,6 +80,7 @@ class CustomerInfoTableViewCell: UITableViewCell {
         nameLabel.text = nil
         addressLabel.text = nil
         onEditTapped = nil
+        editButton.accessibilityLabel = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -43,6 +43,17 @@ final class CustomerNoteTableViewCell: UITableViewCell {
         }
     }
 
+    /// Accessibility label to be used on the edit button, when shown
+    ///
+    var editButtonAccessibilityLabel: String? {
+        get {
+            editButton.accessibilityLabel
+        }
+        set {
+            editButton.accessibilityLabel = newValue
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -55,6 +66,7 @@ final class CustomerNoteTableViewCell: UITableViewCell {
         headlineLabel.text = nil
         bodyLabel.text = nil
         onEditTapped = nil
+        editButton.accessibilityLabel = nil
     }
 }
 


### PR DESCRIPTION
Fixes #5003 

## Description
The two icon-only edit buttons (✎) for Shipping Address and Customer Note in the Order Details screen did not have accessibility labels, which meant that VoiceOver would read them as "Button" with no context or information about what the cell accessory button does.

This adds an accessibility label to these two buttons, briefly describing their function.

## Testing

Steps to reproduce the behavior on simulator:
1. Enable the Accessibility inspector and build on simulator
2. Go to 'Orders' tab
3. Tap on an order
4. Scroll down to 'Customer Provided Note' and 'Shipping Details'
5. Inspect pencil icon (button) on right hand side of cells
6. Element should be identified with specific label

Steps to reproduce the behavior on device:
1. Go to 'Orders' tab
2. Tap on an order
3. Scroll down to 'Customer Provided Note' and 'Shipping Details'
4. Enable VoiceOver
5. Single-tap pencil icon (button) on right hand side of cells
6. Element should be identified with specific label

![Customer Note](https://user-images.githubusercontent.com/2472348/133622654-3f5b26b5-7a5a-4674-9272-0328208d249d.jpg)
![Shipping Address](https://user-images.githubusercontent.com/2472348/133622660-5a68b432-bacd-4c60-91a3-192d7448e98b.jpg)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
