### PR TITLE
Add throttling of orders sync on every viewWillAppear

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -75,9 +75,9 @@ struct OrderListSyncActionUseCase {
 
     /// The reasons passed to `SyncCoordinator` when synchronizing.
     ///
-    /// We're only currently tracking one reason.
     enum SyncReason: String {
         case pullToRefresh = "pull_to_refresh"
+        case viewWillAppear = "view_will_appear"
     }
 
     let siteID: Int64


### PR DESCRIPTION
## Description

This PR adds timeout check on orders sync action that is triggered on every `viewWillAppear`.
It doesn't impact manual pull-to-refresh and new order notification.

### Technical Details

Implementation is simple:
1. Save current datetime after each successful fetch of 1st page.
2. Check saved datetime if sync for 1st page is triggered from `viewWillAppear`.

## Test

1. Add some `print()` lines (OrderListViewController.swift:298) or launch a proxy.
2. Switch Stats-Orders-Stats-Orders tabs multiple times.
3. Observe that only one set of GET `/orders` is requested, on first open.
4. Wait 30s and switch tabs, observe non-throttled `/orders` requests.
5. Immediately trigger pull-to-refresh, observe non-throttled `/orders` requests.
6. Launch app on device, open orders tab and create new order from computer within refresh timeout.
7. Observe that orders list is refreshed immediately.

### Note

In the proxy you can still see requests on every tab open for `/reports/orders/totals` path. It's a known issue that is handled separately.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
