### PR TITLE
Order Detail: Fix bug when searching for countries

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/FilterListSelector.swift
@@ -28,7 +28,7 @@ struct FilterListSelector<ViewModel: FilterListSelectorViewModelable>: View {
 
     /// View model to drive the view content
     ///
-    @ObservedObject private(set) var viewModel: ViewModel
+    @StateObject var viewModel: ViewModel
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
# Why

While testing the country selector I noticed a strange behavior where after selecting a country the screen stopped responding when the filter term changed.

https://user-images.githubusercontent.com/562080/135527353-348daee9-401b-4c02-8704-89dda6b8886b.mov

After some investigation, this happens because:
- Selecting a country makes a published property on the address form(previous) to change
- The previous view is recreated, including its navigation links.
- Each navigation link declaration creates a new view model.
- The current country selector(Wraps an `UIKit` view) is not updated with this new view model.

Ideally, I would solve the issue by making sure the country selector wrapper updates property when the new view model arrives, but this is wrapping a `UIKit` View and that view was not designed to have its command updated.

As changing the `UIKit` screen is riskier right now, I'm solving the problem by telling the country selector to hold onto its view model by using the `@StateObject` property wrapper.

# Demo

https://user-images.githubusercontent.com/562080/135525925-4b5ba549-4161-4e09-be41-708ca5ebf1d1.mov

# Testing steps

- Navigate to EditAddress -> Select Country
- Add some text to filter some countries
- Select a country
- Verify that you can keep filtering countries.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
