### PR TITLE
[Mobile Payments] [SDK 2] Add fetching actual location

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -288,13 +288,11 @@ extension StripeCardReaderService: CardReaderService {
             self.readerLocationProvider?.fetchDefaultLocationID { (locationId, error) in
                 if let error = error {
                     let underlyingError = UnderlyingError(with: error)
-                    promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
-                    return
+                    return promise(.failure(CardReaderServiceError.connection(underlyingError: underlyingError)))
                 }
 
                 if let locationId = locationId {
-                    promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
-                    return
+                    return promise(.success(BluetoothConnectionConfiguration(locationId: locationId)))
                 }
 
                 promise(.failure(CardReaderServiceError.connection()))

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -150,6 +150,10 @@
 		3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE7B26129E2100E566B9 /* wcpay-account-restricted-pending.json */; };
 		3158FE8026129EC300E566B9 /* wcpay-account-restricted-overdue.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE7F26129EC300E566B9 /* wcpay-account-restricted-overdue.json */; };
 		3158FE8426129F3A00E566B9 /* wcpay-account-unknown-status.json in Resources */ = {isa = PBXBuildFile; fileRef = 3158FE8326129F3A00E566B9 /* wcpay-account-unknown-status.json */; };
+		3178A49F2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3178A49E2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift */; };
+		31799AF8270508C600D78179 /* WCPayReaderLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31799AF7270508C600D78179 /* WCPayReaderLocation.swift */; };
+		31799AFC2705189200D78179 /* wcpay-location.json in Resources */ = {isa = PBXBuildFile; fileRef = 31799AFB2705189200D78179 /* wcpay-location.json */; };
+		31799AFE270518AD00D78179 /* wcpay-location-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 31799AFD270518AD00D78179 /* wcpay-location-error.json */; };
 		31884A3B2603F3C7003FE338 /* SitePluginStatusEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */; };
 		318E8FD326C31F1C00F519D7 /* WCPayCustomerMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E8FD226C31F1C00F519D7 /* WCPayCustomerMapper.swift */; };
 		318E8FD526C31F9500F519D7 /* WCPayCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E8FD426C31F9500F519D7 /* WCPayCustomer.swift */; };
@@ -709,6 +713,10 @@
 		3158FE7B26129E2100E566B9 /* wcpay-account-restricted-pending.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-restricted-pending.json"; sourceTree = "<group>"; };
 		3158FE7F26129EC300E566B9 /* wcpay-account-restricted-overdue.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-restricted-overdue.json"; sourceTree = "<group>"; };
 		3158FE8326129F3A00E566B9 /* wcpay-account-unknown-status.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-account-unknown-status.json"; sourceTree = "<group>"; };
+		3178A49E2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayReaderLocationMapper.swift; sourceTree = "<group>"; };
+		31799AF7270508C600D78179 /* WCPayReaderLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayReaderLocation.swift; sourceTree = "<group>"; };
+		31799AFB2705189200D78179 /* wcpay-location.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-location.json"; sourceTree = "<group>"; };
+		31799AFD270518AD00D78179 /* wcpay-location-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-location-error.json"; sourceTree = "<group>"; };
 		31884A3A2603F3C7003FE338 /* SitePluginStatusEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStatusEnum.swift; sourceTree = "<group>"; };
 		318E8FD226C31F1C00F519D7 /* WCPayCustomerMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCustomerMapper.swift; sourceTree = "<group>"; };
 		318E8FD426C31F9500F519D7 /* WCPayCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCustomer.swift; sourceTree = "<group>"; };
@@ -1525,6 +1533,7 @@
 				B5BB1D1120A255EC00112D92 /* OrderStatusEnum.swift */,
 				267313302559CC930026F7EF /* PaymentGateway.swift */,
 				314703072670222500EF253A /* PaymentGatewayAccount.swift */,
+				D89A01D326D3F8D8008195BE /* ReaderLocation.swift */,
 				743E84EB22171F4600FAC9D7 /* ShipmentTracking.swift */,
 				D823D90C2237784A00C90817 /* ShipmentTrackingProvider.swift */,
 				D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */,
@@ -1540,7 +1549,7 @@
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
 				450106842399A7CB00E24722 /* TaxClass.swift */,
 				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
-				D89A01D326D3F8D8008195BE /* ReaderLocation.swift */,
+				31799AF7270508C600D78179 /* WCPayReaderLocation.swift */,
 				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
 				D8EDFE2125EE88C9003D2213 /* WCPayConnectionToken.swift */,
 				318E8FD426C31F9500F519D7 /* WCPayCustomer.swift */,
