### PR TITLE
Shipping Labels: Update the print shipping label endpoint to accept multiple labels

### DIFF
--- a/Networking/Networking/Remote/ShippingLabelRemote.swift
+++ b/Networking/Networking/Remote/ShippingLabelRemote.swift
@@ -4,7 +4,7 @@ import Foundation
 public protocol ShippingLabelRemoteProtocol {
     func loadShippingLabels(siteID: Int64, orderID: Int64, completion: @escaping (Result<OrderShippingLabelListResponse, Error>) -> Void)
     func printShippingLabel(siteID: Int64,
-                            shippingLabelID: Int64,
+                            shippingLabelIDs: [Int64],
                             paperSize: ShippingLabelPaperSize,
                             completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void)
     func refundShippingLabel(siteID: Int64,
@@ -66,17 +66,17 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
 
     /// Generates shipping label data for printing.
     /// - Parameters:
-    ///   - siteID: Remote ID of the site that owns the shipping label.
-    ///   - shippingLabelID: Remote ID of the shipping label.
+    ///   - siteID: Remote ID of the site that owns the shipping labels.
+    ///   - shippingLabelIDs: Remote IDs of the shipping labels.
     ///   - paperSize: Paper size option (current options are "label", "legal", and "letter").
     ///   - completion: Closure to be executed upon completion.
     public func printShippingLabel(siteID: Int64,
-                                   shippingLabelID: Int64,
+                                   shippingLabelIDs: [Int64],
                                    paperSize: ShippingLabelPaperSize,
                                    completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
-        let parameters = [
+        let parameters: [String: Any] = [
             ParameterKey.paperSize: paperSize.rawValue,
-            ParameterKey.labelIDCSV: String(shippingLabelID),
+            ParameterKey.labelIDCSV: shippingLabelIDs.map(String.init).joined(separator: ","),
             ParameterKey.captionCSV: "",
             ParameterKey.json: "true" // `json=true` is necessary, otherwise it results in 500 error "no_response_body".
         ]

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -46,7 +46,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
 
         // When
         let printData: ShippingLabelPrintData = waitFor { promise in
-            remote.printShippingLabel(siteID: self.sampleSiteID, shippingLabelID: 123, paperSize: .label) { result in
+            remote.printShippingLabel(siteID: self.sampleSiteID, shippingLabelIDs: [123], paperSize: .label) { result in
                 guard let printData = try? result.get() else {
                     XCTFail("Error printing shipping label: \(String(describing: result.failure))")
                     return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -136,7 +136,7 @@ private extension PrintShippingLabelCoordinator {
     func requestDocumentForPrinting(paperSize: ShippingLabelPaperSize, completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
         analytics.track(.shippingLabelReprintRequested)
         let action = ShippingLabelAction.printShippingLabel(siteID: shippingLabel.siteID,
-                                                            shippingLabelID: shippingLabel.shippingLabelID,
+                                                            shippingLabelIDs: [shippingLabel.shippingLabelID],
                                                             paperSize: paperSize) { result in
             completion(result)
         }

--- a/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
+++ b/Yosemite/Yosemite/Actions/ShippingLabelAction.swift
@@ -8,7 +8,7 @@ public enum ShippingLabelAction: Action {
     /// Generates a shipping label document for printing.
     ///
     case printShippingLabel(siteID: Int64,
-                            shippingLabelID: Int64,
+                            shippingLabelIDs: [Int64],
                             paperSize: ShippingLabelPaperSize,
                             completion: (Result<ShippingLabelPrintData, Error>) -> Void)
 

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -38,8 +38,8 @@ public final class ShippingLabelStore: Store {
         switch action {
         case .synchronizeShippingLabels(let siteID, let orderID, let completion):
             synchronizeShippingLabels(siteID: siteID, orderID: orderID, completion: completion)
-        case .printShippingLabel(let siteID, let shippingLabelID, let paperSize, let completion):
-            printShippingLabel(siteID: siteID, shippingLabelID: shippingLabelID, paperSize: paperSize, completion: completion)
+        case .printShippingLabel(let siteID, let shippingLabelIDs, let paperSize, let completion):
+            printShippingLabel(siteID: siteID, shippingLabelIDs: shippingLabelIDs, paperSize: paperSize, completion: completion)
         case .refundShippingLabel(let shippingLabel, let completion):
             refundShippingLabel(shippingLabel: shippingLabel,
                                 completion: completion)
@@ -101,10 +101,10 @@ private extension ShippingLabelStore {
     }
 
     func printShippingLabel(siteID: Int64,
-                            shippingLabelID: Int64,
+                            shippingLabelIDs: [Int64],
                             paperSize: ShippingLabelPaperSize,
                             completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
-        remote.printShippingLabel(siteID: siteID, shippingLabelID: shippingLabelID, paperSize: paperSize, completion: completion)
+        remote.printShippingLabel(siteID: siteID, shippingLabelIDs: shippingLabelIDs, paperSize: paperSize, completion: completion)
     }
 
     func refundShippingLabel(shippingLabel: ShippingLabel,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -13,7 +13,7 @@ final class MockShippingLabelRemote {
 
     private struct PrintResultKey: Hashable {
         let siteID: Int64
-        let shippingLabelID: Int64
+        let shippingLabelIDs: [Int64]
         let paperSize: String
     }
 
@@ -109,10 +109,10 @@ final class MockShippingLabelRemote {
 
     /// Set the value passed to the `completion` block if `printShippingLabel` is called.
     func whenPrintingShippingLabel(siteID: Int64,
-                                   shippingLabelID: Int64,
+                                   shippingLabelIDs: [Int64],
                                    paperSize: String,
                                    thenReturn result: Result<ShippingLabelPrintData, Error>) {
-        let key = PrintResultKey(siteID: siteID, shippingLabelID: shippingLabelID, paperSize: paperSize)
+        let key = PrintResultKey(siteID: siteID, shippingLabelIDs: shippingLabelIDs, paperSize: paperSize)
         printResults[key] = result
     }
 
@@ -220,13 +220,13 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
     }
 
     func printShippingLabel(siteID: Int64,
-                            shippingLabelID: Int64,
+                            shippingLabelIDs: [Int64],
                             paperSize: ShippingLabelPaperSize,
                             completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
-            let key = PrintResultKey(siteID: siteID, shippingLabelID: shippingLabelID, paperSize: paperSize.rawValue)
+            let key = PrintResultKey(siteID: siteID, shippingLabelIDs: shippingLabelIDs, paperSize: paperSize.rawValue)
             if let result = self.printResults[key] {
                 completion(result)
             } else {

--- a/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -173,7 +173,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let remote = MockShippingLabelRemote()
         let expectedPrintData = ShippingLabelPrintData(mimeType: "application/pdf", base64Content: "////")
         remote.whenPrintingShippingLabel(siteID: sampleSiteID,
-                                         shippingLabelID: sampleShippingLabelID,
+                                         shippingLabelIDs: [sampleShippingLabelID],
                                          paperSize: "label",
                                          thenReturn: .success(expectedPrintData))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
@@ -181,7 +181,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         // When
         let result: Result<ShippingLabelPrintData, Error> = waitFor { promise in
             let action = ShippingLabelAction.printShippingLabel(siteID: self.sampleSiteID,
-                                                                shippingLabelID: self.sampleShippingLabelID,
+                                                                shippingLabelIDs: [self.sampleShippingLabelID],
                                                                 paperSize: .label) { result in
                 promise(result)
             }
@@ -198,7 +198,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         let remote = MockShippingLabelRemote()
         let expectedError = NetworkError.notFound
         remote.whenPrintingShippingLabel(siteID: sampleSiteID,
-                                         shippingLabelID: sampleShippingLabelID,
+                                         shippingLabelIDs: [sampleShippingLabelID],
                                          paperSize: "label",
                                          thenReturn: .failure(expectedError))
         let store = ShippingLabelStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
@@ -206,7 +206,7 @@ final class ShippingLabelStoreTests: XCTestCase {
         // When
         let result: Result<ShippingLabelPrintData, Error> = waitFor { promise in
             let action = ShippingLabelAction.printShippingLabel(siteID: self.sampleSiteID,
-                                                                shippingLabelID: self.sampleShippingLabelID,
+                                                                shippingLabelIDs: [self.sampleShippingLabelID],
                                                                 paperSize: .label) { result in
                 promise(result)
             }


### PR DESCRIPTION
Part of: #4714

## Description

As part of multi-package support for shipping labels, we need to support printing multiple shipping labels. This is the first step, to update the print endpoint to accept multiple labels, for example: `/v1/connect/label/print?paper_size=label&label_id_csv=1979,C1978`

There aren't any UI changes at this point, so the app should continue to work as before (printing a single shipping label).

## Changes

* Networking: Updates the print endpoint in `ShippingLabelRemote` to accept an array of shipping label IDs to print.
* Yosemite: Updates `ShippingLabelStore` and `ShippingLabelAction` to accept an array of shipping label IDs.
* Updates Networking and Yosemite unit tests and mocks to match those changes.

## Testing

1. Make sure you have configured the WooCommerce WCShip plugin.
2. Make sure you have at least one order with a purchased shipping label.
3. Open the order detail for the order that has a purchased shipping label.
4. Find the package section in the order detail and select "Print Shipping Label."
5. Select a paper size, if needed, and tap the Print Shipping Label button.
6. Confirm you get a print preview with the expected shipping label.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
