### PR TITLE
3722 Update to WPMediaPicker beta with crash fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ target 'WooCommerce' do
 
   aztec
 
-  pod 'WPMediaPicker', '~> 1.7.1'
+  pod 'WPMediaPicker', '~> 1.7.3-beta.1'
 
   # External Libraries
   # ==================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.12.1)
   - Wormholy (1.6.4)
-  - WPMediaPicker (1.7.1)
+  - WPMediaPicker (1.7.3-beta.1)
   - wpxmlrpc (0.9.0)
   - XLPagerTabStrip (9.0.0)
   - ZendeskCommonUISDK (6.1.1)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.1)
   - Wormholy (~> 1.6.4)
-  - WPMediaPicker (~> 1.7.1)
+  - WPMediaPicker (~> 1.7.3-beta.1)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSupportSDK (~> 5.0)
 
@@ -186,7 +186,7 @@ SPEC CHECKSUMS:
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
   Wormholy: 2e70f64227e010d363f8d33268369f77faf12471
-  WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
+  WPMediaPicker: 4236e8fe012cf470e190fbd91d1f50037454a216
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: c652601d27c6c6bbc31005c1204964ca8471f2d4
+PODFILE CHECKSUM: 42e8ea85574d39d7c7df9d35fd87703957c1681a
 
 COCOAPODS: 1.10.2


### PR DESCRIPTION
## Description
In #5034 we worked around a crash in WPMediaPicker, by adding `filename` to our asset implementation. The crash in WPMediaPicker itself is now fixed as well, this change updates the app to use the beta release which implements the fix.

## Testing
The crash can no longer be reproduced anyway, due to the workaround mentioned, but testing that media selection from the WP media library still works is sufficient here.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
