### PR TITLE
Shipping Labels: Update print customs form message for multiple packages and forms

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
@@ -22,7 +22,7 @@ struct PrintCustomsFormsView: View {
                     .padding(.top, Constants.verticalSpacing)
                 VStack(spacing: Constants.verticalSpacing) {
                     Image("woo-shipping-label-printing-instructions")
-                    Text(Localization.printingMessage)
+                    Text(invoiceURLs.count == 1 ? Localization.singlePrintingMessage : Localization.printingMessage)
                         .bodyStyle()
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
@@ -132,8 +132,10 @@ private extension PrintCustomsFormsView {
                                                        comment: "Navigation title of the Print Customs Invoice screen of Shipping Label flow")
         static let customsFormTitle = NSLocalizedString("Customs form",
                                                         comment: "Title on the Print Customs Invoice screen of Shipping Label flow")
-        static let printingMessage = NSLocalizedString("A customs form must be printed and included on this international shipment",
+        static let singlePrintingMessage = NSLocalizedString("A customs form must be printed and included on this international shipment",
                                                        comment: "Main message on the Print Customs Invoice screen of Shipping Label flow")
+        static let printingMessage = NSLocalizedString("Customs forms must be printed and included on these international shipments",
+                                                       comment: "Main message on the Print Customs Invoice screen of Shipping Label flow for multiple invoices")
         static let singlePrintButton = NSLocalizedString("Print customs form",
                                                          comment: "Title of print button on Print Customs Invoice screen" +
                                                             " of Shipping Label flow when there's only one invoice")


### PR DESCRIPTION
Closes: #4714

## Description

As part of multi-package support for shipping labels, we need to support printing multiple shipping labels and customs forms. The print customs form UI already mostly handles multiple customs forms; this PR updates the message on that screen to match the designs for multiple customs forms.

## Changes

* Checks the number of customs forms (invoice URLs) available to print and displays an appropriate message for a single vs. multiple forms ("A customs form ..." vs. "Customs forms ...").

## Testing

The shipping label purchase flow does not yet support purchasing multiple shipping labels, so the case for multiple customs forms cannot yet be tested directly in the app. You can see these changes in the SwiftUI previews in Xcode or compare these screenshots:

Before|After
-|-
![Screen Shot 2021-09-30 at 5 01 33 PM](https://user-images.githubusercontent.com/8658164/135491707-b8524613-79ec-462e-a845-6bc199732a8a.png)|![Screen Shot 2021-09-30 at 4 49 25 PM](https://user-images.githubusercontent.com/8658164/135491748-481fa2df-9372-4bf8-8104-f4c7a3c1d716.png)



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
