### PR TITLE
Shipping Labels: Rename PackageItem to SinglePackage to avoid ambiguity

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesForm.swift
@@ -13,7 +13,7 @@ struct ShippingLabelPackagesForm: View {
         GeometryReader { geometry in
             ScrollView {
                 ForEach(Array(viewModel.itemViewModels.enumerated()), id: \.offset) { index, element in
-                    ShippingLabelPackageItem(packageNumber: index + 1,
+                    ShippingLabelSinglePackage(packageNumber: index + 1,
                                              isCollapsible: viewModel.foundMultiplePackages,
                                              safeAreaInsets: geometry.safeAreaInsets,
                                              viewModel: element)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -15,7 +15,7 @@ final class ShippingLabelPackagesFormViewModel: ObservableObject {
 
     /// References of view models for child items.
     ///
-    @Published private(set) var itemViewModels: [ShippingLabelPackageItemViewModel] = []
+    @Published private(set) var itemViewModels: [ShippingLabelSinglePackageViewModel] = []
 
     /// Whether Done button on Package Details screen should be enabled.
     ///
@@ -105,10 +105,10 @@ private extension ShippingLabelPackagesFormViewModel {
     ///
     func configureItemViewModels(order: Order, packageResponse: ShippingLabelPackagesResponse?) {
         $selectedPackages.combineLatest($products, $productVariations)
-            .map { selectedPackages, products, variations -> [ShippingLabelPackageItemViewModel] in
+            .map { selectedPackages, products, variations -> [ShippingLabelSinglePackageViewModel] in
                 return selectedPackages.map { details in
                     let orderItems = order.items.filter { details.productIDs.contains($0.productOrVariationID) }
-                    return ShippingLabelPackageItemViewModel(order: order,
+                    return ShippingLabelSinglePackageViewModel(order: order,
                                                              orderItems: orderItems,
                                                              packagesResponse: packageResponse,
                                                              selectedPackageID: details.packageID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-struct ShippingLabelPackageItem: View {
+struct ShippingLabelSinglePackage: View {
 
-    @ObservedObject private var viewModel: ShippingLabelPackageItemViewModel
+    @ObservedObject private var viewModel: ShippingLabelSinglePackageViewModel
     @State private var isCollapsed: Bool = false
     @State private var isShowingPackageSelection = false
 
@@ -13,7 +13,7 @@ struct ShippingLabelPackageItem: View {
     init(packageNumber: Int,
          isCollapsible: Bool,
          safeAreaInsets: EdgeInsets,
-         viewModel: ShippingLabelPackageItemViewModel) {
+         viewModel: ShippingLabelSinglePackageViewModel) {
         self.packageNumber = packageNumber
         self.isCollapsible = isCollapsible
         self.safeAreaInsets = safeAreaInsets
@@ -77,7 +77,7 @@ struct ShippingLabelPackageItem: View {
     }
 }
 
-private extension ShippingLabelPackageItem {
+private extension ShippingLabelSinglePackage {
     enum Localization {
         static let itemsToFulfillHeader = NSLocalizedString("ITEMS TO FULFILL", comment: "Header section items to fulfill in Shipping Label Package Detail")
         static let packageDetailsHeader = NSLocalizedString("PACKAGE DETAILS", comment: "Header section package details in Shipping Label Package Detail")
@@ -99,7 +99,7 @@ struct ShippingLabelPackageItem_Previews: PreviewProvider {
     static var previews: some View {
         let order = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let packageResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: packageResponse,
                                                           selectedPackageID: "Box 1",
@@ -108,6 +108,6 @@ struct ShippingLabelPackageItem_Previews: PreviewProvider {
                                                           productVariations: [],
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in })
-        ShippingLabelPackageItem(packageNumber: 1, isCollapsible: true, safeAreaInsets: .zero, viewModel: viewModel)
+        ShippingLabelSinglePackage(packageNumber: 1, isCollapsible: true, safeAreaInsets: .zero, viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -3,6 +3,8 @@ import UIKit
 import SwiftUI
 import Yosemite
 
+/// View model for `ShippingLabelSinglePackage`.
+///
 final class ShippingLabelSinglePackageViewModel: ObservableObject {
 
     typealias PackageSwitchHandler = (_ newPackage: ShippingLabelPackageAttributes) -> Void

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -3,7 +3,7 @@ import UIKit
 import SwiftUI
 import Yosemite
 
-final class ShippingLabelPackageItemViewModel: ObservableObject {
+final class ShippingLabelSinglePackageViewModel: ObservableObject {
 
     typealias PackageSwitchHandler = (_ newPackage: ShippingLabelPackageAttributes) -> Void
     typealias PackagesSyncHandler = (_ packagesResponse: ShippingLabelPackagesResponse?) -> Void
@@ -128,7 +128,7 @@ final class ShippingLabelPackageItemViewModel: ObservableObject {
 }
 
 // MARK: ShippingLabelPackageSelectionDelegate conformance
-extension ShippingLabelPackageItemViewModel: ShippingLabelPackageSelectionDelegate {
+extension ShippingLabelSinglePackageViewModel: ShippingLabelPackageSelectionDelegate {
     func didSelectPackage(id: String) {
         let newTotalWeight = isPackageWeightEdited ? totalWeight : ""
         let newPackage = ShippingLabelPackageAttributes(packageID: id,
@@ -146,7 +146,7 @@ extension ShippingLabelPackageItemViewModel: ShippingLabelPackageSelectionDelega
 }
 
 // MARK: - Helper methods
-private extension ShippingLabelPackageItemViewModel {
+private extension ShippingLabelSinglePackageViewModel {
     /// Generate the items rows, creating an element in the array for every item (eg. if there is an item with quantity 3,
     /// we will generate 3 different items), and we will remove virtual products.
     ///
@@ -230,7 +230,7 @@ private extension ShippingLabelPackageItemViewModel {
     }
 }
 
-private extension ShippingLabelPackageItemViewModel {
+private extension ShippingLabelSinglePackageViewModel {
     enum Localization {
         static let subtitleFormat =
             NSLocalizedString("%1$@", comment: "In Shipping Labels Package Details,"

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1284,10 +1284,10 @@
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
 		DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */; };
 		DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA526E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift */; };
-		DE279BA826E9C8E3002BA963 /* ShippingLabelPackageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA726E9C8E3002BA963 /* ShippingLabelPackageItem.swift */; };
-		DE279BAA26E9C91D002BA963 /* ShippingLabelPackageItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA926E9C91D002BA963 /* ShippingLabelPackageItemViewModel.swift */; };
+		DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA726E9C8E3002BA963 /* ShippingLabelSinglePackage.swift */; };
+		DE279BAA26E9C91D002BA963 /* ShippingLabelSinglePackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA926E9C91D002BA963 /* ShippingLabelSinglePackageViewModel.swift */; };
 		DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */; };
-		DE279BAF26EA03EA002BA963 /* ShippingLabelPackageItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelPackageItemViewModelTests.swift */; };
+		DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */; };
 		DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */; };
 		DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */; };
 		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
@@ -2724,10 +2724,10 @@
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
 		DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesForm.swift; sourceTree = "<group>"; };
 		DE279BA526E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesFormViewModel.swift; sourceTree = "<group>"; };
-		DE279BA726E9C8E3002BA963 /* ShippingLabelPackageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItem.swift; sourceTree = "<group>"; };
-		DE279BA926E9C91D002BA963 /* ShippingLabelPackageItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItemViewModel.swift; sourceTree = "<group>"; };
+		DE279BA726E9C8E3002BA963 /* ShippingLabelSinglePackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackage.swift; sourceTree = "<group>"; };
+		DE279BA926E9C91D002BA963 /* ShippingLabelSinglePackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModel.swift; sourceTree = "<group>"; };
 		DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesFormViewModelTests.swift; sourceTree = "<group>"; };
-		DE279BAE26EA03EA002BA963 /* ShippingLabelPackageItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItemViewModelTests.swift; sourceTree = "<group>"; };
+		DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageListViewModel.swift; sourceTree = "<group>"; };
 		DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCountryListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
@@ -6367,8 +6367,8 @@
 			children = (
 				DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */,
 				DE279BA526E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift */,
-				DE279BA726E9C8E3002BA963 /* ShippingLabelPackageItem.swift */,
-				DE279BA926E9C91D002BA963 /* ShippingLabelPackageItemViewModel.swift */,
+				DE279BA726E9C8E3002BA963 /* ShippingLabelSinglePackage.swift */,
+				DE279BA926E9C91D002BA963 /* ShippingLabelSinglePackageViewModel.swift */,
 			);
 			path = "Multi-package";
 			sourceTree = "<group>";
@@ -6377,7 +6377,7 @@
 			isa = PBXGroup;
 			children = (
 				DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */,
-				DE279BAE26EA03EA002BA963 /* ShippingLabelPackageItemViewModelTests.swift */,
+				DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */,
 			);
 			path = "Multi-package";
 			sourceTree = "<group>";
@@ -7551,7 +7551,7 @@
 				45977EC02604C167006CDFB8 /* PhoneHelper.swift in Sources */,
 				E1906E9A26C4126300CA6819 /* InPersonPaymentsMenuViewController.swift in Sources */,
 				0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */,
-				DE279BAA26E9C91D002BA963 /* ShippingLabelPackageItemViewModel.swift in Sources */,
+				DE279BAA26E9C91D002BA963 /* ShippingLabelSinglePackageViewModel.swift in Sources */,
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				45CE2D322625AA9A00E3CA00 /* ShippingLabelPackageList.swift in Sources */,
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,
@@ -7604,7 +7604,7 @@
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
-				DE279BA826E9C8E3002BA963 /* ShippingLabelPackageItem.swift in Sources */,
+				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,
@@ -7952,7 +7952,7 @@
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */,
 				02BAB01F24D0232800F8B06E /* MockProductVariation.swift in Sources */,
-				DE279BAF26EA03EA002BA963 /* ShippingLabelPackageItemViewModelTests.swift in Sources */,
+				DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 
-class ShippingLabelPackageItemViewModelTests: XCTestCase {
+class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 1234
 
@@ -11,7 +11,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
@@ -53,7 +53,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
                                                      attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
 
         // When
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
@@ -83,7 +83,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
                                                        maxWeight: 11)
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
@@ -115,10 +115,10 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         var packageToTest: ShippingLabelPackageAttributes?
-        let packageSwitchHandler: ShippingLabelPackageItemViewModel.PackageSwitchHandler = { package in
+        let packageSwitchHandler: ShippingLabelSinglePackageViewModel.PackageSwitchHandler = { package in
             packageToTest = package
         }
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -144,7 +144,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -184,7 +184,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
                                                      productVariationID: 49,
                                                      attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
 
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Box",
@@ -223,7 +223,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
                                                      productVariationID: 49,
                                                      attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
 
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Box",
@@ -247,7 +247,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
 
         // When
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -269,7 +269,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: [])
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -308,7 +308,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
 
         // When
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -340,7 +340,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
-        let viewModel = ShippingLabelPackageItemViewModel(order: order,
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
                                                           orderItems: order.items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
@@ -373,7 +373,7 @@ class ShippingLabelPackageItemViewModelTests: XCTestCase {
 }
 
 // MARK: - Mocks
-private extension ShippingLabelPackageItemViewModelTests {
+private extension ShippingLabelSinglePackageViewModelTests {
     func mockPackageResponse(withCustom: Bool = true, withPredefined: Bool = true) -> ShippingLabelPackagesResponse {
         let storeOptions = ShippingLabelStoreOptions(currencySymbol: "$",
                                                      dimensionUnit: "in",


### PR DESCRIPTION
Part of #4599 

# Description
As pointed out by @rachelmcr in #4959, the naming `ShippingLabelPackageItem` can be mistaken into an order item, so this PR aims to rename the view to remove the ambiguity.

# Changes
- Renames `ShippingLabelPackageItem` to `ShippingLabelSinglePackage`
- Renames `ShippingLabelPackageItemViewModel` to `ShippingLabelSinglePackageViewModel`.

# Testing
All unit tests should still pass. Configuring package details for shipping label should work properly as before:

1. Make sure that your test store has installed WCShip plugin and configured packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Open an order detail that is eligible for the shipping label.
3. Configure Ship To and Ship From.
4. Tap Continue on Package Details row. Edit the weight to an invalid value, notice that a validation error shows up and Done button is disabled.
5. Update the weight to a valid value and tap Done. Notice on the purchase form that the correct package name and weight is displayed. Tap on Package Details row again, notice that correct package details are displayed.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
