### PR TITLE
Order Editing: Make address form modal

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -9,6 +9,14 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
     init(viewModel: EditAddressFormViewModel) {
         super.init(rootView: EditAddressForm(viewModel: viewModel))
+
+        // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+
+        // Set presentation delegate to track the user dismiss flow event
+        presentationController?.delegate = self
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -16,9 +24,21 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
     }
 }
 
+/// Intercepts to the dismiss drag gesture.
+///
+extension EditAddressHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // track dimiss gesture
+    }
+}
+
 /// Allows merchant to edit the customer provided address of an order.
 ///
 struct EditAddressForm: View {
+
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
 
     @ObservedObject private var viewModel: EditAddressFormViewModel
 
@@ -35,6 +55,14 @@ struct EditAddressForm: View {
     @State var showStateSelector = false
 
     var body: some View {
+        NavigationView {
+            formContent
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+
+    @ViewBuilder
+    private var formContent: some View {
         GeometryReader { geometry in
             ScrollView {
                 ListHeaderView(text: Localization.detailsSection, alignment: .left)
@@ -131,6 +159,13 @@ struct EditAddressForm: View {
         .navigationTitle(Localization.shippingTitle)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarItems(trailing: navigationBarTrailingItem())
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Localization.close, action: {
+                    dismiss()
+                })
+            }
+        }
         .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
         .shimmering(active: viewModel.showPlaceholders)
         .onAppear {
@@ -167,7 +202,9 @@ struct EditAddressForm: View {
         case .done(let enabled):
             Button(Localization.done) {
                 viewModel.updateRemoteAddress(onFinish: { success in
-                    // TODO: dismiss on success
+                    if success {
+                        dismiss()
+                    }
                 })
             }
             .disabled(!enabled)
@@ -185,6 +222,7 @@ private extension EditAddressForm {
 
     enum Localization {
         static let shippingTitle = NSLocalizedString("Shipping Address", comment: "Title for the Edit Shipping Address Form")
+        static let close = NSLocalizedString("Close", comment: "Text for the close button in the Edit Address Form")
         static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address Form")
 
         static let detailsSection = NSLocalizedString("DETAILS", comment: "Details section title in the Edit Address Form")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -56,7 +56,10 @@ struct EditAddressForm: View {
 
     var body: some View {
         NavigationView {
-            formContent
+            // navigation liks require wrapping in a stack to work
+            ZStack {
+                formContent
+            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -55,17 +55,6 @@ struct EditAddressForm: View {
     @State var showStateSelector = false
 
     var body: some View {
-        NavigationView {
-            // navigation liks require wrapping in a stack to work
-            ZStack {
-                formContent
-            }
-        }
-        .navigationViewStyle(StackNavigationViewStyle())
-    }
-
-    @ViewBuilder
-    private var formContent: some View {
         GeometryReader { geometry in
             ScrollView {
                 ListHeaderView(text: Localization.detailsSection, alignment: .left)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -677,7 +677,7 @@ private extension OrderDetailsViewController {
     func editShippingAddressTapped() {
         let viewModel = EditAddressFormViewModel(siteID: viewModel.order.siteID, address: viewModel.order.shippingAddress)
         let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
-        show(editAddressViewController, sender: self)
+        present(editAddressViewController, animated: true, completion: nil)
     }
 
     @objc private func collectPayment(at: IndexPath) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -677,7 +677,8 @@ private extension OrderDetailsViewController {
     func editShippingAddressTapped() {
         let viewModel = EditAddressFormViewModel(siteID: viewModel.order.siteID, address: viewModel.order.shippingAddress)
         let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
-        present(editAddressViewController, animated: true, completion: nil)
+        let navigationController = WooNavigationController(rootViewController: editAddressViewController)
+        present(navigationController, animated: true, completion: nil)
     }
 
     @objc private func collectPayment(at: IndexPath) {


### PR DESCRIPTION
## Description
This PR changes presentation style of Address Edit Form from navigation to modal as previously discussed.

Ref: p1630933894035500-slack-CGPNUU63E

### Technical Details
SwiftUI navigation strikes again with broken nav links. To keep them working we need parent wrapper like `ZStack` instead of nesting in `NavigationView` directly.

## Screenshots
before|after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/134020848-a7fdca38-0b6c-48ce-98a1-25bee0b3a0e4.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/134020969-199ebfae-8592-40f1-920c-c6dcb1b6d152.png)

## Testing
1. Open existing order.
2. Tap "edit" icon on Shipping Address row.
3. Observe correct modal presentation style.
4. Tap on country and check that navigation inside form works.
5. Try dismissing with swipe gesture and "Close" button.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.