### PR TITLE
[Mobile Payments] [WIP] Disable disconnect button while checking for reader software update

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -92,13 +92,15 @@ private extension CardReaderSettingsConnectedViewController {
 
         /// This section displays whether or not there is update for the reader software
         ///
-        sections.append(
-            Section(title: nil,
-                    rows: [
-                        .updatePrompt
-                    ]
-            )
-        )
+        let checkForReaderUpdateInProgress = viewModel?.checkForReaderUpdateInProgress ?? false
+        var rows = [Row]()
+        if checkForReaderUpdateInProgress {
+            rows = [.checkingForUpdate]
+        } else {
+            rows = [.updatePrompt]
+        }
+
+        sections.append(Section(title: nil, rows: rows))
 
         /// This section displays details about the connected reader
         ///
@@ -165,6 +167,8 @@ private extension CardReaderSettingsConnectedViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
+        case let cell as ActivitySpinnerAndLabelTableViewCell where row == .checkingForUpdate:
+            configureCheckingForUpdate(cell: cell)
         case let cell as LeftImageTableViewCell where row == .updatePrompt:
             configureUpdatePrompt(cell: cell)
         case let cell as ConnectedReaderTableViewCell where row == .connectedReader:
@@ -178,24 +182,26 @@ private extension CardReaderSettingsConnectedViewController {
         }
     }
 
