### PR TITLE
Shipping Labels: Update description for customs form row when customs form is completed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,9 +3,10 @@
 7.7
 -----
 - [***] Shipping Labels: Merchants can now add new payment methods for shipping labels directly from the app. [https://github.com/woocommerce/woocommerce-ios/pull/5023]
-- [x] Fix: now a default paper size will be selected in Shipping Label print screen. [https://github.com/woocommerce/woocommerce-ios/pull/5035]
+- [*] Fix: now a default paper size will be selected in Shipping Label print screen. [https://github.com/woocommerce/woocommerce-ios/pull/5035]
 - [*] Show banner on screens that use cached data when device is offline. [https://github.com/woocommerce/woocommerce-ios/pull/5000]
-
+- [*] Fix incorrect subtitle on customs row of Shipping Label purchase flow. [https://github.com/woocommerce/woocommerce-ios/pull/5093]
+ 
 7.6
 -----
 - [x] Show an improved error modal if there are problems while selecting a store. [https://github.com/woocommerce/woocommerce-ios/pull/5006]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -287,10 +287,11 @@ private extension ShippingLabelFormViewController {
     }
 
     func configureCustoms(cell: ShippingLabelFormStepTableViewCell, row: Row) {
+        let description = viewModel.customsForms.isEmpty ? Localization.customsCellSubtitle : Localization.customsCompletedCellSubtitle
         cell.configure(state: row.cellState,
                        icon: .globeImage,
                        title: Localization.customsCellTitle,
-                       body: Localization.customsCellSubtitle,
+                       body: description,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
@@ -631,6 +632,9 @@ private extension ShippingLabelFormViewController {
                                                              comment: "Continue button inside every cell inside Create Shipping Label form")
         static let customsCellTitle = NSLocalizedString("Customs", comment: "Title of the cell Customs inside Create Shipping Label form")
         static let customsCellSubtitle = NSLocalizedString("Fill out customs form", comment: "Subtitle of the cell Customs inside Create Shipping Label form")
+        static let customsCompletedCellSubtitle = NSLocalizedString("Customs form completed",
+                                                                    comment: "Subtitle of the cell Customs inside " +
+                                                                        "Create Shipping Label form when the form is completed")
         // Purchase progress view
         static let purchaseProgressTitle = NSLocalizedString("Purchasing Label", comment: "Title of the in-progress UI while purchasing a shipping label")
         static let purchaseProgressMessage = NSLocalizedString("Please wait", comment: "Message of the in-progress UI while purchasing a shipping label")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -287,11 +287,10 @@ private extension ShippingLabelFormViewController {
     }
 
     func configureCustoms(cell: ShippingLabelFormStepTableViewCell, row: Row) {
-        let description = viewModel.customsForms.isEmpty ? Localization.customsCellSubtitle : Localization.customsCompletedCellSubtitle
         cell.configure(state: row.cellState,
                        icon: .globeImage,
                        title: Localization.customsCellTitle,
-                       body: description,
+                       body: viewModel.getCustomsFormBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
             guard let self = self else { return }
             self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
@@ -631,10 +630,6 @@ private extension ShippingLabelFormViewController {
         static let continueButtonInCells = NSLocalizedString("Continue",
                                                              comment: "Continue button inside every cell inside Create Shipping Label form")
         static let customsCellTitle = NSLocalizedString("Customs", comment: "Title of the cell Customs inside Create Shipping Label form")
-        static let customsCellSubtitle = NSLocalizedString("Fill out customs form", comment: "Subtitle of the cell Customs inside Create Shipping Label form")
-        static let customsCompletedCellSubtitle = NSLocalizedString("Customs form completed",
-                                                                    comment: "Subtitle of the cell Customs inside " +
-                                                                        "Create Shipping Label form when the form is completed")
         // Purchase progress view
         static let purchaseProgressTitle = NSLocalizedString("Purchasing Label", comment: "Title of the in-progress UI while purchasing a shipping label")
         static let purchaseProgressMessage = NSLocalizedString("Please wait", comment: "Message of the in-progress UI while purchasing a shipping label")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -315,6 +315,21 @@ final class ShippingLabelFormViewModel {
         return packageDescription + "\n" + String.localizedStringWithFormat(Localization.totalPackageWeight, packageWeight)
     }
 
+    /// Returns the description of the Customs Form row.
+    ///
+    func getCustomsFormBody() -> String {
+        guard let rows = state.sections.first?.rows,
+              let customsRow = rows.first(where: { $0.type == .customs }) else {
+            return ""
+        }
+        switch customsRow.dataState {
+        case .pending:
+            return Localization.fillCustomsForm
+        case .validated:
+            return Localization.customsFormCompleted
+        }
+    }
+
     /// Returns the body of the selected Carrier and Rates.
     ///
     func getCarrierAndRatesBody() -> String {
@@ -832,6 +847,10 @@ private extension ShippingLabelFormViewModel {
         static let totalPackageWeight = NSLocalizedString("Total package weight: %1$@",
                                                           comment: "Total package weight label in Shipping Label form. %1$@ is a placeholder for the weight")
         static let packageItemCount = NSLocalizedString("%1$d items in %2$d packages", comment: "Total number of items and packages in Shipping Label form.")
+        static let fillCustomsForm = NSLocalizedString("Fill out customs form", comment: "Subtitle of the cell Customs inside Create Shipping Label form")
+        static let customsFormCompleted = NSLocalizedString("Customs form completed",
+                                                            comment: "Subtitle of the cell Customs inside " +
+                                                                "Create Shipping Label form when the form is completed")
         static let carrierAndRatesPlaceholder = NSLocalizedString("Select your shipping carrier and rates",
                                                                   comment: "Placeholder in Shipping Label form for the Carrier and Rates row.")
         static let businessDaySingular = NSLocalizedString("%1$d business day",


### PR DESCRIPTION
Closes #5081 

# Description
This PR fixes incorrect description for Customs Form row when custom form is completed

# Screenshots
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/135237015-59a201cc-d264-4092-95af-b6e31d5c0059.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/135404110-9fa73724-50ff-4c0f-9429-ffa90372a84f.png" width=320 /> |

# Testing steps
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. On Orders tab select an order that's eligible for creating shipping label and is an international order (origin and destination countries are different).
3. Select Create Shipping Label and configure Ship From, Ship To and Package Details.
4. Notice that subtitle of customs row is now "Fill out customs form".
5. Configure customs form and tap Done. Notice that subtitle of customs row is now "Customs form completed".

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
