### PR TITLE
Convert `MyStoreScreen` to be a `ScreenObject` subclass

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
-          "version": "0.1.0"
+          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
+          "version": "0.2.0"
         }
       },
       {

--- a/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
+++ b/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
@@ -1,0 +1,24 @@
+import ScreenObject
+
+// These are implemented as extensions on `ScreenObject` locally to this target to allow us to
+// finish the transition of the screens from `BaseScreen` to `ScreenObject` and from the different
+// test targets to the share UI tests foundation one. Once that's done, we'll likely want to move
+// these in the package itself.
+public extension ScreenObject {
+
+    // Pops the navigation stack, returning to the item above the current one
+    func pop() {
+        navBackButton.tap()
+    }
+
+    func then(_ completion: () -> Void) -> Self {
+        completion()
+        return self
+    }
+
+    /// This would be way nicer if we could base `Self` as the type of `completion` parameter.
+    func then(_ completion: (ScreenObject) -> Void) -> Self {
+        completion(self)
+        return self
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F92DE025E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift */; };
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
+		3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */; };
 		3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81C26C3542600228BF2 /* XCUITestHelpers */; };
 		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
@@ -1970,6 +1971,7 @@
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LearnMoreTableViewCell.xib; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
+		3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenObject+Extension.swift"; sourceTree = "<group>"; };
 		3FF314DE26FC74450012E68E /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF314E026FC74450012E68E /* UITestsFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestsFoundation.h; sourceTree = "<group>"; };
 		3FF314EF26FC784A0012E68E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -4105,6 +4107,7 @@
 			isa = PBXGroup;
 			children = (
 				F997172B23DBCD8E00592D8E /* BaseScreen.swift */,
+				3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */,
 				3FF314E026FC74450012E68E /* UITestsFoundation.h */,
 				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 			);
@@ -7239,6 +7242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
+				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -9183,7 +9183,7 @@
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -19,7 +19,7 @@ class WooCommerceScreenshots: XCTestCase {
         stopWebServer()
     }
 
-    func testScreenshots() {
+    func testScreenshots() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         setupSnapshot(app)
@@ -30,7 +30,7 @@ class WooCommerceScreenshots: XCTestCase {
 
         app.launch()
 
-        MyStoreScreen()
+        try MyStoreScreen()
 
             // My Store
             .dismissTopBannerIfNeeded()

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginEpilogueScreen.swift
@@ -21,9 +21,9 @@ final class LoginEpilogueScreen: BaseScreen {
         super.init(element: continueButton)
     }
 
-    func continueWithSelectedSite() -> MyStoreScreen {
+    func continueWithSelectedSite() throws -> MyStoreScreen {
         continueButton.tap()
-        return MyStoreScreen()
+        return try MyStoreScreen()
     }
 
     func verifyEpilogueDisplays(displayName expectedDisplayName: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/MyStore/MyStoreScreen.swift
@@ -1,39 +1,36 @@
 import UITestsFoundation
+import ScreenObject
 import XCTest
 
-final class MyStoreScreen: BaseScreen {
-
-    struct ElementStringIDs {
-        static let topBannerCloseButton = "top-banner-view-dismiss-button"
-        static let settingsButton = "dashboard-settings-button"
-    }
+final class MyStoreScreen: ScreenObject {
 
     let tabBar = TabNavComponent()
     let periodStatsTable = PeriodStatsTable()
-    private let settingsButton: XCUIElement
-    private let topBannerCloseButton: XCUIElement
 
-    static var isVisible: Bool {
-        let settingsButton = XCUIApplication().buttons[ElementStringIDs.settingsButton]
-        return settingsButton.exists && settingsButton.isHittable
+    private let settingsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["dashboard-settings-button"]
     }
 
-    init() {
-        settingsButton = XCUIApplication().buttons[ElementStringIDs.settingsButton]
-        topBannerCloseButton = XCUIApplication().buttons[ElementStringIDs.topBannerCloseButton]
+    private var settingsButton: XCUIElement { settingsButtonGetter(app) }
 
-        super.init(element: settingsButton)
+    static var isVisible: Bool {
+        guard let screen = try? MyStoreScreen() else { return false }
+        return screen.settingsButton.isHittable
+    }
 
-        XCTAssert(settingsButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [settingsButtonGetter],
+            app: app
+        )
     }
 
     @discardableResult
     func dismissTopBannerIfNeeded() -> MyStoreScreen {
+        let topBannerCloseButton = app.buttons["top-banner-view-dismiss-button"]
+        guard topBannerCloseButton.waitForExistence(timeout: 3) else { return self }
 
-        if topBannerCloseButton.waitForExistence(timeout: 3) {
-            topBannerCloseButton.tap()
-        }
-
+        topBannerCloseButton.tap()
         return self
     }
 

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -21,9 +21,9 @@ final class SettingsScreen: BaseScreen {
     }
 
     @discardableResult
-    func goBackToMyStore() -> MyStoreScreen {
+    func goBackToMyStore() throws -> MyStoreScreen {
         navBackButton.tap()
-        return MyStoreScreen()
+        return try MyStoreScreen()
     }
 
     @discardableResult

--- a/WooCommerce/WooCommerceUITests/Screens/TabNavComponent.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/TabNavComponent.swift
@@ -31,12 +31,12 @@ final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    func gotoMyStoreScreen() -> MyStoreScreen {
+    func gotoMyStoreScreen() throws -> MyStoreScreen {
         // Avoid transitioning if it is already on screen
         if !MyStoreScreen.isVisible {
             myStoreTabButton.tap()
         }
-        return MyStoreScreen()
+        return try MyStoreScreen()
     }
 
     @discardableResult


### PR DESCRIPTION
My plan of action was to first create a UI tests foundation framework to share between UI tests and screenshot automation and then proceed with converting from `BaseScreen` to `ScreenObject`. But the other day @thehenrybyrd and I were pairing and decided to have some fun playing around with converting one screen and this is the result 😄 

To test it's enough to verify the UI test passed in CI. I'll be working on the tests more anyway soon, so any issue or suggestion will be addressed shortly.

For extra details on how `ScreenObject` subclasses work, see https://github.com/wordpress-mobile/WordPress-iOS/pull/17221

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (N.A.)
