### PR TITLE
Skip broken tests when running on Rosetta

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		02FF056B23DED3670058E6E7 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02FF056A23DED3670058E6E7 /* Media.xcassets */; };
 		02FF056D23DEDCB90058E6E7 /* MockImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */; };
 		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
+		031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */; };
 		077F39DE26A5A1CB00ABEADC /* SystemStatusAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */; };
 		077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */; };
 		077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */; };
@@ -455,6 +456,7 @@
 		02FF056A23DED3670058E6E7 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageSourceWriter.swift; sourceTree = "<group>"; };
 		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
+		031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaTestingHelper.swift; sourceTree = "<group>"; };
 		077F39DD26A5A1CB00ABEADC /* SystemStatusAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusAction.swift; sourceTree = "<group>"; };
 		077F39DF26A5A6F500ABEADC /* SystemStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusStore.swift; sourceTree = "<group>"; };
 		077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemPlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1474,6 +1476,7 @@
 				2614E12B24C74593007CEE60 /* Stats */,
 				B54EAF2021188C470029C35E /* EntityListenerTests.swift */,
 				B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */,
+				031FD89F26FC970300B315C7 /* RosettaTestingHelper.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1999,6 +2002,7 @@
 				578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */,
 				D87F615E2265B1BC0031A13B /* AppSettingsStoreTests.swift in Sources */,
 				02E7FFD52562226B00C53030 /* ShippingLabelStoreTests.swift in Sources */,
+				031FD8A026FC970400B315C7 /* RosettaTestingHelper.swift in Sources */,
 				077F39E526A5C98200ABEADC /* SystemStatusStoreTests.swift in Sources */,
 				022F931D257F27B40011CD94 /* MockShippingLabelAddress.swift in Sources */,
 				02FF056923DECD5B0058E6E7 /* MediaImageExporterTests.swift in Sources */,

