### PR TITLE
Shipping Labels: Move item to new package and existing packages

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -16,3 +16,9 @@ struct ShippingLabelPackageAttributes: Equatable {
     /// List of items in the package.
     let items: [ShippingLabelPackageItem]
 }
+
+extension ShippingLabelPackageAttributes {
+    var isOriginalPackaging: Bool {
+        packageID == Self.originalPackagingBoxID
+    }
+}

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -21,4 +21,25 @@ extension ShippingLabelPackageAttributes {
     var isOriginalPackaging: Bool {
         packageID == Self.originalPackagingBoxID
     }
+
+    func partitionItems(using productOrVariationID: Int64) -> (matchingItem: ShippingLabelPackageItem?, rest: [ShippingLabelPackageItem]) {
+        var matchingItem: ShippingLabelPackageItem?
+        var updatedItems: [ShippingLabelPackageItem] = []
+        for item in items {
+            if item.productOrVariationID == productOrVariationID, matchingItem == nil {
+                // If found an item with matching product or variation ID,
+                // create a copy of the item with quantity = 1.
+                matchingItem = ShippingLabelPackageItem(copy: item, quantity: 1)
+
+                // If the item has quantity > 1, create a copy of the item with the reduced quantity and append to the list.
+                if item.quantity > 1 {
+                    let newItem = ShippingLabelPackageItem(copy: item, quantity: item.quantity - 1)
+                    updatedItems.append(newItem)
+                }
+            } else {
+                updatedItems.append(item)
+            }
+        }
+        return (matchingItem: matchingItem, rest: updatedItems)
+    }
 }

--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -22,6 +22,10 @@ extension ShippingLabelPackageAttributes {
         packageID == Self.originalPackagingBoxID
     }
 
