### PR TITLE
Shipping Labels: New model for package item to prepare for moving items between packages

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -12,10 +12,4 @@ struct ShippingLabelPackageAttributes: Equatable {
 
     /// List of items in the package.
     let items: [ShippingLabelPackageItem]
-
-    init(packageID: String, totalWeight: String, items: [ShippingLabelPackageItem]) {
-        self.packageID = packageID
-        self.totalWeight = totalWeight
-        self.items = items
-    }
 }

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A structure to hold the basic details for a selected package on Package Details screen of Shipping Label purchase flow.
 ///
-struct ShippingLabelPackageAttributes: Hashable, Equatable {
+struct ShippingLabelPackageAttributes: Equatable {
 
     /// Default box ID for original packages.
     static let originalPackagingBoxID = "individual"
@@ -13,24 +13,12 @@ struct ShippingLabelPackageAttributes: Hashable, Equatable {
     /// Total weight of the package in string value.
     let totalWeight: String
 
-    /// List of product or variation IDs for items in the package.
-    let productIDs: [Int64]
+    /// List of items in the package.
+    let items: [ShippingLabelPackageItem]
 
-    /// Length of the package, required if the package is original packaging.
-    let length: Double?
-
-    /// Width of the package, required if the package is original packaging.
-    let width: Double?
-
-    /// Height of the package, required if the package is original packaging.
-    let height: Double?
-
-    init(packageID: String, totalWeight: String, productIDs: [Int64], length: Double? = nil, width: Double? = nil, height: Double? = nil) {
+    init(packageID: String, totalWeight: String, items: [ShippingLabelPackageItem]) {
         self.packageID = packageID
         self.totalWeight = totalWeight
-        self.productIDs = productIDs
-        self.length = length
-        self.width = width
-        self.height = height
+        self.items = items
     }
 }

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -4,9 +4,6 @@ import Foundation
 ///
 struct ShippingLabelPackageAttributes: Equatable {
 
-    /// Default box ID for original packages.
-    static let originalPackagingBoxID = "individual"
-
     /// ID of the selected package.
     let packageID: String
 

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -4,6 +4,9 @@ import Foundation
 ///
 struct ShippingLabelPackageAttributes: Hashable, Equatable {
 
+    /// Default box ID for original packages.
+    static let originalPackagingBoxID = "individual"
+
     /// ID of the selected package.
     let packageID: String
 
@@ -12,4 +15,22 @@ struct ShippingLabelPackageAttributes: Hashable, Equatable {
 
     /// List of product or variation IDs for items in the package.
     let productIDs: [Int64]
+
+    /// Length of the package, required if the package is original packaging.
+    let length: Double?
+
+    /// Width of the package, required if the package is original packaging.
+    let width: Double?
+
+    /// Height of the package, required if the package is original packaging.
+    let height: Double?
+
+    init(packageID: String, totalWeight: String, productIDs: [Int64], length: Double? = nil, width: Double? = nil, height: Double? = nil) {
+        self.packageID = packageID
+        self.totalWeight = totalWeight
+        self.productIDs = productIDs
+        self.length = length
+        self.width = width
+        self.height = height
+    }
 }

--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -19,7 +19,7 @@ struct ShippingLabelPackageItem: Equatable {
     /// Dimensions of the product or variation
     let dimensions: ProductDimensions
 
-    /// Attributes of the product or variation
+    /// Attributes of the variation
     let attributes: [VariationAttributeViewModel]
 }
 

--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// A struct that keeps information about products contained in a package in Shipping Label purchase flow.
+/// A struct that keeps information about items contained in a package in Shipping Label purchase flow.
 ///
-struct ShippingLabelPackageProduct {
+struct ShippingLabelPackageItem: Equatable {
     /// ID of the product
-    let productID: Int64
+    let productOrVariationID: Int64
 
     /// Name of the product
     let name: String

--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -21,19 +21,18 @@ struct ShippingLabelPackageItem: Equatable {
 
     /// Attributes of the product or variation
     let attributes: [VariationAttributeViewModel]
+}
 
-    init(productOrVariationID: Int64,
-         name: String,
-         weight: Double,
-         quantity: Decimal,
-         dimensions: ProductDimensions,
-         attributes: [VariationAttributeViewModel]) {
-        self.productOrVariationID = productOrVariationID
-        self.name = name
-        self.weight = weight
+// MARK: Custom initializers
+//
+extension ShippingLabelPackageItem {
+    init(copy: ShippingLabelPackageItem, quantity: Decimal) {
+        self.name = copy.name
+        self.productOrVariationID = copy.productOrVariationID
         self.quantity = quantity
-        self.dimensions = dimensions
-        self.attributes = attributes
+        self.weight = copy.weight
+        self.dimensions = copy.dimensions
+        self.attributes = copy.attributes
     }
 
     init?(orderItem: OrderItem, products: [Product], productVariations: [ProductVariation]) {

--- a/WooCommerce/Classes/Model/ShippingLabelPackageProduct.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageProduct.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A struct that keeps information about products contained in a package in Shipping Label purchase flow.
+///
+struct ShippingLabelPackageProduct {
+    /// ID of the product
+    let productID: Int64
+
+    /// Name of the product
+    let name: String
+
+    /// Weight of the product
+    let weight: Double
+
+    /// Quantity of the product
+    let quantity: Decimal
+
+    /// Attributes of the product
+    let attributes: [VariationAttributeViewModel]
+}

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 // MARK: - View Model for a Variation Attribute
 //
-struct VariationAttributeViewModel {
+struct VariationAttributeViewModel: Equatable {
 
     /// Attribute name
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -116,11 +116,13 @@ private extension ShippingLabelPackagesFormViewModel {
             .map { selectedPackages, products, variations -> [ShippingLabelSinglePackageViewModel] in
                 return selectedPackages.enumerated().map { index, details in
                     let orderItems = order.items.filter { details.productIDs.contains($0.productOrVariationID) }
+                    let isOriginal = details.packageID == ShippingLabelPackageAttributes.originalPackagingBoxID
                     return ShippingLabelSinglePackageViewModel(order: order,
                                                                orderItems: orderItems,
                                                                packagesResponse: packageResponse,
                                                                selectedPackageID: details.packageID,
                                                                totalWeight: details.totalWeight,
+                                                               isOriginalPackaging: isOriginal,
                                                                products: products,
                                                                productVariations: variations,
                                                                onItemMoveRequest: { [weak self] itemID, packageName in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -69,7 +69,11 @@ struct ShippingLabelSinglePackage: View {
                 .sheet(isPresented: $isShowingPackageSelection, content: {
                     ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
                 })
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(!viewModel.isOriginalPackaging)
 
+            VStack(spacing: 0) {
                 Divider()
 
                 TitleAndTextFieldRow(title: Localization.totalPackageWeight,
@@ -118,15 +122,16 @@ struct ShippingLabelPackageItem_Previews: PreviewProvider {
         let order = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let packageResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
-                                                          packagesResponse: packageResponse,
-                                                          selectedPackageID: "Box 1",
-                                                          totalWeight: "",
-                                                          products: [],
-                                                          productVariations: [],
-                                                          onItemMoveRequest: { _, _ in },
-                                                          onPackageSwitch: { _ in },
-                                                          onPackagesSync: { _ in })
+                                                            orderItems: order.items,
+                                                            packagesResponse: packageResponse,
+                                                            selectedPackageID: "Box 1",
+                                                            totalWeight: "",
+                                                            isOriginalPackaging: false,
+                                                            products: [],
+                                                            productVariations: [],
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in })
         ShippingLabelSinglePackage(packageNumber: 1,
                                    isCollapsible: true,
                                    safeAreaInsets: .zero,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -39,7 +39,7 @@ struct ShippingLabelSinglePackage: View {
                         HStack {
                             Spacer()
                             Button(action: {
-                                viewModel.requestMovingItem(id: productItemRow.itemID, itemName: productItemRow.title)
+                                viewModel.requestMovingItem(productItemRow.productOrVariationID, itemName: productItemRow.title)
                                 shouldShowMoveItemActionSheet = true
                             }, label: {
                                 Text(Localization.moveButton)
@@ -148,18 +148,16 @@ private extension ShippingLabelSinglePackage {
     }
 }
 
-struct ShippingLabelPackageItem_Previews: PreviewProvider {
+struct ShippingLabelSinglePackage_Previews: PreviewProvider {
     static var previews: some View {
         let order = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let packageResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                            orderItems: order.items,
+                                                            orderItems: [],
                                                             packagesResponse: packageResponse,
                                                             selectedPackageID: "Box 1",
                                                             totalWeight: "",
                                                             isOriginalPackaging: false,
-                                                            products: [],
-                                                            productVariations: [],
                                                             onItemMoveRequest: { _, _ in },
                                                             onPackageSwitch: { _ in },
                                                             onPackagesSync: { _ in })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -86,8 +86,8 @@ struct ShippingLabelSinglePackage: View {
                 Divider()
                     .padding(.horizontal, insets: safeAreaInsets)
                     .padding(.leading, Constants.horizontalPadding)
-                TitleAndSubtitleRow(title: Localization.itemDimension,
-                                    subtitle: "12 in x 12 in x 12 in") // TODO: display real data
+                TitleAndSubtitleRow(title: Localization.itemDimensions,
+                                    subtitle: viewModel.originalPackageDimensions)
                     .padding(.horizontal, insets: safeAreaInsets)
             }
             .background(Color(.systemBackground))
@@ -138,9 +138,9 @@ private extension ShippingLabelSinglePackage {
         static let individuallyShipped = NSLocalizedString("Individually shipped item",
                                                            comment: "Description for detail of package shipped in original " +
                                                            "packaging on Package Details screen in Shipping Labels flow.")
-        static let itemDimension = NSLocalizedString("Item dimension",
-                                                     comment: "Row title for dimension of package shipped in original " +
-                                                     "packaging Package Details screen in Shipping Labels flow.")
+        static let itemDimensions = NSLocalizedString("Item dimensions",
+                                                      comment: "Row title for dimensions of package shipped in original " +
+                                                      "packaging Package Details screen in Shipping Labels flow.")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -69,34 +69,8 @@ struct ShippingLabelSinglePackage: View {
                 .sheet(isPresented: $isShowingPackageSelection, content: {
                     ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
                 })
-            }
-            .background(Color(.systemBackground))
-            .renderedIf(!viewModel.isOriginalPackaging)
 
-            VStack(spacing: 0) {
                 Divider()
-                TitleAndSubtitleRow(title: Localization.originalPackaging,
-                                    subtitle: Localization.individuallyShipped)
-                    .padding(.horizontal, insets: safeAreaInsets)
-            }
-            .background(Color(.systemBackground))
-            .renderedIf(viewModel.isOriginalPackaging)
-
-            VStack(spacing: 0) {
-                Divider()
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .padding(.leading, Constants.horizontalPadding)
-                TitleAndSubtitleRow(title: Localization.itemDimensions,
-                                    subtitle: viewModel.originalPackageDimensions)
-                    .padding(.horizontal, insets: safeAreaInsets)
-            }
-            .background(Color(.systemBackground))
-            .renderedIf(viewModel.isOriginalPackaging)
-
-            VStack(spacing: 0) {
-                Divider()
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .padding(.leading, Constants.horizontalPadding)
 
                 TitleAndTextFieldRow(title: Localization.totalPackageWeight,
                                      placeholder: "0",
@@ -132,15 +106,6 @@ private extension ShippingLabelSinglePackage {
                                               comment: "Title of the footer in Shipping Label Package Detail screen")
         static let invalidWeight = NSLocalizedString("Invalid weight", comment: "Error message when total weight is invalid in Package Detail screen")
         static let moveButton = NSLocalizedString("Move", comment: "Button on each order item of the Package Details screen in Shipping Labels flow.")
-        static let originalPackaging = NSLocalizedString("Original packaging",
-                                                         comment: "Row title for detail of package shipped in original " +
-                                                         "packaging on Package Details screen in Shipping Labels flow.")
-        static let individuallyShipped = NSLocalizedString("Individually shipped item",
-                                                           comment: "Description for detail of package shipped in original " +
-                                                           "packaging on Package Details screen in Shipping Labels flow.")
-        static let itemDimensions = NSLocalizedString("Item dimensions",
-                                                      comment: "Row title for dimensions of package shipped in original " +
-                                                      "packaging Package Details screen in Shipping Labels flow.")
     }
 
     enum Constants {
@@ -148,19 +113,18 @@ private extension ShippingLabelSinglePackage {
     }
 }
 
-struct ShippingLabelSinglePackage_Previews: PreviewProvider {
+struct ShippingLabelPackageItem_Previews: PreviewProvider {
     static var previews: some View {
         let order = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let packageResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                            orderItems: [],
-                                                            packagesResponse: packageResponse,
-                                                            selectedPackageID: "Box 1",
-                                                            totalWeight: "",
-                                                            isOriginalPackaging: false,
-                                                            onItemMoveRequest: { _, _ in },
-                                                            onPackageSwitch: { _ in },
-                                                            onPackagesSync: { _ in })
+                                                          orderItems: [],
+                                                          packagesResponse: packageResponse,
+                                                          selectedPackageID: "Box 1",
+                                                          totalWeight: "",
+                                                          onItemMoveRequest: { _, _ in },
+                                                          onPackageSwitch: { _ in },
+                                                          onPackagesSync: { _ in })
         ShippingLabelSinglePackage(packageNumber: 1,
                                    isCollapsible: true,
                                    safeAreaInsets: .zero,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -39,7 +39,7 @@ struct ShippingLabelSinglePackage: View {
                         HStack {
                             Spacer()
                             Button(action: {
-                                viewModel.requestMovingItem(id: productItemRow.id, itemName: productItemRow.title)
+                                viewModel.requestMovingItem(id: productItemRow.itemID, itemName: productItemRow.title)
                                 shouldShowMoveItemActionSheet = true
                             }, label: {
                                 Text(Localization.moveButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -75,6 +75,28 @@ struct ShippingLabelSinglePackage: View {
 
             VStack(spacing: 0) {
                 Divider()
+                TitleAndSubtitleRow(title: Localization.originalPackaging,
+                                    subtitle: Localization.individuallyShipped)
+                    .padding(.horizontal, insets: safeAreaInsets)
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(viewModel.isOriginalPackaging)
+
+            VStack(spacing: 0) {
+                Divider()
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .padding(.leading, Constants.horizontalPadding)
+                TitleAndSubtitleRow(title: Localization.itemDimension,
+                                    subtitle: "12 in x 12 in x 12 in") // TODO: display real data
+                    .padding(.horizontal, insets: safeAreaInsets)
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(viewModel.isOriginalPackaging)
+
+            VStack(spacing: 0) {
+                Divider()
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .padding(.leading, Constants.horizontalPadding)
 
                 TitleAndTextFieldRow(title: Localization.totalPackageWeight,
                                      placeholder: "0",
@@ -110,6 +132,15 @@ private extension ShippingLabelSinglePackage {
                                               comment: "Title of the footer in Shipping Label Package Detail screen")
         static let invalidWeight = NSLocalizedString("Invalid weight", comment: "Error message when total weight is invalid in Package Detail screen")
         static let moveButton = NSLocalizedString("Move", comment: "Button on each order item of the Package Details screen in Shipping Labels flow.")
+        static let originalPackaging = NSLocalizedString("Original packaging",
+                                                         comment: "Row title for detail of package shipped in original " +
+                                                         "packaging on Package Details screen in Shipping Labels flow.")
+        static let individuallyShipped = NSLocalizedString("Individually shipped item",
+                                                           comment: "Description for detail of package shipped in original " +
+                                                           "packaging on Package Details screen in Shipping Labels flow.")
+        static let itemDimension = NSLocalizedString("Item dimension",
+                                                     comment: "Row title for dimension of package shipped in original " +
+                                                     "packaging Package Details screen in Shipping Labels flow.")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -31,6 +31,10 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     ///
     @Published private(set) var isValidTotalWeight: Bool = false
 
+    /// Whether this package is original packaging
+    ///
+    @Published private(set) var isOriginalPackaging: Bool
+
     /// The title of the selected package, if any.
     ///
     var selectedPackageName: String {
@@ -61,7 +65,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     private let onItemMoveRequest: ItemMoveRequestHandler
     private let onPackageSwitch: PackageSwitchHandler
     private let onPackagesSync: PackagesSyncHandler
-    private let isOriginalPackaging: Bool
 
     /// The packages  response fetched from API
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -87,7 +87,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackageID: String,
          totalWeight: String,
-         isOriginalPackaging: Bool,
+         isOriginalPackaging: Bool = false,
          onItemMoveRequest: @escaping ItemMoveRequestHandler,
          onPackageSwitch: @escaping PackageSwitchHandler,
          onPackagesSync: @escaping PackagesSyncHandler,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -232,9 +232,9 @@ private extension ShippingLabelSinglePackageViewModel {
     ///
     func configureOriginalPackageDimensions(for item: ShippingLabelPackageItem) {
         let unit = packagesResponse?.storeOptions.dimensionUnit ?? ""
-        let length = String(item.dimensions.length)
-        let width = String(item.dimensions.width)
-        let height = String(item.dimensions.height)
+        let length = item.dimensions.length.isEmpty ? "0" : item.dimensions.length
+        let width = item.dimensions.width.isEmpty ? "0" : item.dimensions.width
+        let height = item.dimensions.height.isEmpty ? "0" : item.dimensions.height
         originalPackageDimensions = String(format: "%@ x %@ x %@ %@", length, width, height, unit)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -207,7 +207,7 @@ private extension ShippingLabelSinglePackageViewModel {
                     let subtitle = Localization.subtitle(weight: weight.description,
                                                          weightUnit: unit,
                                                          attributes: attributes)
-                    itemsToFulfill.append(ItemToFulfillRow(id: item.itemID, title: item.name, subtitle: subtitle))
+                    itemsToFulfill.append(ItemToFulfillRow(itemID: item.itemID, title: item.name, subtitle: subtitle))
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -31,14 +31,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     ///
     @Published private(set) var isValidTotalWeight: Bool = false
 
-    /// Whether this package is original packaging
-    ///
-    @Published private(set) var isOriginalPackaging: Bool
-
-    /// Description of dimensions
-    ///
-    @Published private(set) var originalPackageDimensions: String = ""
-
     /// The title of the selected package, if any.
     ///
     var selectedPackageName: String {
@@ -87,7 +79,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackageID: String,
          totalWeight: String,
-         isOriginalPackaging: Bool = false,
          onItemMoveRequest: @escaping ItemMoveRequestHandler,
          onPackageSwitch: @escaping PackageSwitchHandler,
          onPackagesSync: @escaping PackagesSyncHandler,
@@ -99,7 +90,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         self.currencyFormatter = formatter
         self.weightUnit = weightUnit
         self.selectedPackageID = selectedPackageID
-        self.isOriginalPackaging = isOriginalPackaging
         self.onItemMoveRequest = onItemMoveRequest
         self.onPackageSwitch = onPackageSwitch
         self.onPackagesSync = onPackagesSync
@@ -109,9 +99,6 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         packageListViewModel.didSelectPackage(selectedPackageID)
         configureItemRows()
         configureTotalWeight(initialTotalWeight: totalWeight)
-        if isOriginalPackaging, let item = orderItems.first {
-            configureOriginalPackageDimensions(for: item)
-        }
     }
 
     func requestMovingItem(_ productOrVariationID: Int64, itemName: String) {
@@ -226,16 +213,6 @@ private extension ShippingLabelSinglePackageViewModel {
             return false
         }
         return value > 0
-    }
-
-    /// Configure dimensions L x W x H <unit> for the original package.
-    ///
-    func configureOriginalPackageDimensions(for item: ShippingLabelPackageItem) {
-        let unit = packagesResponse?.storeOptions.dimensionUnit ?? ""
-        let length = item.dimensions.length.isEmpty ? "0" : item.dimensions.length
-        let width = item.dimensions.width.isEmpty ? "0" : item.dimensions.width
-        let height = item.dimensions.height.isEmpty ? "0" : item.dimensions.height
-        originalPackageDimensions = String(format: "%@ x %@ x %@ %@", length, width, height, unit)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -61,6 +61,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     private let onItemMoveRequest: ItemMoveRequestHandler
     private let onPackageSwitch: PackageSwitchHandler
     private let onPackagesSync: PackagesSyncHandler
+    private let isOriginalPackaging: Bool
 
     /// The packages  response fetched from API
     ///
@@ -79,6 +80,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackageID: String,
          totalWeight: String,
+         isOriginalPackaging: Bool,
          products: [Product],
          productVariations: [ProductVariation],
          onItemMoveRequest: @escaping ItemMoveRequestHandler,
@@ -92,6 +94,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         self.currencyFormatter = formatter
         self.weightUnit = weightUnit
         self.selectedPackageID = selectedPackageID
+        self.isOriginalPackaging = isOriginalPackaging
         self.onItemMoveRequest = onItemMoveRequest
         self.onPackageSwitch = onPackageSwitch
         self.onPackagesSync = onPackagesSync

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -41,7 +41,8 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     @Published var selectedPackageID: String?
 
     /// List of selected package with basic info.
-    /// This is a workaround to work with multi-package solution.
+    /// This is a workaround to work with multi-package solution which requires a list of packages.
+    /// Since this legacy view model works only with one package, the returned list contains at most one item only.
     ///
     var selectedPackagesDetails: [ShippingLabelPackageAttributes] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsViewModel.swift
@@ -41,13 +41,16 @@ final class ShippingLabelPackageDetailsViewModel: ObservableObject {
     @Published var selectedPackageID: String?
 
     /// List of selected package with basic info.
-    /// TODO-4599: update this to properly support multi-package.
+    /// This is a workaround to work with multi-package solution.
     ///
     var selectedPackagesDetails: [ShippingLabelPackageAttributes] {
         guard let id = selectedPackageID, totalWeight.isNotEmpty else {
             return []
         }
-        return [ShippingLabelPackageAttributes(packageID: id, totalWeight: totalWeight, productIDs: orderItems.map { $0.productOrVariationID })]
+        let items = orderItems.compactMap { ShippingLabelPackageItem(orderItem: $0,
+                                                                     products: products,
+                                                                     productVariations: productVariations) }
+        return [ShippingLabelPackageAttributes(packageID: id, totalWeight: totalWeight, items: items)]
     }
 
     /// The title of the selected package, if any.
@@ -217,7 +220,7 @@ private extension ShippingLabelPackageDetailsViewModel {
                     let subtitle = Localization.subtitle(weight: weight.description,
                                                          weightUnit: unit,
                                                          attributes: attributes)
-                    itemsToFulfill.append(ItemToFulfillRow(id: item.itemID, title: item.name, subtitle: subtitle))
+                    itemsToFulfill.append(ItemToFulfillRow(productOrVariationID: item.productOrVariationID, title: item.name, subtitle: subtitle))
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -634,7 +634,7 @@ private extension ShippingLabelFormViewModel {
 
                 return ""
             }()
-            return ShippingLabelCustomsForm(packageID: package.packageID, packageName: packageName, productIDs: package.productIDs)
+            return ShippingLabelCustomsForm(packageID: package.packageID, packageName: packageName, productIDs: package.items.map { $0.productOrVariationID })
         }
     }
 
@@ -770,7 +770,7 @@ extension ShippingLabelFormViewModel {
             }
             return ShippingLabelPackagePurchase(package: package,
                                                 rate: selectedRate,
-                                                productIDs: packageInfo.productIDs,
+                                                productIDs: packageInfo.items.map { $0.productOrVariationID },
                                                 customsForm: package.customsForm)
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
@@ -8,26 +8,7 @@ struct ItemToFulfillRow: View, Identifiable {
     let subtitle: String
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading,
-                   spacing: 8) {
-                Text(title)
-                    .bodyStyle()
-                Text(subtitle)
-                    .footnoteStyle()
-            }.padding([.leading, .trailing], Constants.vStackPadding)
-            Spacer()
-        }
-        .padding([.top, .bottom], Constants.hStackPadding)
-        .frame(minHeight: Constants.height)
-    }
-}
-
-private extension ItemToFulfillRow {
-    enum Constants {
-        static let vStackPadding: CGFloat = 16
-        static let hStackPadding: CGFloat = 10
-        static let height: CGFloat = 64
+        TitleAndSubtitleRow(title: title, subtitle: subtitle)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 struct ItemToFulfillRow: View, Identifiable {
     let id = UUID()
-    let itemID: Int64
+    let productOrVariationID: Int64
     let title: String
     let subtitle: String
 
@@ -15,7 +15,7 @@ struct ItemToFulfillRow: View, Identifiable {
 
 struct ItemToFulfillRow_Previews: PreviewProvider {
     static var previews: some View {
-        ItemToFulfillRow(itemID: 123, title: "Title", subtitle: "My subtitle")
+        ItemToFulfillRow(productOrVariationID: 123, title: "Title", subtitle: "My subtitle")
             .previewLayout(.fixed(width: 375, height: 100))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ItemToFulfillRow.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// Represent a row of a Product Item that should be fulfilled
 ///
 struct ItemToFulfillRow: View, Identifiable {
-    let id: Int64
+    let id = UUID()
+    let itemID: Int64
     let title: String
     let subtitle: String
 
@@ -14,7 +15,7 @@ struct ItemToFulfillRow: View, Identifiable {
 
 struct ItemToFulfillRow_Previews: PreviewProvider {
     static var previews: some View {
-        ItemToFulfillRow(id: 123, title: "Title", subtitle: "My subtitle")
+        ItemToFulfillRow(itemID: 123, title: "Title", subtitle: "My subtitle")
             .previewLayout(.fixed(width: 375, height: 100))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndSubtitleRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndSubtitleRow.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Renders a row with a title and subtitle.
+///
+struct TitleAndSubtitleRow: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading,
+                   spacing: 8) {
+                Text(title)
+                    .bodyStyle()
+                Text(subtitle)
+                    .footnoteStyle()
+            }.padding([.leading, .trailing], Constants.vStackPadding)
+            Spacer()
+        }
+        .padding([.top, .bottom], Constants.hStackPadding)
+        .frame(minHeight: Constants.height)
+    }
+}
+
+private extension TitleAndSubtitleRow {
+    enum Constants {
+        static let vStackPadding: CGFloat = 16
+        static let hStackPadding: CGFloat = 10
+        static let height: CGFloat = 64
+    }
+}
+
+struct TitleAndSubtitleRow_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleAndSubtitleRow(title: "Title", subtitle: "My subtitle")
+            .previewLayout(.fixed(width: 375, height: 100))
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1301,7 +1301,7 @@
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
 		DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */; };
-		DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */; };
+		DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
 		DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */; };
 		DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */; };
@@ -2746,7 +2746,7 @@
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleRow.swift; sourceTree = "<group>"; };
-		DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageProduct.swift; sourceTree = "<group>"; };
+		DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageItem.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
 		DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedTests.swift"; sourceTree = "<group>"; };
 		DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Connectivity.swift"; sourceTree = "<group>"; };
@@ -5221,7 +5221,7 @@
 				FEDD70AE26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift */,
 				E1C5E78326C2B8E8008D4C47 /* Site+Woo.swift */,
 				DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */,
-				DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */,
+				DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7152,7 +7152,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
-				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift in Sources */,
+				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageItem.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1301,6 +1301,7 @@
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
 		DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */; };
+		DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
 		DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */; };
 		DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */; };
@@ -2745,6 +2746,7 @@
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleRow.swift; sourceTree = "<group>"; };
+		DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageProduct.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
 		DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedTests.swift"; sourceTree = "<group>"; };
 		DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Connectivity.swift"; sourceTree = "<group>"; };
@@ -5219,6 +5221,7 @@
 				FEDD70AE26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift */,
 				E1C5E78326C2B8E8008D4C47 /* Site+Woo.swift */,
 				DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */,
+				DE77889926FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7149,6 +7152,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
+				DE77889A26FD7EF0008DFF44 /* ShippingLabelPackageProduct.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1300,6 +1300,7 @@
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
 		DE68B84326FAF17A00C86CFB /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */; };
+		DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */; };
 		DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */; };
 		DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */; };
 		DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */; };
@@ -2743,6 +2744,7 @@
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
 		DE68B84226FAF17A00C86CFB /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleRow.swift; sourceTree = "<group>"; };
 		DE7842EC26F061650030C792 /* NumberFormatter+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Localized.swift"; sourceTree = "<group>"; };
 		DE7842EE26F079A60030C792 /* NumberFormatter+LocalizedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedTests.swift"; sourceTree = "<group>"; };
 		DE7842F626F2E9340030C792 /* UIViewController+Connectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Connectivity.swift"; sourceTree = "<group>"; };
@@ -4408,6 +4410,7 @@
 				45DB704926121F3C0064A6CF /* TitleAndValueRow.swift */,
 				45DB705926124C710064A6CF /* TitleAndTextFieldRow.swift */,
 				CC4A4FF026557D0E00B75DCD /* TitleAndToggleRow.swift */,
+				DE77889726FCA39B008DFF44 /* TitleAndSubtitleRow.swift */,
 				45CE2D842625D7ED00E3CA00 /* SelectableItemRow.swift */,
 				4590B6A7261F0F8300A6FCE0 /* SegmentedView.swift */,
 				45DB6D962632CF9300E83C1A /* ActivityIndicator.swift */,
@@ -7890,6 +7893,7 @@
 				2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */,
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
+				DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */,
 				456396B625C82691001F1A26 /* ShippingLabelFormStepTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
@@ -30,8 +30,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_foundMultiplePackages_returns_correctly() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", productIDs: [1, 2, 3])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", productIDs: [1, 2, 3])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake(), .fake()])
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(), .fake()])
 
         // When & Then
         let viewModel1 = ShippingLabelPackagesFormViewModel(order: order,
@@ -77,8 +77,12 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_itemViewModels_returns_correctly_when_initial_selectedPackages_is_not_empty() {
         // Given
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", productIDs: [1, 33, 23])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", productIDs: [49])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1",
+                                                      totalWeight: "12",
+                                                      items: [.fake(id: 1),
+                                                              .fake(id: 33),
+                                                              .fake(id: 23)])
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake(id: 49)])
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -96,8 +100,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_doneButtonEnabled_returns_true_when_all_packages_are_valid() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", productIDs: [1, 2, 3])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", productIDs: [1, 2, 3])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -113,8 +117,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_doneButtonEnabled_returns_false_when_not_all_packages_are_valid() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", productIDs: [1, 2, 3])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", productIDs: [1, 2, 3])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
 
         // When
         let viewModel = ShippingLabelPackagesFormViewModel(order: order,
@@ -131,8 +135,8 @@ class ShippingLabelPackagesFormViewModelTests: XCTestCase {
     func test_onCompletion_returns_correctly() {
         // Given
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
-        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", productIDs: [1, 2, 3])
-        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", productIDs: [1, 2, 3])
+        let package1 = ShippingLabelPackageAttributes(packageID: "Box 1", totalWeight: "12", items: [.fake(), .fake()])
+        let package2 = ShippingLabelPackageAttributes(packageID: "Box 2", totalWeight: "5.5", items: [.fake()])
 
         var result: [ShippingLabelPackageAttributes] = []
         let completionHandler = { packages in
@@ -168,5 +172,21 @@ private extension ShippingLabelPackagesFormViewModelTests {
     func insert(_ readOnlyAccountSettings: Yosemite.ShippingLabelAccountSettings) {
         let accountSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
         accountSettings.update(with: readOnlyAccountSettings)
+    }
+}
+
+extension ShippingLabelPackageItem {
+    static func fake(id: Int64 = 1,
+                     name: String = "",
+                     weight: Double = 1,
+                     quantity: Decimal = 1,
+                     dimensions: Yosemite.ProductDimensions = .fake(),
+                     attributes: [VariationAttributeViewModel] = []) -> ShippingLabelPackageItem {
+        ShippingLabelPackageItem(productOrVariationID: id,
+                                 name: name,
+                                 weight: weight,
+                                 quantity: quantity,
+                                 dimensions: dimensions,
+                                 attributes: attributes)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -12,12 +12,10 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
                                                           totalWeight: "",
-                                                          products: [],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -31,27 +29,18 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
     func test_itemsRows_returns_expected_values() {
 
         // Given
-        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
-                     MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
-                     MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
-                     MockOrderItem.sampleItem(name: "Jeans",
-                                              productID: 49,
-                                              variationID: 49,
-                                              quantity: 1,
-                                              attributes: orderItemAttributes)]
-        let expectedFirstItemRow = ItemToFulfillRow(id: 123, title: "Easter Egg", subtitle: "123 kg")
-        let expectedLastItemRow = ItemToFulfillRow(id: 234, title: "Jeans", subtitle: "Box・0 kg")
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let orderItemAttribute = OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")
+        let items: [ShippingLabelPackageItem] = [
+            .fake(id: 1, name: "Easter Egg", weight: 123),
+            .fake(id: 33, name: "Jacket", weight: 9),
+            .fake(id: 23, name: "Italian Jacket", weight: 1),
+            .fake(id: 49, name: "Jeans", weight: 0, attributes: [VariationAttributeViewModel(orderItemAttribute: orderItemAttribute)])
+        ]
 
-        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123")
-        let product2 = Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9")
-        let product3 = Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1")
-        let variation = ProductVariation.fake().copy(siteID: sampleSiteID,
-                                                     productID: 49,
-                                                     productVariationID: 49,
-                                                     attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
+        let expectedFirstItemRow = ItemToFulfillRow(productOrVariationID: 1, title: "Easter Egg", subtitle: "123 kg")
+        let expectedLastItemRow = ItemToFulfillRow(productOrVariationID: 49, title: "Jeans", subtitle: "Box・0 kg")
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
@@ -59,8 +48,6 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
                                                           totalWeight: "",
-                                                          products: [product1, product2, product3],
-                                                          productVariations: [variation],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -86,12 +73,10 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "",
                                                           totalWeight: "",
-                                                          products: [],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -122,12 +107,10 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
             packageToTest = package
         }
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "",
-                                                          products: [],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: packageSwitchHandler,
                                                           onPackagesSync: { _ in },
@@ -141,7 +124,7 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(packageToTest, ShippingLabelPackageAttributes(packageID: customPackage.title,
                                                                      totalWeight: "",
-                                                                     productIDs: order.items.map { $0.productOrVariationID }))
+                                                                     items: []))
     }
 
     func test_showCustomPackagesHeader_returns_the_expected_value() {
@@ -149,12 +132,10 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         let order = MockOrders().empty().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "10",
-                                                          products: [],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -168,34 +149,20 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     func test_totalWeight_returns_the_expected_value() {
         // Given
-        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5),
-                     MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
-                     MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
-                     MockOrderItem.sampleItem(name: "Jeans",
-                                              productID: 49,
-                                              variationID: 49,
-                                              quantity: 1,
-                                              attributes: orderItemAttributes)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let items: [ShippingLabelPackageItem] = [
+            .fake(id: 1, name: "Easter Egg", weight: 120, quantity: 0.5),
+            .fake(id: 23, name: "Italian Jacket", weight: 1.44, quantity: 2),
+            .fake(id: 49, name: "Jeans", weight: 0)
+        ]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
-        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
-        let product2 = Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9")
-        let product3 = Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1.44")
-        let variation = ProductVariation.fake().copy(siteID: sampleSiteID,
-                                                     productID: 49,
-                                                     productVariationID: 49,
-                                                     attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
-
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Box",
                                                           totalWeight: "",
-                                                          products: [product1, product2, product3],
-                                                          productVariations: [variation],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -208,34 +175,20 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     func test_totalWeight_returns_the_expected_value_when_already_set() {
         // Given
-        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1),
-                     MockOrderItem.sampleItem(name: "Jacket", productID: 33, quantity: 1),
-                     MockOrderItem.sampleItem(name: "Italian Jacket", productID: 23, quantity: 2),
-                     MockOrderItem.sampleItem(name: "Jeans",
-                                              productID: 49,
-                                              variationID: 49,
-                                              quantity: 1,
-                                              attributes: orderItemAttributes)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let items: [ShippingLabelPackageItem] = [
+            .fake(id: 1, name: "Easter Egg", weight: 120),
+            .fake(id: 23, name: "Italian Jacket", weight: 1.44),
+            .fake(id: 49, name: "Jeans", weight: 0)
+        ]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
-        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "123")
-        let product2 = Product.fake().copy(siteID: sampleSiteID, productID: 33, virtual: true, weight: "9")
-        let product3 = Product.fake().copy(siteID: sampleSiteID, productID: 23, virtual: false, weight: "1")
-        let variation = ProductVariation.fake().copy(siteID: sampleSiteID,
-                                                     productID: 49,
-                                                     productVariationID: 49,
-                                                     attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")])
-
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Box",
                                                           totalWeight: "30",
-                                                          products: [product1, product2, product3],
-                                                          productVariations: [variation],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -248,19 +201,15 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     func test_isValidTotalWeight_returns_true_initially() {
         // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "10",
-                                                          products: [product],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -273,17 +222,14 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     func test_isValidTotalWeight_returns_the_expected_value_when_the_totalWeight_is_not_valid() {
         // Given
-        // Given
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: [])
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: [],
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "10",
-                                                          products: [],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -311,19 +257,16 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
     func test_validatedPackageAttributes_returns_correct_value_when_total_weight_is_valid() {
         // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let items: [ShippingLabelPackageItem] = [.fake(weight: 120, quantity: 0.5)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
         // When
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "10",
-                                                          products: [product],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },
@@ -331,32 +274,28 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
                                                           weightUnit: "kg")
 
         // Then
-        let expectedPackage1 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "10", productIDs: [1])
+        let expectedPackage1 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "10", items: items)
         XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage1)
 
         // When
         viewModel.totalWeight = "12"
 
         // Then
-        let expectedPackage2 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "12", productIDs: [1])
+        let expectedPackage2 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "12", items: items)
         XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage2)
     }
 
     func test_validatedPackageAttributes_returns_nil_when_the_totalWeight_is_not_valid() {
         // Given
-        // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
+        let items: [ShippingLabelPackageItem] = [.fake(weight: 120, quantity: 0.5)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
 
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120")
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: order.items,
+                                                          orderItems: items,
                                                           packagesResponse: mockPackageResponse(),
                                                           selectedPackageID: "Test Box",
                                                           totalWeight: "10",
-                                                          products: [product],
-                                                          productVariations: [],
                                                           onItemMoveRequest: { _, _ in },
                                                           onPackageSwitch: { _ in },
                                                           onPackagesSync: { _ in },

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -881,7 +881,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        let item = ShippingLabelPackageItem(productOrVariationID: expectedProductID, name: "", weight: 1, quantity: 1, dimensions: ProductDimensions.fake(), attributes: [])
+        let item = ShippingLabelPackageItem.fake(id: expectedProductID)
         let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", items: [item])
         viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -185,7 +185,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
 
         // When
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
@@ -201,7 +201,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
@@ -230,7 +230,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     destinationAddress: nil)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, productIDs: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -881,7 +881,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", productIDs: [expectedProductID])
+        let item = ShippingLabelPackageItem(productOrVariationID: expectedProductID, name: "", weight: 1, quantity: 1, dimensions: ProductDimensions.fake(), attributes: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", items: [item])
         viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelPackageDetailsViewModelTests.swift
@@ -60,8 +60,8 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                               variationID: 49,
                                               quantity: 1,
                                               attributes: orderItemAttributes)]
-        let expectedFirstItemRow = ItemToFulfillRow(id: 123, title: "Easter Egg", subtitle: "123 kg")
-        let expectedLastItemRow = ItemToFulfillRow(id: 234, title: "Jeans", subtitle: "Box・0 kg")
+        let expectedFirstItemRow = ItemToFulfillRow(productOrVariationID: 123, title: "Easter Egg", subtitle: "123 kg")
+        let expectedLastItemRow = ItemToFulfillRow(productOrVariationID: 234, title: "Jeans", subtitle: "Box・0 kg")
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
         let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
@@ -329,7 +329,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
                                             productVariationID: 49,
                                             attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")]))
 
-        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Box", totalWeight: "30", productIDs: [1, 33, 23, 49])]
+        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Box", totalWeight: "30", items: [])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
                                                              selectedPackages: selectedPackages,
@@ -386,7 +386,7 @@ final class ShippingLabelPackageDetailsViewModelTests: XCTestCase {
 
         // When
         insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120"))
-        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Package", totalWeight: "500", productIDs: [1])]
+        let selectedPackages = [ShippingLabelPackageAttributes(packageID: "Package", totalWeight: "500", items: [])]
         let viewModel = ShippingLabelPackageDetailsViewModel(order: order,
                                                              packagesResponse: mockPackageResponse(),
                                                              selectedPackages: selectedPackages,


### PR DESCRIPTION
Part of #4717

# Description
While working on moving order items between packages, I realized that simply keeping product ID list in each package is not enough. Each package needs to have other information about the product it contains: quantity of items, weight, dimensions, attributes. 

# Changes
This PR aims to update `ShippingLabelPackageAttributes` by replacing product ID list with a list of information about each item contained in a package. This leads to changes in a lot of files:
- Purchase form view model: to transform the list of items to list of product IDs needed for selected / purchased packages.
- The legacy package details view model: to update the output of the selected package - a workaround for the old solution to work.
- Packages form and single package view models
- A lot of unit tests!

Also: extracted new reusable view `TitleAndSubtitleRow` from `ItemToFulfillRow`. I meant to reuse this in the new rows of original packages, but decided to move that logic for the next PR, so this change looks a bit irrelevant.

# Testing
Although this PR changes a lot of things under the hood, the expectation is that everything still works as before:
1. Make sure that your test store has WCShip plugin installed and configured packages in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Select an order eligible for creating shipping labels.
3. Configure Ship From and Ship To.
4. On Package Details screen, try selecting different packages and then tap Done. Notice that everything works as before with or without custom package weight.
5. Proceed to Carriers and Rates, notice that the rates list still loads correct items.
6. Configure payment method and proceed to purchase the label. Make sure that the purchase succeeds.
7. In `DefaultFeatureFlagService`, turn off feature flag for multiple packages. Repeat steps 2-6 and make sure that everything still works.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
