### PR TITLE
Enable push notifications for all stores behind a feature flag

### DIFF
--- a/Networking/Networking/Remote/DevicesRemote.swift
+++ b/Networking/Networking/Remote/DevicesRemote.swift
@@ -18,6 +18,7 @@ public class DevicesRemote: Remote {
                                applicationId: String,
                                applicationVersion: String,
                                defaultStoreID: Int64,
+                               pushNotificationsForAllStoresEnabled: Bool,
                                completion: @escaping (DotcomDevice?, Error?) -> Void) {
         var parameters = [
             ParameterKeys.applicationId: applicationId,
@@ -27,7 +28,7 @@ public class DevicesRemote: Remote {
             ParameterKeys.deviceModel: device.model,
             ParameterKeys.deviceName: device.name,
             ParameterKeys.deviceOSVersion: device.iOSVersion,
-            ParameterKeys.defaultStoreID: String(defaultStoreID)
+            ParameterKeys.defaultStoreID: pushNotificationsForAllStoresEnabled ? "": String(defaultStoreID)
         ]
 
         if let deviceUUID = device.identifierForVendor {

--- a/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
+++ b/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
@@ -13,6 +13,11 @@ extension MockNetwork {
         guard let urlComponents = URLComponents(string: url.absoluteString) else {
             return nil
         }
+
+        if let dotcomRequest = request as? DotcomRequest {
+            return dotcomRequest.parameters?.map { "\($0.key)=\($0.value)" }
+        }
+
         let parameters = urlComponents.queryItems
 
         guard let queryString = parameters?.first(where: { $0.name == "query" })?.value,

--- a/Networking/NetworkingTests/Remote/DevicesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DevicesRemoteTests.swift
@@ -4,22 +4,23 @@ import XCTest
 
 /// DevicesRemote Unit Tests
 ///
-class DevicesRemoteTests: XCTestCase {
+final class DevicesRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
-    let network = MockNetwork()
+    private let network = MockNetwork()
 
     /// Repeat always!
     ///
     override func setUp() {
+        super.setUp()
         network.removeAllSimulatedResponses()
     }
 
 
     /// Verifies that registerDevice parses a "Success" Backend Response.
     ///
-    func testRegisterDeviceSuccessfullyParsesDeviceIdentifier() {
+    func test_registerDevice_successfully_parses_deviceID() {
         let remote = DevicesRemote(network: network)
         let expectation = self.expectation(description: "Register Device")
 
@@ -28,7 +29,8 @@ class DevicesRemoteTests: XCTestCase {
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
                               applicationVersion: Parameters.applicationVersion,
-                              defaultStoreID: Parameters.defaultStoreID) { (settings, error) in
+                              defaultStoreID: Parameters.defaultStoreID,
+                              pushNotificationsForAllStoresEnabled: false) { (settings, error) in
 
             XCTAssertNil(error)
             XCTAssertNotNil(settings)
@@ -39,9 +41,48 @@ class DevicesRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    /// Verifies that registerDevice when pushNotificationsForAllStores feature is enabled sets the `selected_blog_id` parameter to empty string.
+    ///
+    func test_registerDevice_with_pushNotificationsForAllStores_enabled_sets_selected_blog_id_to_empty_string() throws {
+        // Given
+        let remote = DevicesRemote(network: network)
+
+        // When
+        remote.registerDevice(device: Parameters.appleDevice,
+                              applicationId: Parameters.applicationId,
+                              applicationVersion: Parameters.applicationVersion,
+                              defaultStoreID: Parameters.defaultStoreID,
+                              pushNotificationsForAllStoresEnabled: true) { (_, _) in }
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        let expectedParam = "selected_blog_id="
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
+    /// Verifies that registerDevice when pushNotificationsForAllStores feature is disabled sets the `selected_blog_id` to the default store ID.
+    ///
+    func test_registerDevice_with_pushNotificationsForAllStores_disabled_sets_selected_blog_id() throws {
+        // Given
+        let remote = DevicesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "devices/new", filename: "device-settings")
+
+        // When
+        remote.registerDevice(device: Parameters.appleDevice,
+                              applicationId: Parameters.applicationId,
+                              applicationVersion: Parameters.applicationVersion,
+                              defaultStoreID: Parameters.defaultStoreID,
+                              pushNotificationsForAllStoresEnabled: false) { (_, _) in }
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        let expectedParam = "selected_blog_id=\(Parameters.defaultStoreID)"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
     /// Verifies that registerDevice parses a "Failure" Backend Response.
     ///
-    func testRegisterDeviceParsesGeneralFailureResponse() {
+    func test_registerDevice_parses_general_failure_response() {
         let remote = DevicesRemote(network: network)
         let expectation = self.expectation(description: "Register Device")
 
@@ -50,7 +91,8 @@ class DevicesRemoteTests: XCTestCase {
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
                               applicationVersion: Parameters.applicationVersion,
-                              defaultStoreID: Parameters.defaultStoreID) { (settings, error) in
+                              defaultStoreID: Parameters.defaultStoreID,
+                              pushNotificationsForAllStoresEnabled: false) { (settings, error) in
 
             XCTAssertNotNil(error)
             XCTAssertNil(settings)
@@ -62,7 +104,7 @@ class DevicesRemoteTests: XCTestCase {
 
     /// Verifies that unregisterDevice parses a "Success" Backend Response.
     ///
-    func testUnregisterDeviceParsesSuccessResponse() {
+    func test_unregisterDevice_parses_success_response() {
         let remote = DevicesRemote(network: network)
         let expectation = self.expectation(description: "Unregister Device")
 
@@ -78,7 +120,7 @@ class DevicesRemoteTests: XCTestCase {
 
     /// Verifies that unregisterDevice parses a "Failure" Backend Response.
     ///
-    func testUnregisterDeviceParsesFailureResponse() {
+    func test_unregisterDevice_parses_failure_response() {
         let remote = DevicesRemote(network: network)
         let expectation = self.expectation(description: "Unregister Device")
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -410,10 +410,12 @@ private extension PushNotificationsManager {
     ///
     func registerDotcomDevice(with deviceToken: String, defaultStoreID: Int64, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         let device = APNSDevice(deviceToken: deviceToken)
+        let pushNotificationsForAllStoresEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pushNotificationsForAllStores)
         let action = NotificationAction.registerDevice(device: device,
                                                        applicationId: WooConstants.pushApplicationID,
                                                        applicationVersion: Bundle.main.version,
                                                        defaultStoreID: defaultStoreID,
+                                                       pushNotificationsForAllStoresEnabled: pushNotificationsForAllStoresEnabled,
                                                        onCompletion: onCompletion)
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -21,6 +21,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .whatsNewOnWooCommerce:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pushNotificationsForAllStores:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -45,4 +45,8 @@ enum FeatureFlag: Int {
     /// Display "What's new on WooCommerce" on App Launch and App Settings
     ///
     case whatsNewOnWooCommerce
+
+    /// Push notifications for all stores
+    ///
+    case pushNotificationsForAllStores
 }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -217,7 +217,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         manager.registerDeviceToken(with: tokenAsData, defaultStoreID: Sample.defaultStoreID)
 
-        guard case let .registerDevice(_, _, _, storeID, _) = storesManager.receivedActions.first as! NotificationAction else {
+        guard case let .registerDevice(_, _, _, storeID, _, _) = storesManager.receivedActions.first as! NotificationAction else {
             XCTFail()
             return
         }

--- a/Yosemite/Yosemite/Actions/NotificationAction.swift
+++ b/Yosemite/Yosemite/Actions/NotificationAction.swift
@@ -13,6 +13,7 @@ public enum NotificationAction: Action {
                         applicationId: String,
                         applicationVersion: String,
                         defaultStoreID: Int64,
+                        pushNotificationsForAllStoresEnabled: Bool,
                         onCompletion: (DotcomDevice?, Error?) -> Void)
 
     /// Unregisters a device for Push Notifications Delivery.

--- a/Yosemite/Yosemite/Stores/NotificationStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationStore.swift
@@ -38,11 +38,12 @@ public class NotificationStore: Store {
         }
 
         switch action {
-        case .registerDevice(let device, let applicationId, let applicationVersion, let defaultStoreID, let onCompletion):
+        case .registerDevice(let device, let applicationId, let applicationVersion, let defaultStoreID, let pushNotificationsForAllStoresEnabled, let onCompletion):
             registerDevice(device: device,
                            applicationId: applicationId,
                            applicationVersion: applicationVersion,
                            defaultStoreID: defaultStoreID,
+                           pushNotificationsForAllStoresEnabled: pushNotificationsForAllStoresEnabled,
                            onCompletion: onCompletion)
         case .synchronizeNotifications(let onCompletion):
             synchronizeNotifications(onCompletion: onCompletion)
@@ -73,11 +74,13 @@ private extension NotificationStore {
                         applicationId: String,
                         applicationVersion: String,
                         defaultStoreID: Int64,
+                        pushNotificationsForAllStoresEnabled: Bool,
                         onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         devicesRemote.registerDevice(device: device,
                               applicationId: applicationId,
                               applicationVersion: applicationVersion,
                               defaultStoreID: defaultStoreID,
+                              pushNotificationsForAllStoresEnabled: pushNotificationsForAllStoresEnabled,
                               completion: onCompletion)
     }
 

--- a/Yosemite/Yosemite/Stores/NotificationStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationStore.swift
@@ -38,7 +38,12 @@ public class NotificationStore: Store {
         }
 
         switch action {
-        case .registerDevice(let device, let applicationId, let applicationVersion, let defaultStoreID, let pushNotificationsForAllStoresEnabled, let onCompletion):
+        case .registerDevice(let device,
+                             let applicationId,
+                             let applicationVersion,
+                             let defaultStoreID,
+                             let pushNotificationsForAllStoresEnabled,
+                             let onCompletion):
             registerDevice(device: device,
                            applicationId: applicationId,
                            applicationVersion: applicationVersion,

--- a/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -365,7 +365,8 @@ class NotificationStoreTests: XCTestCase {
         let action = NotificationAction.registerDevice(device: sampleAPNSDevice(),
                                                        applicationId: sampleApplicationID,
                                                        applicationVersion: sampleApplicationVersion,
-                                                       defaultStoreID: sampleDefaultStoreID) { (device, error) in
+                                                       defaultStoreID: sampleDefaultStoreID,
+                                                       pushNotificationsForAllStoresEnabled: false) { (device, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(device)
             XCTAssertEqual(device?.deviceID, "12345678")
@@ -389,7 +390,8 @@ class NotificationStoreTests: XCTestCase {
         let action = NotificationAction.registerDevice(device: sampleAPNSDevice(),
                                                        applicationId: sampleApplicationID,
                                                        applicationVersion: sampleApplicationVersion,
-                                                       defaultStoreID: sampleDefaultStoreID) { (device, error) in
+                                                       defaultStoreID: sampleDefaultStoreID,
+                                                       pushNotificationsForAllStoresEnabled: false) { (device, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(device)
 


### PR DESCRIPTION
Part of #5032 

## Why

The feature to support push notifications for all stores involves several steps as outlined in #5032, and I plan to make code changes behind a feature flag. This PR enables push notifications for all stores behind a new feature flag, the app shall start receiving remote push notifications from all stores when the feature is enabled.

## Changes

- Added a feature flag `pushNotificationsForAllStores` in https://github.com/woocommerce/woocommerce-ios/commit/dde8348f34ff76eb40da04ddcbe0cde2f8a6edf6
- Set `selected_blog_id` to an empty string when registering a device if the feature flag is enabled with unit tests

## Testing

Prerequisites: the logged-in user has more than one site connected to the app. If you are testing with your a8c WP.com account, you can resend previous new order/review notifications from the **MC Push Notifications Debug Console** (MC > Push Notifications > Debug Console > WP.com Notification, or with this path `/mobile/push-notifications/debug/?type=wpcom-notification`).

Please test push notifications on a device, since simulators cannot register for remote notifications from WP.com. You might need a developer sandbox for receiving push notifications in a debug build. If you don't have one, please check out the first step in p99K0U-1qz-p2

### Feature flag is enabled

- Launch the app logged in to a site, allow remote push notifications if you haven't already
- Put the app in the background
- Place an order or resend a new order notification in the MC Debug Console **on a different site** --> a new order push notification should appear
- Leave a review or resend a new review notification in the MC Debug Console **on a different site** --> a new review push notification should appear
- Place an order or resend a new order notification in the MC Debug Console **on the selected site** --> a new order push notification should appear
- Leave a review or resend a new review notification in the MC Debug Console **on the selected site** --> a new review push notification should appear

### Feature flag is disabled

- In `DefaultFeatureFlagService`, return `false` for `pushNotificationsForAllStores` feature flag
- Launch the app logged in to a site, allow remote push notifications if you haven't already
- Put the app in the background
- Place an order or resend a new order notification in the MC Debug Console **on a different site** --> a new order push notification should **not** appear
- Leave a review or resend a new review notification in the MC Debug Console **on a different site** --> a new review push notification should **not** appear
- Place an order or resend a new order notification in the MC Debug Console **on the selected site** --> a new order push notification should appear
- Leave a review or resend a new review notification in the MC Debug Console **on the selected site** --> a new review push notification should appear
- Tapping on the new order notification should show the order details as in the production
- Tapping on the new review notification should show the review details as in the production

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.