### PR TITLE
Establish foundation framework for UI tests components

### DIFF
--- a/WooCommerce/UITestsFoundation/BaseScreen.swift
+++ b/WooCommerce/UITestsFoundation/BaseScreen.swift
@@ -1,16 +1,16 @@
-import UITestsFoundation
 import XCTest
 
-class BaseScreen {
+open class BaseScreen {
+
     enum UITestError: Error {
         case unableToLocateElement
     }
 
-    var app: XCUIApplication!
+    public private(set) var app: XCUIApplication!
     var expectedElement: XCUIElement!
     var waitTimeout: Double!
 
-    init(element: XCUIElement) {
+    public init(element: XCUIElement) {
         app = XCUIApplication()
         expectedElement = element
         waitTimeout = 20
@@ -22,13 +22,12 @@ class BaseScreen {
         XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (activity) in
             let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
             XCTAssert(result, "Page \(self) is not loaded.")
-//            Logger.log(message: "Page \(self) is loaded", event: .i)
         }
         return self
     }
 
     @discardableResult
-    func waitFor(element: XCUIElement, predicate: String, timeout: Int? = nil) -> Bool {
+    public func waitFor(element: XCUIElement, predicate: String, timeout: Int? = nil) -> Bool {
         let timeoutValue = timeout ?? 5
 
         let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
@@ -63,7 +62,7 @@ class BaseScreen {
     }
 
     // Pops the navigation stack, returning to the item above the current one
-    func pop() {
+    public func pop() {
         navBackButton.tap()
     }
 
@@ -73,7 +72,7 @@ class BaseScreen {
     }
 
     /// This would be way nicer if we could base `Self` as the type of object to the block
-    func then(_ block: (BaseScreen) -> Void) -> Self {
+    public func then(_ block: (BaseScreen) -> Void) -> Self {
         block(self)
         return self
     }

--- a/WooCommerce/UITestsFoundation/UITestsFoundation.h
+++ b/WooCommerce/UITestsFoundation/UITestsFoundation.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double UITestsFoundationVersionNumber;
+FOUNDATION_EXPORT const unsigned char UITestsFoundationVersionString[];

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
+public let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
 
 extension XCUIElement {
     /**
@@ -106,7 +106,7 @@ extension XCTestCase {
 
 extension XCUIElement {
 
-    func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
+    public func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
 
         let startCoordinate = self.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
         let destination = startCoordinate.withOffset(CGVector(dx: deltaX, dy: deltaY * -1))

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF314E026FC74450012E68E /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3FF314E726FC74560012E68E /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E626FC74560012E68E /* ScreenObject */; };
 		3FF314E926FC74600012E68E /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E826FC74600012E68E /* XCUITestHelpers */; };
+		3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314EF26FC784A0012E68E /* XCTest.framework */; platformFilter = ios; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -997,7 +998,6 @@
 		CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */; };
 		CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
-		CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
 		CCDC49DB2400011F003166BA /* OrdersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173423DBEB1900592D8E /* OrdersScreen.swift */; };
 		CCDC49DC2400011F003166BA /* SingleOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173623DBF02400592D8E /* SingleOrderScreen.swift */; };
@@ -1015,7 +1015,6 @@
 		CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174823DC0A7800592D8E /* PeriodStatsTable.swift */; };
 		CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
-		CCDC49F324007BD3003166BA /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
 		CCFC00B523E9BD1500157A78 /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */; };
@@ -1396,6 +1395,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3FF314EB26FC76C60012E68E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FF314DD26FC74450012E68E;
+			remoteInfo = UITestsFoundation;
+		};
+		3FF314ED26FC76CB0012E68E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FF314DD26FC74450012E68E;
+			remoteInfo = UITestsFoundation;
+		};
 		B55D4C1420B6131400D7A50F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
@@ -4083,6 +4096,7 @@
 			isa = PBXGroup;
 			children = (
 				3FF314E026FC74450012E68E /* UITestsFoundation.h */,
+				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 			);
 			path = UITestsFoundation;
 			sourceTree = "<group>";
@@ -5497,7 +5511,6 @@
 		CCDC49D8240000A5003166BA /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 				CCDC49EC24000533003166BA /* TestCredentials.swift */,
 			);
 			path = Utils;
