### PR TITLE
Order Editing: Adds toggle to copy Shipping/Billing Address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -146,7 +146,7 @@ struct EditAddressForm: View {
                 .background(Color(.systemBackground))
 
                 Group {
-                    TitleAndToggleRow(title: Localization.useAddressAs(for: viewModel.type), isOn: .constant(false))
+                    TitleAndToggleRow(title: Localization.useAddressAs(for: viewModel.type), isOn: $viewModel.fields.useAsToggle)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -144,6 +144,14 @@ struct EditAddressForm: View {
                 }
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
                 .background(Color(.systemBackground))
+
+                Group {
+                    TitleAndToggleRow(title: Localization.useAddressAs(for: viewModel.type), isOn: .constant(false))
+                        .padding(.horizontal, Constants.horizontalPadding)
+                        .padding(.vertical, Constants.verticalPadding)
+                }
+                .padding(.horizontal, insets: geometry.safeAreaInsets)
+                .background(Color(.systemBackground))
             }
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
@@ -229,6 +237,8 @@ private extension EditAddressForm {
 
     enum Constants {
         static let dividerPadding: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
+        static let verticalPadding: CGFloat = 7
     }
 
     enum Localization {
@@ -258,7 +268,7 @@ private extension EditAddressForm {
         static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address Form")
         static let placeholderSelectOption = NSLocalizedString("Select an option", comment: "Text field placeholder in Edit Address Form")
 
-        static func useAddressAs(for type: EditAddressFormViewModel.AddressType) {
+        static func useAddressAs(for type: EditAddressFormViewModel.AddressType) -> String {
             switch type {
             case .shipping:
                 return NSLocalizedString("Use as Billing Address", comment: "Title for the Use as Billing Address switch in the Address form")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -257,6 +257,15 @@ private extension EditAddressForm {
         static let placeholderRequired = NSLocalizedString("Required", comment: "Text field placeholder in Edit Address Form")
         static let placeholderOptional = NSLocalizedString("Optional", comment: "Text field placeholder in Edit Address Form")
         static let placeholderSelectOption = NSLocalizedString("Select an option", comment: "Text field placeholder in Edit Address Form")
+
+        static func useAddressAs(for type: EditAddressFormViewModel.AddressType) {
+            switch type {
+            case .shipping:
+                return NSLocalizedString("Use as Billing Address", comment: "Title for the Use as Billing Address switch in the Address form")
+            case .billing:
+                return NSLocalizedString("Use as Shipping Address", comment: "Title for the Use as Shipping Address switch in the Address form")
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -194,6 +194,8 @@ extension EditAddressFormViewModel {
         var country: String = ""
         var state: String = ""
 
+        var useAsToggle: Bool = false
+
         mutating func update(with address: Address) {
             firstName = address.firstName
             lastName = address.lastName

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -137,18 +137,25 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
         let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState)
+        let orderFields: [OrderUpdateField]
 
         let modifiedOrder: Yosemite.Order
         switch type {
+        case .shipping where fields.useAsToggle:
+            modifiedOrder = order.copy(billingAddress: updatedAddress, shippingAddress: updatedAddress)
+            orderFields = [.shippingAddress, .billingAddress]
         case .shipping:
             modifiedOrder = order.copy(shippingAddress: updatedAddress)
+            orderFields = [.shippingAddress]
+        case .billing where fields.useAsToggle:
+            modifiedOrder = order.copy(billingAddress: updatedAddress, shippingAddress: updatedAddress)
+            orderFields = [.billingAddress, .shippingAddress]
         case .billing:
             modifiedOrder = order.copy(billingAddress: updatedAddress)
+            orderFields = [.billingAddress]
         }
 
-        let action = OrderAction.updateOrder(siteID: order.siteID,
-                                             order: modifiedOrder,
-                                             fields: [type == .shipping ? .shippingAddress : .billingAddress]) { [weak self] result in
+        let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, fields: orderFields) { [weak self] result in
             guard let self = self else { return }
 
             self.performingNetworkRequest.send(false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -228,6 +228,33 @@ final class EditAddressFormViewModelTests: XCTestCase {
         assertEqual(update.fields, [.shippingAddress])
     }
 
+    func test_view_model_updates_shipping_and_billing_address_fields_when_use_as_toggle_is_on() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, stores: stores)
+
+        // When
+        viewModel.fields.firstName = "Tester"
+        viewModel.fields.useAsToggle = true
+
+        let update: (order: Order, fields: [OrderUpdateField]) = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, fields, _):
+                    promise((order, fields))
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+            viewModel.updateRemoteAddress { _ in }
+        }
+
+        // Then
+        assertEqual(update.order.shippingAddress?.firstName, "Tester")
+        assertEqual(update.order.billingAddress?.firstName, "Tester")
+        assertEqual(update.fields, [.shippingAddress, .billingAddress])
+    }
+
     func test_view_model_only_updates_billing_address_field() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -266,6 +293,33 @@ final class EditAddressFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fields.state, newState.name)
+    }
+
+    func test_view_model_updates_billing_and_shipping_address_fields_when_use_as_toggle_is_on() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = EditAddressFormViewModel(order: order(withBillingAddress: sampleAddress()), type: .billing, stores: stores)
+
+        // When
+        viewModel.fields.firstName = "Tester"
+        viewModel.fields.useAsToggle = true
+
+        let update: (order: Order, fields: [OrderUpdateField]) = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, fields, _):
+                    promise((order, fields))
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+            viewModel.updateRemoteAddress { _ in }
+        }
+
+        // Then
+        assertEqual(update.order.billingAddress?.firstName, "Tester")
+        assertEqual(update.order.shippingAddress?.firstName, "Tester")
+        assertEqual(update.fields, [.billingAddress, .shippingAddress])
     }
 }
 


### PR DESCRIPTION
closes #4808  #4778

# Why

Now that we can update shipping & billing addresses, it is super convenient to be able to update one and also update the other at the same time, this will be done by switching a toggle called "Use as Shipping|Billing address"

# How

- Update `AddressForm` to add the a new row that includes the toggle.
- Update `AddressFormViewModel` to hold the switch value.
- Update `AddressFormViewModel` to update the order correctly when the `useAs` toggle is on.

# Demo

https://user-images.githubusercontent.com/562080/134942368-73e63cfd-3231-4fa3-8779-33edc9625767.mov


# Testing Steps
- Navigate to edit an order shipping address
- Update any of the orders fields
- Enable the "Use as Billing Address" toggle.
- Tap the "Done" button
- Navigate to The Billing address screen
- See that it got updated with the shipping address values.

# Pending
- See if it's possible to save that "use as ... address" toggle state remotely. [Card](https://github.com/woocommerce/woocommerce-ios/projects/39#card-69557498)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
