### PR TITLE
Shipping Labels: Avoid reloading address table view when not neccessary

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -118,9 +118,9 @@ final class ShippingLabelAddressFormViewModel {
             return
         }
 
-        localErrors.send(validateAddressLocally())
         let index: Int? = sections.first?.rows.firstIndex(where: { $0 == row })
         currentRowIndex.send(index)
+        localErrors.send(validateAddressLocally())
     }
 
     func updateSections() {
@@ -202,6 +202,9 @@ extension ShippingLabelAddressFormViewModel {
                 self?.updateSections()
                 self?.onChange?(index)
             }
+
+        // Append any initial local error.
+        localErrors.send(validateAddressLocally())
     }
 
     /// Validates phone number for the address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -198,7 +198,6 @@ extension ShippingLabelAddressFormViewModel {
         validationSubscription = localErrors
             .removeDuplicates()
             .withLatestFrom(currentRowIndex)
-            .dropFirst()
             .sink { [weak self] _, index in
                 self?.updateSections()
                 self?.onChange?(index)


### PR DESCRIPTION
Partially fixes #5015

# Description
When fixing #4971, I added some changes to reload the table view when editing text fields on the Address Form to instantly show error rows when a field's validation fails. This leads to a lot of unnecessary reloading; and a side effect is that holding down the Delete key is impossible because the fields are constantly losing focus.

# Changes
To reload only when needed, I keep track of the list of local errors, and only reload the table view when local errors change.
I also keep track of the row index that's in focus to focus that row again after reloading the table view.

This helps avoiding unnecessary reloading - but only partially fixes the holding Delete key issue. I.e holding down the Delete key only works if there's no change to local error.

# Demo
https://user-images.githubusercontent.com/5533851/135444039-87501699-2fd7-4a7b-9f13-d05da5f99507.mov

# Testing
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. On Orders tab select an order that's eligible for creating shipping label.
3. Select Create Shipping Label and configure Ship From.
4. Type something on any field, then hold down Delete key. You should be able to delete the field as long as there's no change to validation errors of any field.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