@@ -6716,6 +6729,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FF314EC26FC76C60012E68E /* PBXTargetDependency */,
 				CCDC49D023FFFFF4003166BA /* PBXTargetDependency */,
 			);
 			name = WooCommerceUITests;
@@ -6738,6 +6752,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FF314EE26FC76CB0012E68E /* PBXTargetDependency */,
 				F997170823DBB97500592D8E /* PBXTargetDependency */,
 			);
 			name = WooCommerceScreenshots;
@@ -7210,6 +7225,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8339,7 +8355,6 @@
 				CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */,
 				CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */,
 				CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */,
-				CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */,
 				CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */,
 				D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */,
 			);
@@ -8355,7 +8370,6 @@
 				F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */,
 				24C5ACC425A530D6008FD769 /* PrologueScreen.swift in Sources */,
 				F997172323DBCD6100592D8E /* LoginPasswordScreen.swift in Sources */,
-				CCDC49F324007BD3003166BA /* XCTest+Extensions.swift in Sources */,
 				F997172C23DBCD8F00592D8E /* BaseScreen.swift in Sources */,
 				F997173F23DBFFEF00592D8E /* ReviewsScreen.swift in Sources */,
 				F997172223DBCD6100592D8E /* LoginUsernamePasswordScreen.swift in Sources */,
@@ -8382,6 +8396,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3FF314EC26FC76C60012E68E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FF314DD26FC74450012E68E /* UITestsFoundation */;
+			targetProxy = 3FF314EB26FC76C60012E68E /* PBXContainerItemProxy */;
+		};
+		3FF314EE26FC76CB0012E68E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FF314DD26FC74450012E68E /* UITestsFoundation */;
+			targetProxy = 3FF314ED26FC76CB0012E68E /* PBXContainerItemProxy */;
+		};
 		B55D4C1520B6131400D7A50F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B55D4C0F20B612F300D7A50F /* GenerateCredentials */;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -532,6 +532,9 @@
 		3FF314E926FC74600012E68E /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E826FC74600012E68E /* XCUITestHelpers */; };
 		3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
 		3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314EF26FC784A0012E68E /* XCTest.framework */; platformFilter = ios; };
+		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
+		3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
+		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -1011,7 +1014,6 @@
 		CCDC49E42400011F003166BA /* LoginPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171A23DBCD6000592D8E /* LoginPasswordScreen.swift */; };
 		CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */; };
 		CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171923DBCD6000592D8E /* LoginUsernamePasswordScreen.swift */; };
-		CCDC49E92400011F003166BA /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174823DC0A7800592D8E /* PeriodStatsTable.swift */; };
 		CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
@@ -1370,7 +1372,6 @@
 		F997172623DBCD6100592D8E /* LinkOrPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171D23DBCD6000592D8E /* LinkOrPasswordScreen.swift */; };
 		F997172823DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171F23DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift */; };
 		F997172A23DBCD6100592D8E /* LoginSiteAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */; };
-		F997172C23DBCD8F00592D8E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		F997172E23DBCDE900592D8E /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
 		F997173023DBCEB200592D8E /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		F997173523DBEB1900592D8E /* OrdersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173423DBEB1900592D8E /* OrdersScreen.swift */; };
@@ -2890,6 +2891,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */,
 				247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */,
 				3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */,
@@ -2900,6 +2902,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */,
 				24C5AC7625A53021008FD769 /* Embassy in Frameworks */,
 				3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */,
 				3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */,
@@ -4095,6 +4098,7 @@
 		3FF314DF26FC74450012E68E /* UITestsFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				F997172B23DBCD8E00592D8E /* BaseScreen.swift */,
 				3FF314E026FC74450012E68E /* UITestsFoundation.h */,
 				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 			);
@@ -6562,7 +6566,6 @@
 				F997171823DBCD5700592D8E /* Login */,
 				F9BB249623F4B1C60068A420 /* Products */,
 				F9BB249923F501FB0068A420 /* Settings */,
-				F997172B23DBCD8E00592D8E /* BaseScreen.swift */,
 				F997172F23DBCEB200592D8E /* TabNavComponent.swift */,
 			);
 			path = Screens;
@@ -7225,6 +7228,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8351,7 +8355,6 @@
 				CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */,
 				CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */,
 				D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */,
-				CCDC49E92400011F003166BA /* BaseScreen.swift in Sources */,
 				CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */,
 				CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */,
 				CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */,
