### PR TITLE
Billing information accessibility improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -321,6 +321,9 @@ private extension BillingInformationViewController {
         cell.onEditTapped = editingEnabled ? {
             print("Edit Billing Address Tapped")
         } : nil
+        cell.editButtonAccessibilityLabel = NSLocalizedString(
+            "Update Address",
+            comment: "Accessibility Label for the edit button to change the Customer Billing Address in Billing Information")
     }
 
     func setupBillingPhone(cell: WooBasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -195,7 +195,10 @@ private extension BillingInformationViewController {
     }
 
     private func copyEmailHandler() {
-        guard let email = order.billingAddress?.email else { return }
+        guard let email = order.billingAddress?.email else {
+            return
+        }
+
         ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
         sendToPasteboard(email, includeTrailingNewline: false)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -105,26 +105,18 @@ private extension BillingInformationViewController {
     /// Displays an alert that offers several contact methods to reach the customer: [Phone / Message]
     ///
     func displayContactCustomerAlert(from sourceView: UIView) {
-
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
+        // When changing actions in this sheet, please make corresponding accessibility action changes
+        // in BillingInformationViewController.setupBillingPhone(cell:)
         actionSheet.addCancelActionWithTitle(ContactAction.dismiss)
         actionSheet.addDefaultActionWithTitle(ContactAction.call) { [weak self] _ in
-            guard let self = self else { return }
-
-            guard let phoneURL = self.order.billingAddress?.cleanedPhoneNumberAsActionableURL else {
-                return
-            }
-
-            ServiceLocator.analytics.track(.orderDetailCustomerPhoneOptionTapped)
-            self.callCustomerIfPossible(at: phoneURL)
+            self?.callCustomerHandler()
         }
 
         actionSheet.addDefaultActionWithTitle(ContactAction.message) { [weak self] _ in
-            guard let self = self else { return }
-            ServiceLocator.analytics.track(.orderDetailCustomerSMSOptionTapped)
-            self.displayMessageComposerIfPossible(from: self)
+            self?.messageCustomerHandler()
         }
 
         let popoverController = actionSheet.popoverPresentationController
@@ -134,6 +126,20 @@ private extension BillingInformationViewController {
         present(actionSheet, animated: true)
 
         ServiceLocator.analytics.track(.orderDetailCustomerPhoneMenuTapped)
+    }
+
+    private func callCustomerHandler() {
+        guard let phoneURL = order.billingAddress?.cleanedPhoneNumberAsActionableURL else {
+            return
+        }
+
+        ServiceLocator.analytics.track(.orderDetailCustomerPhoneOptionTapped)
+        callCustomerIfPossible(at: phoneURL)
+    }
+
+    private func messageCustomerHandler() {
+        ServiceLocator.analytics.track(.orderDetailCustomerSMSOptionTapped)
+        self.displayMessageComposerIfPossible(from: self)
     }
 
     /// Attempts to perform a phone call at the specified URL
@@ -167,7 +173,7 @@ private extension BillingInformationViewController {
     /// Create an action sheet that offers the option to copy the email address
     ///
     func displayEmailCopyAlert(from sourceView: UIView) {
-        guard let email = order.billingAddress?.email else {
+        guard order.billingAddress?.email != nil else {
             return
         }
 
@@ -176,8 +182,7 @@ private extension BillingInformationViewController {
 
         actionSheet.addCancelActionWithTitle(ContactAction.dismiss)
         actionSheet.addDefaultActionWithTitle(ContactAction.copyEmail) { [weak self] _ in
-            ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
-            self?.sendToPasteboard(email, includeTrailingNewline: false)
+            self?.copyEmailHandler()
         }
 
         let popoverController = actionSheet.popoverPresentationController
@@ -187,6 +192,12 @@ private extension BillingInformationViewController {
         present(actionSheet, animated: true)
 
         ServiceLocator.analytics.track(.orderDetailCustomerEmailMenuTapped)
+    }
+
+    private func copyEmailHandler() {
+        guard let email = order.billingAddress?.email else { return }
+        ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
+        sendToPasteboard(email, includeTrailingNewline: false)
     }
 }
 
@@ -258,18 +269,24 @@ extension BillingInformationViewController: UITableViewDelegate {
             break
 
         case .billingEmail:
-            ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
-            guard displayEmailComposerIfPossible(from: self) else {
-                if let indexPath = sections.indexPathForRow(.billingEmail),
-                    let cell = tableView.cellForRow(at: indexPath) as? WooBasicTableViewCell {
-                    displayEmailCopyAlert(from: cell)
-                }
-                return
-            }
+            // When changing actions for this cell, please make corresponding accessibility action changes
+            // in BillingInformationViewController.setupBillingEmail(cell:)
+            emailCustomerHandler()
 
             break
         default:
             break
+        }
+    }
+
+    private func emailCustomerHandler() {
+        ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
+        guard displayEmailComposerIfPossible(from: self) else {
+            if let indexPath = sections.indexPathForRow(.billingEmail),
+                let cell = tableView.cellForRow(at: indexPath) as? WooBasicTableViewCell {
+                displayEmailCopyAlert(from: cell)
+            }
+            return
         }
     }
 
@@ -345,10 +362,19 @@ private extension BillingInformationViewController {
             phoneNumber
         )
 
-        cell.accessibilityHint = NSLocalizedString(
-            "Prompts with the option to call or message the billing customer.",
-            comment: "VoiceOver accessibility hint, informing the user that the row can be tapped to call or message the billing customer."
-        )
+        let callAccessibilityAction = UIAccessibilityCustomAction(
+            name: ContactAction.call) { [weak self] _ in
+            self?.callCustomerHandler()
+            return true
+        }
+
+        let messageAccessibilityAction = UIAccessibilityCustomAction(
+            name: ContactAction.message) { [weak self] _ in
+            self?.messageCustomerHandler()
+            return true
+        }
+
+        cell.accessibilityCustomActions = [callAccessibilityAction, messageAccessibilityAction]
     }
 
     func setupBillingEmail(cell: WooBasicTableViewCell) {
@@ -368,10 +394,19 @@ private extension BillingInformationViewController {
             email
         )
 
-        cell.accessibilityHint = NSLocalizedString(
-            "Composes a new email message to the billing customer.",
-            comment: "Accessibility hint, informing that a row can be tapped and an email composer view will appear."
-        )
+        let emailAccessibilityAction = UIAccessibilityCustomAction(
+            name: ContactAction.email) { [weak self] _ in
+            self?.emailCustomerHandler()
+            return true
+        }
+
+        let copyEmailAccessibilityAction = UIAccessibilityCustomAction(
+            name: ContactAction.copyEmail) { [weak self] _ in
+            self?.copyEmailHandler()
+            return true
+        }
+
+        cell.accessibilityCustomActions = [emailAccessibilityAction, copyEmailAccessibilityAction]
     }
 }
 
@@ -524,6 +559,7 @@ private extension BillingInformationViewController {
         static let call = NSLocalizedString("Call", comment: "Call phone number button title")
         static let message = NSLocalizedString("Message", comment: "Message phone number button title")
         static let copyEmail = NSLocalizedString("Copy email address", comment: "Copy email address button title")
+        static let email = NSLocalizedString("Email", comment: "Title of Email accessibility action, opens a compose view")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
@@ -41,6 +41,17 @@ final class BillingAddressTableViewCell: UITableViewCell {
         }
     }
 
+    /// Accessibility label to be used on the edit button, when shown
+    ///
+    var editButtonAccessibilityLabel: String? {
+        get {
+            editButton.accessibilityLabel
+        }
+        set {
+            editButton.accessibilityLabel = newValue
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -53,6 +64,7 @@ final class BillingAddressTableViewCell: UITableViewCell {
         nameLabel.text = nil
         addressLabel.text = nil
         onEditTapped = nil
+        editButton.accessibilityLabel = nil
     }
 }
 


### PR DESCRIPTION
Fixes #5007

## Description
The accessibility of the Billing Information screen was incomplete/needing improvement. This change adds an accessibility label for the edit address button, and makes the actions to call, message, or email, the customer easier to notice and access.

## Testing
1. Navigate to `Orders > any order > View Billing Information`
2. Activate VoiceOver
3. Tap on, or flick to, the Pencil edit address icon
4. Observe the edit button is announced as "Update address, button"
5. Tap or flick to the Contact Details cells, and swipe up or down to access actions.
6. Observe that the contact details cells are announced with "Actions available", which when you swipe between them, expose "Call", "Message", "Email", "Copy Email Address"

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