@@ -1720,6 +1729,8 @@
 				31054733262E36AB00C5C02B /* wcpay-payment-intent-error.json */,
 				31B8D6B526583970008E3DB2 /* wcpay-account-implicitly-not-eligible.json */,
 				077F39D726A58EB600ABEADC /* systemPlugins.json */,
+				31799AFB2705189200D78179 /* wcpay-location.json */,
+				31799AFD270518AD00D78179 /* wcpay-location-error.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1785,6 +1796,7 @@
 				3192F21B260D32550067FEF9 /* WCPayAccountMapper.swift */,
 				D8EDFE2525EE8A60003D2213 /* WCPayConnectionTokenMapper.swift */,
 				318E8FD226C31F1C00F519D7 /* WCPayCustomerMapper.swift */,
+				3178A49E2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift */,
 				31054701262E04F700C5C02B /* WCPayPaymentIntentMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift */,
 				CCF48B272628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift */,
@@ -2065,6 +2077,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31799AFE270518AD00D78179 /* wcpay-location-error.json in Resources */,
 				74C8F07020EEC3A800B6EDC9 /* broken-notes.json in Resources */,
 				31B8D6B426583662008E3DB2 /* wcpay-account-not-eligible.json in Resources */,
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
@@ -2173,6 +2186,7 @@
 				45AB8B1324AA34CB00B5B36E /* product-tags-deleted.json in Resources */,
 				02698CFC24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
+				31799AFC2705189200D78179 /* wcpay-location.json in Resources */,
 				74159623224D2C86003C21CF /* settings-product.json in Resources */,
 				266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */,
 				CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */,
@@ -2380,6 +2394,7 @@
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
 				26615473242D596B00A31661 /* ProductCategoriesRemote.swift in Sources */,
 				26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */,
+				3178A49F2703E5CF00A8B4CA /* WCPayReaderLocationMapper.swift in Sources */,
 				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
@@ -2410,6 +2425,7 @@
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,
 				26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */,
