### PR TITLE
Shipping Labels: Ship items in original packaging

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -4,6 +4,9 @@ import Foundation
 ///
 struct ShippingLabelPackageAttributes: Hashable, Equatable {
 
+    /// Default box ID for boxes shipping in original packaging.
+    static let originalPackagingBoxID = "individual"
+
     /// ID of the selected package.
     let packageID: String
 

--- a/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
+++ b/WooCommerce/Classes/View Modifiers/WooStyleModifiers.swift
@@ -56,10 +56,25 @@ struct FootnoteStyle: ViewModifier {
     ///
     var isEnabled: Bool
 
+    /// Whether the View shows error state
+    ///
+    var isError: Bool
+
     func body(content: Content) -> some View {
         content
             .font(.footnote)
-            .foregroundColor(isEnabled ? Color(.textSubtle) : Color(.textTertiary))
+            .foregroundColor(textColor)
+    }
+
+    private var textColor: Color {
+        switch (isEnabled, isError) {
+        case (true, false):
+            return Color(.textSubtle)
+        case (_, true):
+            return Color(.error)
+        case (false, _):
+            return Color(.textTertiary)
+        }
     }
 }
 
@@ -97,8 +112,9 @@ extension View {
 
     /// - Parameters:
     ///     - isEnabled: Whether the view is enabled (to apply specific styles for disabled view)
-    func footnoteStyle(_ isEnabled: Bool = true) -> some View {
-        self.modifier(FootnoteStyle(isEnabled: isEnabled))
+    ///     - isError: Whether the view shows error state.
+    func footnoteStyle(isEnabled: Bool = true, isError: Bool = false) -> some View {
+        self.modifier(FootnoteStyle(isEnabled: isEnabled, isError: isError))
     }
 
     func errorStyle() -> some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -230,7 +230,7 @@ private extension ShippingLabelPackagesFormViewModel {
     ///
     func observeItemViewModels() {
         itemViewModels.forEach { item in
-            item.$isValidTotalWeight
+            item.$isValidPackage
                 .sink { [weak self] isValid in
                     self?.packagesValidation[item.selectedPackageID] = isValid
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -155,7 +155,7 @@ private extension ShippingLabelPackagesFormViewModel {
             // if package is not original packaging, add option to ship in original package
             if currentPackage.packageID != ShippingLabelPackageAttributes.originalPackagingBoxID {
                 buttons.append(.default(Text(Localization.shipInOriginalPackage)) { [weak self] in
-                    self?.shipInOriginalPackage(productOrVariationID: productOrVariationID, from: currentPackage)
+                    self?.shipInOriginalPackage(productOrVariationID: productOrVariationID, from: currentPackage, packageIndex: packageIndex)
                 })
             }
             buttons.append(.cancel())
@@ -166,10 +166,10 @@ private extension ShippingLabelPackagesFormViewModel {
     /// Move the item with `productOrVariationID` from `currentPackage` to a new package,
     /// and update items within `currentPackage` to reflect the change.
     ///
-    func shipInOriginalPackage(productOrVariationID: Int64, from currentPackage: ShippingLabelPackageAttributes) {
+    func shipInOriginalPackage(productOrVariationID: Int64, from currentPackage: ShippingLabelPackageAttributes, packageIndex: Int) {
         var updatedPackages: [ShippingLabelPackageAttributes] = []
-        for package in selectedPackages {
-            if package == currentPackage {
+        for (index, package) in selectedPackages.enumerated() {
+            if index == packageIndex {
                 var matchingItem: ShippingLabelPackageItem?
                 var updatedItems: [ShippingLabelPackageItem] = []
                 for item in package.items {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -118,11 +118,13 @@ private extension ShippingLabelPackagesFormViewModel {
         $selectedPackages
             .map { selectedPackages -> [ShippingLabelSinglePackageViewModel] in
                 return selectedPackages.enumerated().map { index, details in
+                    let isOriginal = details.packageID == ShippingLabelPackageAttributes.originalPackagingBoxID
                     return .init(order: order,
                                  orderItems: details.items,
                                  packagesResponse: packageResponse,
                                  selectedPackageID: details.packageID,
                                  totalWeight: details.totalWeight,
+                                 isOriginalPackaging: isOriginal,
                                  onItemMoveRequest: { [weak self] productOrVariationID, packageName in
                         self?.updateMoveItemActionSheet(for: productOrVariationID, from: details, packageIndex: index, packageName: packageName)
                     },

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -24,7 +24,7 @@ struct ShippingLabelSinglePackage: View {
 
     var body: some View {
         CollapsibleView(isCollapsible: isCollapsible, safeAreaInsets: safeAreaInsets) {
-            ShippingLabelPackageNumberRow(packageNumber: packageNumber, numberOfItems: viewModel.itemsRows.count, isValid: viewModel.isValidTotalWeight)
+            ShippingLabelPackageNumberRow(packageNumber: packageNumber, numberOfItems: viewModel.itemsRows.count, isValid: viewModel.isValidPackage)
         } content: {
             ListHeaderView(text: Localization.itemsToFulfillHeader, alignment: .left)
                 .padding(.horizontal, insets: safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -85,11 +85,16 @@ struct ShippingLabelSinglePackage: View {
                     .padding(.horizontal, insets: safeAreaInsets)
                     .padding(.leading, Constants.horizontalPadding)
                 TitleAndSubtitleRow(title: Localization.itemDimensions,
-                                    subtitle: viewModel.originalPackageDimensions)
+                                    subtitle: viewModel.originalPackageDimensions,
+                                    isError: !viewModel.hasValidPackageDimensions)
                     .padding(.horizontal, insets: safeAreaInsets)
             }
             .background(Color(.systemBackground))
             .renderedIf(viewModel.isOriginalPackaging)
+
+            ValidationErrorRow(errorMessage: Localization.invalidDimensions)
+                .padding(.horizontal, insets: safeAreaInsets)
+                .renderedIf(viewModel.isOriginalPackaging && !viewModel.hasValidPackageDimensions)
 
             VStack(spacing: 0) {
                 Divider()
@@ -139,6 +144,10 @@ private extension ShippingLabelSinglePackage {
         static let itemDimensions = NSLocalizedString("Item dimensions",
                                                       comment: "Row title for dimensions of package shipped in original " +
                                                       "packaging Package Details screen in Shipping Labels flow.")
+        static let invalidDimensions = NSLocalizedString("Package dimensions must be greater than zero. Please update your item’s dimensions in " +
+                                                         "the Shipping section of your product page to continue.",
+                                                         comment: "Validation error for original package without dimensions " +
+                                                         "on Package Details screen in Shipping Labels flow.")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -175,4 +175,3 @@ struct ShippingLabelSinglePackage_Previews: PreviewProvider {
                                    viewModel: viewModel)
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct ShippingLabelSinglePackage: View {
 
     @ObservedObject private var viewModel: ShippingLabelSinglePackageViewModel
-    @State private var isCollapsed: Bool = false
     @State private var isShowingPackageSelection = false
     @Binding private var shouldShowMoveItemActionSheet: Bool
 
@@ -20,12 +19,11 @@ struct ShippingLabelSinglePackage: View {
         self.isCollapsible = isCollapsible
         self.safeAreaInsets = safeAreaInsets
         self.viewModel = viewModel
-        self.isCollapsed = packageNumber > 1
         self._shouldShowMoveItemActionSheet = shouldShowMoveItemActionSheet
     }
 
     var body: some View {
-        CollapsibleView(isCollapsible: isCollapsible, isCollapsed: $isCollapsed, safeAreaInsets: safeAreaInsets) {
+        CollapsibleView(isCollapsible: isCollapsible, safeAreaInsets: safeAreaInsets) {
             ShippingLabelPackageNumberRow(packageNumber: packageNumber, numberOfItems: viewModel.itemsRows.count, isValid: viewModel.isValidTotalWeight)
         } content: {
             ListHeaderView(text: Localization.itemsToFulfillHeader, alignment: .left)
@@ -69,8 +67,34 @@ struct ShippingLabelSinglePackage: View {
                 .sheet(isPresented: $isShowingPackageSelection, content: {
                     ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
                 })
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(!viewModel.isOriginalPackaging)
 
+            VStack(spacing: 0) {
                 Divider()
+                TitleAndSubtitleRow(title: Localization.originalPackaging,
+                                    subtitle: Localization.individuallyShipped)
+                    .padding(.horizontal, insets: safeAreaInsets)
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(viewModel.isOriginalPackaging)
+
+            VStack(spacing: 0) {
+                Divider()
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .padding(.leading, Constants.horizontalPadding)
+                TitleAndSubtitleRow(title: Localization.itemDimensions,
+                                    subtitle: viewModel.originalPackageDimensions)
+                    .padding(.horizontal, insets: safeAreaInsets)
+            }
+            .background(Color(.systemBackground))
+            .renderedIf(viewModel.isOriginalPackaging)
+
+            VStack(spacing: 0) {
+                Divider()
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .padding(.leading, Constants.horizontalPadding)
 
                 TitleAndTextFieldRow(title: Localization.totalPackageWeight,
                                      placeholder: "0",
@@ -106,6 +130,15 @@ private extension ShippingLabelSinglePackage {
                                               comment: "Title of the footer in Shipping Label Package Detail screen")
         static let invalidWeight = NSLocalizedString("Invalid weight", comment: "Error message when total weight is invalid in Package Detail screen")
         static let moveButton = NSLocalizedString("Move", comment: "Button on each order item of the Package Details screen in Shipping Labels flow.")
+        static let originalPackaging = NSLocalizedString("Original packaging",
+                                                         comment: "Row title for detail of package shipped in original " +
+                                                         "packaging on Package Details screen in Shipping Labels flow.")
+        static let individuallyShipped = NSLocalizedString("Individually shipped item",
+                                                           comment: "Description for detail of package shipped in original " +
+                                                           "packaging on Package Details screen in Shipping Labels flow.")
+        static let itemDimensions = NSLocalizedString("Item dimensions",
+                                                      comment: "Row title for dimensions of package shipped in original " +
+                                                      "packaging Package Details screen in Shipping Labels flow.")
     }
 
     enum Constants {
@@ -113,18 +146,19 @@ private extension ShippingLabelSinglePackage {
     }
 }
 
-struct ShippingLabelPackageItem_Previews: PreviewProvider {
+struct ShippingLabelSinglePackage_Previews: PreviewProvider {
     static var previews: some View {
         let order = ShippingLabelPackageDetailsViewModel.sampleOrder()
         let packageResponse = ShippingLabelPackageDetailsViewModel.samplePackageDetails()
         let viewModel = ShippingLabelSinglePackageViewModel(order: order,
-                                                          orderItems: [],
-                                                          packagesResponse: packageResponse,
-                                                          selectedPackageID: "Box 1",
-                                                          totalWeight: "",
-                                                          onItemMoveRequest: { _, _ in },
-                                                          onPackageSwitch: { _ in },
-                                                          onPackagesSync: { _ in })
+                                                            orderItems: [],
+                                                            packagesResponse: packageResponse,
+                                                            selectedPackageID: "Box 1",
+                                                            totalWeight: "",
+                                                            isOriginalPackaging: false,
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in })
         ShippingLabelSinglePackage(packageNumber: 1,
                                    isCollapsible: true,
                                    safeAreaInsets: .zero,
@@ -132,3 +166,4 @@ struct ShippingLabelPackageItem_Previews: PreviewProvider {
                                    viewModel: viewModel)
     }
 }
+

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -15,6 +15,10 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     ///
     let selectedPackageID: String
 
+    /// Whether this package is shipped in original packaging.
+    ///
+    let isOriginalPackaging: Bool
+
     /// View model for the package list
     ///
     lazy var packageListViewModel: ShippingLabelPackageListViewModel = {
@@ -79,6 +83,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
          packagesResponse: ShippingLabelPackagesResponse?,
          selectedPackageID: String,
          totalWeight: String,
+         isOriginalPackaging: Bool = false,
          onItemMoveRequest: @escaping ItemMoveRequestHandler,
          onPackageSwitch: @escaping PackageSwitchHandler,
          onPackagesSync: @escaping PackagesSyncHandler,
@@ -90,6 +95,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         self.currencyFormatter = formatter
         self.weightUnit = weightUnit
         self.selectedPackageID = selectedPackageID
+        self.isOriginalPackaging = isOriginalPackaging
         self.onItemMoveRequest = onItemMoveRequest
         self.onPackageSwitch = onPackageSwitch
         self.onPackagesSync = onPackagesSync

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -35,6 +35,10 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
     ///
     @Published private(set) var isValidTotalWeight: Bool = false
 
+    /// Description of dimensions of the original package.
+    ///
+    @Published private(set) var originalPackageDimensions: String = ""
+
     /// The title of the selected package, if any.
     ///
     var selectedPackageName: String {
@@ -105,6 +109,9 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         packageListViewModel.didSelectPackage(selectedPackageID)
         configureItemRows()
         configureTotalWeight(initialTotalWeight: totalWeight)
+        if isOriginalPackaging, let item = orderItems.first {
+            configureOriginalPackageDimensions(for: item)
+        }
     }
 
     func requestMovingItem(_ productOrVariationID: Int64, itemName: String) {
@@ -219,6 +226,16 @@ private extension ShippingLabelSinglePackageViewModel {
             return false
         }
         return value > 0
+    }
+
+    /// Configure dimensions L x W x H <unit> for the original package.
+    ///
+    func configureOriginalPackageDimensions(for item: ShippingLabelPackageItem) {
+        let unit = packagesResponse?.storeOptions.dimensionUnit ?? ""
+        let length = item.dimensions.length.isEmpty ? "0" : item.dimensions.length
+        let width = item.dimensions.width.isEmpty ? "0" : item.dimensions.width
+        let height = item.dimensions.height.isEmpty ? "0" : item.dimensions.height
+        originalPackageDimensions = String(format: "%@ x %@ x %@ %@", length, width, height, unit)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -168,6 +168,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         let width = item.dimensions.width.isEmpty ? "0" : item.dimensions.width
         let height = item.dimensions.height.isEmpty ? "0" : item.dimensions.height
         originalPackageDimensions = String(format: "%@ x %@ x %@ %@", length, width, height, unit)
+        hasValidPackageDimensions = item.dimensions.length.isNotEmpty && item.dimensions.width.isNotEmpty && item.dimensions.height.isNotEmpty
     }
 
     private func configureValidation(originalPackaging: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -65,6 +65,9 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         guard validateTotalWeight(totalWeight) else {
             return nil
         }
+        if isOriginalPackaging, !hasValidPackageDimensions {
+            return nil
+        }
         return ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                               totalWeight: totalWeight,
                                               items: orderItems)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -27,7 +27,7 @@ struct SelectableItemRow: View {
                     .bodyStyle(isEnabled)
                 subtitle.map {
                     Text($0)
-                        .footnoteStyle(isEnabled)
+                        .footnoteStyle(isEnabled: isEnabled)
                         .padding(.top, 8)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndSubtitleRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndSubtitleRow.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct TitleAndSubtitleRow: View {
     let title: String
     let subtitle: String
+    var isError: Bool = false
 
     var body: some View {
         HStack {
@@ -13,7 +14,7 @@ struct TitleAndSubtitleRow: View {
                 Text(title)
                     .bodyStyle()
                 Text(subtitle)
-                    .footnoteStyle()
+                    .footnoteStyle(isError: isError)
             }.padding([.leading, .trailing], Constants.vStackPadding)
             Spacer()
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -320,6 +320,53 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(viewModel.validatedPackageAttributes)
     }
+
+    func test_originalPackageDimensions_returns_correctly_when_package_has_no_dimensions() {
+        // Given
+        let item = ShippingLabelPackageItem.fake()
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: [item],
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.originalPackageDimensions, "0 x 0 x 0 in")
+    }
+
+    func test_originalPackageDimensions_returns_correctly_when_package_has_dimensions() {
+        // Given
+        let dimensions = ProductDimensions(length: "2", width: "3", height: "5")
+        let item = ShippingLabelPackageItem.fake(dimensions: dimensions)
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: [item],
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.originalPackageDimensions, "2 x 3 x 5 in")
+    }
 }
 
 // MARK: - Mocks

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -321,6 +321,54 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.validatedPackageAttributes)
     }
 
+    func test_validatedPackageAttributes_returns_nil_when_original_package_dimensions_is_invalid() {
+        // Given
+        let items: [ShippingLabelPackageItem] = [.fake(weight: 120, quantity: 0.5)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: items,
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "10",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+
+        // Then
+        XCTAssertEqual(viewModel.validatedPackageAttributes, nil)
+    }
+
+    func test_validatedPackageAttributes_returns_correctly_when_original_package_dimensions_is_valid() {
+        // Given
+        let dimensions = ProductDimensions(length: "2", width: "3", height: "5")
+        let items: [ShippingLabelPackageItem] = [.fake(weight: 120, quantity: 0.5, dimensions: dimensions)]
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let viewModel = ShippingLabelSinglePackageViewModel(order: order,
+                                                            orderItems: items,
+                                                            packagesResponse: mockPackageResponse(),
+                                                            selectedPackageID: "invividual",
+                                                            totalWeight: "",
+                                                            isOriginalPackaging: true,
+                                                            onItemMoveRequest: { _, _ in },
+                                                            onPackageSwitch: { _ in },
+                                                            onPackagesSync: { _ in },
+                                                            formatter: currencyFormatter,
+                                                            weightUnit: "kg")
+
+        // Then
+        let expectedPackage = ShippingLabelPackageAttributes(packageID: "invividual", totalWeight: "60", items: items)
+        XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage)
+    }
+
     func test_originalPackageDimensions_returns_correctly_when_package_has_no_dimensions() {
         // Given
         let item = ShippingLabelPackageItem.fake()
@@ -342,6 +390,7 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.originalPackageDimensions, "0 x 0 x 0 in")
+        XCTAssertFalse(viewModel.hasValidPackageDimensions)
     }
 
     func test_originalPackageDimensions_returns_correctly_when_package_has_dimensions() {
@@ -366,6 +415,7 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.originalPackageDimensions, "2 x 3 x 5 in")
+        XCTAssertTrue(viewModel.hasValidPackageDimensions)
     }
 }
 


### PR DESCRIPTION
Part of #4717 

# Description
This PR adds implementation to move items to individual packages using their original packaging. It also includes validation for original packaging, which requires valid dimensions for individual items.

# Changes
- Packages view model:
   - Handles moving an item to an individual package using original packaging.
   - Updates validation for each package based on new validation variable.
- Single package view model:
   - Adds new parameter to initializer to determine if package is using original packing of its item.
   - Configures displayed dimensions for the original package
   - Updates validation to check for both total weight and dimensions if the package uses original packaging.
- Singe package view:
   - Adds new rows for original package
   - Adds validation error for original package 

# Demo
| Valid dimensions | Invalid dimensions |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/134854534-5237b5c3-5cab-47bd-b042-59cb2ac6c532.gif" width=400 /> | <img src="https://user-images.githubusercontent.com/5533851/134854709-08a49c7f-162c-459b-a4a3-acb6dbab1614.png" width=400 /> |

# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Select an order eligible for creating shipping label. The order item list should contain a product with valid dimensions configured for its packaging.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Select the product with valid dimensions and tap Move > select Ship in original packaging.
5. Notice that the item is displayed in another package, which shows a new row: Original packaging. Correct dimensions are displayed in another row: Item dimensions.
6. Repeat steps 2-5 for another order that contains a product with invalid dimensions. Notice that the invalid dimensions are highlight in red color, with a validation error underneath the Item dimensions row, explaining the error. Done button should be disabled.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
