### PR TITLE
Show review details after tapping on a new review push notification from another store

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -382,9 +382,15 @@ private extension MainTabBarController {
         let productsViewController = createProductsViewController(siteID: siteID)
         productsNavigationController.viewControllers = [productsViewController]
 
-        let reviewsTabCoordinator = createReviewsTabCoordinator(siteID: siteID)
-        self.reviewsTabCoordinator = reviewsTabCoordinator
-        reviewsTabCoordinator.start()
+        // Configure reivews tab coordinator once per logged in session potentially with multiple sites.
+        if reviewsTabCoordinator == nil {
+            let reviewsTabCoordinator = createReviewsTabCoordinator()
+            self.reviewsTabCoordinator = reviewsTabCoordinator
+            reviewsTabCoordinator.start()
+        }
+
+        let reviewsViewController = createReviewsViewController(siteID: siteID)
+        reviewsTabCoordinator?.navigationController.viewControllers = [reviewsViewController]
 
         // Set dashboard to be the default tab.
         selectedIndex = WooTab.myStore.visibleIndex()
@@ -402,9 +408,12 @@ private extension MainTabBarController {
         ProductsViewController(siteID: siteID)
     }
 
-    func createReviewsTabCoordinator(siteID: Int64) -> Coordinator {
-        ReviewsCoordinator(siteID: siteID,
-                           navigationController: reviewsNavigationController,
+    func createReviewsViewController(siteID: Int64) -> UIViewController {
+        ReviewsViewController(siteID: siteID)
+    }
+
+    func createReviewsTabCoordinator() -> Coordinator {
+        ReviewsCoordinator(navigationController: reviewsNavigationController,
                            willPresentReviewDetailsFromPushNotification: { [weak self] in
                             self?.navigateTo(.reviews)
         })

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -87,7 +87,7 @@ final class MainTabBarController: UITabBarController {
     private let ordersNavigationController = WooTabNavigationController()
     private let productsNavigationController = WooTabNavigationController()
     private let reviewsNavigationController = WooTabNavigationController()
-    private var reviewsTabCoordinator: Coordinator?
+    private var reviewsTabCoordinator: ReviewsCoordinator?
 
     private var cancellableSiteID: ObservationToken?
 
@@ -389,8 +389,7 @@ private extension MainTabBarController {
             reviewsTabCoordinator.start()
         }
 
-        let reviewsViewController = createReviewsViewController(siteID: siteID)
-        reviewsTabCoordinator?.navigationController.viewControllers = [reviewsViewController]
+        reviewsTabCoordinator?.activate(siteID: siteID)
 
         // Set dashboard to be the default tab.
         selectedIndex = WooTab.myStore.visibleIndex()
@@ -408,11 +407,7 @@ private extension MainTabBarController {
         ProductsViewController(siteID: siteID)
     }
 
-    func createReviewsViewController(siteID: Int64) -> UIViewController {
-        ReviewsViewController(siteID: siteID)
-    }
-
-    func createReviewsTabCoordinator() -> Coordinator {
+    func createReviewsTabCoordinator() -> ReviewsCoordinator {
         ReviewsCoordinator(navigationController: reviewsNavigationController,
                            willPresentReviewDetailsFromPushNotification: { [weak self] in
                             self?.navigateTo(.reviews)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -382,7 +382,7 @@ private extension MainTabBarController {
         let productsViewController = createProductsViewController(siteID: siteID)
         productsNavigationController.viewControllers = [productsViewController]
 
-        // Configure reivews tab coordinator once per logged in session potentially with multiple sites.
+        // Configure reviews tab coordinator once per logged in session potentially with multiple sites.
         if reviewsTabCoordinator == nil {
             let reviewsTabCoordinator = createReviewsTabCoordinator()
             self.reviewsTabCoordinator = reviewsTabCoordinator

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -21,8 +21,7 @@ final class ReviewsCoordinator: Coordinator {
 
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
-    init(siteID: Int64,
-         navigationController: UINavigationController,
+    init(navigationController: UINavigationController,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          storesManager: StoresManager = ServiceLocator.stores,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
@@ -34,15 +33,12 @@ final class ReviewsCoordinator: Coordinator {
         self.noticePresenter = noticePresenter
         self.switchStoreUseCase = switchStoreUseCase
         self.willPresentReviewDetailsFromPushNotification = willPresentReviewDetailsFromPushNotification
-
         self.navigationController = navigationController
-        navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
     }
 
-    convenience init(siteID: Int64, navigationController: UINavigationController, willPresentReviewDetailsFromPushNotification: @escaping () -> Void) {
+    convenience init(navigationController: UINavigationController, willPresentReviewDetailsFromPushNotification: @escaping () -> Void) {
         let storesManager = ServiceLocator.stores
-        self.init(siteID: siteID,
-                  navigationController: navigationController,
+        self.init(navigationController: navigationController,
                   storesManager: storesManager,
                   switchStoreUseCase: SwitchStoreUseCase(stores: storesManager),
                   willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -49,8 +49,17 @@ final class ReviewsCoordinator: Coordinator {
     }
 
     func start() {
-        observationToken = pushNotificationsManager.inactiveNotifications.subscribe { [weak self] in
-            self?.handleInactiveNotification($0)
+        // No-op: please call `activate(siteID:)` instead when the reviews tab is configured.
+    }
+
+    /// Replaces `start()` because the reviews tab's navigation stack could be updated multiple times when site ID changes.
+    func activate(siteID: Int64) {
+        navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
+
+        if observationToken == nil {
+            observationToken = pushNotificationsManager.inactiveNotifications.subscribe { [weak self] in
+                self?.handleInactiveNotification($0)
+            }
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
+		02E4AF7126FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
@@ -1769,6 +1770,7 @@
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewFromNoteParcel.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
@@ -4727,6 +4729,7 @@
 				311F827526CD8AB100DF5BAD /* MockCardReaderSettingsAlerts.swift */,
 				DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */,
 				FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */,
+				02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8213,6 +8216,7 @@
 				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 				4569D3C925DC065B00CDC3E2 /* SiteAddressTests.swift in Sources */,
 				CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */,
+				02E4AF7126FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift in Sources */,
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
-		02E4AF7126FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */; };
+		02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
@@ -1770,7 +1770,7 @@
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
-		02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewFromNoteParcel.swift; sourceTree = "<group>"; };
+		02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcelFactory.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
@@ -4729,7 +4729,7 @@
 				311F827526CD8AB100DF5BAD /* MockCardReaderSettingsAlerts.swift */,
 				DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */,
 				FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */,
-				02E4AF7026FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift */,
+				02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8216,7 +8216,7 @@
 				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 				4569D3C925DC065B00CDC3E2 /* SiteAddressTests.swift in Sources */,
 				CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */,
-				02E4AF7126FC4F16002AD9F4 /* MockProductReviewFromNoteParcel.swift in Sources */,
+				02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */,
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductReviewFromNoteParcel.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductReviewFromNoteParcel.swift
@@ -1,6 +1,5 @@
-import Foundation
 import XCTest
-@testable import Yosemite
+import Yosemite
 
 
 final class MockProductReviewFromNoteParcel {
@@ -34,7 +33,7 @@ final class MockProductReviewFromNoteParcel {
                         body: Data(),
                         meta: metaAsData)
         let product = Product.fake()
-        let review = MockReviews().anonymousReview()
+        let review = ProductReview.fake()
 
         return ProductReviewFromNoteParcel(note: note, review: review, product: product)
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductReviewFromNoteParcel.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductReviewFromNoteParcel.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import Yosemite
+
+
+final class MockProductReviewFromNoteParcel {
+    func parcel(metaSiteID: Int64 = 0) -> ProductReviewFromNoteParcel {
+        let metaAsData: Data = {
+            var ids = [String: Int64]()
+            ids[MetaContainer.Keys.site.rawValue] = metaSiteID
+
+            var metaAsJSON = [String: [String: Int64]]()
+            metaAsJSON[MetaContainer.Containers.ids.rawValue] = ids
+            do {
+                return try JSONEncoder().encode(metaAsJSON)
+            } catch {
+                XCTFail("Expected to convert MetaContainer JSON to Data. \(error)")
+                return Data()
+            }
+        }()
+
+        let note = Note(noteID: 1,
+                        hash: 0,
+                        read: false,
+                        icon: nil,
+                        noticon: nil,
+                        timestamp: "",
+                        type: "",
+                        subtype: nil,
+                        url: nil,
+                        title: nil,
+                        subject: Data(),
+                        header: Data(),
+                        body: Data(),
+                        meta: metaAsData)
+        let product = Product.fake()
+        let review = MockReviews().anonymousReview()
+
+        return ProductReviewFromNoteParcel(note: note, review: review, product: product)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/ProductReviewFromNoteParcelFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/ProductReviewFromNoteParcelFactory.swift
@@ -2,7 +2,7 @@ import XCTest
 import Yosemite
 
 
-final class MockProductReviewFromNoteParcel {
+final class ProductReviewFromNoteParcelFactory {
     func parcel(metaSiteID: Int64 = 0) -> ProductReviewFromNoteParcel {
         let metaAsData: Data = {
             var ids = [String: Int64]()

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -39,12 +39,6 @@ final class ServiceLocatorTests: XCTestCase {
         XCTAssertNotNil(ServiceLocator.pushNotesManager)
     }
 
-    func test_pushNotesManager_defaults_to_PushNotificationsManager() {
-        let pushNotes = ServiceLocator.pushNotesManager
-
-        XCTAssertTrue(pushNotes is PushNotificationsManager)
-    }
-
     func test_ServiceLocator_provides_authenticationManager() {
         XCTAssertNotNil(ServiceLocator.authenticationManager)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -34,13 +34,13 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(tabBarController.viewControllers?.count, 4)
-        assertThat((tabBarController.viewControllers?[WooTab.myStore.visibleIndex()] as? UINavigationController)?.topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .myStore).topViewController,
                    isAnInstanceOf: DashboardViewController.self)
-        assertThat((tabBarController.viewControllers?[WooTab.orders.visibleIndex()] as? UINavigationController)?.topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .orders).topViewController,
                    isAnInstanceOf: OrdersRootViewController.self)
-        assertThat((tabBarController.viewControllers?[WooTab.products.visibleIndex()] as? UINavigationController)?.topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .products).topViewController,
                    isAnInstanceOf: ProductsViewController.self)
-        assertThat((tabBarController.viewControllers?[WooTab.reviews.visibleIndex()] as? UINavigationController)?.topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .reviews).topViewController,
                    isAnInstanceOf: ReviewsViewController.self)
     }
 
@@ -95,10 +95,72 @@ final class MainTabBarControllerTests: XCTestCase {
         XCTAssertEqual(selectedTabIndexBeforeSiteChange, WooTab.products.visibleIndex())
         XCTAssertEqual(selectedTabIndexAfterSiteChange, WooTab.myStore.visibleIndex())
     }
+
+    func test_when_receiving_a_review_notification_from_a_different_site_navigates_to_reviews_tab_and_presents_review_details() throws {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        ServiceLocator.setPushNotesManager(pushNotificationsManager)
+
+        let storesManager = MockStoresManager(sessionManager: .testingInstance)
+        // Reset `receivedActions`
+        storesManager.reset()
+        ServiceLocator.setStores(storesManager)
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+        stores.updateDefaultStore(storeID: 134)
+
+        // Simulate successful state resetting after logging out from push notification store switching
+        storesManager.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            if case let .resetStoredStats(completion) = action {
+                completion()
+            }
+        }
+        storesManager.whenReceivingAction(ofType: OrderAction.self) { action in
+            if case let .resetStoredOrders(completion) = action {
+                completion()
+            }
+        }
+        storesManager.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            if case let .resetStoredProductReviews(completion) = action {
+                completion()
+            }
+        }
+
+        // Action
+        // Send push notification in inactive state
+        let pushNotification = PushNotification(noteID: 1_234, kind: .comment, message: "")
+        pushNotificationsManager.sendInactiveNotification(pushNotification)
+
+        // Simulate that the network call returns a parcel
+        let receivedAction = try XCTUnwrap(storesManager.receivedActions.first as? ProductReviewAction)
+        guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
+            return XCTFail("Expected retrieveProductReviewFromNote action.")
+        }
+        completion(.success(MockProductReviewFromNoteParcel().parcel(metaSiteID: 606)))
+
+        // Assert
+        waitUntil {
+            self.tabBarController.tabNavigationController(tab: .reviews).viewControllers.count == 2
+        }
+
+        XCTAssertEqual(tabBarController.selectedIndex, WooTab.reviews.visibleIndex())
+
+        let reviewsTabNavigationController = tabBarController.tabNavigationController(tab: .reviews)
+        // A ReviewDetailsViewController should be pushed
+        assertThat(reviewsTabNavigationController.topViewController, isAnInstanceOf: ReviewDetailsViewController.self)
+    }
 }
 
 private extension MainTabBarController {
     var tabRootViewControllers: [UIViewController] {
         viewControllers?.compactMap { $0 as? UINavigationController }.compactMap { $0.viewControllers.first } ?? []
+    }
+
+    func tabNavigationController(tab: WooTab) -> UINavigationController {
+        guard let navigationController = viewControllers?.compactMap({ $0 as? UINavigationController })[tab.visibleIndex()] else {
+            fatalError("Unexpected access to navigation controller at tab: \(tab)")
+        }
+        return navigationController
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -139,7 +139,7 @@ final class MainTabBarControllerTests: XCTestCase {
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
             return XCTFail("Expected retrieveProductReviewFromNote action.")
         }
-        completion(.success(MockProductReviewFromNoteParcel().parcel(metaSiteID: 606)))
+        completion(.success(ProductReviewFromNoteParcelFactory().parcel(metaSiteID: 606)))
 
         // Assert
         waitUntil {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -34,13 +34,13 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(tabBarController.viewControllers?.count, 4)
-        assertThat(tabBarController.tabNavigationController(tab: .myStore).topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .myStore)?.topViewController,
                    isAnInstanceOf: DashboardViewController.self)
-        assertThat(tabBarController.tabNavigationController(tab: .orders).topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .orders)?.topViewController,
                    isAnInstanceOf: OrdersRootViewController.self)
-        assertThat(tabBarController.tabNavigationController(tab: .products).topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .products)?.topViewController,
                    isAnInstanceOf: ProductsViewController.self)
-        assertThat(tabBarController.tabNavigationController(tab: .reviews).topViewController,
+        assertThat(tabBarController.tabNavigationController(tab: .reviews)?.topViewController,
                    isAnInstanceOf: ReviewsViewController.self)
     }
 
@@ -127,6 +127,8 @@ final class MainTabBarControllerTests: XCTestCase {
             }
         }
 
+        assertThat(tabBarController.tabNavigationController(tab: .reviews)?.topViewController, isAnInstanceOf: ReviewsViewController.self)
+
         // Action
         // Send push notification in inactive state
         let pushNotification = PushNotification(noteID: 1_234, kind: .comment, message: "")
@@ -141,14 +143,13 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // Assert
         waitUntil {
-            self.tabBarController.tabNavigationController(tab: .reviews).viewControllers.count == 2
+            self.tabBarController.tabNavigationController(tab: .reviews)?.viewControllers.count == 2
         }
 
         XCTAssertEqual(tabBarController.selectedIndex, WooTab.reviews.visibleIndex())
 
-        let reviewsTabNavigationController = tabBarController.tabNavigationController(tab: .reviews)
         // A ReviewDetailsViewController should be pushed
-        assertThat(reviewsTabNavigationController.topViewController, isAnInstanceOf: ReviewDetailsViewController.self)
+        assertThat(tabBarController.tabNavigationController(tab: .reviews)?.topViewController, isAnInstanceOf: ReviewDetailsViewController.self)
     }
 }
 
@@ -157,9 +158,10 @@ private extension MainTabBarController {
         viewControllers?.compactMap { $0 as? UINavigationController }.compactMap { $0.viewControllers.first } ?? []
     }
 
-    func tabNavigationController(tab: WooTab) -> UINavigationController {
+    func tabNavigationController(tab: WooTab) -> UINavigationController? {
         guard let navigationController = viewControllers?.compactMap({ $0 as? UINavigationController })[tab.visibleIndex()] else {
-            fatalError("Unexpected access to navigation controller at tab: \(tab)")
+            XCTFail("Unexpected access to navigation controller at tab: \(tab)")
+            return nil
         }
         return navigationController
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -185,13 +185,11 @@ final class ReviewsCoordinatorTests: XCTestCase {
 
 private extension ReviewsCoordinatorTests {
     func makeReviewsCoordinator(willPresentReviewDetailsFromPushNotification: (@escaping () -> Void) = { }) -> ReviewsCoordinator {
-        let coordinator = ReviewsCoordinator(navigationController: UINavigationController(),
-                                             pushNotificationsManager: pushNotificationsManager,
-                                             storesManager: storesManager,
-                                             noticePresenter: noticePresenter,
-                                             switchStoreUseCase: switchStoreUseCase,
-                                             willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
-        coordinator.navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
-        return coordinator
+        ReviewsCoordinator(navigationController: UINavigationController(),
+                           pushNotificationsManager: pushNotificationsManager,
+                           storesManager: storesManager,
+                           noticePresenter: noticePresenter,
+                           switchStoreUseCase: switchStoreUseCase,
+                           willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -178,13 +178,14 @@ final class ReviewsCoordinatorTests: XCTestCase {
 
 private extension ReviewsCoordinatorTests {
     func makeReviewsCoordinator(willPresentReviewDetailsFromPushNotification: (@escaping () -> Void) = { }) -> ReviewsCoordinator {
-        return ReviewsCoordinator(siteID: 1,
-                                  navigationController: UINavigationController(),
-                                  pushNotificationsManager: pushNotificationsManager,
-                                  storesManager: storesManager,
-                                  noticePresenter: noticePresenter,
-                                  switchStoreUseCase: switchStoreUseCase,
-                                  willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
+        let coordinator = ReviewsCoordinator(navigationController: UINavigationController(),
+                                             pushNotificationsManager: pushNotificationsManager,
+                                             storesManager: storesManager,
+                                             noticePresenter: noticePresenter,
+                                             switchStoreUseCase: switchStoreUseCase,
+                                             willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
+        coordinator.navigationController.viewControllers = [ReviewsViewController(siteID: 1)]
+        return coordinator
     }
 
     /// Create a dummy Parcel.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -94,7 +94,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
             return XCTFail("Expected retrieveProductReviewFromNote action.")
         }
-        completion(.success(makeParcel()))
+        completion(.success(MockProductReviewFromNoteParcel().parcel()))
 
         // Then
         waitUntil {
@@ -160,7 +160,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedProductReviewAction else {
             return XCTFail("Expected retrieveProductReviewFromNote action.")
         }
-        completion(.success(makeParcel(metaSiteID: differentSiteID)))
+        completion(.success(MockProductReviewFromNoteParcel().parcel(metaSiteID: differentSiteID)))
 
         // Then
         waitUntil {
@@ -186,41 +186,5 @@ private extension ReviewsCoordinatorTests {
                                              willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
         coordinator.navigationController.viewControllers = [ReviewsViewController(siteID: 1)]
         return coordinator
-    }
-
-    /// Create a dummy Parcel.
-    func makeParcel(metaSiteID: Int64 = 0) -> ProductReviewFromNoteParcel {
-        let metaAsData: Data = {
-            var ids = [String: Int64]()
-            ids[MetaContainer.Keys.site.rawValue] = metaSiteID
-
-            var metaAsJSON = [String: [String: Int64]]()
-            metaAsJSON[MetaContainer.Containers.ids.rawValue] = ids
-            do {
-                return try JSONEncoder().encode(metaAsJSON)
-            } catch {
-                XCTFail("Expected to convert MetaContainer JSON to Data. \(error)")
-                return Data()
-            }
-        }()
-
-        let note = Note(noteID: 1,
-                        hash: 0,
-                        read: false,
-                        icon: nil,
-                        noticon: nil,
-                        timestamp: "",
-                        type: "",
-                        subtype: nil,
-                        url: nil,
-                        title: nil,
-                        subject: Data(),
-                        header: Data(),
-                        body: Data(),
-                        meta: metaAsData)
-        let product = Product.fake()
-        let review = MockReviews().anonymousReview()
-
-        return ProductReviewFromNoteParcel(note: note, review: review, product: product)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -14,6 +14,8 @@ final class ReviewsCoordinatorTests: XCTestCase {
     private var noticePresenter: MockNoticePresenter!
     private var switchStoreUseCase: MockSwitchStoreUseCase!
 
+    private let siteID: Int64 = 1
+
     override func setUp() {
         super.setUp()
 
@@ -44,6 +46,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, kind: .storeOrder, message: "")
 
         coordinator.start()
+        coordinator.activate(siteID: siteID)
 
         XCTAssertEqual(coordinator.navigationController.viewControllers.count, 1)
 
@@ -64,6 +67,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, kind: .comment, message: "")
 
         coordinator.start()
+        coordinator.activate(siteID: siteID)
 
         // When
         pushNotificationsManager.sendForegroundNotification(pushNotification)
@@ -85,6 +89,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
             willPresentReviewDetailsFromPushNotificationCallCount += 1
         })
         coordinator.start()
+        coordinator.activate(siteID: siteID)
 
         // When
         pushNotificationsManager.sendInactiveNotification(pushNotification)
@@ -113,6 +118,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, kind: .comment, message: "")
 
         coordinator.start()
+        coordinator.activate(siteID: siteID)
 
         assertEmpty(noticePresenter.queuedNotices)
 
@@ -151,6 +157,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         let differentSiteID: Int64 = 2_000_111
 
         coordinator.start()
+        coordinator.activate(siteID: siteID)
 
         // When
         pushNotificationsManager.sendInactiveNotification(pushNotification)
@@ -184,7 +191,7 @@ private extension ReviewsCoordinatorTests {
                                              noticePresenter: noticePresenter,
                                              switchStoreUseCase: switchStoreUseCase,
                                              willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)
-        coordinator.navigationController.viewControllers = [ReviewsViewController(siteID: 1)]
+        coordinator.navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
         return coordinator
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -99,7 +99,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
             return XCTFail("Expected retrieveProductReviewFromNote action.")
         }
-        completion(.success(MockProductReviewFromNoteParcel().parcel()))
+        completion(.success(ProductReviewFromNoteParcelFactory().parcel()))
 
         // Then
         waitUntil {
@@ -167,7 +167,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedProductReviewAction else {
             return XCTFail("Expected retrieveProductReviewFromNote action.")
         }
-        completion(.success(MockProductReviewFromNoteParcel().parcel(metaSiteID: differentSiteID)))
+        completion(.success(ProductReviewFromNoteParcelFactory().parcel(metaSiteID: differentSiteID)))
 
         // Then
         waitUntil {


### PR DESCRIPTION
Part of #5032 
Based on https://github.com/woocommerce/woocommerce-ios/pull/5033 (the code is independent but the base allows testing for multi-store push notifications)

## Why

`ReviewsCoordinator` nicely handles new review push notifications - it switches store if the notification is not from the currently selected store, navigates to Reviews tab, and then shows review details. After the [site ID DI work](https://github.com/woocommerce/woocommerce-ios/pull/2850/files#diff-447f41e2635ca816fc716d17130a9f977c281b1ea9d73948b0bf0d1369dc070d), `ReviewsCoordinator`'s lifetime becomes per site ID. This is fine when push notifications can only come from the default store, but the code to show review details (shown below) isn't executed anymore when we support multi-store push notifications. `self` becomes `nil` after switching store because a new `ReviewsCoordinator` is instantiated.

https://github.com/woocommerce/woocommerce-ios/blob/0e14c9a99daba7e460554a51b1028e74bcdea07f/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift#L80-L87

This PR updates the lifetime of `ReviewsCoordinator` from per site ID to per logged-in session where users might connect to multiple sites.

## Changes

- Removed `siteID` and Reviews tab navigation controller's setup from `ReviewsCoordinator`. The navigation controller setup is now in `MainTabBarController`.
  - I was hoping to configure `ReviewsCoordinator` when the user logs in, but couldn't find an ideal place to call it. Each tab is [updated for each site ID](https://github.com/woocommerce/woocommerce-ios/blob/0e14c9a99daba7e460554a51b1028e74bcdea07f/WooCommerce/Classes/ViewRelated/MainTabBarController.swift#L358-L367) when the site ID observable changes, and we need to make sure `ReviewsCoordinator` is configured before the first site ID is set. Since the site ID observable isn't obviously sending updates **after** the logged-in event, I decided to configure `ReviewsCoordinator` when it is `nil` (the first site ID for a logged-in session) when updating the tabs per site ID. Feel free to suggest other ways to do this!
- Unit tests:
  - Created `MockProductReviewFromNoteParcel` for mocking a new review notification parcel, and replaced existing usage in `ReviewsCoordinatorTests`
  - In `MainTabBarControllerTests`, added a new test case for handling new review push notifications from another store. I couldn't find an easy way to DI `PushNotesManager` and `SwitchStoreUseCaseProtocol` from `MainTabBarController` (instantiated from Storyboard) to `ReviewsCoordinator`, so I had to pass mocks for these dependencies in `ServiceLocator`. Because I had to mock `PushNotesManager` in `ServiceLocator`, I had to remove `ServiceLocatorTests.test_pushNotesManager_defaults_to_PushNotificationsManager` 😨 

## Testing

Prerequisites: the logged-in user has more than one site connected to the app.
If you are testing with your a8c WP.com account, you can resend previous new order/review notifications from the **MC Push Notifications Debug Console** (MC > Push Notifications > Debug Console > WP.com Notification, or with this path `/mobile/push-notifications/debug/?type=wpcom-notification`).

Please test push notifications on a device, since simulators cannot register for remote notifications from WP.com. You might need a developer sandbox for receiving push notifications in a debug build. If you don't have one, please check out the first step in p99K0U-1qz-p2

- Launch the app logged in to a site, allow remote push notifications if you haven't already
- Put the app in the background
- Leave a review or resend a new review notification in the MC Debug Console **on a different site** --> a new review push notification should appear
- Tap on the new review push notification --> the app should switch to the target site, navigate to the reviews tab, then show the review details (before this PR, the app only switches to the target site because `ReviewsCoordinator` is deallocated after the store switch)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.