### PR TITLE
Convert UI tests screens to be a `ScreenObject` subclasses

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -4,7 +4,8 @@ import XCTest
 public final class MyStoreScreen: ScreenObject {
 
     public let tabBar = TabNavComponent()
-    public let periodStatsTable = PeriodStatsTable()
+    // TODO: Remove force `try` once `ScreenObject` migration is completed
+    public let periodStatsTable = try! PeriodStatsTable()
 
     private let settingsButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["dashboard-settings-button"]

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -3,7 +3,8 @@ import XCTest
 
 public final class MyStoreScreen: ScreenObject {
 
-    public let tabBar = TabNavComponent()
+    // TODO: Remove force `try` once `ScreenObject` migration is completed
+    public let tabBar = try! TabNavComponent()
     // TODO: Remove force `try` once `ScreenObject` migration is completed
     public let periodStatsTable = try! PeriodStatsTable()
 

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -35,8 +35,8 @@ public final class MyStoreScreen: ScreenObject {
     }
 
     @discardableResult
-    public func openSettingsPane() -> SettingsScreen {
+    public func openSettingsPane() throws -> SettingsScreen {
         settingsButton.tap()
-        return SettingsScreen()
+        return try SettingsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -1,28 +1,29 @@
+import ScreenObject
 import XCTest
 
-public final class PeriodStatsTable: BaseScreen {
+public final class PeriodStatsTable: ScreenObject {
 
-    struct ElementStringIDs {
-        static let daysTab = "period-data-today-tab"
-        static let weeksTab = "period-data-thisWeek-tab"
-        static let monthsTab = "period-data-thisMonth-tab"
-        static let yearsTab = "period-data-thisYear-tab"
+    private let daysTabGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["period-data-today-tab"]
     }
 
+    private let weeksTabGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["period-data-thisWeek-tab"]
+    }
 
-    private let daysTab = XCUIApplication().cells[ElementStringIDs.daysTab]
-    private let weeksTab = XCUIApplication().cells[ElementStringIDs.weeksTab]
-    private let monthsTab = XCUIApplication().cells[ElementStringIDs.monthsTab]
-    private let yearsTab = XCUIApplication().cells[ElementStringIDs.yearsTab]
+    private let yearsTabGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["period-data-thisYear-tab"]
+    }
 
-    init() {
+    private var daysTab: XCUIElement { daysTabGetter(app) }
+    private var weeksTab: XCUIElement { weeksTabGetter(app) }
+    private var yearsTab: XCUIElement { yearsTabGetter(app) }
 
-        super.init(element: daysTab)
-
-        XCTAssert(daysTab.waitForExistence(timeout: 3))
-        XCTAssert(weeksTab.waitForExistence(timeout: 3))
-        XCTAssert(monthsTab.waitForExistence(timeout: 3))
-        XCTAssert(yearsTab.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [daysTabGetter, weeksTabGetter, yearsTabGetter],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -20,8 +20,8 @@ public final class OrderSearchScreen: BaseScreen {
     }
 
     @discardableResult
-    public func cancel() -> OrdersScreen {
+    public func cancel() throws -> OrdersScreen {
         cancelButton.tap()
-        return OrdersScreen()
+        return try OrdersScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -1,22 +1,28 @@
+import ScreenObject
 import XCTest
 
-public final class OrderSearchScreen: BaseScreen {
+public final class OrderSearchScreen: ScreenObject {
 
     struct ElementStringIDs {
         static let searchField = "order-search-screen-search-field"
         static let cancelButton = "order-search-screen-cancel-button"
     }
 
-    private let searchField: XCUIElement
-    private let cancelButton: XCUIElement
+    private let cancelButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-search-screen-cancel-button"]
+    }
 
-    init() {
-        searchField = XCUIApplication().otherElements[ElementStringIDs.searchField]
-        cancelButton = XCUIApplication().buttons[ElementStringIDs.cancelButton]
-        super.init(element: cancelButton)
+    private var cancelButton: XCUIElement { cancelButtonGetter(app) }
 
-        XCTAssert(searchField.waitForExistence(timeout: 3))
-        XCTAssert(cancelButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                cancelButtonGetter,
+                // swiftlint:disable:next opening_braces
+                { $0.otherElements["order-search-screen-search-field"] }
+            ],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -3,11 +3,6 @@ import XCTest
 
 public final class OrderSearchScreen: ScreenObject {
 
-    struct ElementStringIDs {
-        static let searchField = "order-search-screen-search-field"
-        static let cancelButton = "order-search-screen-cancel-button"
-    }
-
     private let cancelButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-search-screen-cancel-button"]
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -3,7 +3,8 @@ import XCTest
 
 public final class OrdersScreen: ScreenObject {
 
-    public let tabBar = TabNavComponent()
+    // TODO: Remove force `try` once `ScreenObject` migration is completed
+    public let tabBar = try! TabNavComponent()
 
     private let searchButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-search-button"]

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -1,31 +1,35 @@
+import ScreenObject
 import XCTest
 
-public final class OrdersScreen: BaseScreen {
-
-    struct ElementStringIDs {
-        static let searchButton = "order-search-button"
-        static let filterButton = "order-filter-button"
-    }
+public final class OrdersScreen: ScreenObject {
 
     public let tabBar = TabNavComponent()
-    private let searchButton: XCUIElement
-    private let filterButton: XCUIElement
 
-    static var isVisible: Bool {
-        let searchButton = XCUIApplication().buttons[ElementStringIDs.searchButton]
-        return searchButton.exists && searchButton.isHittable
+    private let searchButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-search-button"]
     }
 
-    init() {
-        searchButton = XCUIApplication().buttons[ElementStringIDs.searchButton]
-        filterButton = XCUIApplication().buttons[ElementStringIDs.filterButton]
+    private var searchButton: XCUIElement { searchButtonGetter(app) }
 
-        super.init(element: searchButton)
+    // TODO: There's only one usage of this and it can be replaced with a screen instantiation
+    static var isVisible: Bool {
+        (try? OrdersScreen().isLoaded) ?? false
+    }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                searchButtonGetter,
+                // swiftlint:disable:next opening_braces
+                { $0.buttons["order-filter-button"] }
+            ],
+            app: app
+        )
     }
 
     @discardableResult
     public func selectOrder(atIndex index: Int) -> SingleOrderScreen {
-        XCUIApplication().tables.cells.element(boundBy: index).tap()
+        app.tables.cells.element(boundBy: index).tap()
         return SingleOrderScreen()
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -28,9 +28,9 @@ public final class OrdersScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectOrder(atIndex index: Int) -> SingleOrderScreen {
+    public func selectOrder(atIndex index: Int) throws -> SingleOrderScreen {
         app.tables.cells.element(boundBy: index).tap()
-        return SingleOrderScreen()
+        return try SingleOrderScreen()
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -34,8 +34,8 @@ public final class OrdersScreen: ScreenObject {
     }
 
     @discardableResult
-    public func openSearchPane() -> OrderSearchScreen {
+    public func openSearchPane() throws -> OrderSearchScreen {
         searchButton.tap()
-        return OrderSearchScreen()
+        return try OrderSearchScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -1,17 +1,15 @@
+import ScreenObject
 import XCTest
 
-public final class SingleOrderScreen: BaseScreen {
-
-    struct ElementStringIDs {
-        static let summaryTitleLabel = "summary-table-view-cell-title-label"
-    }
+public final class SingleOrderScreen: ScreenObject {
 
     let tabBar = TabNavComponent()
-    private let summaryTitleLabel: XCUIElement
 
-    init() {
-        summaryTitleLabel = XCUIApplication().staticTexts[ElementStringIDs.summaryTitleLabel]
-        super.init(element: summaryTitleLabel)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.staticTexts["summary-table-view-cell-title-label"] } ],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -3,7 +3,8 @@ import XCTest
 
 public final class SingleOrderScreen: ScreenObject {
 
-    let tabBar = TabNavComponent()
+    // TODO: Remove force `try` once `ScreenObject` migration is completed
+    let tabBar = try! TabNavComponent()
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -15,8 +15,8 @@ public final class SingleOrderScreen: BaseScreen {
     }
 
     @discardableResult
-    public func goBackToOrdersScreen() -> OrdersScreen {
+    public func goBackToOrdersScreen() throws -> OrdersScreen {
         pop()
-        return OrdersScreen()
+        return try OrdersScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -1,25 +1,32 @@
+import ScreenObject
 import XCTest
 
-public class ProductsScreen: BaseScreen {
+public class ProductsScreen: ScreenObject {
 
-       struct ElementStringIDs {
-        static let searchButton = "product-search-button"
-        static let topBannerCollapseButton = "top-banner-view-expand-collapse-button"
-        static let topBannerInfoLabel = "top-banner-view-info-label"
+    private let topBannerCollapseButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["top-banner-view-expand-collapse-button"]
+    }
+    private let topBannerInfoLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["top-banner-view-info-label"]
     }
 
-    private let searchButton = XCUIApplication().buttons[ElementStringIDs.searchButton]
-    private let topBannerCollapseButton = XCUIApplication().buttons[ElementStringIDs.topBannerCollapseButton]
-    private let topBannerInfoLabel = XCUIApplication().staticTexts[ElementStringIDs.topBannerInfoLabel]
+    private var topBannerInfoLabel: XCUIElement { topBannerInfoLabelGetter(app) }
+    private var topBannerCollapseButton: XCUIElement { topBannerCollapseButtonGetter(app) }
 
     static var isVisible: Bool {
-        let searchButton = XCUIApplication().buttons[ElementStringIDs.searchButton]
-        return searchButton.exists && searchButton.isHittable
+        (try? ProductsScreen().isLoaded) ?? false
     }
 
-    init() {
-        super.init(element: searchButton)
-        XCTAssert(searchButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                topBannerCollapseButtonGetter,
+                topBannerInfoLabelGetter,
+                // swiftlint:skip:next opening_brace
+                { $0.buttons["product-search-button"] }
+            ],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -47,8 +47,8 @@ public class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectProduct(atIndex index: Int) -> SingleProductScreen {
+    public func selectProduct(atIndex index: Int) throws -> SingleProductScreen {
         XCUIApplication().tables.cells.element(boundBy: index).tap()
-        return SingleProductScreen()
+        return try SingleProductScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -1,21 +1,18 @@
+import ScreenObject
 import XCTest
 
-public class SingleProductScreen: BaseScreen {
-
-    struct ElementStringIDs {
-        static let editProductMenuButton = "edit-product-more-options-button"
-    }
-
-    private let editProductMenuButton = XCUIApplication().buttons[ElementStringIDs.editProductMenuButton]
+public class SingleProductScreen: ScreenObject {
 
     static var isVisible: Bool {
-        let updateButton = XCUIApplication().buttons[ElementStringIDs.editProductMenuButton]
-        return updateButton.exists && updateButton.isHittable
+        guard let screen = try? SingleProductScreen() else { return false }
+        return screen.isLoaded && screen.expectedElement.isHittable
     }
 
-    init() {
-        super.init(element: editProductMenuButton)
-        XCTAssert(editProductMenuButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.buttons["edit-product-more-options-button"] }],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -19,8 +19,8 @@ public class SingleProductScreen: BaseScreen {
     }
 
     @discardableResult
-    func goBackToProductList() -> ProductsScreen {
+    func goBackToProductList() throws -> ProductsScreen {
         navBackButton.tap()
-        return ProductsScreen()
+        return try ProductsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -17,8 +17,8 @@ public final class ReviewsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectReview(atIndex index: Int) -> SingleReviewScreen {
+    public func selectReview(atIndex index: Int) throws -> SingleReviewScreen {
         app.tables.cells.element(boundBy: index).tap()
-        return SingleReviewScreen()
+        return try SingleReviewScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -3,7 +3,8 @@ import XCTest
 
 public final class ReviewsScreen: ScreenObject {
 
-    public let tabBar = TabNavComponent()
+    // TODO: Remove force `try` once `ScreenObject` migration is completed
+    public let tabBar = try! TabNavComponent()
 
     static var isVisible: Bool {
         (try? ReviewsScreen().isLoaded) ?? false

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -1,27 +1,24 @@
+import ScreenObject
 import XCTest
 
-public final class ReviewsScreen: BaseScreen {
-
-    struct ElementStringIDs {
-        static let markAllAsReadButton = "reviews-mark-all-as-read-button"
-    }
+public final class ReviewsScreen: ScreenObject {
 
     public let tabBar = TabNavComponent()
-    private let markAllAsReadButton: XCUIElement
 
     static var isVisible: Bool {
-        let markAllAsReadButton = XCUIApplication().buttons[ElementStringIDs.markAllAsReadButton]
-        return markAllAsReadButton.exists && markAllAsReadButton.isHittable
+        (try? ReviewsScreen().isLoaded) ?? false
     }
 
-    init() {
-        markAllAsReadButton = XCUIApplication().buttons[ElementStringIDs.markAllAsReadButton]
-        super.init(element: markAllAsReadButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.buttons["reviews-mark-all-as-read-button"] } ],
+            app: app
+        )
     }
 
     @discardableResult
     public func selectReview(atIndex index: Int) -> SingleReviewScreen {
-        XCUIApplication().tables.cells.element(boundBy: index).tap()
+        app.tables.cells.element(boundBy: index).tap()
         return SingleReviewScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
@@ -21,8 +21,8 @@ public final class SingleReviewScreen: BaseScreen {
     }
 
     @discardableResult
-    public func goBackToReviewsScreen() -> ReviewsScreen {
+    public func goBackToReviewsScreen() throws -> ReviewsScreen {
         pop()
-        return ReviewsScreen()
+        return try ReviewsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
@@ -1,23 +1,19 @@
+import ScreenObject
 import XCTest
 
-public final class SingleReviewScreen: BaseScreen {
+public final class SingleReviewScreen: ScreenObject {
 
-    struct ElementStringIDs {
-        static let spamButton = "single-review-spam-button"
-        static let trashButton = "single-review-trash-button"
-        static let approveButton = "single-review-approval-button"
-    }
-
-    private let spamButton = XCUIApplication().buttons[ElementStringIDs.spamButton]
-    private let trashButton = XCUIApplication().buttons[ElementStringIDs.trashButton]
-    private let approveButton = XCUIApplication().buttons[ElementStringIDs.approveButton]
-
-    init() {
-        super.init(element: spamButton)
-
-        XCTAssert(spamButton.waitForExistence(timeout: 3))
-        XCTAssert(trashButton.waitForExistence(timeout: 3))
-        XCTAssert(approveButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                // swiftlint:disable opening_brace
+                { $0.buttons["single-review-spam-button"] },
+                { $0.buttons["single-review-trash-button"] },
+                { $0.buttons["single-review-approval-button"] }
+                // swiftlint:enable opening_brace
+            ],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -31,8 +31,8 @@ class BetaFeaturesScreen: ScreenObject {
     }
 
     @discardableResult
-    func goBackToSettingsScreen() -> SettingsScreen {
+    func goBackToSettingsScreen() throws -> SettingsScreen {
         navBackButton.tap()
-        return SettingsScreen()
+        return try SettingsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -1,16 +1,24 @@
+import ScreenObject
 import XCTest
 
-class BetaFeaturesScreen: BaseScreen {
+// This screen is currently unused. Given the purpose of UITestsFoundation is to provide developers
+// with an easy to use API to write tests, I'm going to keep the screen in the framework anyway, so
+// it'll be already available if someone needs to work with it or on it in the future.
+class BetaFeaturesScreen: ScreenObject {
 
     struct ElementStringIDs {
         static let enableProductsButton = "beta-features-products-cell"
     }
 
-    private let enableProductsButton = XCUIApplication().cells[ElementStringIDs.enableProductsButton]
+    // `expectedElement` is a `ScreenObject` utility to get the first element for the
+    // `expectedElementGetters` list.
+    private var enableProductsButton: XCUIElement { expectedElement }
 
-    init() {
-        super.init(element: enableProductsButton)
-        XCTAssert(enableProductsButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.cells["beta-features-products-cell"] } ],
+            app: app
+        )
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -6,10 +6,6 @@ import XCTest
 // it'll be already available if someone needs to work with it or on it in the future.
 class BetaFeaturesScreen: ScreenObject {
 
-    struct ElementStringIDs {
-        static let enableProductsButton = "beta-features-products-cell"
-    }
-
     // `expectedElement` is a `ScreenObject` utility to get the first element from the
     // `expectedElementGetters` list.
     private var enableProductsButton: XCUIElement { expectedElement }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -10,7 +10,7 @@ class BetaFeaturesScreen: ScreenObject {
         static let enableProductsButton = "beta-features-products-cell"
     }
 
-    // `expectedElement` is a `ScreenObject` utility to get the first element for the
+    // `expectedElement` is a `ScreenObject` utility to get the first element from the
     // `expectedElementGetters` list.
     private var enableProductsButton: XCUIElement { expectedElement }
 

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -1,32 +1,39 @@
+import ScreenObject
 import XCTest
 
-public final class TabNavComponent: BaseScreen {
+public final class TabNavComponent: ScreenObject {
 
-    struct ElementStringIDs {
-        static let myStoreTabBarItem = "tab-bar-my-store-item"
-        static let ordersTabBarItem = "tab-bar-orders-item"
-        static let reviewsTabBarItem = "tab-bar-reviews-item"
-        static let productsTabBarItem = "tab-bar-products-item"
+    private let myStoreTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tabBars.firstMatch.buttons["tab-bar-my-store-item"]
     }
 
+    private let ordersTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tabBars.firstMatch.buttons["tab-bar-orders-item"]
+    }
 
-    private let myStoreTabButton: XCUIElement
-    private let ordersTabButton: XCUIElement
-    private let reviewsTabButton: XCUIElement
-    let productsTabButton: XCUIElement
+    private let reviewsTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tabBars.firstMatch.buttons["tab-bar-reviews-item"]
+    }
 
-    init() {
-        let tabBar = XCUIApplication().tabBars.firstMatch
+    private let productsTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tabBars.firstMatch.buttons["tab-bar-products-item"]
+    }
 
-        myStoreTabButton = tabBar.buttons[ElementStringIDs.myStoreTabBarItem]
-        ordersTabButton = tabBar.buttons[ElementStringIDs.ordersTabBarItem]
-        reviewsTabButton = tabBar.buttons[ElementStringIDs.reviewsTabBarItem]
-        productsTabButton = tabBar.buttons[ElementStringIDs.productsTabBarItem]
+    private var myStoreTabButton: XCUIElement { myStoreTabButtonGetter(app) }
+    private var ordersTabButton: XCUIElement { ordersTabButtonGetter(app) }
+    private var reviewsTabButton: XCUIElement { reviewsTabButtonGetter(app) }
+    var productsTabButton: XCUIElement { productsTabButtonGetter(app) }
 
-        super.init(element: myStoreTabButton)
-
-        XCTAssert(myStoreTabButton.waitForExistence(timeout: 3))
-        XCTAssert(ordersTabButton.waitForExistence(timeout: 3))
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                myStoreTabButtonGetter,
+                ordersTabButtonGetter,
+                reviewsTabButtonGetter,
+                productsTabButtonGetter
+            ],
+            app: app
+        )
     }
 
     @discardableResult
@@ -67,10 +74,12 @@ public final class TabNavComponent: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.myStoreTabBarItem].exists
+        (try? TabNavComponent().isLoaded) ?? false
     }
 
-    static func isVisible() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.myStoreTabBarItem].isHittable
+    // TODO: This paradigm is used enough around the test suits that it would be worth extracting to `ScreenObject`.
+   static func isVisible() -> Bool {
+        guard let tabNavComponent = try? TabNavComponent() else { return false }
+        return tabNavComponent.isLoaded && tabNavComponent.expectedElement.isHittable
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -39,13 +39,13 @@ public final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    public func gotoOrdersScreen() -> OrdersScreen {
+    public func gotoOrdersScreen() throws -> OrdersScreen {
         // Avoid transitioning if it is already on screen
         if !OrdersScreen.isVisible {
             ordersTabButton.tap()
         }
 
-        return OrdersScreen()
+        return try OrdersScreen()
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -58,12 +58,12 @@ public final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    public func gotoReviewsScreen() -> ReviewsScreen {
+    public func gotoReviewsScreen() throws -> ReviewsScreen {
         if !ReviewsScreen.isVisible {
             reviewsTabButton.tap()
         }
 
-        return ReviewsScreen()
+        return try ReviewsScreen()
     }
 
     static func isLoaded() -> Bool {

--- a/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WooCommerce/UITestsFoundation/Screens/TabNavComponent.swift
@@ -49,12 +49,12 @@ public final class TabNavComponent: BaseScreen {
     }
 
     @discardableResult
-    public func gotoProductsScreen() -> ProductsScreen {
+    public func gotoProductsScreen() throws -> ProductsScreen {
         if !ProductsScreen.isVisible {
             productsTabButton.tap()
         }
 
-        return ProductsScreen()
+        return try ProductsScreen()
     }
 
     @discardableResult


### PR DESCRIPTION
Converts all the `BaseScreen` subclass that are not part of the login and signup flow to be `ScreenObject` subclasses instead.

For more information on the structure of a `ScreenObject` subclass, see [this WordPress iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17221) description and comments.

As you can see, I run the UI tests in CI and [they pass](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/14673/workflows/b18119bb-7322-464f-a2d6-7bc525107d60). Feel free to run them locally, too, if you have time to spare.

The reason I didn't work on the login and signup screens is that the plan for the upcoming weeks is to extract what's in WordPress into a dedicated test helper framework, and use that instead. Working on them here would have been redundant.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.