@@ -8370,7 +8373,6 @@
 				F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */,
 				24C5ACC425A530D6008FD769 /* PrologueScreen.swift in Sources */,
 				F997172323DBCD6100592D8E /* LoginPasswordScreen.swift in Sources */,
-				F997172C23DBCD8F00592D8E /* BaseScreen.swift in Sources */,
 				F997173F23DBFFEF00592D8E /* ReviewsScreen.swift in Sources */,
 				F997172223DBCD6100592D8E /* LoginUsernamePasswordScreen.swift in Sources */,
 				F997172823DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -527,6 +527,10 @@
 		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
 		3FF2248A267073AE008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF22489267073AE008FFA87 /* ScreenObject */; };
+		3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF314E026FC74450012E68E /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FF314E726FC74560012E68E /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E626FC74560012E68E /* ScreenObject */; };
+		3FF314E926FC74600012E68E /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF314E826FC74600012E68E /* XCUITestHelpers */; };
+		3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314EF26FC784A0012E68E /* XCTest.framework */; platformFilter = ios; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -1949,6 +1953,9 @@
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LearnMoreTableViewCell.xib; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
+		3FF314DE26FC74450012E68E /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FF314E026FC74450012E68E /* UITestsFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestsFoundation.h; sourceTree = "<group>"; };
+		3FF314EF26FC784A0012E68E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibilityViewController.swift; sourceTree = "<group>"; };
 		4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVisibilityViewController.xib; sourceTree = "<group>"; };
 		4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierAndRatesTopBanner.swift; sourceTree = "<group>"; };
@@ -2829,6 +2836,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3FF314DB26FC74450012E68E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FF314E726FC74560012E68E /* ScreenObject in Frameworks */,
+				3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */,
+				3FF314E926FC74600012E68E /* XCUITestHelpers in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B56DB3C32049BFAA00D4AA8E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -4062,6 +4079,14 @@
 			path = CardReaderTableViewCells;
 			sourceTree = "<group>";
 		};
+		3FF314DF26FC74450012E68E /* UITestsFoundation */ = {
+			isa = PBXGroup;
+			children = (
+				3FF314E026FC74450012E68E /* UITestsFoundation.h */,
+			);
+			path = UITestsFoundation;
+			sourceTree = "<group>";
+		};
 		4506BD6E2461962700FE6377 /* Visibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -4843,6 +4868,7 @@
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3FF314EF26FC784A0012E68E /* XCTest.framework */,
 				315E14F32698DA24000AD5FF /* PassKit.framework */,
 				D88FDB4425DD223B00CB0DBD /* Hardware.framework */,
 				26FB056725F6CB6000A40B26 /* Fakes.framework */,
@@ -5066,6 +5092,7 @@
 				B56DB3E02049BFAA00D4AA8E /* WooCommerceTests */,
 				F997170323DBB97500592D8E /* WooCommerceScreenshots */,
 				CCDC49CB23FFFFF4003166BA /* WooCommerceUITests */,
+				3FF314DF26FC74450012E68E /* UITestsFoundation */,
 				88A44ABE866401E6DB03AC60 /* Frameworks */,
 				B56DB3C72049BFAA00D4AA8E /* Products */,
 				8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */,
@@ -5083,6 +5110,7 @@
 				B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */,
 				F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */,
 				CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */,
