### PR TITLE
Add order number to receipt

### DIFF
--- a/Hardware/Hardware/CardReader/PaymentIntent.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntent.swift
@@ -19,7 +19,7 @@ public struct PaymentIntent: Identifiable {
     public let currency: String
 
     /// Set of key-value pairs attached to the object.
-    public let metadata: [AnyHashable: Any]?
+    public let metadata: [String: String]?
 
     // Charges that were created by this PaymentIntent, if any.
     public let charges: [Charge]
@@ -89,14 +89,16 @@ public extension PaymentIntent {
                           orderID: Int64? = nil,
                           orderKey: String? = nil,
                           paymentType: PaymentTypes? = nil
-    ) -> [AnyHashable: Any] {
-        var metadata = [AnyHashable: Any]()
+    ) -> [String: String] {
+        var metadata = [String: String]()
 
         metadata[PaymentIntent.MetadataKeys.store] = store
         metadata[PaymentIntent.MetadataKeys.customerName] = customerName
         metadata[PaymentIntent.MetadataKeys.customerEmail] = customerEmail
         metadata[PaymentIntent.MetadataKeys.siteURL] = siteURL
-        metadata[PaymentIntent.MetadataKeys.orderID] = orderID
+        if let orderID = orderID {
+            metadata[PaymentIntent.MetadataKeys.orderID] = String(orderID)
+        }
         metadata[PaymentIntent.MetadataKeys.orderKey] = orderKey
         metadata[PaymentIntent.MetadataKeys.paymentType] = paymentType?.rawValue
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
@@ -10,7 +10,7 @@ extension PaymentIntent {
         self.created = intent.created
         self.amount = intent.amount
         self.currency = intent.currency
-        self.metadata = intent.metadata
+        self.metadata = intent.metadata as? [String: String]
         self.charges = intent.charges.map { .init(charge: $0) }
     }
 }

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -86,7 +86,7 @@ public extension ReceiptRenderer {
                             <span class="card-icon \(parameters.cardDetails.brand.iconName)-icon"></span> - \(parameters.cardDetails.last4)
                         </p>
                     </header>
-                    <h3>\(Localization.summarySectionTitle.uppercased())</h3>
+                    <h3>\(summarySectionTitle.uppercased())</h3>
                     \(summaryTable())
                     <footer>
                         <p>
@@ -169,6 +169,13 @@ private extension ReceiptRenderer {
 
         return .localizedStringWithFormat(Localization.receiptFromFormat, storeName)
     }
+
+    private var summarySectionTitle: String {
+        guard let orderID = parameters.orderID else {
+            return Localization.summarySectionTitle
+        }
+        return String(format: Localization.summarySectionTitleWithOrderFormat, String(orderID))
+    }
 }
 
 
@@ -191,6 +198,11 @@ private extension ReceiptRenderer {
             comment: "Title of receipt."
         )
 
+        static let orderNumberSubtitle = NSLocalizedString(
+            "Order number %1$@",
+            comment: "Subtitle of the receipt, to show the order number. %1$@ is the order number, e.g. 4920"
+        )
+
         static let amountPaidSectionTitle = NSLocalizedString(
             "Amount paid",
             comment: "Title of 'Amount Paid' section in the receipt"
@@ -208,7 +220,12 @@ private extension ReceiptRenderer {
 
         static let summarySectionTitle = NSLocalizedString(
             "Summary",
-            comment: "Title of 'Summary' section in the receipt"
+            comment: "Title of 'Summary' section in the receipt when the order number is unknown"
+        )
+
+        static let summarySectionTitleWithOrderFormat = NSLocalizedString(
+            "Summary: Order #%1$@",
+            comment: "Title of 'Summary' section in the receipt. %1$@ is the order number, e.g. 4920"
         )
 
         static let applicationName = NSLocalizedString(

--- a/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
+++ b/Hardware/Hardware/Printer/CardPresentReceiptParameters.swift
@@ -17,16 +17,21 @@ public struct CardPresentReceiptParameters: Codable {
     /// to be added to the receipt required by the card networks.
     public let cardDetails: CardPresentTransactionDetails
 
+    /// The order ID
+    public let orderID: Int64?
+
     public init(amount: UInt,
                 currency: String,
                 date: Date,
                 storeName: String?,
-                cardDetails: CardPresentTransactionDetails) {
+                cardDetails: CardPresentTransactionDetails,
+                orderID: Int64?) {
         self.amount = amount
         self.currency = currency
         self.date = date
         self.storeName = storeName
         self.cardDetails = cardDetails
+        self.orderID = orderID
     }
 }
 
@@ -41,5 +46,6 @@ extension CardPresentReceiptParameters {
         case date = "date"
         case storeName = "store_name"
         case cardDetails = "card_details"
+        case orderID = "order_id"
     }
 }

--- a/Hardware/HardwareTests/PaymentIntentMetadataTests.swift
+++ b/Hardware/HardwareTests/PaymentIntentMetadataTests.swift
@@ -18,7 +18,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_store() throws {
         let metadata = PaymentIntent.initMetadata(store: "foo")
         let store = try XCTUnwrap(metadata["paymentintent.storename"])
-        XCTAssertEqual(store as? String, "foo")
+        XCTAssertEqual(store, "foo")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -33,7 +33,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_customer_name() throws {
         let metadata = PaymentIntent.initMetadata(customerName: "foo")
         let customerName = try XCTUnwrap(metadata["customer_name"])
-        XCTAssertEqual(customerName as? String, "foo")
+        XCTAssertEqual(customerName, "foo")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -48,7 +48,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_customer_email() throws {
         let metadata = PaymentIntent.initMetadata(customerEmail: "foo")
         let customerEmail = try XCTUnwrap(metadata["customer_email"])
-        XCTAssertEqual(customerEmail as? String, "foo")
+        XCTAssertEqual(customerEmail, "foo")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -63,7 +63,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_site_url() throws {
         let metadata = PaymentIntent.initMetadata(siteURL: "foo")
         let siteURL = try XCTUnwrap(metadata["site_url"])
-        XCTAssertEqual(siteURL as? String, "foo")
+        XCTAssertEqual(siteURL, "foo")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -78,7 +78,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_orderID() throws {
         let metadata = PaymentIntent.initMetadata(orderID: 1234)
         let orderID = try XCTUnwrap(metadata["order_id"])
-        XCTAssertEqual(orderID as? Int64, 1234)
+        XCTAssertEqual(orderID, "1234")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -93,7 +93,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_non_nil_order_key() throws {
         let metadata = PaymentIntent.initMetadata(orderKey: "wc_order_0000000000000")
         let orderKey = try XCTUnwrap(metadata["order_key"])
-        XCTAssertEqual(orderKey as? String, "wc_order_0000000000000")
+        XCTAssertEqual(orderKey, "wc_order_0000000000000")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -108,7 +108,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_single_payment_type() throws {
         let metadata = PaymentIntent.initMetadata(paymentType: PaymentIntent.PaymentTypes.single)
         let paymentType = try XCTUnwrap(metadata["payment_type"])
-        XCTAssertEqual(paymentType as? String, "single")
+        XCTAssertEqual(paymentType, "single")
         XCTAssertEqual(metadata.count, 1)
     }
 
@@ -118,7 +118,7 @@ final class PaymentIntentMetadataTests: XCTestCase {
     func test_recurring_payment_type() throws {
         let metadata = PaymentIntent.initMetadata(paymentType: PaymentIntent.PaymentTypes.recurring)
         let paymentType = try XCTUnwrap(metadata["payment_type"])
-        XCTAssertEqual(paymentType as? String, "recurring")
+        XCTAssertEqual(paymentType, "recurring")
         XCTAssertEqual(metadata.count, 1)
     }
 }

--- a/Hardware/SampleReceiptPrinter/SampleContent.swift
+++ b/Hardware/SampleReceiptPrinter/SampleContent.swift
@@ -40,7 +40,8 @@ extension CardPresentReceiptParameters {
                     transactionStatusInformation: "6800",
                     accountType: "credit"
                 ),
-                emvAuthData: "AD*******")
+                emvAuthData: "AD*******"),
+            orderID: 9201
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -13,7 +13,7 @@ public extension PaymentIntent {
         return CardPresentReceiptParameters(amount: amount,
                                             currency: currency,
                                             date: created,
-                                            storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store] as? String,
+                                            storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store],
                                             cardDetails: cardDetails)
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
+++ b/Yosemite/Yosemite/Model/Payments/PaymentIntent+ReceiptParameters.swift
@@ -10,10 +10,14 @@ public extension PaymentIntent {
             return nil
         }
 
+        let orderID = metadata?[CardPresentReceiptParameters.MetadataKeys.orderID]
+            .flatMap { Int64($0) }
+
         return CardPresentReceiptParameters(amount: amount,
                                             currency: currency,
                                             date: created,
                                             storeName: metadata?[CardPresentReceiptParameters.MetadataKeys.store],
-                                            cardDetails: cardDetails)
+                                            cardDetails: cardDetails,
+                                            orderID: orderID)
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockPaymentIntent.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockPaymentIntent.swift
@@ -7,7 +7,7 @@ struct MockPaymentIntent {
                       created: Date(),
                       amount: 100,
                       currency: "usd",
-                      metadata: nil,
+                      metadata: mockMetadata(),
                       charges: mockCharges())
     }
 }
@@ -51,5 +51,15 @@ private extension MockPaymentIntent {
                        terminalVerificationResults: "verification_result",
                        transactionStatusInformation: "transaction_status_info",
                        accountType: "account_type")
+    }
+
+    static func mockMetadata() -> [String: String] {
+        PaymentIntent.initMetadata(store: "Store Name",
+                                   customerName: "Customer Name",
+                                   customerEmail: "customer@example.com",
+                                   siteURL: "https://store.example.com",
+                                   orderID: 1920,
+                                   orderKey: "wc_order_0000000000000",
+                                   paymentType: .single)
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -5,10 +5,10 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
     func test_receipt_parameters_is_generated_from_valid_intent() {
         let intent = MockPaymentIntent.mock()
 
-        let receiptParametes = intent.receiptParameters()
+        let receiptParameters = intent.receiptParameters()
 
-        XCTAssertEqual(receiptParametes?.amount, intent.amount)
-        XCTAssertEqual(receiptParametes?.currency, intent.currency)
+        XCTAssertEqual(receiptParameters?.amount, intent.amount)
+        XCTAssertEqual(receiptParameters?.currency, intent.currency)
 
         guard let paymentMethod = intent.charges.first?.paymentMethod,
               case .presentCard(details: let cardDetails) = paymentMethod else {
@@ -16,6 +16,6 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(receiptParametes?.cardDetails, cardDetails)
+        XCTAssertEqual(receiptParameters?.cardDetails, cardDetails)
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -18,4 +18,16 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
 
         XCTAssertEqual(receiptParameters?.cardDetails, cardDetails)
     }
+
+    func test_receipt_parameters_includes_store_from_intent_metadata() {
+        let intent = MockPaymentIntent.mock()
+
+        XCTAssertEqual(intent.receiptParameters()?.storeName, "Store Name")
+    }
+
+    func test_receipt_parameters_includes_orderID_from_intent_metadata() {
+        let intent = MockPaymentIntent.mock()
+
+        XCTAssertEqual(intent.receiptParameters()?.orderID, 1920)
+    }
 }


### PR DESCRIPTION
Resolves #4264 

## Description
Receipts did not include any way to link them back to an order, and this was identified as a useful improvement to make to them. This change adds them to the heading above the line details of the receipt.

## Testing
To test, an In Person Payment setup is required. See PdfdoF-D-p2 for info.

1. Go to the Orders tab
2. Open an unpaid "Pay on Delivery" order
3. Take card payment
4. Tap "Print Receipt"
5. Observe that the order details section now has a heading `SUMMARY: ORDER #85`




https://user-images.githubusercontent.com/2472348/135122505-c2ba123c-0163-4217-920d-fe3f5ea01292.mp4

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
