### PR TITLE
4851 Wrap multiple lines on package details row

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -22,6 +22,7 @@ struct TitleAndValueRow: View {
                 Text(value)
                     .font(.body)
                     .foregroundColor(Color(.textSubtle))
+                    .padding(.vertical, Constants.verticalPadding)
 
                 Image(uiImage: .chevronImage)
                     .flipsForRightToLeftLayoutDirection(true)
@@ -31,16 +32,18 @@ struct TitleAndValueRow: View {
             }
             .contentShape(Rectangle())
         })
-        .frame(height: Constants.height)
-        .padding(.horizontal, Constants.padding)
+        .frame(minHeight: Constants.minHeight)
+        .padding(.horizontal, Constants.horizontalPadding)
     }
 }
 
 private extension TitleAndValueRow {
     enum Constants {
         static let imageSize: CGFloat = 22
-        static let height: CGFloat = 44
-        static let padding: CGFloat = 16
+        static let minHeight: CGFloat = 44
+        static let maxHeight: CGFloat = 136
+        static let horizontalPadding: CGFloat = 16
+        static let verticalPadding: CGFloat = 12
     }
 }
 


### PR DESCRIPTION
Fixes #4851

## Description
Some package descriptions are relatively long, and wrap in the Package Selected row, but without any padding. This means they look a little squeezed.

This change allows the row to expand based on the height of the text, adding padding around the text as well.

## Testing
1. View an unfulfilled order on a site, and tap "Create Shipping Label"
2. Continue through the addresses
3. In Package Details, select a package with a long name, which you may need to add. Then tap Done.
4. Observe that the package selected row expands vertically to accommodate the name, along with 12px padding at the top and bottom of the cell.


![After fix](https://user-images.githubusercontent.com/2472348/134533818-bf8016c8-4ef8-441f-ada0-5d55495e3249.mp4)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
