### PR TITLE
Shipping Labels: List of selected rates in purchase form to support multiple packages 

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
@@ -2,13 +2,13 @@ import Foundation
 import Yosemite
 
 struct ShippingLabelSelectedRate {
-    /// Rate for the selected carrier
+    /// Basic rate for the selected carrier without additional service.
     let rate: ShippingLabelCarrierRate
 
-    /// Rate for signature if any
+    /// Rate for signature if any.
     let signatureRate: ShippingLabelCarrierRate?
 
-    /// Rate for adult signature if any
+    /// Rate for adult signature if any.
     let adultSignatureRate: ShippingLabelCarrierRate?
 }
 

--- a/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Yosemite
+
+struct ShippingLabelSelectedRate {
+    /// Rate for the selected carrier
+    let rate: ShippingLabelCarrierRate
+
+    /// Rate for signature if any
+    let signatureRate: ShippingLabelCarrierRate?
+
+    /// Rate for adult signature if any
+    let adultSignatureRate: ShippingLabelCarrierRate?
+}
+
+extension ShippingLabelSelectedRate {
+    var retailRate: Double {
+        if let signatureRate = signatureRate {
+            return signatureRate.retailRate
+        } else if let adultSignatureRate = adultSignatureRate {
+            return adultSignatureRate.retailRate
+        }
+        return rate.retailRate
+    }
+
+    var discount: Double {
+        if let signatureRate = signatureRate {
+            return signatureRate.rate - signatureRate.retailRate
+        } else if let adultSignatureRate = adultSignatureRate {
+            return adultSignatureRate.rate - adultSignatureRate.retailRate
+        }
+        return rate.rate - rate.retailRate
+    }
+
+    var totalRate: Double {
+        if let signatureRate = signatureRate {
+            return signatureRate.rate
+        } else if let adultSignatureRate = adultSignatureRate {
+            return adultSignatureRate.rate
+        }
+        return rate.rate
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -487,9 +487,12 @@ private extension ShippingLabelFormViewController {
         let carriersView = ShippingLabelCarriers(viewModel: vm) { [weak self] (selectedRate,
                                                                                selectedSignatureRate,
                                                                                selectedAdultSignatureRate) in
-            self?.viewModel.handleCarrierAndRatesValueChanges(selectedRate: selectedRate,
-                                                              selectedSignatureRate: selectedSignatureRate,
-                                                              selectedAdultSignatureRate: selectedAdultSignatureRate,
+            // TODO-4716: Fix this workaround when the carriers screen returns an array of selected rates.
+            guard let selectedRate = selectedRate else {
+                return
+            }
+            let rate = ShippingLabelSelectedRate(rate: selectedRate, signatureRate: selectedSignatureRate, adultSignatureRate: selectedAdultSignatureRate)
+            self?.viewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                               editable: true)
         }
         let hostingVC = UIHostingController(rootView: carriersView)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -43,9 +43,23 @@ final class ShippingLabelFormViewModel {
 
     /// Carrier and Rates
     ///
-    private(set) var selectedRate: ShippingLabelCarrierRate?
-    private(set) var selectedSignatureRate: ShippingLabelCarrierRate?
-    private(set) var selectedAdultSignatureRate: ShippingLabelCarrierRate?
+    private(set) var selectedRates: [ShippingLabelSelectedRate] = []
+
+    // TODO-4716: Remove this when carriers & rates is updated for multi-package support
+    var selectedRate: ShippingLabelCarrierRate? {
+        selectedRates.first?.rate
+    }
+
+    // TODO-4716: Remove this when carriers & rates is updated for multi-package support
+    var selectedSignatureRate: ShippingLabelCarrierRate? {
+        selectedRates.first?.signatureRate
+    }
+
+    // TODO-4716: Remove this when carriers & rates is updated for multi-package support
+    var selectedAdultSignatureRate: ShippingLabelCarrierRate? {
+        selectedRates.first?.adultSignatureRate
+    }
+
     var selectedPackages: [ShippingLabelPackageSelected] {
         guard let packagesResponse = packagesResponse else {
             return []
@@ -183,7 +197,7 @@ final class ShippingLabelFormViewModel {
 
         // We reset the carrier and rates selected because if the address change
         // the carrier and rate change accordingly
-        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+        handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
 
         updateRowsForCustomsIfNeeded()
 
@@ -199,7 +213,7 @@ final class ShippingLabelFormViewModel {
 
         // We reset the carrier and rates selected because if the address change
         // the carrier and rate change accordingly
-        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+        handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
 
         updateRowsForCustomsIfNeeded()
 
@@ -225,7 +239,7 @@ final class ShippingLabelFormViewModel {
         // these change accordingly.
         let forms = createDefaultCustomsFormsIfNeeded()
         handleCustomsFormsValueChanges(customsForms: forms, isValidated: false)
-        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+        handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
     }
 
     func handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm], isValidated: Bool) {
@@ -236,18 +250,14 @@ final class ShippingLabelFormViewModel {
         updateRowState(type: .customs, dataState: .validated, displayMode: .editable)
         // We reset the carrier and rates selected because if the package change
         // the carrier and rate change accordingly
-        handleCarrierAndRatesValueChanges(selectedRate: nil, selectedSignatureRate: nil, selectedAdultSignatureRate: nil, editable: false)
+        handleCarrierAndRatesValueChanges(selectedRates: [], editable: false)
     }
 
-    func handleCarrierAndRatesValueChanges(selectedRate: ShippingLabelCarrierRate?,
-                                           selectedSignatureRate: ShippingLabelCarrierRate?,
-                                           selectedAdultSignatureRate: ShippingLabelCarrierRate?,
+    func handleCarrierAndRatesValueChanges(selectedRates: [ShippingLabelSelectedRate],
                                            editable: Bool) {
-        self.selectedRate = selectedRate
-        self.selectedSignatureRate = selectedSignatureRate
-        self.selectedAdultSignatureRate = selectedAdultSignatureRate
+        self.selectedRates = selectedRates
 
-        guard selectedRate != nil || selectedSignatureRate != nil || selectedAdultSignatureRate != nil else {
+        guard selectedRates.isNotEmpty else {
             updateRowState(type: .shippingCarrierAndRates, dataState: .pending, displayMode: editable ? .editable : .disabled)
             return
         }
@@ -302,29 +312,26 @@ final class ShippingLabelFormViewModel {
     /// Returns the body of the selected Carrier and Rates.
     ///
     func getCarrierAndRatesBody() -> String {
-        guard let selectedRate = selectedRate else {
+        guard selectedRates.isNotEmpty else {
             return Localization.carrierAndRatesPlaceholder
         }
 
-        var rate: Double = selectedRate.retailRate
-        if let selectedSignatureRate = selectedSignatureRate {
-            rate = selectedSignatureRate.retailRate
+        if selectedRates.count == 1, let selectedRate = selectedRates.first {
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            let price = currencyFormatter.formatAmount(Decimal(selectedRate.retailRate)) ?? ""
+
+            let formatString = selectedRate.rate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
+
+            var shippingDays = ""
+            if let deliveryDays = selectedRate.rate.deliveryDays {
+                shippingDays = " - " + String(format: formatString, deliveryDays)
+            }
+
+            return selectedRate.rate.title + "\n" + price + shippingDays
+        } else {
+            // TODO:
+            return ""
         }
-        else if let selectedAdultSignatureRate = selectedAdultSignatureRate {
-            rate = selectedAdultSignatureRate.retailRate
-        }
-
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let price = currencyFormatter.formatAmount(Decimal(rate)) ?? ""
-
-        let formatString = selectedRate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
-
-        var shippingDays = ""
-        if let deliveryDays = selectedRate.deliveryDays {
-            shippingDays = " - " + String(format: formatString, deliveryDays)
-        }
-
-        return selectedRate.title + "\n" + price + shippingDays
     }
 
     /// Returns the body of the Payment Methods cell.
@@ -343,18 +350,11 @@ final class ShippingLabelFormViewModel {
     /// Returns the subtotal under the Order Summary.
     ///
     func getSubtotal() -> String {
-        guard let selectedRate = selectedRate else {
+        guard selectedRates.isNotEmpty else {
             return ""
         }
 
-        var retailRate: Double = selectedRate.retailRate
-        if let selectedSignatureRate = selectedSignatureRate {
-            retailRate = selectedSignatureRate.retailRate
-        }
-        else if let selectedAdultSignatureRate = selectedAdultSignatureRate {
-            retailRate = selectedAdultSignatureRate.retailRate
-        }
-
+        let retailRate: Double = selectedRates.reduce(0, { $0 + $1.retailRate })
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let price = currencyFormatter.formatAmount(Decimal(retailRate)) ?? ""
 
@@ -364,24 +364,16 @@ final class ShippingLabelFormViewModel {
     /// Returns, if available, the discount under the Order Summary.
     ///
     func getDiscount() -> String? {
-        guard let selectedRate = selectedRate else {
+        guard selectedRates.isNotEmpty else {
             return nil
         }
-
-        var rate: Double = selectedRate.rate - selectedRate.retailRate
-        if let selectedSignatureRate = selectedSignatureRate {
-            rate = selectedSignatureRate.rate - selectedSignatureRate.retailRate
-        }
-        else if let selectedAdultSignatureRate = selectedAdultSignatureRate {
-            rate = selectedAdultSignatureRate.rate - selectedAdultSignatureRate.retailRate
-        }
-
-        guard rate != 0 else {
+        let discountValue = selectedRates.reduce(0, { $0 + $1.discount })
+        guard discountValue != 0 else {
             return nil
         }
 
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let discount = currencyFormatter.formatAmount(Decimal(rate)) ?? nil
+        let discount = currencyFormatter.formatAmount(Decimal(discountValue)) ?? nil
 
         return discount
     }
@@ -389,20 +381,13 @@ final class ShippingLabelFormViewModel {
     /// Returns the order total under the Order Summary.
     ///
     func getOrderTotal() -> String {
-        guard let selectedRate = selectedRate else {
+        guard selectedRates.isNotEmpty else {
             return ""
         }
 
-        var rate: Double = selectedRate.rate
-        if let selectedSignatureRate = selectedSignatureRate {
-            rate = selectedSignatureRate.rate
-        }
-        else if let selectedAdultSignatureRate = selectedAdultSignatureRate {
-            rate = selectedAdultSignatureRate.rate
-        }
-
+        let totalValue = selectedRates.reduce(0, { $0 + $1.totalRate })
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-        let price = currencyFormatter.formatAmount(Decimal(rate)) ?? ""
+        let price = currencyFormatter.formatAmount(Decimal(totalValue)) ?? ""
 
         return price
     }
@@ -758,19 +743,20 @@ extension ShippingLabelFormViewModel {
         guard let originAddress = originAddress,
               let destinationAddress = destinationAddress,
               selectedPackages.isNotEmpty,
-              let selectedRate = selectedRate,
+              selectedRates.isNotEmpty,
               let accountSettings = shippingLabelAccountSettings else {
             onCompletion(.failure(PurchaseError.labelDetailsMissing))
             return
         }
 
-        let packages = selectedPackages.compactMap { package -> ShippingLabelPackagePurchase? in
-            guard let packageInfo = selectedPackagesDetails.first(where: { $0.packageID == package.boxID }) else {
+        let packages = selectedPackages.enumerated().compactMap { (index, package) -> ShippingLabelPackagePurchase? in
+            guard let selectedRate = selectedRates[safe: index],
+                  let details = selectedPackagesDetails[safe: index] else {
                 return nil
             }
             return ShippingLabelPackagePurchase(package: package,
-                                                rate: selectedRate,
-                                                productIDs: packageInfo.items.map { $0.productOrVariationID },
+                                                rate: selectedRate.rate,
+                                                productIDs: details.items.map { $0.productOrVariationID },
                                                 customsForm: package.customsForm)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -329,8 +329,14 @@ final class ShippingLabelFormViewModel {
 
             return selectedRate.rate.title + "\n" + price + shippingDays
         } else {
-            // TODO:
-            return ""
+            let ratesCount = String(format: Localization.selectedRatesCount, selectedRates.count)
+
+            let total = selectedRates.reduce(0, { $0 + $1.retailRate })
+            let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+            let price = currencyFormatter.formatAmount(Decimal(total)) ?? ""
+            let totalRate = String(format: Localization.totalRate, price)
+
+            return ratesCount + "\n" + totalRate
         }
     }
 
@@ -803,6 +809,10 @@ private extension ShippingLabelFormViewModel {
                                                            comment: "Singular format of number of business day in Shipping Labels > Carrier and Rates")
         static let businessDaysPlural = NSLocalizedString("%1$d business days",
                                                           comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
+        static let selectedRatesCount = NSLocalizedString("%1$d rates selected",
+                                                          comment: "Number of rates selected in Shipping Labels > Carrier and Rates")
+        static let totalRate = NSLocalizedString("$1$@ total",
+                                                 comment: "Total value for the selected rates in Shipping Labels > Carrier and Rates")
         static let paymentMethodPlaceholder = NSLocalizedString("Add a new credit card",
                                                                 comment: "Placeholder in Shipping Label form for the Payment Method row.")
         static let paymentMethodLabel =

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1326,6 +1326,7 @@
 		DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */; };
 		DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */; };
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
+		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
@@ -2782,6 +2783,7 @@
 		DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageAttributes.swift; sourceTree = "<group>"; };
 		DEE6437526D87C4100888A75 /* PrintCustomsFormsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintCustomsFormsView.swift; sourceTree = "<group>"; };
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
+		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
@@ -5267,6 +5269,7 @@
 				E1C5E78326C2B8E8008D4C47 /* Site+Woo.swift */,
 				DEDB886A26E8531E00981595 /* ShippingLabelPackageAttributes.swift */,
 				DE77889926FD7EF0008DFF44 /* ShippingLabelPackageItem.swift */,
+				DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7492,6 +7495,7 @@
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
 				02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */,
 				02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */,
+				DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */,
 				CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -92,9 +92,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                            address2: "Street #343",
                                                            city: "San Francisco",
                                                            postcode: "94121-2303")
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: nil,
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(), signatureRate: nil, adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
@@ -146,9 +145,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                            address2: "Street #343",
                                                            city: "San Francisco",
                                                            postcode: "94121-2303")
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: nil,
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(), signatureRate: nil, adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
@@ -205,9 +203,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(), validated: true)
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: nil,
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(), signatureRate: nil, adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
@@ -237,9 +234,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0987654321", country: "VN"),
                                                                         validated: true)
         shippingLabelFormViewModel.handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm.fake()], isValidated: true)
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: nil,
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(), signatureRate: nil, adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
         XCTAssertFalse(shippingLabelFormViewModel.customsForms.isEmpty)
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
@@ -271,9 +267,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                    validated: true)
         shippingLabelFormViewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
         shippingLabelFormViewModel.handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm.fake()], isValidated: true)
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: nil,
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(), signatureRate: nil, adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
         XCTAssertNotNil(shippingLabelFormViewModel.selectedRate)
 
@@ -299,9 +294,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertNil(shippingLabelFormViewModel.selectedAdultSignatureRate)
 
         // When
-        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRate: MockShippingLabelCarrierRate.makeRate(),
-                                                                     selectedSignatureRate: MockShippingLabelCarrierRate.makeRate(title: "UPS"),
-                                                                     selectedAdultSignatureRate: nil,
+        let rate = ShippingLabelSelectedRate(rate: MockShippingLabelCarrierRate.makeRate(),
+                                             signatureRate: MockShippingLabelCarrierRate.makeRate(title: "UPS"),
+                                             adultSignatureRate: nil)
+        shippingLabelFormViewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate],
                                                                      editable: true)
 
         // Then


### PR DESCRIPTION
Part of #4715 and #4716 

# Description
To prepare for multi-package support of carriers and rates, I'm adding a list of selected rates which will be used to calculate rates for each package in order summary section.

Since updates for carriers & rates to support multiple packages hasn't been completed yet, some parts of this are still workaround and need to be updated as part of #4716.

# Changes
- Adds new model `ShippingLabelSelectedRate` containing information about the selected rate and extra rate for signature if any.
- Adds new list of selected rates in `ShippingLabelFormViewModel` and updates input type of `handleCarrierAndRatesValueChanges` method as well as related parts.
- Updates body of Carrier and Rates row for multi-package case.
- Updates calculation of subtotal, discount and total value of the purchase to support multi-package case.

# Testing
With these changes under the hood, everything needs to still work as before - including the Carrier and Rate row and the content of the order summary section. More updates for multi-package case will be added in the next PR.
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. On Orders tab select an order that's eligible for creating shipping label.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Tap Done to proceed with every item in the same one package.
5. Configure Carriers & Rates and Payment Method. Notice that content displayed on Carriers and Rates row is correct.
6. Notice that content (subtotal, discount and total values) in Order Summary section is correct.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