+				31799AF8270508C600D78179 /* WCPayReaderLocation.swift in Sources */,
 				D8FBFF1122D3B3FC006E3336 /* OrderStatsV4Mapper.swift in Sources */,
 				4595827C264D5B3F000A4413 /* ShippingLabelPackageSelected.swift in Sources */,
 				D823D905223746CE00C90817 /* NewShipmentTrackingMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/WCPayReaderLocationMapper.swift
+++ b/Networking/Networking/Mapper/WCPayReaderLocationMapper.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Mapper: WCPay Reader Location
+///
+struct WCPayReaderLocationMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into a location.
+    ///
+    func map(response: Data) throws -> WCPayReaderLocation {
+        let decoder = JSONDecoder()
+
+        return try decoder.decode(WCPayReaderLocationEnvelope.self, from: response).location
+    }
+}
+
+/// WCPayLocationEnvelope Disposable Entity
+///
+/// Endpoint returns the location in the `data` key. This entity
+/// allows us to parse it with JSONDecoder.
+///
+private struct WCPayReaderLocationEnvelope: Decodable {
+    let location: WCPayReaderLocation
+
+    private enum CodingKeys: String, CodingKey {
+        case location = "data"
+    }
+}

--- a/Networking/Networking/Model/WCPayReaderLocation.swift
+++ b/Networking/Networking/Model/WCPayReaderLocation.swift
@@ -1,0 +1,79 @@
+/// Represent a WCPay Reader Location Entity.
+///
+public struct WCPayReaderLocation: Decodable {
+    public let locationID: String
+    public let city: String?
+    public let country: String
+    public let addressLine1: String
+    public let addressLine2: String?
+    public let postalCode: String?
+    public let stateProvinceRegion: String?
+    public let displayName: String
+    public let liveMode: Bool
+
+    public init(
+        locationID: String,
+        city: String? = nil,
+        country: String,
+        addressLine1: String,
+        addressLine2: String? = nil,
+        postalCode: String? = nil,
+        stateProvinceRegion: String? = nil,
+        displayName: String,
+        liveMode: Bool
+    ) {
+        self.locationID = locationID
+        self.city = city
+        self.country = country
+        self.addressLine1 = addressLine1
+        self.addressLine2 = addressLine2
+        self.postalCode = postalCode
+        self.stateProvinceRegion = stateProvinceRegion
+        self.displayName = displayName
+        self.liveMode = liveMode
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let locationID = try container.decode(String.self, forKey: .locationID)
+        let addressContainer = try container.nestedContainer(keyedBy: AddressCodingKeys.self, forKey: .address)
+        let city = try addressContainer.decode(String.self, forKey: .city)
+        let country = try addressContainer.decode(String.self, forKey: .country)
+        let addressLine1 = try addressContainer.decode(String.self, forKey: .addressLine1)
+        let addressLine2 = try addressContainer.decode(String.self, forKey: .addressLine2)
+        let postalCode = try addressContainer.decode(String.self, forKey: .postalCode)
+        let stateProvinceRegion = try addressContainer.decode(String.self, forKey: .stateProvinceRegion)
+        let displayName = try container.decode(String.self, forKey: .displayName)
+        let liveMode = try container.decode(Bool.self, forKey: .liveMode)
+
+        self.init(
+            locationID: locationID,
+            city: city,
+            country: country,
+            addressLine1: addressLine1,
+            addressLine2: addressLine2,
+            postalCode: postalCode,
+            stateProvinceRegion: stateProvinceRegion,
+            displayName: displayName,
+            liveMode: liveMode
+        )
+    }
+}
+
+private extension WCPayReaderLocation {
+    enum CodingKeys: String, CodingKey {
+        case locationID = "id"
+        case address = "address"
+        case displayName = "display_name"
+        case liveMode = "livemode"
+    }
+
+    enum AddressCodingKeys: String, CodingKey {
+        case city = "city"
+        case country = "country"
+        case addressLine1 = "line1"
+        case addressLine2 = "line2"
+        case postalCode = "postal_code"
+        case stateProvinceRegion = "state"
+    }
+}

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -75,10 +75,19 @@ public class WCPayRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Load the store's location for use as a default location for a card reader
+    /// The backend (since WCPay plugin 3.0.0) coordinates this with Stripe to return a proper Stripe Location object ID
+    ///- Parameters:
+    ///   - siteID: Site for which we'll fetch the location.
+    ///   - completion: Closure to be run on completion.
+    ///
     public func loadDefaultReaderLocation(for siteID: Int64,
-                                          onCompletion: @escaping (Result<ReaderLocation, Error>) -> Void) {
-        let mockLocation = ReaderLocation(siteID: siteID, id: "tml_ESzXnASTnYZK5y", displayName: "st_simulated_display_name")
-        onCompletion(.success(mockLocation))
+                                          onCompletion: @escaping (Result<WCPayReaderLocation, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Path.locations, parameters: [:])
+
+        let mapper = WCPayReaderLocationMapper()
+
+        enqueue(request, mapper: mapper, completion: onCompletion)
     }
 }
 
@@ -91,7 +100,7 @@ private extension WCPayRemote {
         static let orders = "payments/orders"
         static let captureTerminalPayment = "capture_terminal_payment"
         static let createCustomer = "create_customer"
-        static let locations = "terminals/locations/store"
+        static let locations = "payments/terminal/locations/store"
     }
 
     enum AccountParameterKeys {

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -565,4 +565,41 @@ final class WCPayRemoteTests: XCTestCase {
 
         XCTAssertTrue(result.isFailure)
     }
+
+    func test_loadDefaultReaderLocation_properly_returns_location() throws {
+        let remote = WCPayRemote(network: network)
+        let expectedLocationID = "tml_0123456789abcd"
+
+        network.simulateResponse(
+            requestUrlSuffix: "payments/terminal/locations/store",
+            filename: "wcpay-location"
+        )
+
+        let result: Result<WCPayReaderLocation, Error> = waitFor { promise in
+            remote.loadDefaultReaderLocation(for: self.sampleSiteID) { result in
+                promise(result)
+            }
+        }
+
+        XCTAssertTrue(result.isSuccess)
+        let location = try result.get()
+        XCTAssertEqual(location.locationID, expectedLocationID)
+    }
+
+    func test_loadDefaultReaderLocation_properly_handles_error_response() throws {
+        let remote = WCPayRemote(network: network)
+
+        network.simulateResponse(
+            requestUrlSuffix: "payments/terminal/locations/store",
+            filename: "wcpay-location-error"
+        )
+
+        let result: Result<WCPayCustomer, Error> = waitFor { promise in
+            remote.fetchOrderCustomer(for: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        XCTAssertTrue(result.isFailure)
+    }
 }

--- a/Networking/NetworkingTests/Responses/wcpay-location-error.json
+++ b/Networking/NetworkingTests/Responses/wcpay-location-error.json
@@ -1,0 +1,7 @@
+{
+    "code": "wcpay_invalid_request",
+    "message": "Error: You passed an empty string for 'address[line2]'",
+    "data": {
+        "status": 400
+    }
+}

--- a/Networking/NetworkingTests/Responses/wcpay-location.json
+++ b/Networking/NetworkingTests/Responses/wcpay-location.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "tml_0123456789abcd",
+        "address": {
+            "city": "Bothell",
+            "country": "US",
+            "line1": "15000 Main Street",
+            "line2": "Suite 42",
+            "postal_code": "98012",
+            "state": "WA"
+        },
+        "display_name": "MY COOL STORE IN BOTHELL",
+        "livemode": true
+    }
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		3147030626701E2800EF253A /* PaymentGatewayAccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */; };
 		3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314703092670295300EF253A /* PaymentGatewayAccountStore.swift */; };
 		3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */; };
