### PR TITLE
[Mobile Payments] Handle software update errors for all cases

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderServiceError.swift
+++ b/Hardware/Hardware/CardReader/CardReaderServiceError.swift
@@ -194,7 +194,7 @@ public enum UnderlyingError: Error {
 extension UnderlyingError {
     /// Returns true if the error is related to card reader software updates
     ///
-    var isSoftwareUpdateError: Bool {
+    public var isSoftwareUpdateError: Bool {
         switch self {
         case .readerSoftwareUpdateFailed,
              .readerSoftwareUpdateFailedReader,

--- a/Hardware/Hardware/CardReader/CardReaderSoftwareUpdateState.swift
+++ b/Hardware/Hardware/CardReader/CardReaderSoftwareUpdateState.swift
@@ -9,6 +9,9 @@ public enum CardReaderSoftwareUpdateState {
     /// The update is being installed
     case installing(progress: Float)
 
+    /// The update failed to install
+    case failed(error: Error)
+
     /// The update has finished installing
     case completed
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -471,12 +471,13 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
     }
 
     public func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
-        guard error == nil else {
+        if let error = error {
+            softwareUpdateSubject.send(.failed(error: error))
             softwareUpdateSubject.send(.available)
-            return
+        } else {
+            softwareUpdateSubject.send(.completed)
+            softwareUpdateSubject.send(.none)
         }
-        softwareUpdateSubject.send(.completed)
-        softwareUpdateSubject.send(.none)
     }
 
     /// This method is called by the Stripe Terminal SDK when it wants client apps

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailed.swift
@@ -1,0 +1,56 @@
+import UIKit
+
+final class CardPresentModalUpdateFailed: CardPresentPaymentsModalViewModel {
+    private let close: () -> Void
+
+    /// The error returned by the stack
+    private let error: Error
+
+    let textMode: PaymentsModalTextMode = .reducedBottomInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .paymentErrorImage
+
+    let primaryButtonTitle: String? = Localization.dismiss
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? {
+        error.localizedDescription
+    }
+
+    let bottomSubtitle: String? = nil
+
+    init(error: Error, close: @escaping () -> Void) {
+        self.error = error
+        self.close = close
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        close()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalUpdateFailed {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Software update failed",
+            comment: "Error message. Presented to users when updating the card reader software fails"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "Dismiss",
+            comment: "Button to dismiss. Presented to users when updating the card reader software fails"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailedNonRetryable.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailedNonRetryable.swift
@@ -1,11 +1,10 @@
 import UIKit
 
-final class CardPresentModalUpdateFailed: CardPresentPaymentsModalViewModel {
-    private let tryAgain: () -> Void
+final class CardPresentModalUpdateFailedNonRetryable: CardPresentPaymentsModalViewModel {
     private let close: () -> Void
 
     let textMode: PaymentsModalTextMode = .noBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .twoAction
+    let actionsMode: PaymentsModalActionsMode = .secondaryOnlyAction
 
     let topTitle: String = Localization.title
 
@@ -13,9 +12,9 @@ final class CardPresentModalUpdateFailed: CardPresentPaymentsModalViewModel {
 
     let image: UIImage = .paymentErrorImage
 
-    let primaryButtonTitle: String? = Localization.tryAgain
+    let primaryButtonTitle: String? = nil
 
-    let secondaryButtonTitle: String? = Localization.cancel
+    let secondaryButtonTitle: String? = Localization.dismiss
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -23,14 +22,11 @@ final class CardPresentModalUpdateFailed: CardPresentPaymentsModalViewModel {
 
     let bottomSubtitle: String? = nil
 
-    init(tryAgain: @escaping () -> Void, close: @escaping () -> Void) {
-        self.tryAgain = tryAgain
+    init(close: @escaping () -> Void) {
         self.close = close
     }
 
-    func didTapPrimaryButton(in viewController: UIViewController?) {
-        tryAgain()
-    }
+    func didTapPrimaryButton(in viewController: UIViewController?) { }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         close()
@@ -39,20 +35,15 @@ final class CardPresentModalUpdateFailed: CardPresentPaymentsModalViewModel {
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-private extension CardPresentModalUpdateFailed {
+private extension CardPresentModalUpdateFailedNonRetryable {
     enum Localization {
         static let title = NSLocalizedString(
             "We couldn’t update your reader’s software",
             comment: "Error message. Presented to users when updating the card reader software fails"
         )
 
-        static let tryAgain = NSLocalizedString(
-            "Try Again",
-            comment: "Button to retry a software update. Presented to users when updating the card reader software fails"
-        )
-
-        static let cancel = NSLocalizedString(
-            "Cancel",
+        static let dismiss = NSLocalizedString(
+            "Dismiss",
             comment: "Button to dismiss. Presented to users when updating the card reader software fails"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -46,6 +46,7 @@ final class CardPresentPaymentsModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        initializeContent()
         setBackgroundColor()
         setButtonsActions()
         styleContent()
@@ -160,6 +161,13 @@ private extension CardPresentPaymentsModalViewController {
         auxiliaryButton.applyLinkButtonStyle()
         auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
+    }
+
+    func initializeContent() {
+        topTitleLabel.text = ""
+        topSubtitleLabel.text = ""
+        bottomTitleLabel.text = ""
+        bottomSubtitleLabel.text = ""
     }
 
     func populateContent() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -535,7 +535,7 @@ private extension CardReaderConnectionController {
         } else {
             alerts.updatingFailed(
                 from: from,
-                error: underlyingError,
+                tryAgain: nil,
                 close: {
                     self.state = .searching
                 })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -29,6 +29,10 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: updatingFailedLowBattery(from: from, batteryLevel: batteryLevel, close: close))
     }
 
+    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: updatingFailed(from: from, error: error, close: close))
+    }
+
     func foundReader(from: UIViewController,
                      name: String,
                      connect: @escaping () -> Void,
@@ -158,6 +162,10 @@ private extension CardReaderSettingsAlerts {
 
     func updatingFailedLowBattery(from: UIViewController, batteryLevel: Double?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalUpdateFailedLowBattery(batteryLevel: batteryLevel, close: close)
+    }
+
+    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalUpdateFailed(error: error, close: close)
     }
 
     func foundReader(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -29,8 +29,8 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: updatingFailedLowBattery(from: from, batteryLevel: batteryLevel, close: close))
     }
 
-    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void) {
-        setViewModelAndPresent(from: from, viewModel: updatingFailed(from: from, error: error, close: close))
+    func updatingFailed(from: UIViewController, tryAgain: (() -> Void)?, close: @escaping () -> Void) {
+        setViewModelAndPresent(from: from, viewModel: updatingFailed(from: from, tryAgain: tryAgain, close: close))
     }
 
     func foundReader(from: UIViewController,
@@ -164,8 +164,12 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalUpdateFailedLowBattery(batteryLevel: batteryLevel, close: close)
     }
 
-    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalUpdateFailed(error: error, close: close)
+    func updatingFailed(from: UIViewController, tryAgain: (() -> Void)?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        if let tryAgain = tryAgain {
+            return CardPresentModalUpdateFailed(tryAgain: tryAgain, close: close)
+        } else {
+            return CardPresentModalUpdateFailedNonRetryable(close: close)
+        }
     }
 
     func foundReader(name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -51,6 +51,10 @@ protocol CardReaderSettingsAlertsProvider {
                                   batteryLevel: Double?,
                                   close: @escaping () -> Void)
 
+    /// Defines an alert indicating an update couldn't be installed.
+    ///
+    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void)
+
     /// Shows progress when a software update is being installed
     ///
     func updateProgress(from: UIViewController, requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -53,7 +53,7 @@ protocol CardReaderSettingsAlertsProvider {
 
     /// Defines an alert indicating an update couldn't be installed.
     ///
-    func updatingFailed(from: UIViewController, error: Error, close: @escaping () -> Void)
+    func updatingFailed(from: UIViewController, tryAgain: (() -> Void)?, close: @escaping () -> Void)
 
     /// Shows progress when a software update is being installed
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Yosemite
 
 /// This view controller is used when a reader is currently connected. It assists
 /// the merchant in updating and/or disconnecting from the reader, as needed.
@@ -17,9 +18,6 @@ final class CardReaderSettingsConnectedViewController: UIViewController, CardRea
     /// Table Sections to be rendered
     ///
     private var sections = [Section]()
-
-    /// Last known update view
-    private var readerUpdateProgress: Float? = nil
 
     /// Card Present Payments alerts
     private lazy var paymentAlerts: OrderDetailsPaymentAlerts = {
@@ -121,15 +119,22 @@ private extension CardReaderSettingsConnectedViewController {
     }
 
     func configureUpdateView() {
-        // Only proceed if the view model reader update flag has changed since we last looked at it
-        guard let viewModel = viewModel, readerUpdateProgress != viewModel.readerUpdateProgress else {
+        guard let viewModel = viewModel else {
             return
         }
 
-        // Update our flag to match the view model's
-        readerUpdateProgress = viewModel.readerUpdateProgress
-
-        if let readerUpdateProgress = viewModel.readerUpdateProgress {
+        if let error = viewModel.readerUpdateError {
+            if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: let batteryLevel) = error,
+               underlyingError == .readerSoftwareUpdateFailedBatteryLow {
+                settingsAlerts.updatingFailedLowBattery(from: self, batteryLevel: batteryLevel, close: { [settingsAlerts] in
+                    settingsAlerts.dismiss()
+                })
+            } else {
+                settingsAlerts.updatingFailed(from: self, error: error, close: { [settingsAlerts] in
+                    settingsAlerts.dismiss()
+                })
+            }
+        } else if let readerUpdateProgress = viewModel.readerUpdateProgress {
             // If we are updating a reader, show the progress alert
             settingsAlerts.updateProgress(from: self, requiredUpdate: false, progress: readerUpdateProgress, cancel: { [weak self] in
                 self?.viewModel?.cancelCardReaderUpdate()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -130,9 +130,15 @@ private extension CardReaderSettingsConnectedViewController {
                     settingsAlerts.dismiss()
                 })
             } else {
-                settingsAlerts.updatingFailed(from: self, error: error, close: { [settingsAlerts] in
-                    settingsAlerts.dismiss()
-                })
+                settingsAlerts.updatingFailed(
+                    from: self,
+                    tryAgain: {
+                        viewModel.startCardReaderUpdate()
+                    },
+                    close: { [settingsAlerts] in
+                        settingsAlerts.dismiss()
+                    }
+                )
             }
         } else if let readerUpdateProgress = viewModel.readerUpdateProgress {
             // If we are updating a reader, show the progress alert

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -16,6 +16,7 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         readerUpdateProgress != nil
     }
     private(set) var readerUpdateProgress: Float? = nil
+    private(set) var readerUpdateError: Error? = nil
     private var softwareUpdateCancelable: FallibleCancelable? = nil
 
     private(set) var readerDisconnectInProgress: Bool = false
@@ -55,10 +56,14 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
 
                     switch state {
                     case .started(cancelable: let cancelable):
+                        self.readerUpdateError = nil
                         self.softwareUpdateCancelable = cancelable
                         self.readerUpdateProgress = 0
                     case .installing(progress: let progress):
                         self.readerUpdateProgress = progress
+                    case .failed(error: let error):
+                        self.readerUpdateError = error
+                        self.completeCardReaderUpdate(success: false)
                     case .completed:
                         self.readerUpdateProgress = 1
                         self.softwareUpdateCancelable = nil

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1319,6 +1319,7 @@
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
 		E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */; };
+		E11228BE2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11228BD2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift */; };
 		E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */; };
 		E12AF69926BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */; };
 		E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */; };
@@ -2763,6 +2764,7 @@
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalUpdateFailed.swift; sourceTree = "<group>"; };
+		E11228BD2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalUpdateFailedNonRetryable.swift; sourceTree = "<group>"; };
 		E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLoadingView.swift; sourceTree = "<group>"; };
 		E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCaseTests.swift; sourceTree = "<group>"; };
@@ -6280,6 +6282,7 @@
 				E1E125A926EB42530068A9B0 /* CardPresentModalUpdateProgress.swift */,
 				E1308380270311E200D5A68D /* CardPresentModalUpdateFailedLowBattery.swift */,
 				E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */,
+				E11228BD2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift */,
 				E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */,
 				3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */,
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
@@ -7152,6 +7155,7 @@
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
+				E11228BE2707267F004E9F2D /* CardPresentModalUpdateFailedNonRetryable.swift in Sources */,
 				5739D2D426274D580020E737 /* NoSecureConnectionErrorViewModel.swift in Sources */,
 				7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */,
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1318,6 +1318,7 @@
 		E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */; };
 		E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */; };
 		E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DFC792673595A0083AFF2 /* ShareSheet.swift */; };
+		E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */; };
 		E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */; };
 		E12AF69926BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */; };
 		E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */; };
@@ -2761,6 +2762,7 @@
 		E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableVStack.swift; sourceTree = "<group>"; };
 		E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModelTests.swift; sourceTree = "<group>"; };
 		E10DFC792673595A0083AFF2 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
+		E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalUpdateFailed.swift; sourceTree = "<group>"; };
 		E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLoadingView.swift; sourceTree = "<group>"; };
 		E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingUseCaseTests.swift; sourceTree = "<group>"; };
@@ -6277,6 +6279,7 @@
 				31B0551D264B3C7A00134D87 /* CardPresentModalFoundReader.swift */,
 				E1E125A926EB42530068A9B0 /* CardPresentModalUpdateProgress.swift */,
 				E1308380270311E200D5A68D /* CardPresentModalUpdateFailedLowBattery.swift */,
+				E11228BB2707161E004E9F2D /* CardPresentModalUpdateFailed.swift */,
 				E1BE7039265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift */,
 				3190D61A26D6D82900EF364D /* CardPresentRetryableError.swift */,
 				E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */,
@@ -7675,6 +7678,7 @@
 				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
+				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
 				45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -87,6 +87,10 @@ final class MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         close()
     }
 