+    private func configureCheckingForUpdate(cell: ActivitySpinnerAndLabelTableViewCell) {
+        cell.configure(labelText: Localization.updateChecking)
+        cell.selectionStyle = .none
+    }
+
     private func configureUpdatePrompt(cell: LeftImageTableViewCell) {
         guard let readerUpdateAvailable = viewModel?.readerUpdateAvailable else {
             return
         }
 
-        switch readerUpdateAvailable {
-            case .isUnknown:
-                cell.configure(image: .infoOutlineImage, text: Localization.updateChecking)
-                cell.backgroundColor = .none
-                cell.imageView?.tintColor = .warning
-            case .isFalse:
-                cell.configure(image: .infoOutlineImage, text: Localization.updateNotNeeded)
-                cell.backgroundColor = .none
-                cell.imageView?.tintColor = .info
-            case .isTrue:
-                cell.configure(image: .infoOutlineImage, text: Localization.updateAvailable)
-                cell.backgroundColor = .warningBackground
-                cell.imageView?.tintColor = .warning
+        if readerUpdateAvailable == .isFalse {
+            cell.configure(image: .infoOutlineImage, text: Localization.updateNotNeeded)
+            cell.backgroundColor = .none
+            cell.imageView?.tintColor = .info
+        }
+
+        if readerUpdateAvailable == .isTrue {
+            cell.configure(image: .infoOutlineImage, text: Localization.updateAvailable)
+            cell.backgroundColor = .warningBackground
+            cell.imageView?.tintColor = .warning
         }
 
         cell.selectionStyle = .none
@@ -327,6 +333,7 @@ private struct Section {
 }
 
 private enum Row: CaseIterable {
+    case checkingForUpdate
     case updatePrompt
     case connectedReader
     case updateButton
@@ -334,6 +341,8 @@ private enum Row: CaseIterable {
 
     var type: UITableViewCell.Type {
         switch self {
+        case .checkingForUpdate:
+            return ActivitySpinnerAndLabelTableViewCell.self
         case .updatePrompt:
             return LeftImageTableViewCell.self
         case .connectedReader:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -79,13 +79,6 @@ private extension CardReaderSettingsConnectedViewController {
         configureUpdateView()
     }
 
-    func shouldShowUpdateControls() -> Bool {
-        guard let viewModel = viewModel else {
-            return false
-        }
-        return viewModel.readerUpdateAvailable == .isTrue
-    }
-
     /// Set the title and back button.
     ///
     func configureNavigation() {
@@ -97,31 +90,25 @@ private extension CardReaderSettingsConnectedViewController {
     func configureSections() {
         sections = []
 
-        /// This section, if present, displays a prompt to update a reader running old software
+        /// This section displays whether or not there is update for the reader software
         ///
-        if shouldShowUpdateControls() {
-            sections.append(
-                Section(title: nil,
-                        rows: [
-                            .updatePrompt
-                        ]
-                )
+        sections.append(
+            Section(title: nil,
+                    rows: [
+                        .updatePrompt
+                    ]
             )
-        }
+        )
 
         /// This section displays details about the connected reader
         ///
-        var rows: [Row] = [.connectedReader]
-
-        if shouldShowUpdateControls() {
-            rows.append(.updateButton)
-        }
-
-        rows.append(.disconnectButton)
-
         sections.append(
             Section(title: Localization.sectionHeaderTitle.uppercased(),
-                    rows: rows
+                    rows: [
+                        .connectedReader,
+                        .updateButton,
+                        .disconnectButton
+                    ]
             )
         )
     }
@@ -192,10 +179,26 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     private func configureUpdatePrompt(cell: LeftImageTableViewCell) {
-        cell.configure(image: .infoOutlineImage, text: Localization.updatePromptText)
+        guard let readerUpdateAvailable = viewModel?.readerUpdateAvailable else {
+            return
+        }
+
+        switch readerUpdateAvailable {
+            case .isUnknown:
+                cell.configure(image: .infoOutlineImage, text: Localization.updateChecking)
+                cell.backgroundColor = .none
+                cell.imageView?.tintColor = .warning
+            case .isFalse:
+                cell.configure(image: .infoOutlineImage, text: Localization.updateNotNeeded)
+                cell.backgroundColor = .none
+                cell.imageView?.tintColor = .info
+            case .isTrue:
+                cell.configure(image: .infoOutlineImage, text: Localization.updateAvailable)
+                cell.backgroundColor = .warningBackground
+                cell.imageView?.tintColor = .warning
+        }
+
         cell.selectionStyle = .none
-        cell.backgroundColor = .warningBackground
-        cell.imageView?.tintColor = .warning
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.textColor = .text
     }
@@ -210,29 +213,39 @@ private extension CardReaderSettingsConnectedViewController {
         cell.selectionStyle = .none
     }
 
+    /// If a reader update is available, make the update button primary
+    /// If a reader update is available and a disconnect or update isn't already in progress, enable the button
+    ///
     private func configureUpdateButton(cell: ButtonTableViewCell) {
-        cell.configure(style: .primary, title: Localization.updateButtonTitle, bottomSpacing: 0) {
+        let readerUpdateAvailable = viewModel?.readerUpdateAvailable == .isTrue
+        let style: ButtonTableViewCell.Style = readerUpdateAvailable ? .primary : .secondary
+        cell.configure(style: style, title: Localization.updateButtonTitle, bottomSpacing: 0) {
             self.viewModel?.startCardReaderUpdate()
         }
 
         let readerDisconnectInProgress = viewModel?.readerDisconnectInProgress ?? false
         let readerUpdateInProgress = viewModel?.readerUpdateInProgress ?? false
-        cell.enableButton(!readerDisconnectInProgress && !readerUpdateInProgress)
+        cell.enableButton(readerUpdateAvailable && !readerDisconnectInProgress && !readerUpdateInProgress)
         cell.showActivityIndicator(readerUpdateInProgress)
 
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
     }
 
+    /// If a reader update is not available, make the disconnect button primary
+    /// If a check for updates, a disconnect or an update isn't already in progress, enable the disconnect button
+    ///
     private func configureDisconnectButton(cell: ButtonTableViewCell) {
-        let style: ButtonTableViewCell.Style = shouldShowUpdateControls() ? .secondary : .primary
+        let checkForReaderUpdateInProgress = viewModel?.checkForReaderUpdateInProgress ?? false
+        let readerUpdateAvailable = viewModel?.readerUpdateAvailable == .isTrue
+        let style: ButtonTableViewCell.Style = readerUpdateAvailable ? .secondary : .primary
         cell.configure(style: style, title: Localization.disconnectButtonTitle) { [weak self] in
             self?.viewModel?.disconnectReader()
         }
 
         let readerDisconnectInProgress = viewModel?.readerDisconnectInProgress ?? false
         let readerUpdateInProgress = viewModel?.readerUpdateInProgress ?? false
-        cell.enableButton(!readerDisconnectInProgress && !readerUpdateInProgress)
+        cell.enableButton(!checkForReaderUpdateInProgress && !readerDisconnectInProgress && !readerUpdateInProgress)
         cell.showActivityIndicator(readerDisconnectInProgress)
 
         cell.selectionStyle = .none
@@ -262,10 +275,7 @@ extension CardReaderSettingsConnectedViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if shouldShowUpdateControls() {
-            return section == 0 ? CGFloat.leastNonzeroMagnitude : UITableView.automaticDimension
-        }
-        return UITableView.automaticDimension
+        return section == 0 ? CGFloat.leastNonzeroMagnitude : UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -349,8 +359,18 @@ private extension CardReaderSettingsConnectedViewController {
             comment: "Settings > Manage Card Reader > Title for the reader connected screen in settings."
         )
 
-        static let updatePromptText = NSLocalizedString(
+        static let updateChecking = NSLocalizedString(
+            "Checking for reader software updates",
+            comment: "Settings > Manage Card Reader > Connected Reader > A prompt to indicate we are checking for reader updates"
+        )
+
+        static let updateAvailable = NSLocalizedString(
             "Please update your reader software to keep accepting payments",
+            comment: "Settings > Manage Card Reader > Connected Reader > A prompt to update a reader running older software"
+        )
+
+        static let updateNotNeeded = NSLocalizedString(
+            "Congratulations! Your reader is running the latest software",
             comment: "Settings > Manage Card Reader > Connected Reader > A prompt to update a reader running older software"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -10,6 +10,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     private var connectedReaders = [CardReader]()
     private let knownReadersProvider: CardReaderSettingsKnownReadersProvider?
 
+    private(set) var checkForReaderUpdateInProgress: Bool = false
     private(set) var readerUpdateAvailable: CardReaderSettingsTriState = .isUnknown
     private(set) var readerUpdateInProgress: Bool = false
     private(set) var readerUpdateCompletedSuccessfully: Bool = false
@@ -47,6 +48,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         updateReaderID()
         updateBatteryLevel()
         updateSoftwareVersion()
+        didUpdate?()
     }
 
     private func updateReaderID() {
@@ -76,6 +78,14 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
     /// Dispatch a request to check for reader updates
     ///
     func checkForCardReaderUpdate() {
+        guard !checkForReaderUpdateInProgress else {
+            return
+        }
+
+        readerUpdateAvailable = .isUnknown
+        checkForReaderUpdateInProgress = true
+        didUpdate?()
+
         let action = CardPresentPaymentAction.checkForCardReaderUpdate() { [weak self] result in
             guard let self = self else {
                 return
@@ -90,6 +100,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
                 DDLogError("Unexpected error when checking for reader update")
                 self.readerUpdateAvailable = .isFalse
             }
+            self.checkForReaderUpdateInProgress = false
             self.didUpdate?()
         }
         ServiceLocator.stores.dispatch(action)


### PR DESCRIPTION
Fixes #4922 

Changes:
- Update status remains on screen the entire time, showing whether it is checking for updates, has an update, or if the reader is already running the latest software
- Update button is disabled unless an update is available, in which case it is enabled and primary
- Disconnect button is disabled while checking for whether an update is available. If the check completes and no update is available, it is made primary

@adamzelinski  - I've changed the info image to an activity spinner while we are checking for updates. I'll posted that movie here below. Please let me know if there other design changes you'd expect (see movies below)

@koke - I've based this off of issue/4990-display-version in order to pick up the changes there - once that is reviewed this can be rebased and merged to develop

Movie (with spinner added)

https://user-images.githubusercontent.com/1595739/133701488-a5db5db4-7a2a-4fff-91e9-7fc0ef27289f.MP4

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