+    /// Returns an item in the package that contains product or variation with the specified ID,
+    /// and the rest of the items in the package. If the item has quantity great than one,
+    /// the rest of the items will contain an item with the same `productOrVariationID` but with reduced quantity.
+    ///
     func partitionItems(using productOrVariationID: Int64) -> (matchingItem: ShippingLabelPackageItem?, rest: [ShippingLabelPackageItem]) {
         var matchingItem: ShippingLabelPackageItem?
         var updatedItems: [ShippingLabelPackageItem] = []

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -153,7 +153,10 @@ private extension ShippingLabelPackagesFormViewModel {
             var buttons: [ActionSheet.Button] = []
 
             // Add options to move to other packages.
-            for index in 0..<selectedPackages.count {
+            for (index, package) in selectedPackages.enumerated() {
+                guard !package.isOriginalPackaging else {
+                    continue
+                }
                 if index != packageIndex {
                     guard let name = itemViewModels[safe: index]?.packageName else {
                         continue

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -283,6 +283,7 @@ private extension ShippingLabelPackagesFormViewModel {
         }
 
         var itemToMove: ShippingLabelPackageItem?
+        var updatedCurrentPackage: ShippingLabelPackageAttributes?
 
         if currentPackage.isOriginalPackaging {
             itemToMove = currentPackage.items.first
@@ -293,10 +294,9 @@ private extension ShippingLabelPackagesFormViewModel {
             // If the resulting item list is not empty, create a copy of the package with the items,
             // and add the new package to the list.
             if updatedItems.isNotEmpty {
-                let updatedPackage = ShippingLabelPackageAttributes(packageID: currentPackage.packageID,
-                                                                    totalWeight: "",
-                                                                    items: updatedItems)
-                temporaryPackages[currentPackageIndex] = updatedPackage
+                updatedCurrentPackage = ShippingLabelPackageAttributes(packageID: currentPackage.packageID,
+                                                                       totalWeight: "",
+                                                                       items: updatedItems)
             }
         }
 
@@ -321,7 +321,9 @@ private extension ShippingLabelPackagesFormViewModel {
                                                                items: newItems)
         temporaryPackages[newPackageIndex] = updatedNewPackage
 
-        if currentPackage.isOriginalPackaging {
+        if let updatedCurrentPackage = updatedCurrentPackage {
+            temporaryPackages[currentPackageIndex] = updatedCurrentPackage
+        } else {
             // Remove current package from list
             temporaryPackages.remove(at: currentPackageIndex)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -157,7 +157,7 @@ private extension ShippingLabelPackagesFormViewModel {
                 if hasMultipleItems {
                     // Add option to add item to new package if current package has more than one item.
                     buttons.append(.default(Text(Localization.addToNewPackage)) { [weak self] in
-                        self?.addItemToNewPackage(productOrVariationID: productOrVariationID, from: currentPackage)
+                        self?.addItemToNewPackage(productOrVariationID: productOrVariationID, from: currentPackage, packageIndex: packageIndex)
                     })
                 }
 
@@ -167,7 +167,7 @@ private extension ShippingLabelPackagesFormViewModel {
                 })
             } else {
                 buttons.append(.default(Text(Localization.addToNewPackage)) { [weak self] in
-                    self?.addItemToNewPackage(productOrVariationID: productOrVariationID, from: currentPackage)
+                    self?.addItemToNewPackage(productOrVariationID: productOrVariationID, from: currentPackage, packageIndex: packageIndex)
                 })
             }
             buttons.append(.cancel())
@@ -213,14 +213,10 @@ private extension ShippingLabelPackagesFormViewModel {
     /// Move the item with `productOrVariationID` to a separate non-original package,
     /// and update the old package appropriately.
     ///
-    func addItemToNewPackage(productOrVariationID: Int64, from currentPackage: ShippingLabelPackageAttributes) {
+    func addItemToNewPackage(productOrVariationID: Int64, from currentPackage: ShippingLabelPackageAttributes, packageIndex: Int) {
         var temporaryPackages = selectedPackages
-        guard let foundIndex = temporaryPackages.firstIndex(of: currentPackage) else {
-            return assertionFailure("⛔️ Cannot find current package in the list!")
-        }
-
         // Remove current package from list
-        temporaryPackages.remove(at: foundIndex)
+        temporaryPackages.remove(at: packageIndex)
 
         if !currentPackage.isOriginalPackaging {
             let (matchingItem, updatedItems) = currentPackage.partitionItems(using: productOrVariationID)
@@ -250,7 +246,7 @@ private extension ShippingLabelPackagesFormViewModel {
             let newPackage = ShippingLabelPackageAttributes(packageID: selectedPackageID,
                                                             totalWeight: "",
                                                             items: currentPackage.items)
-            temporaryPackages.insert(newPackage, at: foundIndex)
+            temporaryPackages.insert(newPackage, at: packageIndex)
         }
         // This will trigger updating item view models, and therefore updates the package list UI.
         selectedPackages = temporaryPackages

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -37,7 +37,7 @@ struct ShippingLabelSinglePackage: View {
                         HStack {
                             Spacer()
                             Button(action: {
-                                viewModel.requestMovingItem(productItemRow.productOrVariationID, itemName: productItemRow.title)
+                                viewModel.requestMovingItem(productItemRow.productOrVariationID)
                                 shouldShowMoveItemActionSheet = true
                             }, label: {
                                 Text(Localization.moveButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -4,6 +4,7 @@ struct ShippingLabelSinglePackage: View {
 
     @ObservedObject private var viewModel: ShippingLabelSinglePackageViewModel
     @State private var isShowingPackageSelection = false
+    @State private var isCollapsed: Bool = false
     @Binding private var shouldShowMoveItemActionSheet: Bool
 
     private let isCollapsible: Bool
@@ -23,7 +24,7 @@ struct ShippingLabelSinglePackage: View {
     }
 
     var body: some View {
-        CollapsibleView(isCollapsible: isCollapsible, safeAreaInsets: safeAreaInsets) {
+        CollapsibleView(isCollapsible: isCollapsible, isCollapsed: $isCollapsed, safeAreaInsets: safeAreaInsets) {
             ShippingLabelPackageNumberRow(packageNumber: packageNumber, numberOfItems: viewModel.itemsRows.count, isValid: viewModel.isValidPackage)
         } content: {
             ListHeaderView(text: Localization.itemsToFulfillHeader, alignment: .left)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -59,6 +59,15 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         }
     }
 
+    /// The package name to be displayed in Move Item action sheet.
+    ///
+    var packageName: String {
+        if isOriginalPackaging {
+            return orderItems.first?.name ?? ""
+        }
+        return selectedPackageName
+    }
+
     /// Attributes of the package if validated.
     ///
     var validatedPackageAttributes: ShippingLabelPackageAttributes? {
@@ -126,13 +135,7 @@ final class ShippingLabelSinglePackageViewModel: ObservableObject {
         configureValidation(originalPackaging: isOriginalPackaging)
     }
 
-    func requestMovingItem(_ productOrVariationID: Int64, itemName: String) {
-        let packageName: String = {
-            if selectedPackageName == Localization.selectPackagePlaceholder {
-                return itemName
-            }
-            return selectedPackageName
-        }()
+    func requestMovingItem(_ productOrVariationID: Int64) {
         onItemMoveRequest(productOrVariationID, packageName)
     }
 


### PR DESCRIPTION
Closes #4717 
⚠️ This PR depends on #5061, so please make sure that PR is reviewed and merged first ⚠️

# Description
This PR completes moving items between packages by adding options to move item to a new package or existing packages. The general rules for each option to be available are:
- For each item in a package, there's an option to move to other existing packages that are not in original packaging.
- If an item is in original packaging, there's an option to move it back to a predefined / custom package.
- If an item is not in original packaging, and the item quantity is larger than 1 / or the package containing it has at least another item - then there's an option to move it to a new package.

# Changes
- Updates single package view model with a `packageName` variable to be accessed from outside.
- Updates logic for buttons on the Move Item action sheet.
- Handles logic to move item to a new package and to move it to other existing packages.

# Demo
https://user-images.githubusercontent.com/5533851/134892148-bc1829cc-6d27-409c-ad5d-1f5f2867b4ef.mp4

# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Select an order eligible for creating shipping label. The order item list should contain more than one item / or there should be an order item whose quantity is larger one.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Tap Move on one of the items, select Add to new package. Notice that the item is now in a new package, the old package is also updated to reflect the change.
5. Continue moving each item to new package until no other package as more than one item. Notice that there's no more option to move to new package on any item now.
6. Choose an item and move it to an existing package. Notice that the old package is removed and the existing package is updated correctly.
7. Continue moving items to make sure that there's no issue at all.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
