### PR TITLE
5022 Fix VoiceOver loop on Order Details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
@@ -36,66 +36,81 @@ final class LedgerTableViewCell: UITableViewCell {
     /// Configure an order payment summary "table"
     ///
     func configure(with viewModel: OrderPaymentDetailsViewModel) {
-        subtotalLabel.text = Titles.subtotalLabel
-        subtotalValue.text = viewModel.subtotalValue
-
-        discountLabel.text = viewModel.discountText
-        discountValue.text = viewModel.discountValue
-        discountView.isHidden = viewModel.shouldHideDiscount
-
-        feesLabel.text = Titles.feesLabel
-        feesValue.text = viewModel.feesValue
-        feesView.isHidden = viewModel.shouldHideFees
-
-        shippingLabel.text = Titles.shippingLabel
-        shippingValue.text = viewModel.shippingValue
-
-        taxesLabel.text = Titles.taxesLabel
-        taxesValue.text = viewModel.taxesValue
-        taxesView.isHidden = viewModel.shouldHideTaxes
-
-        totalLabel.text = Titles.totalLabel
-        totalValue.text = viewModel.totalValue
-
-        accessibilityElements = [subtotalLabel as Any,
-                                 subtotalValue as Any,
-                                 discountLabel as Any,
-                                 discountValue as Any,
-                                 feesLabel as Any,
-                                 feesValue as Any,
-                                 shippingLabel as Any,
-                                 shippingValue as Any,
-                                 taxesLabel as Any,
-                                 taxesValue as Any,
-                                 totalLabel as Any,
-                                 totalValue as Any
-                                ]
+        configureSubtotal(label: Titles.subtotalLabel, value: viewModel.subtotalValue)
+        configureDiscount(label: viewModel.discountText, value: viewModel.discountValue, hidden: viewModel.shouldHideDiscount)
+        configureFees(label: Titles.feesLabel, value: viewModel.feesValue, hidden: viewModel.shouldHideFees)
+        configureShipping(label: Titles.shippingLabel, value: viewModel.shippingValue, hidden: false)
+        configureTaxes(label: Titles.taxesLabel, value: viewModel.taxesValue, hidden: viewModel.shouldHideTaxes)
+        configureTotal(label: Titles.totalLabel, value: viewModel.totalValue)
+        configureAccessibility()
     }
 
     /// Configure a refund details "table"
     ///
     func configure(with viewModel: RefundDetailsViewModel) {
-        subtotalLabel.text = Titles.subtotal
-        subtotalValue.text = viewModel.itemSubtotal
+        configureSubtotal(label: Titles.subtotal, value: viewModel.itemSubtotal)
+        configureDiscount(label: nil, value: nil, hidden: true)
+        configureFees(label: nil, value: nil, hidden: true)
+        configureShipping(label: nil, value: nil, hidden: true)
+        configureTaxes(label: Titles.tax, value: viewModel.taxSubtotal, hidden: taxesValue == nil)
+        configureTotal(label: Titles.productsRefund, value: viewModel.productsRefund)
+        configureAccessibility()
+    }
 
-        discountLabel.text = nil
-        discountValue.text = nil
-        discountView.isHidden = true
+    private func configureSubtotal(label: String, value: String) {
+        subtotalLabel.text = label
+        subtotalValue.text = value
+        subtotalView.accessibilityLabel = "\(label) \(value)"
+    }
 
-        feesLabel.text = nil
-        feesValue.text = nil
-        feesView.isHidden = true
+    private func configureDiscount(label: String?, value: String?, hidden: Bool) {
+        discountLabel.text = label
+        discountValue.text = value
+        discountView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
+        discountView.isHidden = hidden
+    }
 
-        shippingLabel.text = nil
-        shippingValue.text = nil
-        shippingView.isHidden = true
+    private func configureFees(label: String?, value: String?, hidden: Bool) {
+        feesLabel.text = label
+        feesValue.text = value
+        feesView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
+        feesView.isHidden = hidden
+    }
 
-        taxesLabel.text = Titles.tax
-        taxesValue.text = viewModel.taxSubtotal
-        taxesView.isHidden = taxesValue == nil
+    private func configureShipping(label: String?, value: String?, hidden: Bool) {
+        shippingLabel.text = label
+        shippingValue.text = value
+        shippingView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
+        shippingView.isHidden = hidden
+    }
 
-        totalLabel.text = Titles.productsRefund
-        totalValue.text = viewModel.productsRefund
+    private func configureTaxes(label: String, value: String?, hidden: Bool) {
+        taxesLabel.text = label
+        taxesValue.text = value
+        taxesView.accessibilityLabel = "\(label) \(value ?? "")"
+        taxesView.isHidden = hidden
+    }
+
+    private func configureTotal(label: String, value: String) {
+        totalLabel.text = label
+        totalValue.text = value
+        totalView.accessibilityLabel = "\(label) \(value)"
+    }
+
+    private func configureAccessibility() {
+        let visibleViews = [subtotalView,
+                            discountView,
+                            feesView,
+                            shippingView,
+                            taxesView,
+                            totalView].filter({
+                                $0?.isHidden == false
+                            })
+                            .map({
+                                $0 as Any
+                            })
+
+        accessibilityElements = visibleViews
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
@@ -5,27 +5,46 @@ final class LedgerTableViewCell: UITableViewCell {
     @IBOutlet var subtotalView: UIView!
     @IBOutlet private weak var subtotalLabel: UILabel!
     @IBOutlet private weak var subtotalValue: UILabel!
+    private lazy var subtotalViews = RowGroup(containerView: subtotalView, label: subtotalLabel, value: subtotalValue)
 
     @IBOutlet private var discountView: UIView!
     @IBOutlet private weak var discountLabel: UILabel!
     @IBOutlet private weak var discountValue: UILabel!
+    private lazy var discountViews = RowGroup(containerView: discountView, label: discountLabel, value: discountValue)
 
     @IBOutlet private weak var feesView: UIView!
     @IBOutlet private weak var feesLabel: UILabel!
     @IBOutlet private weak var feesValue: UILabel!
+    private lazy var feesViews = RowGroup(containerView: feesView, label: feesLabel, value: feesValue)
 
     @IBOutlet private var shippingView: UIView!
     @IBOutlet private weak var shippingLabel: UILabel!
     @IBOutlet private weak var shippingValue: UILabel!
+    private lazy var shippingViews = RowGroup(containerView: shippingView, label: shippingLabel, value: shippingValue)
 
     @IBOutlet private var taxesView: UIView!
     @IBOutlet private weak var taxesLabel: UILabel!
     @IBOutlet private weak var taxesValue: UILabel!
+    private lazy var taxesViews = RowGroup(containerView: taxesView, label: taxesLabel, value: taxesValue)
 
     @IBOutlet private var totalView: UIView!
     @IBOutlet private weak var totalLabel: UILabel!
     @IBOutlet private weak var totalValue: UILabel!
     @IBOutlet private weak var totalBottomConstraint: NSLayoutConstraint?
+    private lazy var totalViews = RowGroup(containerView: totalView, label: totalLabel, value: totalValue)
+
+    struct RowGroup {
+        let containerView: UIView
+        let label: UILabel
+        let value: UILabel
+
+        func configure(title: String?, amount: String?, hidden: Bool) {
+            label.text = title
+            value.text = amount
+            containerView.accessibilityLabel = "\(title ?? "") \(amount ?? "")"
+            containerView.isHidden = hidden
+        }
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -36,65 +55,25 @@ final class LedgerTableViewCell: UITableViewCell {
     /// Configure an order payment summary "table"
     ///
     func configure(with viewModel: OrderPaymentDetailsViewModel) {
-        configureSubtotal(label: Titles.subtotalLabel, value: viewModel.subtotalValue)
-        configureDiscount(label: viewModel.discountText, value: viewModel.discountValue, hidden: viewModel.shouldHideDiscount)
-        configureFees(label: Titles.feesLabel, value: viewModel.feesValue, hidden: viewModel.shouldHideFees)
-        configureShipping(label: Titles.shippingLabel, value: viewModel.shippingValue, hidden: false)
-        configureTaxes(label: Titles.taxesLabel, value: viewModel.taxesValue, hidden: viewModel.shouldHideTaxes)
-        configureTotal(label: Titles.totalLabel, value: viewModel.totalValue)
+        subtotalViews.configure(title: Titles.subtotalLabel, amount: viewModel.subtotalValue, hidden: false)
+        discountViews.configure(title: viewModel.discountText, amount: viewModel.discountValue, hidden: viewModel.shouldHideDiscount)
+        feesViews.configure(title: Titles.feesLabel, amount: viewModel.feesValue, hidden: viewModel.shouldHideFees)
+        shippingViews.configure(title: Titles.shippingLabel, amount: viewModel.shippingValue, hidden: false)
+        taxesViews.configure(title: Titles.taxesLabel, amount: viewModel.taxesValue, hidden: viewModel.shouldHideTaxes)
+        totalViews.configure(title: Titles.totalLabel, amount: viewModel.totalValue, hidden: false)
         configureAccessibility()
     }
 
     /// Configure a refund details "table"
     ///
     func configure(with viewModel: RefundDetailsViewModel) {
-        configureSubtotal(label: Titles.subtotal, value: viewModel.itemSubtotal)
-        configureDiscount(label: nil, value: nil, hidden: true)
-        configureFees(label: nil, value: nil, hidden: true)
-        configureShipping(label: nil, value: nil, hidden: true)
-        configureTaxes(label: Titles.tax, value: viewModel.taxSubtotal, hidden: taxesValue == nil)
-        configureTotal(label: Titles.productsRefund, value: viewModel.productsRefund)
+        subtotalViews.configure(title: Titles.subtotal, amount: viewModel.itemSubtotal, hidden: false)
+        discountViews.configure(title: nil, amount: nil, hidden: true)
+        feesViews.configure(title: nil, amount: nil, hidden: true)
+        shippingViews.configure(title: nil, amount: nil, hidden: true)
+        taxesViews.configure(title: Titles.tax, amount: viewModel.taxSubtotal, hidden: taxesValue == nil)
+        totalViews.configure(title: Titles.productsRefund, amount: viewModel.productsRefund, hidden: false)
         configureAccessibility()
-    }
-
-    private func configureSubtotal(label: String, value: String) {
-        subtotalLabel.text = label
-        subtotalValue.text = value
-        subtotalView.accessibilityLabel = "\(label) \(value)"
-    }
-
-    private func configureDiscount(label: String?, value: String?, hidden: Bool) {
-        discountLabel.text = label
-        discountValue.text = value
-        discountView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
-        discountView.isHidden = hidden
-    }
-
-    private func configureFees(label: String?, value: String?, hidden: Bool) {
-        feesLabel.text = label
-        feesValue.text = value
-        feesView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
-        feesView.isHidden = hidden
-    }
-
-    private func configureShipping(label: String?, value: String?, hidden: Bool) {
-        shippingLabel.text = label
-        shippingValue.text = value
-        shippingView.accessibilityLabel = "\(label ?? "") \(value ?? "")"
-        shippingView.isHidden = hidden
-    }
-
-    private func configureTaxes(label: String, value: String?, hidden: Bool) {
-        taxesLabel.text = label
-        taxesValue.text = value
-        taxesView.accessibilityLabel = "\(label) \(value ?? "")"
-        taxesView.isHidden = hidden
-    }
-
-    private func configureTotal(label: String, value: String) {
-        totalLabel.text = label
-        totalValue.text = value
-        totalView.accessibilityLabel = "\(label) \(value)"
     }
 
     private func configureAccessibility() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,12 +27,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SUBTOTAL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Xb-4v-uVN">
                                                 <rect key="frame" x="0.0" y="0.0" width="84.5" height="60.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$999.99" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k43-i3-sNC">
                                                 <rect key="frame" x="222" y="0.0" width="66" height="60.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -41,6 +46,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstItem="IHU-N8-p4k" firstAttribute="leading" secondItem="tfd-et-ehF" secondAttribute="leading" id="2Js-iv-hWR"/>
                                     <constraint firstAttribute="trailing" secondItem="IHU-N8-p4k" secondAttribute="trailing" id="Feg-PF-iBd"/>
@@ -56,12 +64,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DISCOUNT" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LgV-BP-GFN">
                                                 <rect key="frame" x="0.0" y="0.0" width="140" height="20.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-$601.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f7h-H4-cVj">
                                                 <rect key="frame" x="217.5" y="0.0" width="70.5" height="20.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -69,6 +83,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstItem="dqG-xo-5BL" firstAttribute="top" secondItem="Q5b-zU-7fY" secondAttribute="top" priority="800" id="3JV-to-qqx"/>
                                     <constraint firstAttribute="bottom" secondItem="dqG-xo-5BL" secondAttribute="bottom" priority="800" id="7HZ-2O-N35"/>
@@ -85,12 +102,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FEES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kuu-gt-Uht">
                                                 <rect key="frame" x="0.0" y="0.0" width="39.5" height="70"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$0.01" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="om6-u8-QDq">
                                                 <rect key="frame" x="246" y="0.0" width="42" height="70"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -99,6 +122,9 @@
                                     </stackView>
                                 </subviews>
                                 <viewLayoutGuide key="safeArea" id="Sjt-NG-ZQr"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="zF1-6f-QTS" secondAttribute="trailing" id="6EL-EM-5oa"/>
                                     <constraint firstItem="zF1-6f-QTS" firstAttribute="leading" secondItem="De3-wg-68K" secondAttribute="leading" id="8Qq-Da-gko"/>
@@ -114,12 +140,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SHIPPING" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gTx-ab-CBl">
                                                 <rect key="frame" x="0.0" y="0.0" width="76.5" height="60.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$0.01" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h6Q-Cf-oXh">
                                                 <rect key="frame" x="246" y="0.0" width="42" height="60.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -127,6 +159,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstItem="5kf-hJ-JoD" firstAttribute="leading" secondItem="MYg-Hq-mwx" secondAttribute="leading" id="81v-0y-CUV"/>
                                     <constraint firstAttribute="bottom" secondItem="5kf-hJ-JoD" secondAttribute="bottom" id="8Ua-pH-6wn"/>
@@ -142,12 +177,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TAXES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z9r-YA-aG9">
                                                 <rect key="frame" x="0.0" y="0.0" width="51.5" height="60"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$333.33" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pCA-4f-cjt">
                                                 <rect key="frame" x="223" y="0.0" width="65" height="60"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -155,6 +196,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="Dmz-oH-Z9g" secondAttribute="trailing" priority="800" id="7gB-gm-450"/>
                                     <constraint firstAttribute="bottom" secondItem="Dmz-oH-Z9g" secondAttribute="bottom" priority="800" id="A67-cb-9Wa"/>
@@ -170,12 +214,18 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="$40.00" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Pa-jd-Tcj">
                                                 <rect key="frame" x="0.0" y="53" width="55" height="20.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="$40.00" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="awb-Pi-AeE">
                                                 <rect key="frame" x="233" y="53" width="55" height="20.5"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -183,6 +233,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstItem="ehO-OF-bQV" firstAttribute="leading" secondItem="K4G-Fo-ooM" secondAttribute="leading" id="Fzt-RY-YsS"/>
                                     <constraint firstAttribute="trailing" secondItem="ehO-OF-bQV" secondAttribute="trailing" id="VPh-Qn-wOB"/>


### PR DESCRIPTION
Fixes #5022 
Fixes #4977

## Description

The Order Details screen had hidden views, some of which were still announced by VoiceOver. These also caused a loop, making it impossible to swipe below the Payment (LedgerTableViewCell.swift) section of the screen.

The views in the ledger cell were separately exposed to VoiceOver, via the `accessibilityElement` array, however this included all the subviews, regardless of their visibility and their parent view's visibility.

Ordinarily, VoiceOver will remove hidden views from the announced set automatically, but by specifying subviews in `accessibilityElements`, we were breaking that or possibly falling foul of an a11y bug in Apple's frameworks. This change only adds visible rows to the `accessibilityElements`, which prevents the navigation loop.

The views being specified in `accessibilityElements` is a good thing for the VoiceOver experience; this cell is very information dense, and the ability to individually select individual rows and hear them separately is helpful. However, both labels in each row were individually announced, meaning the user had to swipe through two elements per row. This change groups the rows together, for easier and clearer navigation.

## Testing
1. Go to Orders
2. Tap on an order without fees
3. Enable VoiceOver
4. Swipe through controls until you get to Product Total
5. Continue swiping
6. Observe that you can swipe beyond Product Total through the entire screen

Additionally, the same test should be done on the Refund details screen:
1. Go to Orders
2. Tap on an order without fees, with a refund
3. Tap on the Refund row
4. Enable VoiceOver
5. Swipe through controls until you get to Product Total
6. Continue swiping
7. Observe that you can swipe beyond Product Total through the entire screen

https://user-images.githubusercontent.com/2472348/134694245-c4c0d418-20d5-4dd2-a0a9-9a6559d81748.mp4




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
