### PR TITLE
Remove some unused code from UI tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/PeriodStatsTable.swift
@@ -42,12 +42,4 @@ public final class PeriodStatsTable: BaseScreen {
         yearsTab.tap()
         return self
     }
-
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.daysTab].exists
-    }
-
-    static func isVisible() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.daysTab].isHittable
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -10,11 +10,6 @@ public final class OrderSearchScreen: BaseScreen {
     private let searchField: XCUIElement
     private let cancelButton: XCUIElement
 
-    static var isVisible: Bool {
-        let cancelButton = XCUIApplication().buttons[ElementStringIDs.cancelButton]
-        return cancelButton.exists && cancelButton.isHittable
-    }
-
     init() {
         searchField = XCUIApplication().otherElements[ElementStringIDs.searchField]
         cancelButton = XCUIApplication().buttons[ElementStringIDs.cancelButton]

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -9,11 +9,6 @@ public final class SingleOrderScreen: BaseScreen {
     let tabBar = TabNavComponent()
     private let summaryTitleLabel: XCUIElement
 
-    static var isVisible: Bool {
-        let summaryTitleLabel = XCUIApplication().staticTexts[ElementStringIDs.summaryTitleLabel]
-        return summaryTitleLabel.exists && summaryTitleLabel.isHittable
-    }
-
     init() {
         summaryTitleLabel = XCUIApplication().staticTexts[ElementStringIDs.summaryTitleLabel]
         super.init(element: summaryTitleLabel)

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
@@ -8,15 +8,9 @@ public final class SingleReviewScreen: BaseScreen {
         static let approveButton = "single-review-approval-button"
     }
 
-    let tabBar = TabNavComponent()
     private let spamButton = XCUIApplication().buttons[ElementStringIDs.spamButton]
     private let trashButton = XCUIApplication().buttons[ElementStringIDs.trashButton]
     private let approveButton = XCUIApplication().buttons[ElementStringIDs.approveButton]
-
-    static var isVisible: Bool {
-        let spamButton = XCUIApplication().buttons[ElementStringIDs.spamButton]
-        return spamButton.exists && spamButton.isHittable
-    }
 
     init() {
         super.init(element: spamButton)

--- a/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -8,11 +8,6 @@ class BetaFeaturesScreen: BaseScreen {
 
     private let enableProductsButton = XCUIApplication().cells[ElementStringIDs.enableProductsButton]
 
-    static var isVisible: Bool {
-        let enableProductsButton = XCUIApplication().buttons[ElementStringIDs.enableProductsButton]
-        return enableProductsButton.exists && enableProductsButton.isHittable
-    }
-
     init() {
         super.init(element: enableProductsButton)
         XCTAssert(enableProductsButton.waitForExistence(timeout: 3))


### PR DESCRIPTION
What it says in the title 😄 

Noticed that I run _all_ the tests in CI to validate this `+0 -29` change doesn't break the build.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
