### PR TITLE
Order Editing: Add State Selection Support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/CountrySelectorViewModel.swift
@@ -1,7 +1,6 @@
 import Combine
 import SwiftUI
 import Yosemite
-import protocol Storage.StorageManagerType
 
 /// View Model for the `CountrySelector` view.
 ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -171,7 +171,7 @@ struct EditAddressForm: View {
 
         // Go to edit state
         // TODO: Move `StateSelectorViewModel` creation to the VM when it exists.
-        LazyNavigationLink(destination: FilterListSelector(viewModel: StateSelectorViewModel()), isActive: $showStateSelector) {
+        LazyNavigationLink(destination: FilterListSelector(viewModel: viewModel.createStateViewModel()), isActive: $showStateSelector) {
             EmptyView()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -137,7 +137,7 @@ struct EditAddressForm: View {
                         }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
-                        TitleAndValueRow(title: Localization.stateField, value: Localization.placeholderSelectOption, selectable: true) {
+                        TitleAndValueRow(title: Localization.stateField, value: viewModel.fields.state, selectable: true) {
                             showStateSelector = true
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -162,22 +162,24 @@ extension EditAddressFormViewModel {
             address2 = address.address2 ?? ""
             city = address.city
             postcode = address.postcode
-            state = address.state
         }
 
         mutating func update(with selectedCountry: Yosemite.Country?) {
             country = selectedCountry?.name ?? country
         }
 
+        mutating func update(with selectedState: Yosemite.StateOfACountry?) {
+            state = selectedState?.name ?? state
+        }
 
-        func toAddress(selectedCountry: Yosemite.Country?) -> Yosemite.Address {
+        func toAddress(selectedCountry: Yosemite.Country?, selectedState: Yosemite.StateOfACountry?) -> Yosemite.Address {
             Address(firstName: firstName,
                     lastName: lastName,
                     company: company.isEmpty ? nil : company,
                     address1: address1,
                     address2: address2.isEmpty ? nil : address2,
                     city: city,
-                    state: state,
+                    state: selectedState?.code ?? state,
                     postcode: postcode,
                     country: selectedCountry?.code ?? country,
                     phone: phone.isEmpty ? nil : phone,
@@ -197,12 +199,12 @@ private extension EditAddressFormViewModel {
     /// Calculates what navigation trailing item should be shown depending on our internal state.
     ///
     func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest3($fields, performingNetworkRequest, $selectedCountry)
-            .map { [originalAddress] fields, performingNetworkRequest, selectedCountry -> NavigationItem in
+        Publishers.CombineLatest4($fields, performingNetworkRequest, $selectedCountry, $selectedState)
+            .map { [originalAddress] fields, performingNetworkRequest, selectedCountry, selectedState -> NavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
                 }
-                return .done(enabled: originalAddress != fields.toAddress(selectedCountry: selectedCountry))
+                return .done(enabled: originalAddress != fields.toAddress(selectedCountry: selectedCountry, selectedState: selectedState))
             }
             .assign(to: &$navigationTrailingItem)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -190,10 +190,11 @@ extension EditAddressFormViewModel {
 }
 
 private extension EditAddressFormViewModel {
-    /// Set initial values from `originalAddress` using the stored countries to compute the current selected country.
+    /// Set initial values from `originalAddress` using the stored countries to compute the current selected country & state.
     ///
     func setFieldsInitialValues() {
         selectedCountry = countriesResultsController.fetchedObjects.first { $0.code == originalAddress.country }
+        selectedState = selectedCountry?.states.first { $0.code == originalAddress.state }
         fields.update(with: originalAddress)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -100,8 +100,10 @@ final class EditAddressFormViewModel: ObservableObject {
             get: { self.selectedState },
             set: { self.selectedState = $0 }
         )
-        // TODO: PASS REAL STATES
-        return StateSelectorViewModel(states: [], selected: selectedStateBinding)
+
+        // Sort states from the selected country
+        let states = selectedCountry?.states.sorted { $0.name < $1.name } ?? []
+        return StateSelectorViewModel(states: states, selected: selectedStateBinding)
     }
 
     /// Update the address remotely and invoke a completion block when finished

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -89,6 +89,12 @@ final class EditAddressFormViewModel: ObservableObject {
         return CountrySelectorViewModel(countries: countriesResultsController.fetchedObjects, selected: selectedCountryBinding)
     }
 
+    /// Creates a view model to be used when selecting a state
+    ///
+    func createStateViewModel() -> StateSelectorViewModel {
+        StateSelectorViewModel()
+    }
+
     /// Update the address remotely and invoke a completion block when finished
     ///
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -39,6 +39,7 @@ final class EditAddressFormViewModel: ObservableObject {
             guard let self = self else { return }
             self.bindSyncTrigger()
             self.bindSelectedCountryIntoFields()
+            self.bindSelectedStateIntoFields()
             self.bindNavigationTrailingItemPublisher()
 
             self.fetchStoredCountriesAndTriggerSyncIfNeeded()
@@ -217,6 +218,13 @@ private extension EditAddressFormViewModel {
                 self?.fields.update(with: newCountry)
             }
             .store(in: &subscriptions)
+    }
+
+    func bindSelectedStateIntoFields() {
+        $selectedState.sink { [weak self] newState in
+            self?.fields.update(with: newState)
+        }
+        .store(in: &subscriptions)
     }
 
     /// Fetches countries from storage, If there are no stored countries, trigger a sync request.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -208,7 +208,7 @@ private extension EditAddressFormViewModel {
     }
 
     /// Update published fields when the selected country and state is updated.
-    /// If the current selected state does not exists within the selected country, then the sate is nilled.
+    /// If the current selected state does not exists within the selected country, then the state is nilled.
     ///
     func bindSelectedCountryAndStateIntoFields() {
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -54,6 +54,10 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     @Published private var selectedCountry: Yosemite.Country?
 
+    /// Current selected state.
+    ///
+    @Published private var selectedState: Yosemite.StateOfACountry?
+
     /// Address form fields
     ///
     @Published var fields = FormFields()
@@ -92,7 +96,12 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Creates a view model to be used when selecting a state
     ///
     func createStateViewModel() -> StateSelectorViewModel {
-        StateSelectorViewModel()
+        let selectedStateBinding = Binding(
+            get: { self.selectedState },
+            set: { self.selectedState = $0 }
+        )
+        // TODO: PASS REAL STATES
+        return StateSelectorViewModel(states: [], selected: selectedStateBinding)
     }
 
     /// Update the address remotely and invoke a completion block when finished

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorCommand.swift
@@ -7,26 +7,26 @@ final class StateSelectorCommand: ObservableListSelectorCommand {
     typealias Model = StateOfACountry
     typealias Cell = BasicTableViewCell
 
-    /// Original array of countries.
+    /// Original array of states.
     ///
     private let states: [StateOfACountry]
 
     /// Data to display
     ///
-    private(set) var data: [StateOfACountry]
+    @Published private(set) var data: [StateOfACountry]
 
-    /// Current selected country
+    /// Current selected state
     ///
-    private(set) var selected: StateOfACountry?
+    @Binding private(set) var selected: StateOfACountry?
 
     /// Navigation bar title
     ///
     let navigationBarTitle: String? = ""
 
-    init(states: [StateOfACountry] = temporaryStates, selected: StateOfACountry? = nil) {
+    init(states: [StateOfACountry], selected: Binding<StateOfACountry?>) {
         self.states = states
         self.data = states
-        self.selected = selected
+        self._selected = selected
     }
 
     func handleSelectedChange(selected: StateOfACountry, viewController: ViewController) {
@@ -50,17 +50,4 @@ final class StateSelectorCommand: ObservableListSelectorCommand {
 
         data = states.filter { $0.name.localizedCaseInsensitiveContains(term) }
     }
-}
-
-// MARK: Temporary Methods
-extension StateSelectorCommand {
-
-    // Supported states will come from the view model later.
-    //
-    private static let temporaryStates: [StateOfACountry] = {
-        return Locale.isoRegionCodes.map { regionCode in
-            let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
-            return StateOfACountry(code: regionCode, name: name)
-        }
-    }()
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/StateSelectorViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import SwiftUI
+import Yosemite
 
 /// View Model for the `StateSelector` view.
 ///
@@ -10,13 +11,12 @@ final class StateSelectorViewModel: FilterListSelectorViewModelable, ObservableO
     var searchTerm: String = "" {
         didSet {
             command.filterStates(term: searchTerm)
-            objectWillChange.send()
         }
     }
 
     /// Command that powers the `ListSelector` view.
     ///
-    let command = StateSelectorCommand()
+    let command: StateSelectorCommand
 
     /// Navigation title
     ///
@@ -25,6 +25,10 @@ final class StateSelectorViewModel: FilterListSelectorViewModelable, ObservableO
     /// Filter text field placeholder
     ///
     let filterPlaceholder = Localization.placeholder
+
+    init(states: [StateOfACountry], selected: Binding<StateOfACountry?>) {
+        self.command = StateSelectorCommand(states: states, selected: selected)
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -43,10 +43,10 @@ final class EditAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fields.address2, address.address2 ?? "")
         XCTAssertEqual(viewModel.fields.city, address.city)
         XCTAssertEqual(viewModel.fields.postcode, address.postcode)
-        XCTAssertEqual(viewModel.fields.state, address.state)
 
-        let countryName = Self.sampleCountries.first { $0.code == address.country }?.name
-        XCTAssertEqual(viewModel.fields.country, countryName)
+        let country = Self.sampleCountries.first { $0.code == address.country }
+        XCTAssertEqual(viewModel.fields.country, country?.name)
+        XCTAssertEqual(viewModel.fields.state, country?.states.first?.name) // Only one state supported in tests
 
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
     }
@@ -261,7 +261,8 @@ private extension EditAddressFormViewModelTests {
     static let sampleCountries: [Country] = {
         return Locale.isoRegionCodes.map { regionCode in
             let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""
-            return Country(code: regionCode, name: name, states: [])
+            let states = regionCode == "US" ? [StateOfACountry(code: "NY", name: "New York")] : []
+            return Country(code: regionCode, name: name, states: states)
         }.sorted { a, b in
             a.name <= b.name
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -221,6 +221,22 @@ final class EditAddressFormViewModelTests: XCTestCase {
         assertEqual(update.order.shippingAddress?.firstName, "Tester")
         assertEqual(update.fields, [.shippingAddress])
     }
+
+    func test_selecting_state_updates_state_field() {
+        // Given
+        let newState = StateOfACountry(code: "CA", name: "California")
+
+        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), storageManager: testingStorage)
+        viewModel.onLoadTrigger.send()
+
+        // When
+        let stateViewModel = viewModel.createStateViewModel()
+        let viewController = ListSelectorViewController(command: stateViewModel.command, onDismiss: { _ in }) // Needed because of legacy UIKit ways
+        stateViewModel.command.handleSelectedChange(selected: newState, viewController: viewController)
+
+        // Then
+        XCTAssertEqual(viewModel.fields.state, newState.name)
+    }
 }
 
 private extension EditAddressFormViewModelTests {

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -158,6 +158,12 @@ extension MockStorageManager {
         let storedCountries: [StorageCountry] = readOnlyCountries.map { readOnlyCountry in
             let newCountry = viewStorage.insertNewObject(ofType: StorageCountry.self)
             newCountry.update(with: readOnlyCountry)
+            readOnlyCountry.states.forEach { readOnlyState in
+                let newState = viewStorage.insertNewObject(ofType: StorageStateOfACountry.self)
+                newState.update(with: readOnlyState)
+                newCountry.states.insert(newState)
+            }
+
             return newCountry
         }
         return storedCountries


### PR DESCRIPTION
closes #4780

# Why

After the last bits to make the country selection work were implemented in #4981.
Now it is time to add support for state selection.

# How

- A lot of small changes are copied from `CountrySelectorCommand` & `CountrySelectorViewModel`

- The main change on the `EditAddressFormViewModel` is to make sure that a new state updates the state field and to make sure to `nil` the selected state if a different country is selected. PS I'm retaining the state name in fields to mimic core behavior.

# Demo

https://user-images.githubusercontent.com/562080/134587437-0b20baed-b3d3-420a-be00-4f53b941dcb1.mov

# Testing Steps

- Navigate to an order
- Tap on the "shipping address" edit icon
- See that the country & state field is property populated
- See that you can update the state.
- See that you change the country but the state value is persisted (to mimic core)

# Pending 

- Handle situations where there are no states. [Card 1](https://github.com/woocommerce/woocommerce-ios/projects/39#card-69408423) [Card 2](https://github.com/woocommerce/woocommerce-ios/projects/39#card-69336455)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
