### PR TITLE
Order Editing: Add "Discard Changes" warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -84,11 +84,13 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 ///
 extension EditAddressHostingController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-
+        !rootView.viewModel.hasPendingChanges()
     }
 
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        // track dimiss gesture
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self) { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -33,10 +33,18 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
         }
 
         // Set up notices
-        bindNoticeIntent(of: viewModel)
+        bindNoticeIntent()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
         // Set presentation delegate to track the user dismiss flow event
-        presentationController?.delegate = self
+        if let navigationController = navigationController {
+            navigationController.presentationController?.delegate = self
+        } else {
+            presentationController?.delegate = self
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -45,8 +53,8 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
     /// Observe the present notice intent and set it back after presented.
     ///
-    private func bindNoticeIntent(of viewModel: EditAddressFormViewModel) {
-        viewModel.$presentNotice
+    private func bindNoticeIntent() {
+        rootView.viewModel.$presentNotice
             .compactMap { $0 }
             .sink { [weak self] notice in
 
@@ -66,7 +74,7 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
                 }
 
                 // Nullify the presentation intent.
-                viewModel.presentNotice = nil
+                self?.rootView.viewModel.presentNotice = nil
             }
             .store(in: &subscriptions)
     }
@@ -75,6 +83,10 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 /// Intercepts to the dismiss drag gesture.
 ///
 extension EditAddressHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+
+    }
+
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         // track dimiss gesture
     }
@@ -88,7 +100,7 @@ struct EditAddressForm: View {
     ///
     var dismiss: (() -> Void) = {}
 
-    @ObservedObject private var viewModel: EditAddressFormViewModel
+    @ObservedObject private(set) var viewModel: EditAddressFormViewModel
 
     /// Set it to `true` to present the country selector.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -178,6 +178,12 @@ final class EditAddressFormViewModel: ObservableObject {
         performingNetworkRequest.send(true)
         stores.dispatch(action)
     }
+
+    /// Returns `true` if there are changes pending to commit. `False` otherwise.
+    ///
+    func hasPendingChanges() -> Bool {
+        return navigationTrailingItem == .done(enabled: true)
+    }
 }
 
 extension EditAddressFormViewModel {


### PR DESCRIPTION
closes #4785

# Why 

As the order address editing flow is almost complete™️, this PR adds a "Discard Changes" confirmation sheet when the user tries to dismiss the flow via a drag gesture while there are changes to commit.

# How

- Update View Model to expose a `hasPendingChanges()` function that checks if the `done` button is enabled.

- Update Hosting Controller to assign the correct presentation delegate (because the navigation is the presentation controller owner) and to show the discard changes when needed.
 
# Demo

https://user-images.githubusercontent.com/562080/135162257-e01ec53e-e0e1-4423-b09b-de08109ea664.mov

# Testing Steps

- Go to edit the shipping or the billing address of an order
- Make any change
- Try to dismiss the view via de drag gesture
- See the discard changes sheet.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