+    func updatingFailed(from: UIViewController, tryAgain: (() -> Void)?, close: @escaping () -> Void) {
+        close()
+    }
+
     func updateSeveralReadersList(readerIDs: [String]) {
         // GNDN
     }


### PR DESCRIPTION
Fixes #5036 

In #5073, I handled the error case for a required update that would fail due to low battery, as it was the only failure case that it's possible to simulate.

After talking to Stripe and clarifying the expected behavior:
- Errors installing a required update will be reported as a failure to connect. The `didFinishInstallingUpdate` delegate method is not being called right now, at least on the simulator, but Stripe plans to fix that in a future SDK version
- Errors installing an optional update will be reported through the `didFinishInstallingUpdate` delegate method
- When an optional update fails, we can assume that the reader is still connected, otherwise we would receive a `didReportUnexpectedReaderDisconnect` delegate call, which I think we're handling correctly.

For @woocommerce/mobile-designers: the designs for a generic error contain a "Try again" button, but it's not possible it manually initiate required updates (they happen transparently during connection), so this will only be present for optional updates

## To test

First, edit the WooCommerce scheme, and enable -simulate-stripe-card-reader in the Arguments tab.

### Optional updates

In `StripeCardReaderService.start(_:)`, after the SDK has been initialized (I add this right after Terminal.shared.delegate = self), add the following line: `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .available`

