### PR TITLE
Shipping Labels: Update print label screen to support multiple purchased labels

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -518,7 +518,9 @@ private extension OrderDetailsViewController {
                 assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
                 return
             }
-            let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .reprint, sourceNavigationController: navigationController)
+            let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
+                                                            printType: .reprint,
+                                                            sourceNavigationController: navigationController)
             coordinator.showPrintUI()
         case .createShippingLabel:
             let shippingLabelFormVC = ShippingLabelFormViewController(order: viewModel.order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -521,11 +521,9 @@ private extension ShippingLabelFormViewController {
 
     /// Removes the Shipping Label Form from the navigation stack and displays the Print Shipping Label screen.
     /// This prevents navigating back to the purchase form after successfully purchasing the label.
-    /// TODO-4599: Update for multi-package support
     ///
     func displayPrintShippingLabelVC() {
-        guard let purchasedShippingLabel = viewModel.purchasedShippingLabels.first,
-              let navigationController = navigationController else {
+        guard let navigationController = navigationController else {
             return
         }
 
@@ -533,7 +531,7 @@ private extension ShippingLabelFormViewController {
             let viewControllersExcludingSelf = Array(navigationController.viewControllers[0..<indexOfSelf])
             navigationController.setViewControllers(viewControllersExcludingSelf, animated: false)
         }
-        let printCoordinator = PrintShippingLabelCoordinator(shippingLabel: purchasedShippingLabel,
+        let printCoordinator = PrintShippingLabelCoordinator(shippingLabels: viewModel.purchasedShippingLabels,
                                                              printType: .print,
                                                              sourceNavigationController: navigationController,
                                                              onCompletion: onLabelSave)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -135,8 +135,11 @@ private extension PrintShippingLabelCoordinator {
 private extension PrintShippingLabelCoordinator {
     /// Requests document data for printing a shipping label with the selected paper size.
     func requestDocumentForPrinting(paperSize: ShippingLabelPaperSize, completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
+        guard let firstLabel = shippingLabels.first else {
+            return
+        }
         analytics.track(.shippingLabelReprintRequested)
-        let action = ShippingLabelAction.printShippingLabel(siteID: shippingLabels[0].siteID,
+        let action = ShippingLabelAction.printShippingLabel(siteID: firstLabel.siteID,
                                                             shippingLabelIDs: shippingLabels.map { $0.shippingLabelID },
                                                             paperSize: paperSize) { result in
             completion(result)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -93,7 +93,8 @@ private extension PrintShippingLabelCoordinator {
     }
 
     func presentPrintInProgressUI() {
-        let viewProperties = InProgressViewProperties(title: Localization.inProgressTitle, message: Localization.inProgressMessage)
+        let viewProperties = InProgressViewProperties(title: Localization.inProgressTitle(labelCount: shippingLabels.count),
+                                                      message: Localization.inProgressMessage)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
         inProgressViewController.modalPresentationStyle = .overCurrentContext
         sourceNavigationController.present(inProgressViewController, animated: true, completion: nil)
@@ -180,8 +181,15 @@ private extension PrintShippingLabelCoordinator {
 
 private extension PrintShippingLabelCoordinator {
     enum Localization {
-        static let inProgressTitle = NSLocalizedString("Printing Label",
-                                                       comment: "Title of in-progress modal when requesting shipping label document for printing")
+        static func inProgressTitle(labelCount: Int) -> String {
+            if labelCount == 1 {
+                return NSLocalizedString("Printing Label",
+                                         comment: "Title of in-progress modal when requesting shipping label document for printing")
+            } else {
+                return NSLocalizedString("Printing Labels",
+                                         comment: "Title of in-progress modal when requesting document with multiple shipping labels for printing")
+            }
+        }
         static let inProgressMessage = NSLocalizedString("Please wait",
                                                          comment: "Message of in-progress modal when requesting shipping label document for printing")
         static let printErrorAlertTitle = NSLocalizedString("Error previewing shipping label",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -158,7 +158,9 @@ private extension PrintShippingLabelCoordinator {
     /// Show customs form printing if separate customs form is available
     ///
     func showCustomsFormPrintingIfNeeded() {
-        let urls = shippingLabels.compactMap { $0.commercialInvoiceURL }
+        let urls = shippingLabels
+            .compactMap { $0.commercialInvoiceURL }
+            .filter { $0.isNotEmpty }
         guard urls.isNotEmpty, printType == .print else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -2,27 +2,27 @@ import UIKit
 import SwiftUI
 import Yosemite
 
-/// Coordinates navigation actions for printing a shipping label.
+/// Coordinates navigation actions for printing shipping labels.
 final class PrintShippingLabelCoordinator {
     private let sourceNavigationController: UINavigationController
-    private let shippingLabel: ShippingLabel
+    private let shippingLabels: [ShippingLabel]
     private let stores: StoresManager
     private let analytics: Analytics
     private let printType: PrintType
     private let onCompletion: (() -> Void)?
 
-    /// - Parameter shippingLabel: The shipping label to print.
+    /// - Parameter shippingLabels: The shipping labels to print.
     /// - Parameter printType: Whether the label is being printed for the first time or reprinted.
     /// - Parameter sourceNavigationController: The navigation controller that shows the print UI in the first place.
     /// - Parameter stores: Handles Yosemite store actions.
     /// - Parameter analytics: Tracks analytics events.
-    init(shippingLabel: ShippingLabel,
+    init(shippingLabels: [ShippingLabel],
          printType: PrintType,
          sourceNavigationController: UINavigationController,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: (() -> Void)? = nil) {
-        self.shippingLabel = shippingLabel
+        self.shippingLabels = shippingLabels
         self.printType = printType
         self.sourceNavigationController = sourceNavigationController
         self.stores = stores
@@ -34,7 +34,7 @@ final class PrintShippingLabelCoordinator {
     /// `self` is retained in the action callbacks so that the coordinator has the same life cycle as the main view controller
     /// (`PrintShippingLabelViewController`).
     func showPrintUI() {
-        let printViewController = PrintShippingLabelViewController(shippingLabel: shippingLabel, printType: printType)
+        let printViewController = PrintShippingLabelViewController(shippingLabels: shippingLabels, printType: printType)
 
         printViewController.onAction = { actionType in
             switch actionType {
@@ -135,8 +135,8 @@ private extension PrintShippingLabelCoordinator {
     /// Requests document data for printing a shipping label with the selected paper size.
     func requestDocumentForPrinting(paperSize: ShippingLabelPaperSize, completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
         analytics.track(.shippingLabelReprintRequested)
-        let action = ShippingLabelAction.printShippingLabel(siteID: shippingLabel.siteID,
-                                                            shippingLabelIDs: [shippingLabel.shippingLabelID],
+        let action = ShippingLabelAction.printShippingLabel(siteID: shippingLabels[0].siteID,
+                                                            shippingLabelIDs: shippingLabels.map { $0.shippingLabelID },
                                                             paperSize: paperSize) { result in
             completion(result)
         }
@@ -158,12 +158,12 @@ private extension PrintShippingLabelCoordinator {
     /// Show customs form printing if separate customs form is available
     ///
     func showCustomsFormPrintingIfNeeded() {
-        guard let url = shippingLabel.commercialInvoiceURL,
-              printType == .print else {
+        let urls = shippingLabels.compactMap { $0.commercialInvoiceURL }
+        guard urls.isNotEmpty, printType == .print else {
             return
         }
 
-        let printCustomsFormsView = PrintCustomsFormsView(invoiceURLs: [url], showsSaveForLater: true)
+        let printCustomsFormsView = PrintCustomsFormsView(invoiceURLs: urls, showsSaveForLater: true)
         let hostingController = UIHostingController(rootView: printCustomsFormsView)
         hostingController.hidesBottomBarWhenPushed = true
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -25,8 +25,8 @@ final class PrintShippingLabelViewController: UIViewController {
     ///
     var onAction: ((ActionType) -> Void)?
 
-    init(shippingLabel: ShippingLabel, printType: PrintShippingLabelCoordinator.PrintType) {
-        self.viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
+    init(shippingLabels: [ShippingLabel], printType: PrintShippingLabelCoordinator.PrintType) {
+        self.viewModel = PrintShippingLabelViewModel(shippingLabels: shippingLabels)
         self.printType = printType
         super.init(nibName: nil, bundle: nil)
         self.rows = rowsToDisplay()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -106,7 +106,7 @@ private extension PrintShippingLabelViewController {
 // MARK: Configuration
 private extension PrintShippingLabelViewController {
     func configureNavigationBar() {
-        navigationItem.title = Localization.navigationBarTitle
+        navigationItem.title = Localization.navigationBarTitle(labelCount: viewModel.shippingLabels.count)
     }
 
     func configureTableView() {
@@ -130,7 +130,7 @@ private extension PrintShippingLabelViewController {
             return
         }
         reprintButton.applyPrimaryButtonStyle()
-        reprintButton.setTitle(Localization.printButtonTitle, for: .normal)
+        reprintButton.setTitle(Localization.printButtonTitle(labelCount: viewModel.shippingLabels.count), for: .normal)
         reprintButton.on(.touchUpInside) { [weak self] _ in
             self?.printShippingLabel()
         }
@@ -250,7 +250,7 @@ private extension PrintShippingLabelViewController {
     func configureHeaderText(cell: BasicTableViewCell) {
         switch printType {
         case .print:
-            cell.textLabel?.text = Localization.printHeaderText
+            cell.textLabel?.text = Localization.printHeaderText(labelCount: viewModel.shippingLabels.count)
             cell.textLabel?.applyHeadlineStyle()
             cell.textLabel?.textAlignment = .center
         case .reprint:
@@ -326,7 +326,7 @@ private extension PrintShippingLabelViewController {
 
     func configurePrintButtonRow(cell: ButtonTableViewCell) {
         cell.configure(style: .primary,
-                       title: Localization.printButtonTitle,
+                       title: Localization.printButtonTitle(labelCount: viewModel.shippingLabels.count),
                        topSpacing: Constants.buttonVerticalSpacing,
                        bottomSpacing: Constants.buttonVerticalSpacing) { [weak self] in
             self?.printShippingLabel()
@@ -355,14 +355,34 @@ private extension PrintShippingLabelViewController {
     }
 
     enum Localization {
-        static let navigationBarTitle = NSLocalizedString("Print Shipping Label",
-                                                          comment: "Navigation bar title to print a shipping label")
-        static let printButtonTitle = NSLocalizedString("Print Shipping Label",
-                                                          comment: "Button title to generate a shipping label document for printing")
+        static func navigationBarTitle(labelCount: Int) -> String {
+            if labelCount == 1 {
+                return NSLocalizedString("Print Shipping Label",
+                                         comment: "Navigation bar title to print a shipping label")
+            } else {
+                return NSLocalizedString("Print Shipping Labels",
+                                         comment: "Navigation bar title to print multiple shipping labels")
+            }
+        }
+        static func printButtonTitle(labelCount: Int) -> String {
+            if labelCount == 1 {
+                return NSLocalizedString("Print Shipping Label",
+                                         comment: "Button title to generate a shipping label document for printing")
+            } else {
+                return NSLocalizedString("Print Shipping Labels",
+                                         comment: "Button title to generate a document with multiple shipping labels for printing")
+            }
+        }
         static let saveButtonTitle = NSLocalizedString("Save for Later",
                                                           comment: "Button title to save a shipping label to print later")
         static let paperSizeSelectorTitle = NSLocalizedString("Paper Size", comment: "Title of the paper size selector row for printing a shipping label")
-        static let printHeaderText = NSLocalizedString("Shipping label purchased!", comment: "Header text when printing a newly purchased shipping label")
+        static func printHeaderText(labelCount: Int) -> String {
+            if labelCount == 1 {
+                return NSLocalizedString("Shipping label purchased!", comment: "Header text when printing a newly purchased shipping label")
+            } else {
+                return NSLocalizedString("Shipping labels purchased!", comment: "Header text when printing multiple newly purchased shipping labels")
+            }
+        }
         static let reprintHeaderText = NSLocalizedString(
             "If there was a printing error when you purchased the label, you can print it again.",
             comment: "Header text when reprinting a shipping label")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
@@ -11,11 +11,11 @@ final class PrintShippingLabelViewModel {
     /// Observable selected paper size.
     @Published private(set) var selectedPaperSize: ShippingLabelPaperSize?
 
-    private let shippingLabel: ShippingLabel
+    private let shippingLabels: [ShippingLabel]
     private let stores: StoresManager
 
-    init(shippingLabel: ShippingLabel, stores: StoresManager = ServiceLocator.stores) {
-        self.shippingLabel = shippingLabel
+    init(shippingLabels: [ShippingLabel], stores: StoresManager = ServiceLocator.stores) {
+        self.shippingLabels = shippingLabels
         self.stores = stores
     }
 }
@@ -23,9 +23,9 @@ final class PrintShippingLabelViewModel {
 // MARK: Public methods
 //
 extension PrintShippingLabelViewModel {
-    /// Sets the default selected paper size to the one from shipping label settings, if the user has not selected one in the print UI.
+    /// Sets the default selected paper size to the one from the first shipping label's settings, if the user has not selected one in the print UI.
     func loadShippingLabelSettingsForDefaultPaperSize() {
-        let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabel) { [weak self] settings in
+        let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabels[0]) { [weak self] settings in
             guard let self = self else { return }
             guard let settings = settings, self.selectedPaperSize == nil else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
@@ -25,7 +25,10 @@ final class PrintShippingLabelViewModel {
 extension PrintShippingLabelViewModel {
     /// Sets the default selected paper size to the one from the first shipping label's settings, if the user has not selected one in the print UI.
     func loadShippingLabelSettingsForDefaultPaperSize() {
-        let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: shippingLabels[0]) { [weak self] settings in
+        guard let firstLabel = shippingLabels.first else {
+            return
+        }
+        let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: firstLabel) { [weak self] settings in
             guard let self = self else { return }
             guard let settings = settings, self.selectedPaperSize == nil else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
@@ -11,7 +11,7 @@ final class PrintShippingLabelViewModel {
     /// Observable selected paper size.
     @Published private(set) var selectedPaperSize: ShippingLabelPaperSize?
 
-    private let shippingLabels: [ShippingLabel]
+    let shippingLabels: [ShippingLabel]
     private let stores: StoresManager
 
     init(shippingLabels: [ShippingLabel], stores: StoresManager = ServiceLocator.stores) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -8,7 +8,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         // Given
         let viewController = MockSourceNavigationController()
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: shippingLabel, printType: .print, sourceNavigationController: viewController)
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel], printType: .print, sourceNavigationController: viewController)
 
         // When
         coordinator.showPrintUI()
@@ -23,7 +23,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_showPaperSizeSelector_shows_ListSelectorViewController() throws {
         // Given
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
         coordinator.showPrintUI()
@@ -44,7 +45,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores)
@@ -73,7 +75,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores)
@@ -105,7 +108,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         }
 
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores)
@@ -127,7 +131,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
 
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores,
@@ -148,7 +153,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPaperSizeOptions_presents_ShippingLabelPaperSizeOptionsViewController() throws {
         // Given
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
         coordinator.showPrintUI()
@@ -168,7 +174,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
     func test_presentPrintingInstructions_presents_ShippingLabelPrintingInstructionsViewController() throws {
         // Given
         let viewController = MockSourceNavigationController()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabel: MockShippingLabel.emptyLabel(),
+        let shippingLabel = MockShippingLabel.emptyLabel()
+        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
         coordinator.showPrintUI()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelViewModelTests.swift
@@ -17,7 +17,7 @@ final class PrintShippingLabelViewModelTests: XCTestCase {
     func test_paperSizeOptions_contain_all_supported_paper_sizes() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabels: [shippingLabel])
 
         // When
         let paperSizeOptions = viewModel.paperSizeOptions
@@ -31,7 +31,7 @@ final class PrintShippingLabelViewModelTests: XCTestCase {
     func test_selectedPaperSize_starts_with_nil() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabels: [shippingLabel])
 
         // When
         var paperSizeValues = [ShippingLabelPaperSize?]()
@@ -47,7 +47,7 @@ final class PrintShippingLabelViewModelTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
+        let viewModel = PrintShippingLabelViewModel(shippingLabels: [shippingLabel], stores: stores)
         let shippingLabelSettings = ShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID, paperSize: .letter)
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
             switch action {
@@ -74,7 +74,7 @@ final class PrintShippingLabelViewModelTests: XCTestCase {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel, stores: stores)
+        let viewModel = PrintShippingLabelViewModel(shippingLabels: [shippingLabel], stores: stores)
         // A4 paper size is not supported in mobile yet.
         let shippingLabelSettings = ShippingLabelSettings(siteID: shippingLabel.siteID, orderID: shippingLabel.orderID, paperSize: .a4)
         stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
@@ -101,7 +101,7 @@ final class PrintShippingLabelViewModelTests: XCTestCase {
     func test_updateSelectedPaperSize_sets_selectedPaperSize_to_selected_value() {
         // Given
         let shippingLabel = MockShippingLabel.emptyLabel()
-        let viewModel = PrintShippingLabelViewModel(shippingLabel: shippingLabel)
+        let viewModel = PrintShippingLabelViewModel(shippingLabels: [shippingLabel])
         var paperSizeValues = [ShippingLabelPaperSize?]()
         viewModel.$selectedPaperSize.sink { paperSize in
             paperSizeValues.append(paperSize)


### PR DESCRIPTION
Part of: #4714

## Description

As part of multi-package support for shipping labels, we need to support printing multiple shipping labels. This change allows the print screen to support multiple purchased labels:

* After purchasing multiple labels, all purchased labels are passed to the print screen and the UI reflects that there are multiple labels to print.
* After purchasing a single label, or when reprinting a single label, the UI is the same as before.

It isn't yet possible to purchase multiple labels, so that flow can't be directly tested but I've included screenshots below to show the changes in the UI.

## Changes

* `PrintShippingLabelCoordinator`, `PrintShippingLabelViewController`, and `PrintShippingLabelViewModel` are updated to handle an array shipping labels.
  * The print coordinator prints all of the labels and sends all of the labels' (non-nil, non-empty) customs forms to the `PrintCustomsFormsView` to be printed. (Full support for printing multiple customs forms will be done in another PR.) It also updates the printing progress view to show "Printing labels" when multiple labels are available to print.
  * The print view controller handles multiple labels and updates the UI to show plural strings ("Print Shipping Labels" and "Shipping labels purchased!") when there are multiple purchased labels.
* Updated unit tests to match the print screen changes.

Single label|Multiple labels
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-30 at 11 44 54](https://user-images.githubusercontent.com/8658164/135449526-dbf3a392-dfe0-4db8-9066-8ac3a0e1b084.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-30 at 11 32 44](https://user-images.githubusercontent.com/8658164/135449510-5369467e-41b7-44cb-a0aa-81bfaaa998e5.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-09-30 at 11 45 01](https://user-images.githubusercontent.com/8658164/135449398-8fe8f895-4481-4e2a-abb9-d0dd33aeefdd.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-30 at 11 33 03](https://user-images.githubusercontent.com/8658164/135449405-7b0f9dde-80ff-4fc5-99e7-e9aabf7f7eb9.png)

## Testing

1. Make sure you have configured the WooCommerce WCShip plugin.
2. Make sure you have at least one order with a purchased shipping label, and one order eligible to purchase a shipping label.
3. Turn off the feature flag `shippingLabelsMultiPackage` under `DefaultFeatureFlagService`.
4. Open the order detail for the order that has a purchased shipping label.
5. Find the package section in the order detail and select "Print Shipping Label."
6. Confirm the print screen reflects that there is a single label to print (no plural strings) and you can print the label.
7. Open the order detail for the order that is eligible to purchase a shipping label.
8. Select "Create Shipping Label" and fill out the form to complete the shipping label purchase.
9. After the purchase, confirm the print screen reflects that there is a single label to print (no plural strings) and you can print the label.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
