### PR TITLE
Order Editing: Add remote action to update shipping address

### DIFF
--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Address Entity.
 ///
-public struct Address: Decodable, GeneratedFakeable {
+public struct Address: Codable, GeneratedFakeable {
     public let firstName: String
     public let lastName: String
     public let company: String?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -252,9 +252,37 @@ private extension EditAddressForm {
 
 #if DEBUG
 
+import struct Yosemite.Order
 import struct Yosemite.Address
 
 struct EditAddressForm_Previews: PreviewProvider {
+    static let sampleOrder = Order(siteID: 123,
+                                   orderID: 456,
+                                   parentID: 2,
+                                   customerID: 11,
+                                   number: "789",
+                                   status: .processing,
+                                   currency: "USD",
+                                   customerNote: "",
+                                   dateCreated: Date(),
+                                   dateModified: Date(),
+                                   datePaid: Date(),
+                                   discountTotal: "0.00",
+                                   discountTax: "0.00",
+                                   shippingTotal: "0.00",
+                                   shippingTax: "0.00",
+                                   total: "31.20",
+                                   totalTax: "1.20",
+                                   paymentMethodID: "stripe",
+                                   paymentMethodTitle: "Credit Card (Stripe)",
+                                   items: [],
+                                   billingAddress: sampleAddress,
+                                   shippingAddress: sampleAddress,
+                                   shippingLines: [],
+                                   coupons: [],
+                                   refunds: [],
+                                   fees: [])
+
     static let sampleAddress = Address(firstName: "Johnny",
                                        lastName: "Appleseed",
                                        company: nil,
@@ -266,7 +294,8 @@ struct EditAddressForm_Previews: PreviewProvider {
                                        country: "US",
                                        phone: "333-333-3333",
                                        email: "scrambled@scrambled.com")
-    static let sampleViewModel = EditAddressFormViewModel(siteID: 123, address: sampleAddress)
+
+    static let sampleViewModel = EditAddressFormViewModel(order: sampleOrder)
 
     static var previews: some View {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -92,13 +92,18 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Update the address remotely and invoke a completion block when finished
     ///
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
-        // TODO: perform network request
-        // TODO: add success/failure notice
-        performingNetworkRequest.send(true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-            self?.performingNetworkRequest.send(false)
-            onFinish(true)
+        let updatedAddress = fields.toAddress(selectedCountry: selectedCountry)
+        let modifiedOrder = order.copy(shippingAddress: updatedAddress)
+        let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, fields: [.shippingAddress]) { [weak self] result in
+            guard let self = self else { return }
+
+            self.performingNetworkRequest.send(false)
+            // TODO: add success/failure notice
+            onFinish(result.isSuccess)
         }
+
+        performingNetworkRequest.send(true)
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -3,9 +3,6 @@ import Storage
 import Combine
 
 final class EditAddressFormViewModel: ObservableObject {
-    /// Current site ID
-    ///
-    private let siteID: Int64
 
     /// ResultsController for stored countries.
     ///
@@ -31,9 +28,9 @@ final class EditAddressFormViewModel: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
 
 
-    init(siteID: Int64, address: Address?, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
-        self.siteID = siteID
-        self.originalAddress = address ?? .empty
+    init(order: Yosemite.Order, storageManager: StorageManagerType = ServiceLocator.storageManager, stores: StoresManager = ServiceLocator.stores) {
+        self.order = order
+        self.originalAddress = order.shippingAddress ?? .empty
         self.storageManager = storageManager
         self.stores = stores
 
@@ -60,6 +57,10 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Address form fields
     ///
     @Published var fields = FormFields()
+
+    /// Order to be edited.
+    ///
+    private let order: Yosemite.Order
 
     /// Trigger to perform any one time setups.
     ///
@@ -235,7 +236,7 @@ private extension EditAddressFormViewModel {
         Future<Void, Error> { [weak self] promise in
             guard let self = self else { return }
 
-            let action = DataAction.synchronizeCountries(siteID: self.siteID) { result in
+            let action = DataAction.synchronizeCountries(siteID: self.order.siteID) { result in
                 let newResult = result.map { _ in } // Hides the result success type because we don't need it.
                 promise(newResult)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -675,7 +675,7 @@ private extension OrderDetailsViewController {
     }
 
     func editShippingAddressTapped() {
-        let viewModel = EditAddressFormViewModel(siteID: viewModel.order.siteID, address: viewModel.order.shippingAddress)
+        let viewModel = EditAddressFormViewModel(order: viewModel.order)
         let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
         present(editAddressViewController, animated: true, completion: nil)
     }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/4783.
Based on https://github.com/woocommerce/woocommerce-ios/pull/5020.

## Description

Add ability to save updated shipping address remotely.

### Technical Details

- Added `shippingAddress` field support to `updateOrder` action on `OrdersRemote`.
- Updated `EditAddressFormViewModel` to init it with `Order`.
- Added `OrderAction.updateOrder` dispatch to view model.
- Branch is based on [modal presentation PR](https://github.com/woocommerce/woocommerce-ios/pull/5020) to simplify testing (no need to navigate back and forward).

## Testing

1. Open existing order.
2. Tap "edit" icon on Shipping Address row.
3. Update any of fields and tap "Done".
4. Wait for remote action to complete and modal to close automatically.
5. Observe correctly updated shipping address in order details.

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
