### PR TITLE
[Mobile Payments] Payments Unavailable - Learn More - Replace AttributedText with Link

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -4,25 +4,39 @@ struct InPersonPaymentsLearnMore: View {
     @Environment(\.customOpenURL) var customOpenURL
 
     var body: some View {
-        HStack(alignment: .center, spacing: 20) {
-            Image(uiImage: .infoOutlineImage)
-                .resizable()
-                .foregroundColor(Color(.textSubtle))
-                .frame(width: iconSize, height: iconSize)
-            AttributedText(Localization.learnMore)
-                .font(.subheadline)
-                .attributedTextForegroundColor(Color(.textSubtle))
-                .attributedTextLinkColor(Color(.textLink))
-                .customOpenURL { url in
-                    ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
-                    customOpenURL?(url)
-                }
-        }
+        Link(destination: Constants.learnMoreURL!) {
+            Label {
+                Text(Localization.learnMore)
+                    .font(.subheadline)
+                    .foregroundColor(Color(.accent))
+            } icon: {
+                Image(uiImage: .infoOutlineImage)
+                    .resizable()
+                    .foregroundColor(Color(.textSubtle))
+                    .frame(width: iconSize, height: iconSize)
+            }.labelStyle(VerticallyCenteredLabelStyle())
+        }.onOpenURL(perform: { url in
+            ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
+            customOpenURL?(url)
+        })
     }
 
     var iconSize: CGFloat {
         UIFontMetrics(forTextStyle: .subheadline).scaledValue(for: 20)
     }
+
+    struct VerticallyCenteredLabelStyle: LabelStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            HStack(alignment: .center, spacing: 20) {
+                configuration.icon
+                configuration.title
+            }
+        }
+    }
+}
+
+private enum Constants {
+    static let learnMoreURL = URL(string: "https://woocommerce.com/payments")
 }
 
 private enum Localization {
@@ -36,24 +50,10 @@ private enum Localization {
         comment: "Generic error message when In-Person Payments is unavailable"
     )
 
-    static let learnMore: NSAttributedString = {
-        let learnMoreText = NSLocalizedString(
-            "<a href=\"https://woocommerce.com/payments\">Learn more</a> about accepting payments with your mobile device and ordering card readers",
-            comment: "A label prompting users to learn more about card readers with an embedded hyperlink"
-        )
-
-        let learnMoreAttributes: [NSAttributedString.Key: Any] = [
-            .font: StyleManager.footerLabelFont,
-            .foregroundColor: UIColor.textSubtle
-        ]
-
-        let learnMoreAttrText = NSMutableAttributedString()
-        learnMoreAttrText.append(learnMoreText.htmlToAttributedString)
-        let range = NSRange(location: 0, length: learnMoreAttrText.length)
-        learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
-
-        return learnMoreAttrText
-    }()
+    static let learnMore = NSLocalizedString(
+        "Tap to learn more about accepting payments with your mobile device and ordering card readers",
+        comment: "A label prompting users to learn more about card readers"
+    )
 }
 
 struct InPersonPaymentsLearnMore_Previews: PreviewProvider {


### PR DESCRIPTION
Closes #5031 

Changes
- Replaces HStack with AttributedText with a [Link](https://developer.apple.com/documentation/swiftui/link)
- Makes the entire learn more prompt tappable and avoids the crash
- Stand in until we move our minimum to iOS15

To test:
- Switch your store to Canada in wp-admin > WooCommerce > Settings > General > Country
- Launch the app and tap on the gear (Settings) then In-Person Payments

Screenshots and movies:

<img src="https://user-images.githubusercontent.com/1595739/134986718-0c775bf1-f68c-4fce-a388-322e4a65bd56.PNG" width=50% />

<img src="https://user-images.githubusercontent.com/1595739/134986725-ca615b0e-4ebc-41e2-aa72-0c7f7c17c751.PNG" width=50% />

https://user-images.githubusercontent.com/1595739/134986731-3a832090-d55c-4cff-a726-58506687054b.MP4

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