+				3FF314DE26FC74450012E68E /* UITestsFoundation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -6592,7 +6620,40 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		3FF314D926FC74450012E68E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		3FF314DD26FC74450012E68E /* UITestsFoundation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FF314E526FC74450012E68E /* Build configuration list for PBXNativeTarget "UITestsFoundation" */;
+			buildPhases = (
+				3FF314D926FC74450012E68E /* Headers */,
+				3FF314DA26FC74450012E68E /* Sources */,
+				3FF314DB26FC74450012E68E /* Frameworks */,
+				3FF314DC26FC74450012E68E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UITestsFoundation;
+			packageProductDependencies = (
+				3FF314E626FC74560012E68E /* ScreenObject */,
+				3FF314E826FC74600012E68E /* XCUITestHelpers */,
+			);
+			productName = UITestsFoundation;
+			productReference = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		B56DB3C52049BFAA00D4AA8E /* WooCommerce */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B56DB3E62049BFAA00D4AA8E /* Build configuration list for PBXNativeTarget "WooCommerce" */;
@@ -6699,6 +6760,9 @@
 				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = Automattic;
 				TargetAttributes = {
+					3FF314DD26FC74450012E68E = {
+						CreatedOnToolsVersion = 13.0;
+					};
 					B55D4C0F20B612F300D7A50F = {
 						CreatedOnToolsVersion = 9.3.1;
 						ProvisioningStyle = Automatic;
@@ -6780,11 +6844,19 @@
 				B55D4C0F20B612F300D7A50F /* GenerateCredentials */,
 				F997170123DBB97500592D8E /* WooCommerceScreenshots */,
 				CCDC49C923FFFFF4003166BA /* WooCommerceUITests */,
+				3FF314DD26FC74450012E68E /* UITestsFoundation */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3FF314DC26FC74450012E68E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B56DB3C42049BFAA00D4AA8E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -7134,6 +7206,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3FF314DA26FC74450012E68E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B56DB3C22049BFAA00D4AA8E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -8490,6 +8569,106 @@
 			};
 			name = "Release-Alpha";
 		};
+		3FF314E226FC74450012E68E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.woocommerce.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3FF314E326FC74450012E68E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.woocommerce.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3FF314E426FC74450012E68E /* Release-Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.woocommerce.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Release-Alpha";
+		};
 		B55D4C1120B612F300D7A50F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -8872,6 +9051,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3FF314E526FC74450012E68E /* Build configuration list for PBXNativeTarget "UITestsFoundation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FF314E226FC74450012E68E /* Debug */,
+				3FF314E326FC74450012E68E /* Release */,
+				3FF314E426FC74450012E68E /* Release-Alpha */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B55D4C1020B612F300D7A50F /* Build configuration list for PBXAggregateTarget "GenerateCredentials" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -9002,6 +9191,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
+		};
+		3FF314E626FC74560012E68E /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
+		};
+		3FF314E826FC74600012E68E /* XCUITestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
+			productName = XCUITestHelpers;
 		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -1,5 +1,6 @@
 import Embassy
 import ScreenObject
+import UITestsFoundation
 import XCTest
 
 class WooCommerceScreenshots: XCTestCase {

--- a/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/BaseScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 class BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/GetStartedScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginEmailScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginEpilogueScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
@@ -1,3 +1,4 @@
+import UITestsFoundation
 import XCTest
 import XCUITestHelpers
 

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/PasswordScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/WooCommerceUITests/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/MyStore/MyStoreScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class MyStoreScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/MyStore/PeriodStatsTable.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class PeriodStatsTable: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/OrderSearchScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class OrderSearchScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/OrdersScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class OrdersScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/SingleOrderScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class SingleOrderScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Products/ProductsScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 class ProductsScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Products/SingleProductScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 class SingleProductScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Reviews/ReviewsScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class ReviewsScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Reviews/SingleReviewScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Reviews/SingleReviewScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class SingleReviewScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/BetaFeaturesScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 class BetaFeaturesScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class SettingsScreen: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Screens/TabNavComponent.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/TabNavComponent.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UITestsFoundation
 import XCTest
 
 final class TabNavComponent: BaseScreen {

--- a/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/XCTest+Extensions.swift
@@ -26,19 +26,6 @@ extension XCUIElement {
 
 extension XCTestCase {
 
-//    public func setUpTestSuite() {
-//        super.setUp()
-//
-//        // In UI tests it is usually best to stop immediately when a failure occurs.
-//        continueAfterFailure = false
-//
-//        let app = XCUIApplication()
-//        app.activate()
-//
-//        // Media permissions alert handler
-//        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
-//    }
-
     public func takeScreenshotOfFailedTest() {
         if let failureCount = testRun?.failureCount, failureCount > 0 {
             XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (activity) in


### PR DESCRIPTION
This adds a framework where to put all the "foundation" components and utilities for the UI tests, following the same principle as what [WordPress iOS does](https://github.com/wordpress-mobile/WordPress-iOS/pull/16662).

To keep this setup PR small, I only moved `BaseScreen` and the `XCTest` extensions file to the new framework.

The next steps are:

- Move all the screens to UITestsFoundation
- Convert all the screens to be `ScreenObject` subclasses

Notice that I run the UI tests in CI and they passed 😄 ✅ 

### Test

You can verify the tests run locally. I also run the full suite in CI.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**