### PR TITLE
Shipping Labels: Fix customs form issues for multiple packages

### DIFF
--- a/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Networking/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -63,10 +63,7 @@ public struct ShippingLabelCustomsForm: Hashable, Equatable, GeneratedFakeable, 
 
     /// Convenient intializer
     ///
-    public init(packageID: String, packageName: String, productIDs: [Int64]) {
-        let items = productIDs.map { id in
-            Item(description: "", quantity: 1, value: 0, weight: 0, hsTariffNumber: "", originCountry: "", productID: id)
-        }
+    public init(packageID: String, packageName: String, items: [Item]) {
         self.init(packageID: packageID,
                   packageName: packageName,
                   contentsType: .merchandise,

--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -16,6 +16,9 @@ struct ShippingLabelPackageItem: Equatable {
     /// Quantity of the product or variation
     let quantity: Decimal
 
+    /// Value of the product or variation
+    let value: Double
+
     /// Dimensions of the product or variation
     let dimensions: ProductDimensions
 
@@ -33,11 +36,13 @@ extension ShippingLabelPackageItem {
         self.weight = copy.weight
         self.dimensions = copy.dimensions
         self.attributes = copy.attributes
+        self.value = copy.value
     }
 
     init?(orderItem: OrderItem, products: [Product], productVariations: [ProductVariation]) {
         self.name = orderItem.name
         self.quantity = orderItem.quantity
+        self.value = orderItem.price.doubleValue
         self.attributes = orderItem.attributes.map { VariationAttributeViewModel(orderItemAttribute: $0) }
 
         let isVariation = orderItem.variationID > 0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -215,7 +215,7 @@ private extension ShippingLabelCustomsFormInput {
 struct ShippingLabelCustomsFormInput_Previews: PreviewProvider {
     static let sampleViewModel: ShippingLabelCustomsFormInputViewModel = {
         let sampleOrder = ShippingLabelPackageDetailsViewModel.sampleOrder()
-        let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", packageName: "Food Package", productIDs: sampleOrder.items.map { $0.productID })
+        let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", packageName: "Food Package", items: [])
         return .init(customsForm: sampleForm, destinationCountry: Country(code: "VN", name: "Vietnam", states: []), countries: [], currency: "$")
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -57,6 +57,10 @@ struct ShippingLabelCustomsFormInput: View {
                 .font(.body)
             Text(viewModel.packageName)
                 .font(.body)
+            Spacer()
+            Image(uiImage: .noticeImage)
+                .foregroundColor(Color(.error))
+                .renderedIf(!viewModel.validForm)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -16,14 +16,11 @@ struct ShippingLabelCustomsFormList: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
-                ForEach(Array(viewModel.customsForms.enumerated()), id: \.element) { (index, item) in
-                    viewModel.inputViewModels.first(where: { $0.packageID == item.packageID })
-                        .map { inputModel in
-                            ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
-                                                          packageNumber: index + 1,
-                                                          safeAreaInsets: geometry.safeAreaInsets,
-                                                          viewModel: inputModel)
-                        }
+                ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
+                    ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
+                                                  packageNumber: index + 1,
+                                                  safeAreaInsets: geometry.safeAreaInsets,
+                                                  viewModel: item)
                 }
                 .padding(.bottom, insets: geometry.safeAreaInsets)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -49,7 +49,7 @@ private extension ShippingLabelCustomsFormList {
 struct ShippingLabelCustomsFormList_Previews: PreviewProvider {
     static let sampleViewModel: ShippingLabelCustomsFormListViewModel = {
         let sampleOrder = ShippingLabelPackageDetailsViewModel.sampleOrder()
-        let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", packageName: "Food Package", productIDs: sampleOrder.items.map { $0.productID })
+        let sampleForm = ShippingLabelCustomsForm(packageID: "Food Package", packageName: "Food Package", items: [])
         return ShippingLabelCustomsFormListViewModel(order: sampleOrder,
                                                      customsForms: [sampleForm],
                                                      destinationCountry: Country(code: "VN", name: "Vietnam", states: []),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -1,24 +1,17 @@
 import Combine
 import Foundation
 import Yosemite
-import protocol Storage.StorageManagerType
 
 /// View model for ShippingLabelsCustomsFormList
 ///
 final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     /// Whether multiple packages are found.
     ///
-    lazy var multiplePackagesDetected: Bool = {
-        customsForms.count > 1
-    }()
+    let multiplePackagesDetected: Bool
 
     /// References of input view models.
     ///
-    @Published private(set) var inputViewModels: [ShippingLabelCustomsFormInputViewModel]
-
-    /// Input customs forms of the shipping label if added initially.
-    ///
-    private let customsForms: [ShippingLabelCustomsForm]
+    let inputViewModels: [ShippingLabelCustomsFormInputViewModel]
 
     /// Whether done button should be enabled.
     ///
@@ -32,10 +25,6 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    /// Storage to fetch products and variations.
-    ///
-    private let storageManager: StorageManagerType
-
     /// Persisted countries to send to item details form.
     ///
     private let allCountries: [Country]
@@ -47,18 +36,6 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
     var validatedCustomsForms: [ShippingLabelCustomsForm] {
         inputViewModels.compactMap { $0.validatedCustomsForm }
     }
-
-    /// Reusing Package Details results controllers since we're interested in the same models.
-    ///
-    private var resultsControllers: ShippingLabelPackageDetailsResultsControllers?
-
-    /// Products contained inside the Order and fetched from Core Data
-    ///
-    @Published private var products: [Product] = []
-
-    /// ProductVariations contained inside the Order and fetched from Core Data
-    ///
-    @Published private var productVariations: [ProductVariation] = []
 
     /// Symbol of currency in the order.
     ///
@@ -80,12 +57,10 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
          customsForms: [ShippingLabelCustomsForm],
          destinationCountry: Country,
          countries: [Country],
-         stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         stores: StoresManager = ServiceLocator.stores) {
         self.order = order
-        self.customsForms = customsForms
+        self.multiplePackagesDetected = customsForms.count > 1
         self.stores = stores
-        self.storageManager = storageManager
         self.allCountries = countries
         self.destinationCountry = destinationCountry
         let currencySymbol: String = {
@@ -100,8 +75,6 @@ final class ShippingLabelCustomsFormListViewModel: ObservableObject {
                                                         countries: countries,
                                                         currency: currencySymbol) }
         configureFormsValidation()
-        configureResultsControllers()
-        updateItemDetails()
     }
 }
 
@@ -111,7 +84,6 @@ private extension ShippingLabelCustomsFormListViewModel {
     /// Observe changes in all customs forms and save their validation states by package ID.
     ///
     func configureFormsValidation() {
-        customsFormValidation.removeAll()
         inputViewModels.enumerated().forEach { (index, viewModel) in
             viewModel.$validForm
                 .sink { [weak self] isValid in
@@ -125,105 +97,5 @@ private extension ShippingLabelCustomsFormListViewModel {
     ///
     func configureDoneButton() {
         doneButtonEnabled = customsFormValidation.values.first(where: { !$0 }) == nil
-    }
-}
-
-// MARK: - Fetching and updating item details.
-//
-private extension ShippingLabelCustomsFormListViewModel {
-    /// Update item details for current customs forms
-    /// with every change in products and product variations.
-    ///
-    func updateItemDetails() {
-        $products.combineLatest($productVariations) { [weak self] (products, variations) -> [ShippingLabelCustomsForm] in
-            self?.updateCustomsForms(products: products, productVariations: variations) ?? []
-        }
-        .sink { [weak self] customsForms in
-            guard let self = self else { return }
-            self.inputViewModels = customsForms.map { .init(customsForm: $0,
-                                                            destinationCountry: self.destinationCountry,
-                                                            countries: self.allCountries,
-                                                            currency: self.currencySymbol) }
-            self.configureFormsValidation()
-        }
-        .store(in: &cancellables)
-    }
-
-    /// Configure result controllers for products and product variations.
-    ///
-    func configureResultsControllers() {
-        resultsControllers = ShippingLabelPackageDetailsResultsControllers(siteID: order.siteID,
-                                                                           orderItems: order.items,
-                                                                           storageManager: storageManager,
-           onProductReload: { [weak self] (products) in
-            self?.products = products
-        }, onProductVariationsReload: { [weak self] (productVariations) in
-            self?.productVariations = productVariations
-        })
-
-        products = resultsControllers?.products ?? []
-        productVariations = resultsControllers?.productVariations ?? []
-    }
-
-    /// Return copy of customs forms with updated item details based on fetched products and variations.
-    ///
-    func updateCustomsForms(products: [Product], productVariations: [ProductVariation]) -> [ShippingLabelCustomsForm] {
-        var updatedForms: [ShippingLabelCustomsForm] = []
-
-        for form in customsForms {
-            let updatedItems = form.items.map { item -> ShippingLabelCustomsForm.Item? in
-                // Only proceed for default items.
-                // If an item has been validated, its weight should be larger than 0.
-                guard item.weight == 0 else {
-                    return item
-                }
-
-                // Find the matching order item
-                guard let orderItem = order.items.first(where: { $0.variationID == item.productID || $0.productID == item.productID }) else {
-                    return item
-                }
-
-                // Find matching product or variation
-                let productVariation = productVariations.first(where: { $0.productVariationID == orderItem.variationID })
-                let product = products.first(where: { $0.productID == orderItem.productID })
-
-                // Exclude the item if its associating product or variation is virtual or not found.
-                if productVariation?.virtual == true || product?.virtual == true || (productVariation == nil && product == nil) {
-                    return nil
-                }
-
-                // Find weight for the item
-                let weight: Double = {
-                    if orderItem.variationID > 0,
-                       let productVariation = productVariation {
-                        return Double(productVariation.weight ?? "") ?? 0
-                    } else if let product = product {
-                        return Double(product.weight ?? "0") ?? 0
-                    }
-                    return 0
-                }()
-
-                return .init(description: orderItem.name,
-                             quantity: orderItem.quantity,
-                             value: orderItem.price.doubleValue,
-                             weight: weight,
-                             hsTariffNumber: "",
-                             originCountry: SiteAddress().countryCode, // Default value
-                             productID: item.productID)
-            }
-            .compactMap { $0 }
-
-            // Append new form with updated items
-            updatedForms.append(.init(packageID: form.packageID,
-                                      packageName: form.packageName,
-                                      contentsType: form.contentsType,
-                                      contentExplanation: form.contentExplanation,
-                                      restrictionType: form.restrictionType,
-                                      restrictionComments: form.restrictionComments,
-                                      nonDeliveryOption: form.nonDeliveryOption,
-                                      itn: form.itn,
-                                      items: updatedItems))
-        }
-        return updatedForms
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -606,8 +606,7 @@ private extension ShippingLabelFormViewModel {
         return nil
     }
 
-    /// Temporary solution for creating default customs forms.
-    /// When multi-package support is available, we should create separate form for each package ID.
+    /// Create customs forms based on `selectedPackageDetails` and default values for HS Tariff number and origin country.
     ///
     private func createDefaultCustomsFormsIfNeeded() -> [ShippingLabelCustomsForm] {
         guard customsFormRequired, selectedPackagesDetails.isNotEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -618,23 +618,21 @@ private extension ShippingLabelFormViewModel {
 
         return selectedPackagesDetails.map { package -> ShippingLabelCustomsForm in
             let packageName: String = {
-                guard let response = packagesResponse else {
-                    return ""
+                guard package.isOriginalPackaging else {
+                    return package.packageID
                 }
-
-                if let customPackage = response.customPackages.first(where: { $0.title == package.packageID }) {
-                    return customPackage.title
-                }
-
-                for option in response.predefinedOptions {
-                    if let package = option.predefinedPackages.first(where: { $0.id == package.packageID }) {
-                        return package.title
-                    }
-                }
-
-                return ""
+                return package.items.first?.name ?? ""
             }()
-            return ShippingLabelCustomsForm(packageID: package.packageID, packageName: packageName, productIDs: package.items.map { $0.productOrVariationID })
+            let items: [ShippingLabelCustomsForm.Item] = package.items.map { item in
+                .init(description: item.name,
+                      quantity: item.quantity,
+                      value: item.value,
+                      weight: item.weight,
+                      hsTariffNumber: "",
+                      originCountry: SiteAddress().countryCode,
+                      productID: item.productOrVariationID)
+            }
+            return ShippingLabelCustomsForm(packageID: package.packageID, packageName: packageName, items: items)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -574,14 +574,13 @@ private extension ShippingLabelFormViewModel {
 
     // Search the custom package based on the id
     //
-    private func searchCustomPackage(id: String?) -> ShippingLabelCustomPackage? {
-        guard let packagesResponse = packagesResponse,
-              let packageID = id else {
+    private func searchCustomPackage(id: String) -> ShippingLabelCustomPackage? {
+        guard let packagesResponse = packagesResponse else {
             return nil
         }
 
         for customPackage in packagesResponse.customPackages {
-            if customPackage.title == packageID {
+            if customPackage.title == id {
                 return customPackage
             }
         }
@@ -591,15 +590,14 @@ private extension ShippingLabelFormViewModel {
 
     // Search the predefined package based on the id
     //
-    private func searchPredefinedPackage(id: String?) -> ShippingLabelPredefinedPackage? {
-        guard let packagesResponse = packagesResponse,
-              let packageID = id else {
+    private func searchPredefinedPackage(id: String) -> ShippingLabelPredefinedPackage? {
+        guard let packagesResponse = packagesResponse else {
             return nil
         }
 
         for option in packagesResponse.predefinedOptions {
             for predefinedPackage in option.predefinedPackages {
-                if predefinedPackage.id == packageID {
+                if predefinedPackage.id == id {
                     return predefinedPackage
                 }
             }
@@ -622,19 +620,14 @@ private extension ShippingLabelFormViewModel {
                     return package.items.first?.name ?? ""
                 }
 
-                guard let response = packagesResponse else {
-                    return ""
-                }
-
-                if let customPackage = response.customPackages.first(where: { $0.title == package.packageID }) {
+                if let customPackage = searchCustomPackage(id: package.packageID) {
                     return customPackage.title
                 }
 
-                for option in response.predefinedOptions {
-                    if let package = option.predefinedPackages.first(where: { $0.id == package.packageID }) {
-                        return package.title
-                    }
+                if let predefinedPackage = searchPredefinedPackage(id: package.packageID) {
+                    return predefinedPackage.title
                 }
+
                 return ""
             }()
             let items: [ShippingLabelCustomsForm.Item] = package.items.map { item in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -618,10 +618,24 @@ private extension ShippingLabelFormViewModel {
 
         return selectedPackagesDetails.map { package -> ShippingLabelCustomsForm in
             let packageName: String = {
-                guard package.isOriginalPackaging else {
-                    return package.packageID
+                guard !package.isOriginalPackaging else {
+                    return package.items.first?.name ?? ""
                 }
-                return package.items.first?.name ?? ""
+
+                guard let response = packagesResponse else {
+                    return ""
+                }
+
+                if let customPackage = response.customPackages.first(where: { $0.title == package.packageID }) {
+                    return customPackage.title
+                }
+
+                for option in response.predefinedOptions {
+                    if let package = option.predefinedPackages.first(where: { $0.id == package.packageID }) {
+                        return package.title
+                    }
+                }
+                return ""
             }()
             let items: [ShippingLabelCustomsForm.Item] = package.items.map { item in
                 .init(description: item.name,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -1,134 +1,22 @@
 import XCTest
 @testable import WooCommerce
 import Yosemite
-@testable import Storage
 
 class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 1234
 
-    private var storageManager: StorageManagerType!
-
-    private var storage: StorageType {
-        storageManager.viewStorage
-    }
-
-    override func setUp() {
-        super.setUp()
-        storageManager = MockStorageManager()
-    }
-
-    override func tearDown() {
-        storageManager = nil
-        super.tearDown()
-    }
-
-    func test_customsForms_items_are_updated_correctly_after_fetching_products_and_variations() {
-        // Given
-        let orderItemAttributes = [OrderItemAttribute(metaID: 170, name: "Packaging", value: "Box")]
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
-                     MockOrderItem.sampleItem(name: "Jeans",
-                                              productID: 49,
-                                              variationID: 49,
-                                              quantity: 1,
-                                              price: 49,
-                                              attributes: orderItemAttributes)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
-
-        // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
-        insert(ProductVariation.fake().copy(siteID: sampleSiteID,
-                                            productID: 49,
-                                            productVariationID: 49,
-                                            attributes: [ProductVariationAttribute(id: 1, name: "Color", option: "Blue")],
-                                            weight: "10.0"))
-        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
-                                                              customsForms: [customsForm],
-                                                              destinationCountry: Country.fake(),
-                                                              countries: [],
-                                                              storageManager: storageManager)
-
-        // Then
-        let form = viewModel.customsForms.first
-        XCTAssertEqual(form?.items.count, 2)
-        XCTAssertEqual(form?.items.first?.description, items.first?.name)
-        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
-        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
-        XCTAssertEqual(form?.items.first?.weight, Double(120))
-        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
-
-        XCTAssertEqual(form?.items.last?.description, items.last?.name)
-        XCTAssertEqual(form?.items.last?.productID, items.last?.productID)
-        XCTAssertEqual(form?.items.last?.quantity, items.last?.quantity)
-        XCTAssertEqual(form?.items.last?.weight, Double(10))
-        XCTAssertEqual(form?.items.last?.value, items.last?.price.doubleValue)
-    }
-
-    func test_virtual_products_are_excluded_in_customs_item_list() {
-        // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
-                     MockOrderItem.sampleItem(name: "Ebook", productID: 49, quantity: 1, price: 15)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
-
-        // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 49, virtual: true, weight: "0"))
-        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
-                                                              customsForms: [customsForm],
-                                                              destinationCountry: Country.fake(),
-                                                              countries: [],
-                                                              storageManager: storageManager)
-
-        // Then
-        let form = viewModel.customsForms.first
-        XCTAssertEqual(form?.items.count, 1)
-        XCTAssertEqual(form?.items.first?.description, items.first?.name)
-        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
-        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
-        XCTAssertEqual(form?.items.first?.weight, Double(120))
-        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
-    }
-
-    func test_nonexistent_products_are_excluded_in_customs_item_list() {
-        // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15),
-                     MockOrderItem.sampleItem(name: "Ebook", productID: 49, quantity: 1, price: 15)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1, 49])
-
-        // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
-        let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
-                                                              customsForms: [customsForm],
-                                                              destinationCountry: Country.fake(),
-                                                              countries: [],
-                                                              storageManager: storageManager)
-
-        // Then
-        let form = viewModel.customsForms.first
-        XCTAssertEqual(form?.items.count, 1)
-        XCTAssertEqual(form?.items.first?.description, items.first?.name)
-        XCTAssertEqual(form?.items.first?.productID, items.first?.productID)
-        XCTAssertEqual(form?.items.first?.quantity, items.first?.quantity)
-        XCTAssertEqual(form?.items.first?.weight, Double(120))
-        XCTAssertEqual(form?.items.first?.value, items.first?.price.doubleValue)
-    }
-
     func test_done_button_is_enabled_when_all_fields_are_valid() {
         // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 0.5, price: 15)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1])
+        let item = ShippingLabelCustomsForm.Item.fake()
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", items: [item])
 
         // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
         let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
                                                               customsForms: [customsForm],
                                                               destinationCountry: Country.fake(),
-                                                              countries: [],
-                                                              storageManager: storageManager)
+                                                              countries: [])
 
         let firstInputModel = viewModel.inputViewModels.first
         firstInputModel?.returnOnNonDelivery = true
@@ -150,17 +38,15 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
 
     func test_done_button_is_disable_when_not_all_fields_are_valid() {
         // Given
-        let items = [MockOrderItem.sampleItem(name: "Easter Egg", productID: 1, quantity: 1, price: 15)]
-        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID, items: items)
-        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", productIDs: [1])
+        let item = ShippingLabelCustomsForm.Item.fake()
+        let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
+        let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", items: [item])
 
         // When
-        insert(Product.fake().copy(siteID: sampleSiteID, productID: 1, virtual: false, weight: "120.0"))
         let viewModel = ShippingLabelCustomsFormListViewModel(order: order,
                                                               customsForms: [customsForm],
                                                               destinationCountry: Country.fake(),
-                                                              countries: [],
-                                                              storageManager: storageManager)
+                                                              countries: [])
 
         let firstInputModel = viewModel.inputViewModels.first
         firstInputModel?.returnOnNonDelivery = true
@@ -179,23 +65,5 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.doneButtonEnabled)
-    }
-}
-
-// MARK: - Utils
-private extension ShippingLabelCustomsFormListViewModelTests {
-    func insert(_ readOnlyOrderProduct: Yosemite.Product) {
-        let product = storage.insertNewObject(ofType: StorageProduct.self)
-        product.update(with: readOnlyOrderProduct)
-    }
-
-    func insert(_ readOnlyOrderProductVariation: Yosemite.ProductVariation) {
-        let productVariation = storage.insertNewObject(ofType: StorageProductVariation.self)
-        productVariation.update(with: readOnlyOrderProductVariation)
-    }
-
-    func insert(_ readOnlyAccountSettings: Yosemite.ShippingLabelAccountSettings) {
-        let accountSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
-        accountSettings.update(with: readOnlyAccountSettings)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -64,6 +64,8 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
         firstItem?.hsTariffNumber = "111111"
 
         // Then
-        XCTAssertFalse(viewModel.doneButtonEnabled)
+        DispatchQueue.main.async {
+            XCTAssertFalse(viewModel.doneButtonEnabled)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelPackagesFormViewModelTests.swift
@@ -180,12 +180,14 @@ extension ShippingLabelPackageItem {
                      name: String = "",
                      weight: Double = 1,
                      quantity: Decimal = 1,
+                     value: Double = 10,
                      dimensions: Yosemite.ProductDimensions = .fake(),
                      attributes: [VariationAttributeViewModel] = []) -> ShippingLabelPackageItem {
         ShippingLabelPackageItem(productOrVariationID: id,
                                  name: name,
                                  weight: weight,
                                  quantity: quantity,
+                                 value: value,
                                  dimensions: dimensions,
                                  attributes: attributes)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -891,10 +891,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(defaultForms.first?.packageID, expectedPackageID)
         XCTAssertEqual(defaultForms.first?.items.count, 1)
         XCTAssertEqual(defaultForms.first?.items.first?.productID, expectedProductID)
-        XCTAssertEqual(defaultForms.first?.items.first?.weight, 0)
-        XCTAssertEqual(defaultForms.first?.items.first?.description, "")
+        XCTAssertEqual(defaultForms.first?.items.first?.weight, item.weight)
+        XCTAssertEqual(defaultForms.first?.items.first?.description, item.name)
         XCTAssertEqual(defaultForms.first?.items.first?.hsTariffNumber, "")
-        XCTAssertEqual(defaultForms.first?.items.first?.value, 0)
+        XCTAssertEqual(defaultForms.first?.items.first?.value, item.value)
         XCTAssertEqual(defaultForms.first?.items.first?.originCountry, "")
     }
 }


### PR DESCRIPTION
Closes #4718 

# Description
Although I did prepare for multi-package support in customs forms, I found that there are still some issues with the current implementation:
- The customs forms are differentiated by package IDs, which can cause issues since we can have different packages of the same ID. Hence when we update one of the package, the change is reflected on another with the same ID and that's not what we want.
- Validation is not working properly as well since validation states are being tracked by package ID, which is again incorrect.
- The customs form list view model is currently fetching products and variations to update information customs form items. All these values however can now be fetched from the package details, so these trips to the database are redundant.

# Changes
- Updates customs form list by differentiating packages using their indices in the list.
- Updates customs form validation: keep track of each form using its index in the list.
- Shows error on the header of each package when validation for its fails.
- Updates `ShippingLabelPackageItem` with value of the item.
- Updates initializer of `ShippingLabelCustomsForm` to accept a list of items instead of just product IDs.
- Updates default customs forms and removes usage of database in customs form list.

# Demo
https://user-images.githubusercontent.com/5533851/135067055-46b0bf23-aa3c-48d8-9069-4db9af58d0d5.mp4


# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an international order (i.e origin country different from destination country). The order item list should contain more than one item / or there should be an order item whose quantity is larger one.
3. In Orders tab, select the new order and select Create Shipping Label. Configure Ship From and Ship To.
4. Proceed to configure Package Details. Move items to different packages, keep at least 2 packages with the same custom / predefined package.
5. Proceed to configure Customs form. Notice that value for all items in the forms are correct.
6. Update content type / restriction type of one of the two packages that share the same package ID. Notice that only that one form is updated, the other stays intact.
7. Update values of any form so that validation fails; notice that an error icon is shown on the header of that form and Done button is disabled.
8. Turn off feature flag for multi-package support, notice that everything still works correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
