### PR TITLE
Add guard statement to not display empty section

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -437,6 +437,9 @@ private extension BillingInformationViewController {
             }
 
             let title = NSLocalizedString("Contact Details", comment: "Section header title for contact details in billing information")
+            guard rows.count != 0 else {
+                return nil
+            }
             return Section(title: title, secondaryTitle: nil, rows: rows)
         }()
 


### PR DESCRIPTION
Fix #4694

Contact Details section was displayed even without information, to fix that I added a guard statement to avoid the return of an empty section.

| Before  |  After  |
| ------------------- | ------------------- |
| <img width="220" src="https://user-images.githubusercontent.com/38385635/134822231-8d3e5c1e-20ad-4a16-898a-9301813c821d.png"/> | <img width="220" src="https://user-images.githubusercontent.com/38385635/134822232-c2519366-9d14-4012-94ab-7783ea2e318e.png"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
