### PR TITLE
Shipping Labels: Fix validation for Package Details screen in multi-package cases

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -38,9 +38,9 @@ final class ShippingLabelPackagesFormViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    /// Validation states of all items.
+    /// Validation states of all items by index of each package.
     ///
-    private var packagesValidation: [String: Bool] = [:] {
+    private var packagesValidation: [Int: Bool] = [:] {
         didSet {
             configureDoneButton()
         }
@@ -347,10 +347,11 @@ private extension ShippingLabelPackagesFormViewModel {
     /// Observe validation state of each package and save it by package ID.
     ///
     func observeItemViewModels() {
-        itemViewModels.forEach { item in
+        packagesValidation.removeAll()
+        itemViewModels.enumerated().forEach { (index, item) in
             item.$isValidPackage
                 .sink { [weak self] isValid in
-                    self?.packagesValidation[item.selectedPackageID] = isValid
+                    self?.packagesValidation[index] = isValid
                 }
                 .store(in: &cancellables)
         }


### PR DESCRIPTION
Part of #4599 

# Description
Previously when working on validation for Package Details screen, I used selected package ID to as the key for the validation dictionary. The problem is we can have several packages with the same package ID, so this is not a good way to keep track of validation states of packages.

Another problem is when shipping items to original packaging and then moving them back together, the states of the old packages weren't cleared. This leads to the Done button not being enabled after moving an item without dimensions from original packaging to a predefined package.

This PR makes sure that the validation states are reset for every new set of `itemViewModels`.

# Changes
- Updates `packagesValidation` to keep track of package index instead of selected package ID.
- Resets `packagesValidation` at the beginning of `observeItemViewModels`.

# Demo
https://user-images.githubusercontent.com/5533851/135023901-33204c11-6e7f-401f-838c-a93ebb887cdb.mp4

# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Select an order eligible for creating shipping label. The order item list should contain more than one item / or there should be an order item whose quantity is larger one. Try with products / variations without dimensions.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Move an item without dimensions to original packaging. Notice that the Done button is disabled.
5. Move the item back to a predefined / custom package (using Add to a new package), or move it to an existing package. Notice that the Done button should now be enabled.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