Then replace the `installUpdate` method in `StripeCardReaderService` with this, and try with a few different `readerSoftwareUpdateFailed*` errors :

```swift
    public func installUpdate() -> Void {
//        Terminal.shared.installAvailableUpdate()
        softwareUpdateSubject.send(.started(cancelable: nil))
        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [softwareUpdateSubject] in
            softwareUpdateSubject.send(.installing(progress: 0.1))
        }
        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) { [softwareUpdateSubject] in
            softwareUpdateSubject.send(.failed(error: CardReaderServiceError.softwareUpdate(underlyingError: .readerSoftwareUpdateFailedBatteryLow, batteryLevel: 0.25)))
            softwareUpdateSubject.send(.available)
        }
    }
```

1. Go to Settings > In-Person Payments > Manage Card Reader and connect to a reader
2. After the reader connects, it should show an available update
3. Tap on "Update Reader Software"
4. A modal with the error should appear
5. If there's a "Try again" button, tapping on it would attempt to install again. Tapping on Cancel/Dismiss should close the modal.

The low battery case has a special design, but the rest should show a generic error modal

Generic error | Low battery
-|-
![optional-generic](https://user-images.githubusercontent.com/8739/135614745-e00fc4ac-9dea-4b50-89e1-56d024cc8838.png)|![optional-low](https://user-images.githubusercontent.com/8739/135614752-5dfc6d15-8ea6-4b49-99a3-71f06c064ef3.png)

### Required updates

In `StripeCardReaderService.start(_:)`, after the SDK has been initialized (I add this right after Terminal.shared.delegate = self), add the following line: `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .lowBattery`

If you want to try a different error than low battery, in `StripeCardReaderService.connect(_:configuration:)`, edit the completion block so that we pass a custom error:

```swift
//...
                if let error = error {
                    let underlyingError = UnderlyingError.readerSoftwareUpdateFailedInterrupted //UnderlyingError(with: error)
                    // Starting with StripeTerminal 2.0, required software updates happen transparently on connection
                    // Any error related to that will be reported here, but we don't want to treat it as a connection error
                    let serviceError: CardReaderServiceError = underlyingError.isSoftwareUpdateError ?
                        .softwareUpdate(underlyingError: underlyingError, batteryLevel: batteryLevel) :
                        .connection(underlyingError: underlyingError)
                    promise(.failure(serviceError))
                }


//...
```

1. Go to Settings > In-Person Payments > Manage Card Reader and connect to a reader
2. After the reader connects, it should automatically attempt to update and show an error

Generic error | Low battery
-|-
![required-generic](https://user-images.githubusercontent.com/8739/135615086-418398e8-d41e-407a-9628-5ac2e532b582.png)|![required-low](https://user-images.githubusercontent.com/8739/135614693-76c01654-fac7-4ea7-80c2-c2151f6d6ee8.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
