### PR TITLE
Add unit tests for Connectivity Service

### DIFF
--- a/WooCommerce/Classes/Tools/Connectivity/DefaultConnectivityObserver.swift
+++ b/WooCommerce/Classes/Tools/Connectivity/DefaultConnectivityObserver.swift
@@ -5,17 +5,17 @@ final class DefaultConnectivityObserver: ConnectivityObserver {
 
     /// Network monitor to evaluate connection.
     ///
-    private let networkMonitor: NWPathMonitor
+    private let networkMonitor: NetworkMonitoring
     private let observingQueue: DispatchQueue = .global(qos: .background)
 
     var isConnectivityAvailable: Bool {
-        if case .reachable = connectivityStatus(from: networkMonitor.currentPath) {
+        if case .reachable = connectivityStatus(from: networkMonitor.currentNetwork) {
             return true
         }
         return false
     }
 
-    init(networkMonitor: NWPathMonitor = .init()) {
+    init(networkMonitor: NetworkMonitoring = NWPathMonitor()) {
         self.networkMonitor = networkMonitor
         startObserving()
     }
@@ -25,7 +25,7 @@ final class DefaultConnectivityObserver: ConnectivityObserver {
     }
 
     func updateListener(_ listener: @escaping (ConnectivityStatus) -> Void) {
-        networkMonitor.pathUpdateHandler = { [weak self] path in
+        networkMonitor.networkUpdateHandler = { [weak self] path in
             guard let self = self else { return }
             let connectivityStatus = self.connectivityStatus(from: path)
             DispatchQueue.main.async {
@@ -38,7 +38,7 @@ final class DefaultConnectivityObserver: ConnectivityObserver {
         networkMonitor.cancel()
     }
 
-    private func connectivityStatus(from path: NWPath) -> ConnectivityStatus {
+    private func connectivityStatus(from path: NetworkMonitorable) -> ConnectivityStatus {
         let connectivityStatus: ConnectivityStatus
         switch path.status {
         case .satisfied:
@@ -58,5 +58,53 @@ final class DefaultConnectivityObserver: ConnectivityObserver {
             connectivityStatus = .unknown
         }
         return connectivityStatus
+    }
+}
+
+// MARK: - Testability
+
+/// Proxy protocol for mocking `NWPathMonitor`.
+protocol NetworkMonitoring: AnyObject {
+    var currentNetwork: NetworkMonitorable { get }
+
+    /// A handler that receives network updates.
+    var networkUpdateHandler: ((NetworkMonitorable) -> Void)? { get set }
+
+    /// Starts monitoring network changes, and sets a queue on which to deliver events.
+    func start(queue: DispatchQueue)
+
+    /// Stops receiving network monitoring updates.
+    func cancel()
+}
+
+/// Proxy protocol for mocking `NWPath`.
+protocol NetworkMonitorable {
+    /// A status indicating whether a network can be used by connections.
+    var status: NWPath.Status { get }
+
+    /// Checks if the network uses an NWInterface with the specified type
+    func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool
+}
+
+extension NWPath: NetworkMonitorable {}
+extension NWPathMonitor: NetworkMonitoring {
+    var currentNetwork: NetworkMonitorable {
+        currentPath
+    }
+
+    var networkUpdateHandler: ((NetworkMonitorable) -> Void)? {
+        get {
+            let closure: ((NetworkMonitorable) -> Void)? = {
+                [weak self] network in
+                guard let path = network as? NWPath else {
+                    return
+                }
+                self?.pathUpdateHandler?(path)
+            }
+            return closure
+        }
+        set {
+            pathUpdateHandler = newValue
+        }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1294,10 +1294,11 @@
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
-		DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1726EF35F40071200C /* ConnectivityObserver.swift */; };
-		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
 		DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */; };
+		DE7842F926F435070030C792 /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842F826F435070030C792 /* DefaultConnectivityObserver.swift */; };
+		DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1726EF35F40071200C /* ConnectivityObserver.swift */; };
+		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
 		DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C94652646990000C94823 /* PluginListViewController.swift */; };
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
@@ -2730,10 +2731,11 @@
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
-		DE792E1726EF35F40071200C /* ConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityObserver.swift; sourceTree = "<group>"; };
-		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
 		DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedTests.swift"; sourceTree = "<group>"; };
+		DE7842F826F435070030C792 /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE792E1726EF35F40071200C /* ConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE8C94652646990000C94823 /* PluginListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewController.swift; sourceTree = "<group>"; };
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
@@ -4937,6 +4939,7 @@
 				0277AEAA256CAA5300F45C4A /* MockShippingLabelAddress.swift */,
 				0211252D25773FB00075AD2A /* MockAggregateOrderItem.swift */,
 				4590B651261C8D1E00A6FCE0 /* WeightFormatterTests.swift */,
+				DE7842F826F435070030C792 /* DefaultConnectivityObserver.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -7916,6 +7919,7 @@
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,
 				CC593A6726EA116300EF0E04 /* ShippingLabelAddNewPackageViewModelTests.swift in Sources */,
+				DE7842F926F435070030C792 /* DefaultConnectivityObserver.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				0215C6FC2518A3CD005240CD /* ProductFormViewModel+SaveTests.swift in Sources */,
 				265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/DefaultConnectivityObserver.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultConnectivityObserver.swift
@@ -1,0 +1,89 @@
+import Network
+import XCTest
+@testable import WooCommerce
+
+final class DefaultConnectivityObserverTests: XCTestCase {
+    func test_initializing_observer_triggers_network_monitoring() {
+        // Given
+        let network = MockNetwork(status: .satisfied, currentInterface: .wifi)
+        let networkMonitor = MockNetworkMonitor(currentNetwork: network)
+
+        // When
+        let _ = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+
+        // Then
+        XCTAssertTrue(networkMonitor.didStartMonitoring)
+    }
+
+    func test_stopping_observer_stops_network_monitoring() {
+        // Given
+        let network = MockNetwork(status: .satisfied, currentInterface: .wifi)
+        let networkMonitor = MockNetworkMonitor(currentNetwork: network)
+
+        // When
+        let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+        observer.stopObserving()
+
+        // Then
+        XCTAssertTrue(networkMonitor.didStopMonitoring)
+    }
+
+    func test_isConnectivityAvailable_returns_true_when_network_is_satisfied() {
+        // Given
+        let network = MockNetwork(status: .satisfied, currentInterface: .wifi)
+        let networkMonitor = MockNetworkMonitor(currentNetwork: network)
+
+        // When
+        let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+
+        // Then
+        XCTAssertTrue(observer.isConnectivityAvailable)
+    }
+
+    func test_isConnectivityAvailable_returns_false_when_network_is_unsatisfied() {
+        // Given
+        let network = MockNetwork(status: .unsatisfied, currentInterface: .wifi)
+        let networkMonitor = MockNetworkMonitor(currentNetwork: network)
+
+        // When
+        let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+
+        // Then
+        XCTAssertFalse(observer.isConnectivityAvailable)
+    }
+}
+
+final class MockNetworkMonitor: NetworkMonitoring {
+    let currentNetwork: NetworkMonitorable
+
+    var networkUpdateHandler: ((NetworkMonitorable) -> Void)?
+
+    private(set) var didStartMonitoring = false
+    private(set) var didStopMonitoring = false
+
+    init(currentNetwork: NetworkMonitorable) {
+        self.currentNetwork = currentNetwork
+    }
+
+    func start(queue: DispatchQueue) {
+        didStartMonitoring = true
+    }
+
+    func cancel() {
+        didStopMonitoring = true
+    }
+}
+
+struct MockNetwork: NetworkMonitorable {
+    let status: NWPath.Status
+    private let currentInterface: NWInterface.InterfaceType
+
+    init(status: NWPath.Status, currentInterface: NWInterface.InterfaceType) {
+        self.status = status
+        self.currentInterface = currentInterface
+    }
+
+    func usesInterfaceType(_ type: NWInterface.InterfaceType) -> Bool {
+        type == currentInterface
+    }
+}

--- a/WooCommerce/WooCommerceTests/Tools/DefaultConnectivityObserver.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultConnectivityObserver.swift
@@ -51,6 +51,31 @@ final class DefaultConnectivityObserverTests: XCTestCase {
         // Then
         XCTAssertFalse(observer.isConnectivityAvailable)
     }
+
+    func test_updateListener_returns_correct_status_in_callback_closure() {
+        // Given
+        let network = MockNetwork(status: .satisfied, currentInterface: .wifi)
+        let networkMonitor = MockNetworkMonitor(currentNetwork: network)
+        let networkUpdate = MockNetwork(status: .satisfied, currentInterface: .cellular)
+        let statusExpectation = expectation(description: "Status in callback closure")
+
+        // When
+        let observer = DefaultConnectivityObserver(networkMonitor: networkMonitor)
+        var result: ConnectivityStatus = .unknown
+        observer.updateListener { status in
+            result = status
+            statusExpectation.fulfill()
+        }
+        networkMonitor.fakeNetworkUpdate(network: networkUpdate)
+
+        // Then
+        waitForExpectations(timeout: 0.3, handler: nil)
+        if case .reachable(let type) = result {
+            XCTAssertEqual(type, .cellular)
+        } else {
+            XCTFail("Incorrect result status in callback closure")
+        }
+    }
 }
 
 final class MockNetworkMonitor: NetworkMonitoring {
@@ -63,6 +88,10 @@ final class MockNetworkMonitor: NetworkMonitoring {
 
     init(currentNetwork: NetworkMonitorable) {
         self.currentNetwork = currentNetwork
+    }
+
+    func fakeNetworkUpdate(network: NetworkMonitorable) {
+        networkUpdateHandler?(network)
     }
 
     func start(queue: DispatchQueue) {


### PR DESCRIPTION
Part of #4384 

# Description
This PR improves testability for `DefaultConnectivityObserver` and adds tests for its functionality.

# Changes
- Adds proxy protocols for `NWPath` and `NWPathMonitor`.
- Replaces occurrences of `NWPath` and `NWPathMonitor` in `DefaultConnectivityObserver` with proxy protocols.
- Add mock for `NWPath` and `NWPathMonitor` and unit tests for `DefaultConnectivityObserver`.

# Tests
All tests should pass.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
