### PR TITLE
Shipping Labels: Update package details description for multi-package

### DIFF
--- a/WooCommerce/Classes/Tools/WeightFormatter.swift
+++ b/WooCommerce/Classes/Tools/WeightFormatter.swift
@@ -31,6 +31,15 @@ final class WeightFormatter {
         }
         return formatWithFormatter(weight: weightValue, unit: unit)
     }
+
+    /// Returns the formatted weight with the unit.
+    ///
+    func formatWeight(weight: Double) -> String {
+        guard let unit = unit(symbol: weightUnit) else {
+            return fallbackFormatWeight(weight: String(weight))
+        }
+        return formatWithFormatter(weight: weight, unit: unit)
+    }
 }
 
 private extension WeightFormatter {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -293,7 +293,9 @@ final class ShippingLabelFormViewModel {
 
         if selectedPackagesDetails.count == 1,
            let selectedPackage = selectedPackagesDetails.first {
-            packageDescription = searchCustomPackage(id: selectedPackage.packageID)?.title ?? searchPredefinedPackage(id: selectedPackage.packageID)?.title ?? ""
+            let customPackageTitle = searchCustomPackage(id: selectedPackage.packageID)?.title
+            let predefinedPackageTitle = searchPredefinedPackage(id: selectedPackage.packageID)?.title
+            packageDescription = customPackageTitle ?? predefinedPackageTitle ?? ""
         } else {
             let itemCount = selectedPackagesDetails
                 .map { package -> Decimal in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -289,11 +289,11 @@ final class ShippingLabelFormViewModel {
             return Localization.packageDetailsPlaceholder
         }
 
-        let packageTitle: String
+        let packageDescription: String
 
         if selectedPackagesDetails.count == 1,
            let selectedPackage = selectedPackagesDetails.first {
-            packageTitle = searchCustomPackage(id: selectedPackage.packageID)?.title ?? searchPredefinedPackage(id: selectedPackage.packageID)?.title ?? ""
+            packageDescription = searchCustomPackage(id: selectedPackage.packageID)?.title ?? searchPredefinedPackage(id: selectedPackage.packageID)?.title ?? ""
         } else {
             let itemCount = selectedPackagesDetails
                 .map { package -> Decimal in
@@ -301,7 +301,7 @@ final class ShippingLabelFormViewModel {
                 }
                 .reduce(0, { $0 + $1 })
                 .intValue
-            packageTitle = String(format: Localization.packageItemCount, itemCount, selectedPackagesDetails.count)
+            packageDescription = String(format: Localization.packageItemCount, itemCount, selectedPackagesDetails.count)
         }
 
         let formatter = WeightFormatter(weightUnit: packagesResponse?.storeOptions.weightUnit ?? "")
@@ -310,7 +310,7 @@ final class ShippingLabelFormViewModel {
             .reduce(0, { $0 + $1 })
         let packageWeight = formatter.formatWeight(weight: totalWeight)
 
-        return packageTitle + "\n" + String.localizedStringWithFormat(Localization.totalPackageWeight, packageWeight)
+        return packageDescription + "\n" + String.localizedStringWithFormat(Localization.totalPackageWeight, packageWeight)
     }
 
     /// Returns the body of the selected Carrier and Rates.


### PR DESCRIPTION
Part of #4599

# Description
This PR updates the details displayed on the Package Details row of the Shipping Label form for the multi-package case.

# Changes
- Adds new method for `WeightFormatter` to accept double as the weight type for formatting.
- Updates `ShippingLabelFormViewModel` to display appropriate description of package depending on the number of packages selected.

# Demo
https://user-images.githubusercontent.com/5533851/135201991-8cbc8db8-0dba-4b5d-9c9c-0a581c95e018.mp4

# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Create an order with more than one item / or there should be an order item whose quantity is larger one.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Tap Done to proceed with every item in the same one package. Notice that the correct name and total weight of the package is then displayed on Package Details row.
5. Select Package Details again, this time move items to different packages. Tap Done, notice that the Package Details row now displays the correct number of items and packages as well as total weight.
6. Turn off multi-package feature flag and repeat step 4, make sure that everything still works properly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
