### PR TITLE
Shipping Labels: Disable Done button on Package Details screen when no default package is set

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -351,7 +351,7 @@ private extension ShippingLabelPackagesFormViewModel {
         itemViewModels.enumerated().forEach { (index, item) in
             item.$isValidPackage
                 .sink { [weak self] isValid in
-                    self?.packagesValidation[index] = isValid
+                    self?.packagesValidation[index] = isValid && item.selectedPackageID.isNotEmpty
                 }
                 .store(in: &cancellables)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -100,10 +100,10 @@ private extension ShippingLabelPackagesFormViewModel {
     /// If no initial packages was input, set up default package from last selected package ID and all order items.
     ///
     func configureDefaultPackage() {
-        guard selectedPackages.isEmpty,
-              let selectedPackageID = resultsControllers?.accountSettings?.lastSelectedPackageID else {
+        guard selectedPackages.isEmpty else {
             return
         }
+        let selectedPackageID = resultsControllers?.accountSettings?.lastSelectedPackageID ?? ""
         let items = order.items.compactMap { ShippingLabelPackageItem(orderItem: $0,
                                                                       products: products,
                                                                       productVariations: productVariations) }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -33,23 +33,21 @@ struct ShippingLabelSinglePackage: View {
             Divider()
 
             ForEach(viewModel.itemsRows) { productItemRow in
-                productItemRow
-                    .overlay(
-                        HStack {
-                            Spacer()
-                            Button(action: {
-                                viewModel.requestMovingItem(productItemRow.productOrVariationID)
-                                shouldShowMoveItemActionSheet = true
-                            }, label: {
-                                Text(Localization.moveButton)
-                                    .font(.footnote)
-                                    .foregroundColor(Color(UIColor(color: .accent)))
-                            })
-                        }
-                        .padding(.trailing, Constants.horizontalPadding)
-                    )
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(.systemBackground))
+                HStack {
+                    productItemRow
+                    Spacer()
+                    Button(action: {
+                        viewModel.requestMovingItem(productItemRow.productOrVariationID)
+                        shouldShowMoveItemActionSheet = true
+                    }, label: {
+                        Text(Localization.moveButton)
+                            .font(.footnote)
+                            .foregroundColor(Color(UIColor(color: .accent)))
+                    })
+                    .padding(.trailing, Constants.horizontalPadding)
+                }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Color(.systemBackground))
                 Divider()
                     .padding(.horizontal, insets: safeAreaInsets)
                     .padding(.leading, Constants.horizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -59,18 +59,30 @@ struct ShippingLabelSinglePackage: View {
                 .padding(.horizontal, insets: safeAreaInsets)
 
             VStack(spacing: 0) {
-                Divider()
+                VStack(spacing: 0) {
+                    Divider()
 
-                TitleAndValueRow(title: Localization.packageSelected, value: viewModel.selectedPackageName, selectable: true) {
-                    isShowingPackageSelection.toggle()
+                    TitleAndValueRow(title: Localization.packageSelected, value: viewModel.selectedPackageName, selectable: true) {
+                        isShowingPackageSelection.toggle()
+                    }
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .sheet(isPresented: $isShowingPackageSelection, content: {
+                        ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
+                    })
                 }
-                .padding(.horizontal, insets: safeAreaInsets)
-                .sheet(isPresented: $isShowingPackageSelection, content: {
-                    ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
-                })
+                .background(Color(.systemBackground))
+                .renderedIf(!viewModel.isOriginalPackaging)
+
+                VStack(spacing: 0) {
+                    Divider()
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .padding(.leading, Constants.horizontalPadding)
+
+                    ValidationErrorRow(errorMessage: Localization.selectPackage)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                }
+                .renderedIf(!viewModel.isOriginalPackaging && viewModel.selectedPackageID.isEmpty)
             }
-            .background(Color(.systemBackground))
-            .renderedIf(!viewModel.isOriginalPackaging)
 
             VStack(spacing: 0) {
                 Divider()
@@ -130,6 +142,8 @@ private extension ShippingLabelSinglePackage {
         static let packageDetailsHeader = NSLocalizedString("PACKAGE DETAILS", comment: "Header section package details in Shipping Label Package Detail")
         static let packageSelected = NSLocalizedString("Package Selected",
                                                        comment: "Title of the row for selecting a package in Shipping Label Package Detail screen")
+        static let selectPackage = NSLocalizedString("Please select a package",
+                                                     comment: "Error message when no package is selected on Shipping Label Package Details screen")
         static let totalPackageWeight = NSLocalizedString("Total package weight",
                                                           comment: "Title of the row for adding the package weight in Shipping Label Package Detail screen")
         static let footer = NSLocalizedString("Sum of products and package weight",


### PR DESCRIPTION
Part of #4599 

# Description
The new Package Details screen (supporting multi-package) currently only disables Done button when a package weight or dimension is invalid. If user has never purchased a label, no default package is set, the Done button should also be disabled to prevent proceeding without a selected package.

Extra: This PR also fixes the overlapping of the Move button on order item rows.

# Changes
- Sets default package ID an empty string if not found in settings.
- Updates Done button configuration to also consider a valid selected package ID.
- Updates Order Item rows to avoid overlapping Move button on contents.
- Adds validation error when selected package ID is empty to better communicate the error.

# Screenshot
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/135565728-d6dabd95-9759-4259-a373-958f538f80b5.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/135565764-413cc94f-82f0-44df-8924-df3e98461901.png" width=320 />

# Testing
1. Make sure to test with a test store that's never created a shipping label before. Hint: use appstestadmin account with store named For The Birds (info can be found in the Shared Test Accounts in the Field Guide).
2. Select an order that's eligible for creating shipping label.
3. Select Create Shipping Label, and configure Ship From and Ship To.
4. On Package Details screen, notice that the Move button does not overlap with order item details if the details are long.
5. Notice that when no default package is selected, Done button is disabled and a validation error is displayed beneath the Selected Package row. Selecting a package should make this error go away and enable the Done button.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
