### PR TITLE
Move all screens to UITestsFoundation

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
@@ -7,7 +6,7 @@ private struct ElementStringIDs {
     static let continueButton = "Get Started Email Continue Button"
 }
 
-final class GetStartedScreen: BaseScreen {
+public final class GetStartedScreen: BaseScreen {
     private let navBar: XCUIElement
     private let emailTextField: XCUIElement
     private let continueButton: XCUIElement
@@ -21,7 +20,7 @@ final class GetStartedScreen: BaseScreen {
         super.init(element: emailTextField)
     }
 
-    func proceedWith(email: String) -> PasswordScreen {
+    public func proceedWith(email: String) -> PasswordScreen {
         emailTextField.tap()
         emailTextField.typeText(email)
         continueButton.tap()

--- a/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
@@ -7,7 +6,7 @@ private struct ElementStringIDs {
     static let continueButton = "login-epilogue-continue-button"
 }
 
-final class LoginEpilogueScreen: BaseScreen {
+public final class LoginEpilogueScreen: BaseScreen {
     private let continueButton: XCUIElement
     private let displayNameField: XCUIElement
     private let siteUrlField: XCUIElement
@@ -21,12 +20,12 @@ final class LoginEpilogueScreen: BaseScreen {
         super.init(element: continueButton)
     }
 
-    func continueWithSelectedSite() throws -> MyStoreScreen {
+    public func continueWithSelectedSite() throws -> MyStoreScreen {
         continueButton.tap()
         return try MyStoreScreen()
     }
 
-    func verifyEpilogueDisplays(displayName expectedDisplayName: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
+    public func verifyEpilogueDisplays(displayName expectedDisplayName: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
         let actualDisplayName = displayNameField.label
         let actualSiteUrl = siteUrlField.label
 

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 import XCUITestHelpers
 

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
@@ -15,7 +14,7 @@ private struct ElementStringIDs {
     static let siteAddressTextField = "Site address"
 }
 
-final class LoginSiteAddressScreen: BaseScreen {
+public final class LoginSiteAddressScreen: BaseScreen {
     private let navBar: XCUIElement
     private let siteAddressTextField: XCUIElement
     private let nextButton: XCUIElement
@@ -29,7 +28,7 @@ final class LoginSiteAddressScreen: BaseScreen {
         super.init(element: siteAddressTextField)
     }
 
-    func proceedWith(siteUrl: String) -> GetStartedScreen {
+    public func proceedWith(siteUrl: String) -> GetStartedScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
         nextButton.tap()

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
@@ -8,7 +7,7 @@ private struct ElementStringIDs {
     static let errorLabel = "Password Error"
 }
 
-final class PasswordScreen: BaseScreen {
+public final class PasswordScreen: BaseScreen {
     private let navBar: XCUIElement
     private let passwordTextField: XCUIElement
     private let continueButton: XCUIElement
@@ -22,13 +21,13 @@ final class PasswordScreen: BaseScreen {
         super.init(element: passwordTextField)
     }
 
-    func proceedWith(password: String) -> LoginEpilogueScreen {
+    public func proceedWith(password: String) -> LoginEpilogueScreen {
         _ = tryProceed(password: password)
 
         return LoginEpilogueScreen()
     }
 
-    func tryProceed(password: String) -> PasswordScreen {
+    public func tryProceed(password: String) -> PasswordScreen {
         passwordTextField.tap()
         passwordTextField.typeText(password)
         continueButton.tap()
@@ -38,7 +37,7 @@ final class PasswordScreen: BaseScreen {
         return self
     }
 
-    func verifyLoginError() -> PasswordScreen {
+    public func verifyLoginError() -> PasswordScreen {
         let errorLabel = app.cells[ElementStringIDs.errorLabel]
         _ = errorLabel.waitForExistence(timeout: 2)
 

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -6,25 +6,25 @@ private struct ElementStringIDs {
     static let siteAddressButton = "Prologue Self Hosted Button"
 }
 
-final class PrologueScreen: ScreenObject {
+public final class PrologueScreen: ScreenObject {
 
     private var continueButton: XCUIElement { expectedElement }
     private var siteAddressButton: XCUIElement { app.buttons[ElementStringIDs.siteAddressButton] }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetter: { $0.buttons[ElementStringIDs.continueButton] },
             app: app
         )
     }
 
-    func selectContinueWithWordPress() -> GetStartedScreen {
+    public func selectContinueWithWordPress() -> GetStartedScreen {
         continueButton.tap()
 
         return GetStartedScreen()
     }
 
-    func selectSiteAddress() -> LoginSiteAddressScreen {
+    public func selectSiteAddress() -> LoginSiteAddressScreen {
         siteAddressButton.tap()
 
         return LoginSiteAddressScreen()

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -1,11 +1,10 @@
-import UITestsFoundation
 import ScreenObject
 import XCTest
 
-final class MyStoreScreen: ScreenObject {
+public final class MyStoreScreen: ScreenObject {
 
-    let tabBar = TabNavComponent()
-    let periodStatsTable = PeriodStatsTable()
+    public let tabBar = TabNavComponent()
+    public let periodStatsTable = PeriodStatsTable()
 
     private let settingsButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["dashboard-settings-button"]
@@ -18,7 +17,7 @@ final class MyStoreScreen: ScreenObject {
         return screen.settingsButton.isHittable
     }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [settingsButtonGetter],
             app: app
@@ -26,7 +25,7 @@ final class MyStoreScreen: ScreenObject {
     }
 
     @discardableResult
-    func dismissTopBannerIfNeeded() -> MyStoreScreen {
+    public func dismissTopBannerIfNeeded() -> MyStoreScreen {
         let topBannerCloseButton = app.buttons["top-banner-view-dismiss-button"]
         guard topBannerCloseButton.waitForExistence(timeout: 3) else { return self }
 
@@ -35,7 +34,7 @@ final class MyStoreScreen: ScreenObject {
     }
 
     @discardableResult
-    func openSettingsPane() -> SettingsScreen {
+    public func openSettingsPane() -> SettingsScreen {
         settingsButton.tap()
         return SettingsScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class PeriodStatsTable: BaseScreen {
+public final class PeriodStatsTable: BaseScreen {
 
     struct ElementStringIDs {
         static let daysTab = "period-data-today-tab"
@@ -39,7 +38,7 @@ final class PeriodStatsTable: BaseScreen {
        }
 
     @discardableResult
-    func switchToYearsTab() -> Self {
+    public func switchToYearsTab() -> Self {
         yearsTab.tap()
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class OrderSearchScreen: BaseScreen {
+public final class OrderSearchScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let searchField = "order-search-screen-search-field"
@@ -26,7 +25,7 @@ final class OrderSearchScreen: BaseScreen {
     }
 
     @discardableResult
-    func cancel() -> OrdersScreen {
+    public func cancel() -> OrdersScreen {
         cancelButton.tap()
         return OrdersScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -1,14 +1,13 @@
-import UITestsFoundation
 import XCTest
 
-final class OrdersScreen: BaseScreen {
+public final class OrdersScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let searchButton = "order-search-button"
         static let filterButton = "order-filter-button"
     }
 
-    let tabBar = TabNavComponent()
+    public let tabBar = TabNavComponent()
     private let searchButton: XCUIElement
     private let filterButton: XCUIElement
 
@@ -25,13 +24,13 @@ final class OrdersScreen: BaseScreen {
     }
 
     @discardableResult
-    func selectOrder(atIndex index: Int) -> SingleOrderScreen {
+    public func selectOrder(atIndex index: Int) -> SingleOrderScreen {
         XCUIApplication().tables.cells.element(boundBy: index).tap()
         return SingleOrderScreen()
     }
 
     @discardableResult
-    func openSearchPane() -> OrderSearchScreen {
+    public func openSearchPane() -> OrderSearchScreen {
         searchButton.tap()
         return OrderSearchScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class SingleOrderScreen: BaseScreen {
+public final class SingleOrderScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let summaryTitleLabel = "summary-table-view-cell-title-label"
@@ -21,7 +20,7 @@ final class SingleOrderScreen: BaseScreen {
     }
 
     @discardableResult
-    func goBackToOrdersScreen() -> OrdersScreen {
+    public func goBackToOrdersScreen() -> OrdersScreen {
         pop()
         return OrdersScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-class ProductsScreen: BaseScreen {
+public class ProductsScreen: BaseScreen {
 
        struct ElementStringIDs {
         static let searchButton = "product-search-button"
@@ -24,7 +23,7 @@ class ProductsScreen: BaseScreen {
     }
 
     @discardableResult
-    func collapseTopBannerIfNeeded() -> Self {
+    public func collapseTopBannerIfNeeded() -> Self {
 
         /// Without the info label, we don't need to collapse the top banner
         guard topBannerInfoLabel.waitForExistence(timeout: 3) else {
@@ -41,7 +40,7 @@ class ProductsScreen: BaseScreen {
     }
 
     @discardableResult
-    func selectProduct(atIndex index: Int) -> SingleProductScreen {
+    public func selectProduct(atIndex index: Int) -> SingleProductScreen {
         XCUIApplication().tables.cells.element(boundBy: index).tap()
         return SingleProductScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-class SingleProductScreen: BaseScreen {
+public class SingleProductScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let editProductMenuButton = "edit-product-more-options-button"

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -1,13 +1,12 @@
-import UITestsFoundation
 import XCTest
 
-final class ReviewsScreen: BaseScreen {
+public final class ReviewsScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let markAllAsReadButton = "reviews-mark-all-as-read-button"
     }
 
-    let tabBar = TabNavComponent()
+    public let tabBar = TabNavComponent()
     private let markAllAsReadButton: XCUIElement
 
     static var isVisible: Bool {
@@ -21,7 +20,7 @@ final class ReviewsScreen: BaseScreen {
     }
 
     @discardableResult
-    func selectReview(atIndex index: Int) -> SingleReviewScreen {
+    public func selectReview(atIndex index: Int) -> SingleReviewScreen {
         XCUIApplication().tables.cells.element(boundBy: index).tap()
         return SingleReviewScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class SingleReviewScreen: BaseScreen {
+public final class SingleReviewScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let spamButton = "single-review-spam-button"
@@ -28,7 +27,7 @@ final class SingleReviewScreen: BaseScreen {
     }
 
     @discardableResult
-    func goBackToReviewsScreen() -> ReviewsScreen {
+    public func goBackToReviewsScreen() -> ReviewsScreen {
         pop()
         return ReviewsScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -1,4 +1,3 @@
-import UITestsFoundation
 import XCTest
 
 class BetaFeaturesScreen: BaseScreen {

--- a/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class SettingsScreen: BaseScreen {
+public final class SettingsScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let headlineLabel = "headline-label"
@@ -27,7 +26,7 @@ final class SettingsScreen: BaseScreen {
     }
 
     @discardableResult
-    func logOut() throws -> PrologueScreen {
+    public func logOut() throws -> PrologueScreen {
         logOutButton.tap()
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
@@ -46,7 +45,7 @@ final class SettingsScreen: BaseScreen {
 /// Assertions
 extension SettingsScreen {
 
-    func verifySelectedStoreDisplays(storeName expectedStoreName: String, siteUrl expectedSiteUrl: String) -> SettingsScreen {
+    public func verifySelectedStoreDisplays(storeName expectedStoreName: String, siteUrl expectedSiteUrl: String) -> SettingsScreen {
         let actualStoreName = selectedStoreName.label
         let expectedSiteUrl = expectedSiteUrl.replacingOccurrences(of: "http://", with: "")
         let actualSiteUrl = selectedSiteUrl.label

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -1,7 +1,6 @@
-import UITestsFoundation
 import XCTest
 
-final class TabNavComponent: BaseScreen {
+public final class TabNavComponent: BaseScreen {
 
     struct ElementStringIDs {
         static let myStoreTabBarItem = "tab-bar-my-store-item"
@@ -40,7 +39,7 @@ final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    func gotoOrdersScreen() -> OrdersScreen {
+    public func gotoOrdersScreen() -> OrdersScreen {
         // Avoid transitioning if it is already on screen
         if !OrdersScreen.isVisible {
             ordersTabButton.tap()
@@ -50,7 +49,7 @@ final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    func gotoProductsScreen() -> ProductsScreen {
+    public func gotoProductsScreen() -> ProductsScreen {
         if !ProductsScreen.isVisible {
             productsTabButton.tap()
         }
@@ -59,7 +58,7 @@ final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    func gotoReviewsScreen() -> ReviewsScreen {
+    public func gotoReviewsScreen() -> ReviewsScreen {
         if !ReviewsScreen.isVisible {
             reviewsTabButton.tap()
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -374,9 +374,6 @@
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
 		24C5AC7625A53021008FD769 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
-		24C5ACBA25A530A4008FD769 /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
-		24C5ACBF25A530B7008FD769 /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
-		24C5ACC425A530D6008FD769 /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
@@ -524,6 +521,28 @@
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
 		3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */; };
+		3F0CF2FF2704490A00EF3D71 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
+		3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */; };
+		3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173E23DBFFEF00592D8E /* ReviewsScreen.swift */; };
+		3F0CF3022704490A00EF3D71 /* LinkOrPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171D23DBCD6000592D8E /* LinkOrPasswordScreen.swift */; };
+		3F0CF3032704490A00EF3D71 /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
+		3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174823DC0A7800592D8E /* PeriodStatsTable.swift */; };
+		3F0CF3052704490A00EF3D71 /* LoginEpilogueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171C23DBCD6000592D8E /* LoginEpilogueScreen.swift */; };
+		3F0CF3062704490A00EF3D71 /* SingleReviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174123DC006F00592D8E /* SingleReviewScreen.swift */; };
+		3F0CF3072704490A00EF3D71 /* LoginEmailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171B23DBCD6000592D8E /* LoginEmailScreen.swift */; };
+		3F0CF3082704490A00EF3D71 /* LoginUsernamePasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171923DBCD6000592D8E /* LoginUsernamePasswordScreen.swift */; };
+		3F0CF3092704490A00EF3D71 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
+		3F0CF30A2704490A00EF3D71 /* OrdersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173423DBEB1900592D8E /* OrdersScreen.swift */; };
+		3F0CF30B2704490A00EF3D71 /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
+		3F0CF30C2704490A00EF3D71 /* LoginPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171A23DBCD6000592D8E /* LoginPasswordScreen.swift */; };
+		3F0CF30D2704490A00EF3D71 /* LoginSiteAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */; };
+		3F0CF30E2704490A00EF3D71 /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
+		3F0CF30F2704490A00EF3D71 /* SingleProductScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5824087FE10057FF21 /* SingleProductScreen.swift */; };
+		3F0CF3102704490A00EF3D71 /* SingleOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173623DBF02400592D8E /* SingleOrderScreen.swift */; };
+		3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5724087FE10057FF21 /* ProductsScreen.swift */; };
+		3F0CF3122704490A00EF3D71 /* LoginCheckMagicLinkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171F23DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift */; };
+		3F0CF3132704490A00EF3D71 /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
+		3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		3F1CA81D26C3542600228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81C26C3542600228BF2 /* XCUITestHelpers */; };
 		3F1CA81F26C3543C00228BF2 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F1CA81E26C3543C00228BF2 /* XCUITestHelpers */; };
 		3FF2247326706AA3008FFA87 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF2247226706AA3008FFA87 /* ScreenObject */; };
@@ -1004,21 +1023,6 @@
 		CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51926D67BB50010E679 /* ShippingLabelServicePackageList.swift */; };
 		CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F51B26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
-		CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
-		CCDC49DB2400011F003166BA /* OrdersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173423DBEB1900592D8E /* OrdersScreen.swift */; };
-		CCDC49DC2400011F003166BA /* SingleOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173623DBF02400592D8E /* SingleOrderScreen.swift */; };
-		CCDC49DD2400011F003166BA /* OrderSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */; };
-		CCDC49DE2400011F003166BA /* ReviewsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173E23DBFFEF00592D8E /* ReviewsScreen.swift */; };
-		CCDC49DF2400011F003166BA /* SingleReviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174123DC006F00592D8E /* SingleReviewScreen.swift */; };
-		CCDC49E02400011F003166BA /* LinkOrPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171D23DBCD6000592D8E /* LinkOrPasswordScreen.swift */; };
-		CCDC49E12400011F003166BA /* LoginCheckMagicLinkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171F23DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift */; };
-		CCDC49E22400011F003166BA /* LoginEmailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171B23DBCD6000592D8E /* LoginEmailScreen.swift */; };
-		CCDC49E32400011F003166BA /* LoginEpilogueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171C23DBCD6000592D8E /* LoginEpilogueScreen.swift */; };
-		CCDC49E42400011F003166BA /* LoginPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171A23DBCD6000592D8E /* LoginPasswordScreen.swift */; };
-		CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */; };
-		CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171923DBCD6000592D8E /* LoginUsernamePasswordScreen.swift */; };
-		CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174823DC0A7800592D8E /* PeriodStatsTable.swift */; };
-		CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
@@ -1277,9 +1281,6 @@
 		D8EE9698264D3CCB0033B2F9 /* ReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */; };
 		D8EF1E562605121C00380EA4 /* OrderPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EF1E552605121C00380EA4 /* OrderPaymentMethod.swift */; };
 		D8F01DD325DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DD225DEDC1C00CE70BE /* StripeCardReaderIntegrationTests.swift */; };
-		D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A972258862BE0085859B /* PrologueScreen.swift */; };
-		D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A9782588659E0085859B /* GetStartedScreen.swift */; };
-		D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F3A97E258865BD0085859B /* PasswordScreen.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
@@ -1360,32 +1361,9 @@
 		E1D4E84526776AD900256B83 /* HeadlineTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1D4E84226776A6A00256B83 /* HeadlineTableViewCell.xib */; };
 		E1ED16E4266E10A10037B8DB /* ApplicationLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */; };
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
-		F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
-		F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5124087FDA0057FF21 /* BetaFeaturesScreen.swift */; };
-		F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
-		F93E8E5624087FDA0057FF21 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5224087FDA0057FF21 /* SettingsScreen.swift */; };
-		F93E8E5924087FE10057FF21 /* ProductsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5724087FE10057FF21 /* ProductsScreen.swift */; };
-		F93E8E5A24087FE10057FF21 /* ProductsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5724087FE10057FF21 /* ProductsScreen.swift */; };
-		F93E8E5B24087FE10057FF21 /* SingleProductScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5824087FE10057FF21 /* SingleProductScreen.swift */; };
-		F93E8E5C24087FE10057FF21 /* SingleProductScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E8E5824087FE10057FF21 /* SingleProductScreen.swift */; };
 		F997170523DBB97500592D8E /* WooCommerceScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997170423DBB97500592D8E /* WooCommerceScreenshots.swift */; };
-		F997172223DBCD6100592D8E /* LoginUsernamePasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171923DBCD6000592D8E /* LoginUsernamePasswordScreen.swift */; };
-		F997172323DBCD6100592D8E /* LoginPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171A23DBCD6000592D8E /* LoginPasswordScreen.swift */; };
-		F997172423DBCD6100592D8E /* LoginEmailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171B23DBCD6000592D8E /* LoginEmailScreen.swift */; };
-		F997172523DBCD6100592D8E /* LoginEpilogueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171C23DBCD6000592D8E /* LoginEpilogueScreen.swift */; };
-		F997172623DBCD6100592D8E /* LinkOrPasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171D23DBCD6000592D8E /* LinkOrPasswordScreen.swift */; };
-		F997172823DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997171F23DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift */; };
-		F997172A23DBCD6100592D8E /* LoginSiteAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172123DBCD6100592D8E /* LoginSiteAddressScreen.swift */; };
-		F997172E23DBCDE900592D8E /* MyStoreScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172D23DBCDE900592D8E /* MyStoreScreen.swift */; };
-		F997173023DBCEB200592D8E /* TabNavComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172F23DBCEB200592D8E /* TabNavComponent.swift */; };
-		F997173523DBEB1900592D8E /* OrdersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173423DBEB1900592D8E /* OrdersScreen.swift */; };
-		F997173723DBF02400592D8E /* SingleOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173623DBF02400592D8E /* SingleOrderScreen.swift */; };
-		F997173D23DBFBBF00592D8E /* OrderSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */; };
-		F997173F23DBFFEF00592D8E /* ReviewsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173E23DBFFEF00592D8E /* ReviewsScreen.swift */; };
-		F997174223DC006F00592D8E /* SingleReviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174123DC006F00592D8E /* SingleReviewScreen.swift */; };
 		F997174523DC068500592D8E /* XLPagerStrip+AccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174323DC065900592D8E /* XLPagerStrip+AccessibilityIdentifier.swift */; };
 		F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174623DC070C00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift */; };
-		F997174923DC0A7800592D8E /* PeriodStatsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174823DC0A7800592D8E /* PeriodStatsTable.swift */; };
 		F997174B23DC10B300592D8E /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997174A23DC10B300592D8E /* SnapshotHelper.swift */; };
 		FE28F6F4268477C1004465C7 /* RoleEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */; };
 		FE28F7122684CA29004465C7 /* RoleErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F7102684CA29004465C7 /* RoleErrorViewController.swift */; };
@@ -4108,6 +4086,7 @@
 			children = (
 				F997172B23DBCD8E00592D8E /* BaseScreen.swift */,
 				3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */,
+				F997171723DBCD5100592D8E /* Screens */,
 				3FF314E026FC74450012E68E /* UITestsFoundation.h */,
 				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 			);
@@ -5515,7 +5494,6 @@
 				CCDC49F224006130003166BA /* UITests.xctestplan */,
 				CCDC49D9240000B7003166BA /* Tests */,
 				CCFC00B623E9BD5500157A78 /* Mocks */,
-				F997171723DBCD5100592D8E /* Screens */,
 				CCDC49D8240000A5003166BA /* Utils */,
 				CCDC49CE23FFFFF4003166BA /* Info.plist */,
 			);
@@ -7241,9 +7219,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F0CF3032704490A00EF3D71 /* GetStartedScreen.swift in Sources */,
+				3F0CF30B2704490A00EF3D71 /* MyStoreScreen.swift in Sources */,
+				3F0CF3082704490A00EF3D71 /* LoginUsernamePasswordScreen.swift in Sources */,
+				3F0CF3122704490A00EF3D71 /* LoginCheckMagicLinkScreen.swift in Sources */,
+				3F0CF30F2704490A00EF3D71 /* SingleProductScreen.swift in Sources */,
+				3F0CF30C2704490A00EF3D71 /* LoginPasswordScreen.swift in Sources */,
+				3F0CF30E2704490A00EF3D71 /* PasswordScreen.swift in Sources */,
+				3F0CF3092704490A00EF3D71 /* BetaFeaturesScreen.swift in Sources */,
+				3F0CF3022704490A00EF3D71 /* LinkOrPasswordScreen.swift in Sources */,
+				3F0CF2FF2704490A00EF3D71 /* SettingsScreen.swift in Sources */,
+				3F0CF3052704490A00EF3D71 /* LoginEpilogueScreen.swift in Sources */,
 				3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */,
+				3F0CF3042704490A00EF3D71 /* PeriodStatsTable.swift in Sources */,
+				3F0CF3142704494A00EF3D71 /* TabNavComponent.swift in Sources */,
+				3F0CF3072704490A00EF3D71 /* LoginEmailScreen.swift in Sources */,
+				3F0CF30D2704490A00EF3D71 /* LoginSiteAddressScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
+				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
+				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,
+				3F0CF30A2704490A00EF3D71 /* OrdersScreen.swift in Sources */,
+				3F0CF3132704490A00EF3D71 /* PrologueScreen.swift in Sources */,
+				3F0CF3102704490A00EF3D71 /* SingleOrderScreen.swift in Sources */,
+				3F0CF3062704490A00EF3D71 /* SingleReviewScreen.swift in Sources */,
+				3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8352,30 +8352,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */,
-				CCDC49DB2400011F003166BA /* OrdersScreen.swift in Sources */,
-				F93E8E5C24087FE10057FF21 /* SingleProductScreen.swift in Sources */,
-				F93E8E5A24087FE10057FF21 /* ProductsScreen.swift in Sources */,
-				CCDC49DC2400011F003166BA /* SingleOrderScreen.swift in Sources */,
-				F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */,
-				F93E8E5624087FDA0057FF21 /* SettingsScreen.swift in Sources */,
-				CCDC49DD2400011F003166BA /* OrderSearchScreen.swift in Sources */,
-				CCDC49DE2400011F003166BA /* ReviewsScreen.swift in Sources */,
-				CCDC49DF2400011F003166BA /* SingleReviewScreen.swift in Sources */,
-				CCDC49E02400011F003166BA /* LinkOrPasswordScreen.swift in Sources */,
-				CCDC49E12400011F003166BA /* LoginCheckMagicLinkScreen.swift in Sources */,
-				CCDC49E22400011F003166BA /* LoginEmailScreen.swift in Sources */,
-				CCDC49E32400011F003166BA /* LoginEpilogueScreen.swift in Sources */,
-				CCDC49E42400011F003166BA /* LoginPasswordScreen.swift in Sources */,
-				D8F3A97F258865BD0085859B /* PasswordScreen.swift in Sources */,
-				CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */,
-				CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */,
-				D8F3A9792588659E0085859B /* GetStartedScreen.swift in Sources */,
-				CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */,
-				CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */,
 				CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */,
 				CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */,
-				D8F3A973258862BE0085859B /* PrologueScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8383,31 +8361,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F997173723DBF02400592D8E /* SingleOrderScreen.swift in Sources */,
-				F997172623DBCD6100592D8E /* LinkOrPasswordScreen.swift in Sources */,
 				F997174B23DC10B300592D8E /* SnapshotHelper.swift in Sources */,
-				F93E8E5524087FDA0057FF21 /* SettingsScreen.swift in Sources */,
-				24C5ACC425A530D6008FD769 /* PrologueScreen.swift in Sources */,
-				F997172323DBCD6100592D8E /* LoginPasswordScreen.swift in Sources */,
-				F997173F23DBFFEF00592D8E /* ReviewsScreen.swift in Sources */,
-				F997172223DBCD6100592D8E /* LoginUsernamePasswordScreen.swift in Sources */,
-				F997172823DBCD6100592D8E /* LoginCheckMagicLinkScreen.swift in Sources */,
-				24C5ACBA25A530A4008FD769 /* GetStartedScreen.swift in Sources */,
 				CCFC00B523E9BD1500157A78 /* ScreenshotCredentials.swift in Sources */,
-				F997173023DBCEB200592D8E /* TabNavComponent.swift in Sources */,
-				F93E8E5B24087FE10057FF21 /* SingleProductScreen.swift in Sources */,
 				F997170523DBB97500592D8E /* WooCommerceScreenshots.swift in Sources */,
-				F93E8E5924087FE10057FF21 /* ProductsScreen.swift in Sources */,
-				F93E8E5324087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */,
-				F997174923DC0A7800592D8E /* PeriodStatsTable.swift in Sources */,
-				F997172E23DBCDE900592D8E /* MyStoreScreen.swift in Sources */,
-				F997172423DBCD6100592D8E /* LoginEmailScreen.swift in Sources */,
-				F997172A23DBCD6100592D8E /* LoginSiteAddressScreen.swift in Sources */,
-				F997173523DBEB1900592D8E /* OrdersScreen.swift in Sources */,
-				F997172523DBCD6100592D8E /* LoginEpilogueScreen.swift in Sources */,
-				F997174223DC006F00592D8E /* SingleReviewScreen.swift in Sources */,
-				F997173D23DBFBBF00592D8E /* OrderSearchScreen.swift in Sources */,
-				24C5ACBF25A530B7008FD769 /* PasswordScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -1,3 +1,4 @@
+import UITestsFoundation
 import XCTest
 
 final class LoginTests: XCTestCase {


### PR DESCRIPTION
To make the review of the following work, in which I'll convert the `BaseScreen`s to be `ScreenObject` subclasses, I'm moving all of them in the UITestFoundation target in a decidated PR.

Notice that I've done the move in one "big bang" commit. In WordPress, I did it in multiple commits, moving isolated files first. The idea was to learn a bit about the structure of the test suite. Unfortunately, it turned out to bee a very tedious process that took way to long for what I got out of it. So in this instance I took a more pragmatic approach and did it all in one go. 😅 

As far as testing go, this PR doesn't change any code. You can see that CI runs the UI tests successfully, which is enough validation these changes don't break anything.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – **N.A.**

---

Also notice this is based on top of #5042, I'll wait for that one to merge first, but I'd still appreciate a review.