--- a/Yosemite/YosemiteTests/Tools/Media/Media+MediaTypeTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/Media+MediaTypeTests.swift
@@ -4,70 +4,82 @@ import XCTest
 final class Media_MediaTypeTests: XCTestCase {
     // MARK: - Image types
 
-    func testGIFMediaType() {
+    func testGIFMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "gif", mimeType: "image/gif")
         XCTAssertEqual(media.mediaType, .image, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testJPGMediaType() {
+    func testJPGMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "jpg", mimeType: "image/jpeg")
         XCTAssertEqual(media.mediaType, .image, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testJPEGMediaType() {
+    func testJPEGMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "jpeg", mimeType: "image/jpeg")
         XCTAssertEqual(media.mediaType, .image, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testPNGMediaType() {
+    func testPNGMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "png", mimeType: "image/png")
         XCTAssertEqual(media.mediaType, .image, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
     // MARK: - Video types
 
-    func testMP4MediaType() {
+    func testMP4MediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "mp4", mimeType: "video/mp4")
         XCTAssertEqual(media.mediaType, .video, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testMOVMediaType() {
+    func testMOVMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "mov", mimeType: "video/quicktime")
         XCTAssertEqual(media.mediaType, .video, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testM4VMediaType() {
+    func testM4VMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "m4v", mimeType: "video/mp4")
         XCTAssertEqual(media.mediaType, .video, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
     // MARK: - Audio types
 
-    func testWAVMediaType() {
+    func testWAVMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "wav", mimeType: "audio/wav")
         XCTAssertEqual(media.mediaType, .audio, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testMP3MediaType() {
+    func testMP3MediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "mp3", mimeType: "audio/mpeg")
         XCTAssertEqual(media.mediaType, .audio, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
     // MARK: - Presentation types
 
-    func testPPTMediaType() {
+    func testPPTMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "ppt", mimeType: "application/vnd.ms-powerpoint")
         XCTAssertEqual(media.mediaType, .powerpoint, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
     // MARK: - Other types
 
-    func testZIPMediaType() {
+    func testZIPMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "zip", mimeType: "application/zip")
         XCTAssertEqual(media.mediaType, .other, "Unexpected media type \(media.mediaType) for media: \(media)")
     }
 
-    func testPDFMediaType() {
+    func testPDFMediaType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let media = createSampleMedia(fileExtension: "pdf", mimeType: "application/pdf")
         XCTAssertEqual(media.mediaType, .other, "Unexpected media type \(media.mediaType) for media: \(media)")
     }

--- a/Yosemite/YosemiteTests/Tools/Media/MediaTypeTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaTypeTests.swift
@@ -5,14 +5,16 @@ final class MediaTypeTests: XCTestCase {
     // MARK: - `init(fileExtension: String)`
     // Reference: https://wordpress.com/support/accepted-filetypes/
 
-    func testInitWithImageFileExtensions() {
+    func testInitWithImageFileExtensions() throws {
+        try XCTSkipIf(testingOnRosetta())
         let imageFileExtensions = ["jpg", "jpeg", "gif", "png"]
         imageFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .image, "Unexpected media type for file extension: \(fileExtension)")
         }
     }
 
-    func testInitWithVideoFileExtensions() {
+    func testInitWithVideoFileExtensions() throws {
+        try XCTSkipIf(testingOnRosetta())
         // Note: "ogv" isn't supported on iOS.
         let videoFileExtensions = ["mp4", "m4v", "mov", "wmv", "avi", "mpg", "3gp", "3g2"]
         videoFileExtensions.forEach { fileExtension in
@@ -20,7 +22,8 @@ final class MediaTypeTests: XCTestCase {
         }
     }
 
-    func testInitWithAudioFileExtensions() {
+    func testInitWithAudioFileExtensions() throws {
+        try XCTSkipIf(testingOnRosetta())
         // Note: "ogg" isn't supported on iOS.
         let audioFileExtensions = ["mp3", "m4a", "wav"]
         audioFileExtensions.forEach { fileExtension in
@@ -28,14 +31,16 @@ final class MediaTypeTests: XCTestCase {
         }
     }
 
-    func testInitWithPowerpointFileExtensions() {
+    func testInitWithPowerpointFileExtensions() throws {
+        try XCTSkipIf(testingOnRosetta())
         let presentationFileExtensions = ["ppt", "pptx", "pps", "ppsx"]
         presentationFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .powerpoint, "Unexpected media type for file extension: \(fileExtension)")
         }
     }
 
-    func testInitWithOtherFileExtensions() {
+    func testInitWithOtherFileExtensions() throws {
+        try XCTSkipIf(testingOnRosetta())
         let presentationFileExtensions = [
             "pdf", "doc", "odt", "xls", "xlsx",
             // Audio/video formats that are not supported on iOS
@@ -53,14 +58,16 @@ final class MediaTypeTests: XCTestCase {
     // - IANA, the official registry of MIME media types and maintains a list of all the official MIME types:
     //   http://www.iana.org/assignments/media-types/media-types.xhtml
 
-    func testInitWithImageMimeType() {
+    func testInitWithImageMimeType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let imageMimeTypes = ["image/jpeg", "image/gif", "image/png"]
         imageMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .image, "Unexpected media type for file extension: \(mimeType)")
         }
     }
 
-    func testInitWithVideoMimeType() {
+    func testInitWithVideoMimeType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let videoMimeTypes = [
             "video/mp4", "video/x-msvideo", "video/mpeg", "video/3gpp", "video/3gpp2",
             // 3gpp/3gpp2 audio is considered as video on iOS
@@ -71,21 +78,24 @@ final class MediaTypeTests: XCTestCase {
         }
     }
 
-    func testInitWithAudioMimeType() {
+    func testInitWithAudioMimeType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let audioMimeTypes = ["audio/midi", "audio/x-midi", "audio/mpeg", "audio/wav"]
         audioMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .audio, "Unexpected media type for file extension: \(mimeType)")
         }
     }
 
-    func testInitWithPowerpointMimeType() {
+    func testInitWithPowerpointMimeType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let presentationMimeTypes = ["application/vnd.ms-powerpoint", "application/vnd.openxmlformats-officedocument.presentationml.presentation"]
         presentationMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .powerpoint, "Unexpected media type for file extension: \(mimeType)")
         }
     }
 
-    func testInitWithOtherMimeType() {
+    func testInitWithOtherMimeType() throws {
+        try XCTSkipIf(testingOnRosetta())
         let otherMimeTypes = [
             "application/pdf", "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/vnd.oasis.opendocument.text", "application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
@@ -6,25 +6,29 @@ final class URL_MediaTests: XCTestCase {
 
     // MARK: tests for `mimeTypeForPathExtension`
 
-    func testMimeTypeForJPEGFileURL() {
+    func testMimeTypeForJPEGFileURL() throws {
+        try XCTSkipIf(testingOnRosetta())
         let url = URL(string: "/test/product.jpeg")
         let expectedMimeType = "image/jpeg"
         XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
     }
 
-    func testMimeTypeForJPGFileURL() {
+    func testMimeTypeForJPGFileURL() throws {
+        try XCTSkipIf(testingOnRosetta())
         let url = URL(string: "/test/product.jpg")
         let expectedMimeType = "image/jpeg"
         XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
     }
 
-    func testMimeTypeForGIFFileURL() {
+    func testMimeTypeForGIFFileURL() throws {
+        try XCTSkipIf(testingOnRosetta())
         let url = URL(string: "/test/product.gif")
         let expectedMimeType = "image/gif"
         XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
     }
 
-    func testMimeTypeForPNGFileURL() {
+    func testMimeTypeForPNGFileURL() throws {
+        try XCTSkipIf(testingOnRosetta())
         let url = URL(string: "/test/product.png")
         let expectedMimeType = "image/png"
         XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)

--- a/Yosemite/YosemiteTests/Tools/RosettaTestingHelper.swift
+++ b/Yosemite/YosemiteTests/Tools/RosettaTestingHelper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+private let NATIVE = Int32(0)
+private let EMULATED = Int32(1)
+private let UNKNOWN = -Int32(1)
+
+/// Based on Apple guidance on how to determine when running under Rosetta.
+/// https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+/// Intended for use in tests only.
+private func processIsTranslated() -> Int32 {
+    var ret = Int32(0)
+    var size = ret.bitWidth
+    if sysctlbyname("sysctl.proc_translated", &ret, &size, nil, 0) == -1 {
+        if errno == ENOENT {
+            return NATIVE
+        }
+        return UNKNOWN
+    }
+    return ret
+}
+
+func testingOnRosetta() -> Bool {
+    return processIsTranslated() == EMULATED
+}


### PR DESCRIPTION
## Description
UTType will not determine mimetypes correctly for file extensions when run under Rosetta on an M1 Mac.

This causes 26 related tests to fail when run this way.

This change skips those tests, only when run under Rosetta.
![Screenshot 2021-09-23 at 13 54 26](https://user-images.githubusercontent.com/2472348/134510341-86fada3c-0963-4008-8d3a-4d9145e0232c.jpg)

## Testing
- [x] Run tests on M1 Mac in Rosetta – 26 tests skipped
- [x] Run tests on M1 Mac natively – all tests run
- [x] Run tests on Intel Mac – all tests run

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
