### PR TITLE
Add a lane to register new device and update certs and profiles

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,8 @@ SCREENSHOT_DEVICES = [
   'iPad Pro (12.9-inch) (3rd generation)'
 ].freeze
 
-MAIN_BUNDLE_IDENTIFIERS = %[com.automattic.woocommerce]        # Registered in our main account, for development and AppStore
-ALPHA_BUNDLE_IDENTIFIERS = %[com.automattic.alpha.woocommerce] # Registered in our Enterprise account, for AppCenter / Installable Builds
+MAIN_BUNDLE_IDENTIFIERS = %w[com.automattic.woocommerce]        # Registered in our main account, for development and AppStore
+ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce] # Registered in our Enterprise account, for AppCenter / Installable Builds
 
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,9 @@ SCREENSHOT_DEVICES = [
   'iPad Pro (12.9-inch) (3rd generation)'
 ].freeze
 
+MAIN_BUNDLE_IDENTIFIERS = %[com.automattic.woocommerce]        # Registered in our main account, for development and AppStore
+ALPHA_BUNDLE_IDENTIFIERS = %[com.automattic.alpha.woocommerce] # Registered in our Enterprise account, for AppCenter / Installable Builds
+
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing
 def get_required_env(key)
@@ -499,6 +502,48 @@ platform :ios do
     )
   end
 
+  #####################################################################################
+  # register_new_device
+  # -----------------------------------------------------------------------------------
+  # This lane helps a developer register a new device in the App Store Portal
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane register_new_device
+  #
+  # Example:
+  # bundle exec fastlane register_new_device
+  #####################################################################################
+  desc 'Registers a Device in the developer console'
+  lane :register_new_device do |options|
+    device_name = UI.input('Device Name (leave empty if already added in portal): ') if options[:device_name].nil?
+    unless device_name.empty?
+      device_id = UI.input('Device ID: ') if options[:device_id].nil?
+      UI.message "Registering #{device_name} with ID #{device_id} and registering it with any provisioning profiles associated with these bundle identifiers:"
+      MAIN_BUNDLE_IDENTIFIERS.each do |identifier|
+        puts "\t#{identifier}"
+      end
+
+      # Register the user's device
+      register_device(
+        name: device_name,
+        udid: device_id,
+        team_id: get_required_env('EXT_EXPORT_TEAM_ID')
+      )
+    end
+
+    # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
+    add_development_certificates_to_provisioning_profiles(
+      team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+      app_identifier: MAIN_BUNDLE_IDENTIFIERS
+    )
+
+    # Add all devices to the provisioning profiles
+    add_all_devices_to_provisioning_profiles(
+      team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+      app_identifier: MAIN_BUNDLE_IDENTIFIERS
+    )
+  end
+
   ########################################################################
   # Screenshot Lanes
   ########################################################################
@@ -745,7 +790,7 @@ platform :ios do
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
       readonly: true,
-      app_identifier: ['com.automattic.alpha.woocommerce']
+      app_identifier: ALPHA_BUNDLE_IDENTIFIERS
     )
   end
 
@@ -754,7 +799,7 @@ platform :ios do
       type: 'appstore',
       team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       readonly: false,
-      app_identifier: ['com.automattic.woocommerce'],
+      app_identifier: MAIN_BUNDLE_IDENTIFIERS,
       template_name: 'Apple Pay Pass Suppression',
     )
   end


### PR DESCRIPTION
Add a `register_new_device` lane similar to the same lane we have in WPiOS, but this one would be updating the WC profiles instead.

Since the typical process is to call the `register_new_device` from the WPiOS repo first, I made it possible in this WC lane to skip the device registration if the device was already added (typically via the WPiOS lane), and directly jump to the actions updating the certificates and profiles.

I've also updated the instructions in our FieldGuide page (ref: PCYsg-B2Y-p2) accordingly.