### PR TITLE
[Mobile Payments] Bump Stripe Terminal to 2.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -62,7 +62,7 @@ target 'WooCommerce' do
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.6.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
-  pod 'StripeTerminal', '~> 2.0'
+  pod 'StripeTerminal', '~> 2.2'
   pod 'Kingfisher', '~> 6.0.0'
   pod 'Wormholy', '~> 1.6.4', configurations: ['Debug']
 
@@ -79,7 +79,7 @@ end
 #
 def yosemite_pods
   pod 'Alamofire', '~> 4.8'
-  pod 'StripeTerminal', '~> 2.0'
+  pod 'StripeTerminal', '~> 2.2'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 
@@ -164,7 +164,7 @@ end
 # =================
 #
 def hardware_pods
-  pod 'StripeTerminal', '~> 2.0'
+  pod 'StripeTerminal', '~> 2.2'
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
   - Sentry/Core (6.2.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.0.1)
+  - StripeTerminal (2.2.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -100,7 +100,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 6.0.0)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.0)
+  - StripeTerminal (~> 2.2)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.42.0)
   - WordPressKit (~> 4.40.0)
@@ -176,7 +176,7 @@ SPEC CHECKSUMS:
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: c0f7f64bdd1505d3133f27b4e03b9a43452e710c
+  StripeTerminal: d06c83ebcc000de142df04ad16713b08bdc0b7b9
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 52d830399bbfea036106a6b37f8ef09e9a000a85
+PODFILE CHECKSUM: 4ac9e5451b1049283d046177807426ccb960e069
 
 COCOAPODS: 1.10.2


### PR DESCRIPTION
⚠️  This PR is against the feature branch, not develop ⚠️ 

Part of the migration to the Stripe SDK 2.x

When I started tinkering with the migration, I pointed the podfile to the 2.0 release (pulling 2.0.1). In the meantime, Stripe has released a couple of significant bug fixes.

## Changes
* Point the Stripe SDK to 2.2

## How to test
* Check out the branch, run `bundle exec pod install`
* The branch should run. It should be possible to capture a payment with a simulated reader, enabling `-simulate-stripe-card-reader`  in the scheme
* It should be possible to capture a payment with a hardware reader, provided there is a hardcoded location id: pdfdoF-7s-p2

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
