### PR TITLE
Shipping Labels: Update order summary to display retail rate for each package when there are multiple packages

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -75,11 +75,10 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
     }
 
     func setPackageRates(_ rates: [String]) {
-        if rates.isEmpty {
-            packageRatesStackViews.forEach { stackView in
-                mainStackView.removeArrangedSubview(stackView)
-            }
-        } else {
+        packageRatesStackViews.forEach { stackView in
+            mainStackView.removeArrangedSubview(stackView)
+        }
+        if rates.isNotEmpty {
             packageRatesStackViews = rates.enumerated().map { (index, rateText) in
                 let titleLabel = UILabel()
                 titleLabel.applyBodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -90,6 +90,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
                 descriptionLabel.applyBodyStyle()
                 // swiftlint:disable:next inverse_text_alignment
                 descriptionLabel.textAlignment = .right
+                // swiftlint:enable:next inverse_text_alignment
                 descriptionLabel.text = rateText
                 descriptionLabel.setContentHuggingPriority(UILayoutPriority(250), for: .horizontal)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -88,9 +88,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
 
                 let descriptionLabel = UILabel()
                 descriptionLabel.applyBodyStyle()
-                // swiftlint:disable:next inverse_text_alignment
-                descriptionLabel.textAlignment = .right
-                // swiftlint:enable:next inverse_text_alignment
+                descriptionLabel.textAlignment = .right // swiftlint:disable:this inverse_text_alignment
                 descriptionLabel.text = rateText
                 descriptionLabel.setContentHuggingPriority(UILayoutPriority(250), for: .horizontal)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -2,6 +2,8 @@ import UIKit
 
 final class ShippingLabelSummaryTableViewCell: UITableViewCell {
 
+    @IBOutlet private weak var mainStackView: UIStackView!
+
     @IBOutlet private weak var subtotalTitle: UILabel!
     @IBOutlet private weak var subtotalBody: UILabel!
 
@@ -18,6 +20,10 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var separator: UIImageView!
     @IBOutlet private weak var button: ButtonActivityIndicator!
+
+    /// Extra stack views for package rates when there are more than one label.
+    ///
+    private var packageRatesStackViews: [UIStackView] = []
 
     /// Boolean indicating if the Switch is On or Off.
     ///
@@ -68,6 +74,38 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
         onButtonTouchUp?()
     }
 
+    func setPackageRates(_ rates: [String]) {
+        if rates.isEmpty {
+            packageRatesStackViews.forEach { stackView in
+                mainStackView.removeArrangedSubview(stackView)
+            }
+        } else {
+            packageRatesStackViews = rates.enumerated().map { (index, rateText) in
+                let titleLabel = UILabel()
+                titleLabel.applyBodyStyle()
+                titleLabel.text = String(format: Localization.packageNumber, index + 1)
+                titleLabel.setContentHuggingPriority(UILayoutPriority(251), for: .horizontal)
+
+                let descriptionLabel = UILabel()
+                descriptionLabel.applyBodyStyle()
+                // swiftlint:disable:next inverse_text_alignment
+                descriptionLabel.textAlignment = .right
+                descriptionLabel.text = rateText
+                descriptionLabel.setContentHuggingPriority(UILayoutPriority(250), for: .horizontal)
+
+                let stackView = UIStackView()
+                stackView.axis = .horizontal
+                stackView.spacing = 8.0
+                stackView.addArrangedSubviews([titleLabel, descriptionLabel])
+                return stackView
+            }
+            packageRatesStackViews.enumerated().forEach { (index, stackView) in
+                mainStackView.insertArrangedSubview(stackView, at: index)
+            }
+        }
+        updateSubtotalLabels()
+    }
+
     func setSubtotal(_ total: String) {
         subtotalBody.text = total
     }
@@ -99,11 +137,10 @@ private extension ShippingLabelSummaryTableViewCell {
     }
 
     func configureLabels() {
-        subtotalTitle.applyBodyStyle()
         subtotalTitle.text = Localization.subtotal
         subtotalTitle.numberOfLines = 0
-        subtotalBody.applyBodyStyle()
         subtotalBody.numberOfLines = 0
+        updateSubtotalLabels()
         discountTitle.applyBodyStyle()
         discountTitle.text = Localization.discount
         discountTitle.numberOfLines = 0
@@ -117,6 +154,16 @@ private extension ShippingLabelSummaryTableViewCell {
         orderCompleteTitle.applySubheadlineStyle()
         orderCompleteTitle.text = Localization.orderComplete
         orderCompleteTitle.numberOfLines = 0
+    }
+
+    func updateSubtotalLabels() {
+        if packageRatesStackViews.isEmpty {
+            subtotalTitle.applyBodyStyle()
+            subtotalBody.applyBodyStyle()
+        } else {
+            subtotalTitle.applyHeadlineStyle()
+            subtotalBody.applyHeadlineStyle()
+        }
     }
 
     func configureSwitch() {
@@ -148,5 +195,6 @@ private extension ShippingLabelSummaryTableViewCell {
         static let orderComplete = NSLocalizedString("Mark this order as complete and notify the customer",
                                                      comment: "Create Shipping Label form -> Mark order as complete label")
         static let button = NSLocalizedString("Purchase Label", comment: "Create Shipping Label form -> Purchase Label button")
+        static let packageNumber = NSLocalizedString("Package %1$d", comment: "Create Shipping Label form -> Package number")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -77,6 +77,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
     func setPackageRates(_ rates: [String]) {
         packageRatesStackViews.forEach { stackView in
             mainStackView.removeArrangedSubview(stackView)
+            stackView.removeFromSuperview()
         }
         if rates.isNotEmpty {
             packageRatesStackViews = rates.enumerated().map { (index, rateText) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -159,6 +159,7 @@
                 <outlet property="discountImage" destination="rKt-4t-goT" id="1dn-pm-SUL"/>
                 <outlet property="discountTitle" destination="Q6d-eZ-aR6" id="D9P-3z-CQA"/>
                 <outlet property="discountView" destination="pze-kN-rzd" id="vbz-LS-guY"/>
+                <outlet property="mainStackView" destination="x8R-iF-LrA" id="UlZ-GN-Dmo"/>
                 <outlet property="orderCompleteSwitch" destination="JZh-Fj-mpq" id="81U-az-KPg"/>
                 <outlet property="orderCompleteTitle" destination="Nbh-nn-FoU" id="Bbd-5f-tgM"/>
                 <outlet property="orderTotalBody" destination="ZPT-Tu-548" id="aaT-QM-yGn"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -355,6 +355,7 @@ private extension ShippingLabelFormViewController {
             }
         }
         cell.isOn = false
+        cell.setPackageRates(viewModel.getPackageRates())
         cell.setSubtotal(viewModel.getSubtotal())
         cell.setDiscount(viewModel.getDiscount())
         cell.setOrderTotal(viewModel.getOrderTotal())

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -823,7 +823,7 @@ private extension ShippingLabelFormViewModel {
                                                           comment: "Plural format of number of business days in Shipping Labels > Carrier and Rates")
         static let selectedRatesCount = NSLocalizedString("%1$d rates selected",
                                                           comment: "Number of rates selected in Shipping Labels > Carrier and Rates")
-        static let totalRate = NSLocalizedString("$1$@ total",
+        static let totalRate = NSLocalizedString("%1$@ total",
                                                  comment: "Total value for the selected rates in Shipping Labels > Carrier and Rates")
         static let paymentMethodPlaceholder = NSLocalizedString("Add a new credit card",
                                                                 comment: "Placeholder in Shipping Label form for the Payment Method row.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -353,6 +353,18 @@ final class ShippingLabelFormViewModel {
         return String.localizedStringWithFormat(Localization.paymentMethodLabel, selectedPaymentMethod.cardDigits)
     }
 
+    /// Returns retail rate for each package if there are more than one label.
+    ///
+    func getPackageRates() -> [String] {
+        guard selectedRates.count > 1 else {
+            return []
+        }
+        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        return selectedRates.map { rate in
+            currencyFormatter.formatAmount(Decimal(rate.retailRate)) ?? ""
+        }
+    }
+
     /// Returns the subtotal under the Order Summary.
     ///
     func getSubtotal() -> String {


### PR DESCRIPTION
Closes #4715 

# Description
This PR updates shipping label purchase form's order summary section by adding extra lines for individual retail rate of each package if there are more than one package.

# Changes
- `ShippingLabelSummaryTableViewCell`: adds new method `setPackageRates` to update the section. If the input rate list is not empty, additional lines for each package's rate are inserted at the top of the section, and Subtotal line is made bolder.
- `ShippingLabelFormViewModel`: adds new method `getPackageRates` that returns retail rate for each package if there are more than one label.

# Screenshots
| Single package | Multiple packages |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/135795434-d638a360-7ebe-4d2e-b6d9-b5d85e0c083a.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/135796320-7c3b2c4e-276f-4691-ac02-fb206370a3d1.png" width=320 /> |

# Testing
Precondition: Make sure your test store has installed and activated WCShip plugin. Then on Orders tab, select an order that's eligible for creating Shipping Label.

#### Case 1: Single package
1. Select Create Shipping Label, proceed to fill all information. In Package Details, keep everything in one package.
2. Notice on Order Summary section: no separate rate for the single package is listed. Make sure all other information is correct: subtotal, discount, total.

#### Case 2: Multiple packages
1. Depending on the status of #4716, we can test this case in different ways:
   - If not finished: simulate multiple packages for selected carrier's rates by updating method `displayCarriersAndRatesVC` in `ShippingLabelFormViewController` with an extra rate in the selected rate list:
   ```Swift
   self?.viewModel.handleCarrierAndRatesValueChanges(selectedRates: [rate, rate], editable: true)
   ```
   - If done and merged: select Create Shipping Label, proceed to fill all information. In Package Details, move some items to other packages.
2. Notice on Order Summary section: there are separate lines for rate of each package. Make sure all information is correct: subtotal, discount, total.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
