### PR TITLE
Shipping Labels: enable feature flag for adding new payment methods

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 7.7
 -----
+- [***] Shipping Labels: Merchants can now add new payment methods for shipping labels directly from the app.
 - [x] Fix: now a default paper size will be selected in Shipping Label print screen. [https://github.com/woocommerce/woocommerce-ios/pull/5035]
 - [*] Show banner on screens that use cached data when device is offline. [https://github.com/woocommerce/woocommerce-ios/pull/5000]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.7
 -----
-- [***] Shipping Labels: Merchants can now add new payment methods for shipping labels directly from the app.
+- [***] Shipping Labels: Merchants can now add new payment methods for shipping labels directly from the app. [https://github.com/woocommerce/woocommerce-ios/pull/5023]
 - [x] Fix: now a default paper size will be selected in Shipping Label print screen. [https://github.com/woocommerce/woocommerce-ios/pull/5035]
 - [*] Show banner on screens that use cached data when device is offline. [https://github.com/woocommerce/woocommerce-ios/pull/5000]
 

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -12,7 +12,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .shippingLabelsInternational:
             return true
         case .shippingLabelsAddPaymentMethods:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .shippingLabelsAddCustomPackages:
             return true
         case .shippingLabelsMultiPackage:


### PR DESCRIPTION
## Description
This PR enables the feature flag for adding new payment methods to shipping labels, to release this feature to the public.

## Testing
1. Make sure that your test store has installed WCShip plugin and payment methods added in the "Shipping Labels" section in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Open an order eligible for shipping label creation.
3. Click on Create shipping label.
4. Pass all steps until you reach the payment step.
5. Click on edit.
6. You should see the "Add another credit card" button and you should be able to press it for adding a new payment method.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/134937063-3ee14d6d-6b14-442f-807c-1795581a6812.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