+		31799AFA27050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31799AF927050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift */; };
 		31BF226526715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BF226426715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
@@ -513,6 +514,7 @@
 		3147030526701E2800EF253A /* PaymentGatewayAccountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountAction.swift; sourceTree = "<group>"; };
 		314703092670295300EF253A /* PaymentGatewayAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStore.swift; sourceTree = "<group>"; };
 		3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayAccount+PaymentGatewayAccount.swift"; sourceTree = "<group>"; };
+		31799AF927050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayReaderLocation+ReaderLocation.swift"; sourceTree = "<group>"; };
 		31BF226426715FDE00BC5A4B /* PaymentGatewayAccountStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayAccountStoreTests.swift; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1483,6 +1485,7 @@
 			children = (
 				D8652E1F26303D4800350F37 /* PaymentIntent+ReceiptParameters.swift */,
 				3147030B2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift */,
+				31799AF927050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift */,
 			);
 			path = Payments;
 			sourceTree = "<group>";
@@ -1829,6 +1832,7 @@
 				2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */,
 				02FF055323D983F30058E6E7 /* URL+Media.swift in Sources */,
 				022F00BE24725BAF008CD97F /* NotificationCountStore.swift in Sources */,
+				31799AFA27050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift in Sources */,
 				7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */,
 				74858DB421C02B5A00754F3E /* OrderNote+ReadOnlyType.swift in Sources */,
 				0248B3652459018100A271A4 /* ResultsController+FilterProducts.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Payments/WCPayReaderLocation+ReaderLocation.swift
+++ b/Yosemite/Yosemite/Model/Payments/WCPayReaderLocation+ReaderLocation.swift
@@ -1,0 +1,13 @@
+import Networking
+
+public extension WCPayReaderLocation {
+    /// Maps a WCPayReaderLocation into the ReaderLocation struct
+    ///
+    func toReaderLocation(siteID: Int64) -> ReaderLocation {
+        return ReaderLocation(
+            siteID: siteID,
+            id: locationID,
+            displayName: displayName
+        )
+    }
+}

--- a/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -251,8 +251,9 @@ private final class WCPayTokenProvider: CardReaderConfigProvider {
     func fetchDefaultLocationID(completion: @escaping(String?, Error?) -> Void) {
         remote.loadDefaultReaderLocation(for: siteID) { result in
             switch result {
-            case .success(let location):
-                completion(location.id, nil)
+            case .success(let wcpayReaderLocation):
+                let readerLocation = wcpayReaderLocation.toReaderLocation(siteID: self.siteID)
+                completion(readerLocation.id, nil)
             case .failure(let error):
                 completion(nil, error)
             }


### PR DESCRIPTION
Closes #5078 

Changes:
- Adds WCPayReaderLocation for WCPayRemote to populate through WCPayReaderLocationMapper
- Adds WCPayReaderLocation+ReaderLocation.swift to translate WCPayReaderLocation into ReaderLocation
- Adds unit tests
- Removes hardcoded location value

Questions:
- Do we need to do something special for simulators?

Not included:
- Presenting specific failure message to user: https://github.com/woocommerce/woocommerce-ios/issues/5088

To test:
- Install WooCommerce Payments 3.0 or newer: https://github.com/woocommerce/woocommerce-ios/issues/5077
- Make sure your store is gated into the beta: (wcpay server 1199)
- Make sure you have both address line 1 AND address line 2 set up on your store : https://github.com/Automattic/woocommerce-payments/issues/3012
- Ensure you can connect to a reader
- For bonus points, set a breakpoint in`fetchDefaultLocationID` and make sure that the location ID provided is consistent for repeated connections to a reader. Then change the street address for the business in WooCommerce settings and connect again - the location ID should change.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
