### PR TITLE
Order Edit: Better email handling

### DIFF
--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Address Entity.
 ///
-public struct Address: Codable, GeneratedFakeable {
+public struct Address: Codable, GeneratedFakeable, GeneratedCopiable {
     public let firstName: String
     public let lastName: String
     public let company: String?

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -28,6 +28,48 @@ extension AddOnGroup {
     }
 }
 
+extension Address {
+    public func copy(
+        firstName: CopiableProp<String> = .copy,
+        lastName: CopiableProp<String> = .copy,
+        company: NullableCopiableProp<String> = .copy,
+        address1: CopiableProp<String> = .copy,
+        address2: NullableCopiableProp<String> = .copy,
+        city: CopiableProp<String> = .copy,
+        state: CopiableProp<String> = .copy,
+        postcode: CopiableProp<String> = .copy,
+        country: CopiableProp<String> = .copy,
+        phone: NullableCopiableProp<String> = .copy,
+        email: NullableCopiableProp<String> = .copy
+    ) -> Address {
+        let firstName = firstName ?? self.firstName
+        let lastName = lastName ?? self.lastName
+        let company = company ?? self.company
+        let address1 = address1 ?? self.address1
+        let address2 = address2 ?? self.address2
+        let city = city ?? self.city
+        let state = state ?? self.state
+        let postcode = postcode ?? self.postcode
+        let country = country ?? self.country
+        let phone = phone ?? self.phone
+        let email = email ?? self.email
+
+        return Address(
+            firstName: firstName,
+            lastName: lastName,
+            company: company,
+            address1: address1,
+            address2: address2,
+            city: city,
+            state: state,
+            postcode: postcode,
+            country: country,
+            phone: phone,
+            email: email
+        )
+    }
+}
+
 extension Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -141,8 +141,10 @@ struct EditAddressForm: View {
                                          text: $viewModel.fields.email,
                                          symbol: nil,
                                          keyboardType: .emailAddress)
+                        .renderedIf(viewModel.showEmailField)
                     Divider()
                         .padding(.leading, Constants.dividerPadding)
+                        .renderedIf(viewModel.showEmailField)
                     TitleAndTextFieldRow(title: Localization.phoneField,
                                          placeholder: "",
                                          text: $viewModel.fields.phone,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -259,15 +259,15 @@ extension EditAddressFormViewModel {
         func toAddress(country: Yosemite.Country?, state: Yosemite.StateOfACountry?) -> Yosemite.Address {
             Address(firstName: firstName,
                     lastName: lastName,
-                    company: company.isEmpty ? nil : company,
+                    company: company,
                     address1: address1,
-                    address2: address2.isEmpty ? nil : address2,
+                    address2: address2,
                     city: city,
                     state: state?.code ?? self.state,
                     postcode: postcode,
                     country: country?.code ?? self.country,
-                    phone: phone.isEmpty ? nil : phone,
-                    email: email.isEmpty ? nil : email)
+                    phone: phone,
+                    email: email.isEmpty ? nil : email) // Core has a validation on email where we are not allowed to send an empty email.
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -395,7 +395,7 @@ private extension EditAddressFormViewModel {
 }
 
 private extension Address {
-    /// Sets the email value to `nil` when it is empty..
+    /// Sets the email value to `nil` when it is empty.
     /// Needed because core has a validation where a billing address can have a valid email or `nil`.
     ///
     func removingEmptyEmail() -> Yosemite.Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -141,7 +141,7 @@ final class EditAddressFormViewModel: ObservableObject {
     /// Update the address remotely and invoke a completion block when finished
     ///
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
-        let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState)
+        let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState).removingEmptyEmail()
         let orderFields: [OrderUpdateField]
 
         let modifiedOrder: Yosemite.Order
@@ -267,7 +267,7 @@ extension EditAddressFormViewModel {
                     postcode: postcode,
                     country: country?.code ?? self.country,
                     phone: phone,
-                    email: email.isEmpty ? nil : email) // Core has a validation on email where we are not allowed to send an empty email.
+                    email: email)
         }
     }
 }
@@ -380,5 +380,17 @@ private extension EditAddressFormViewModel {
             self.stores.dispatch(action)
         }
         .eraseToAnyPublisher()
+    }
+}
+
+private extension Address {
+    /// Sets the email value to `nil` when it is empty..
+    /// Needed because core has a validation where a billing address can have a valid email or `nil`.
+    ///
+    func removingEmptyEmail() -> Yosemite.Address {
+        guard let email = email, email.isEmpty else {
+            return self
+        }
+        return copy(email: .some(nil))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -115,6 +115,17 @@ final class EditAddressFormViewModel: ObservableObject {
     ///
     @Published var presentNotice: Notice?
 
+    /// Defines if the email field should be shown
+    ///
+    var showEmailField: Bool {
+        switch type {
+        case .shipping:
+            return false
+        case .billing:
+            return true
+        }
+    }
+
     /// Creates a view model to be used when selecting a country
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditAddressFormViewModelTests.swift
@@ -384,6 +384,46 @@ final class EditAddressFormViewModelTests: XCTestCase {
         // Then
         assertEqual(viewModel.presentNotice, .error(.unableToLoadCountries))
     }
+
+    func test_copying_empty_shipping_address_for_billing_does_not_sends_an_empty_email_field() {
+        // Given
+        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, storageManager: testingStorage, stores: testingStores)
+        viewModel.onLoadTrigger.send()
+        viewModel.fields.useAsToggle = true
+
+        // When
+        let billingAddress: Address? = waitFor { promise in
+            self.testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, _, _):
+                    promise(order.billingAddress)
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+
+            viewModel.updateRemoteAddress(onFinish: { _ in })
+        }
+
+        // Then
+        XCTAssertNil(billingAddress?.email)
+    }
+
+    func test_shipping_view_model_does_not_shows_email_field() {
+        // Given
+        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping)
+
+        // When & Then
+        XCTAssertFalse(viewModel.showEmailField)
+    }
+
+    func test_billing_view_model_does_shows_email_field() {
+        // Given
+        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .billing)
+
+        // When & Then
+        XCTAssertTrue(viewModel.showEmailField)
+    }
 }
 
 private extension EditAddressFormViewModelTests {


### PR DESCRIPTION
# Why

Address fields sent as `nil` is not a good way to represent empty values. Because `nil` won't be encoded in the network request. Making those fields remain unaltered.

Sending empty fields as `""` works well for all fields except for `email` because Core has a validation that requires a valid email address and an empty string does not pass that validation.

Also, we just realized that the shipping address form does not contain the email field.

For those reasons, this PR works around that limitation by:

- Hiding the email row in the shipping address form.
- Setting the email to `nil` before sending it to Core when the email is empty.

Note: This means that we can't clear an email address at the moment. Core appears to be using some kind of `admin-ajax` function to clear the email.

# How

- Add `GeneratedCopiable` to `Address`
- Update ViewModel to provide a `showEmailField` variable so the view can be rendered appropriately.
- Update ViewModel to not `nil` the rest of the fields when they are empty.

# Demo

https://user-images.githubusercontent.com/562080/135352037-8b24200e-3e50-4fa9-be92-870bde2a3a6d.mov

# Testing Steps

- Open the shipping address form and see that there is no email field.
- Remove content for phone, company, or last name.
- Tap on the "use as shipping address" row.
- Tap on the Done button.
- Corroborate that the correct changes were performed in the billing address form


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
