### PR TITLE
Order Detail: Allow state to be entered by text when needed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressForm.swift
@@ -206,9 +206,7 @@ struct EditAddressForm: View {
                         }
                         Divider()
                             .padding(.leading, Constants.dividerPadding)
-                        TitleAndValueRow(title: Localization.stateField, value: viewModel.fields.state, selectable: true) {
-                            showStateSelector = true
-                        }
+                        stateRow()
                     }
                 }
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
@@ -280,6 +278,22 @@ struct EditAddressForm: View {
             .disabled(!enabled)
         case .loading:
             ProgressView()
+        }
+    }
+
+    /// Decides if the state row should be rendered as a list selector field or as a text input field.
+    ///
+    @ViewBuilder private func stateRow() -> some View {
+        if viewModel.showStateFieldAsSelector {
+            TitleAndValueRow(title: Localization.stateField, value: viewModel.fields.state, selectable: true) {
+                showStateSelector = true
+            }
+        } else {
+            TitleAndTextFieldRow(title: Localization.stateField,
+                                 placeholder: "",
+                                 text: $viewModel.fields.state,
+                                 symbol: nil,
+                                 keyboardType: .default)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -333,23 +333,27 @@ private extension EditAddressFormViewModel {
     }
 
     /// Update published fields when the selected country and state is updated.
-    /// If the selected country changes and it has a specific state to choose, clear the previous state.
+    /// If the selected country changes and it has a specific state to choose, clear the previous selected state.
     ///
     func bindSelectedCountryAndStateIntoFields() {
 
         typealias StatePublisher = AnyPublisher<Yosemite.StateOfACountry?, Never>
 
-        // When a country is selected, check if the current state is a valid state for that country, otherwise `nil` it.
+        // When a country is selected, check if the new country has a state list.
+        // If it has, clear the selected state and the state field.
+        // If it doesn't only clear the selected state
         $selectedCountry
-            .flatMap { country -> StatePublisher in
-                guard let country = country, country.states.isNotEmpty else {
-                    return StatePublisher.init(Empty())
+            .withLatestFrom($selectedState)
+            .map { country, state -> String in
+                guard let country = country else {
+                    return ""
                 }
-                return StatePublisher.init(Just(nil))
+                let currentStateName = state?.name ?? ""
+                return country.states.isEmpty ? currentStateName : ""
             }
-            .sink { _ in
+            .sink { stateName in
                 self.selectedState = nil
-                self.fields.state = ""
+                self.fields.state = stateName
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditAddressFormViewModel.swift
@@ -134,6 +134,12 @@ final class EditAddressFormViewModel: ObservableObject {
         }
     }
 
+    /// Defines if the state field should be defined as a list selector.
+    ///
+    var showStateFieldAsSelector: Bool {
+        selectedCountry?.states.isNotEmpty ?? false
+    }
+
     /// Creates a view model to be used when selecting a country
     ///
     func createCountryViewModel() -> CountrySelectorViewModel {


### PR DESCRIPTION
# Why

While comparing the app to Core I noticed that when a selected country does not have a list of states the merchant can manually enter a state as raw text.

This PR adjusts the address form to provide an input text field for those cases.

Additionally, it fixes a bug when the selected country changes so it properly clears the state fields.

# How

- Update `EditAddressForm` to show either an input text field or a selectable field when the ViewModel defines it.

- Update ViewModel to define `showStateFieldAsSelector` when the selected country does not have a state list.

- Update ViewModel to clear the selected state and the state field when a new country with states is selected.

# Demo


https://user-images.githubusercontent.com/562080/135550982-47d46528-9fef-47cd-87db-aaebf002967f.mov


# Testing Steps

- Navigate to the address form
- Select a country with states and select a state
- Select a country without states and see that you can enter another state manually.

Note: When switching to countries without a state list, the state is not cleared to mimic core behavior.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
