### PR TITLE
Fix screenshot generation tests from recent app changes

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		0212AC62242C68B600C51F6C /* ResultsController+SortProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212AC61242C68B600C51F6C /* ResultsController+SortProducts.swift */; };
 		0212AC64242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212AC63242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift */; };
 		0212AC67242C799B00C51F6C /* ResultsController+StorageProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212AC66242C799B00C51F6C /* ResultsController+StorageProductTests.swift */; };
+		02137901270AB204006430F7 /* MockUserActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02137900270AB204006430F7 /* MockUserActionHandler.swift */; };
+		02137903270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02137902270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift */; };
+		02137905270AC39C006430F7 /* MockPaymentGatewayAccountActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02137904270AC39C006430F7 /* MockPaymentGatewayAccountActionHandler.swift */; };
+		02137907270AC5A0006430F7 /* MockReceiptActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */; };
 		0218B4EE242E08B20083A847 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4ED242E08B20083A847 /* MediaType.swift */; };
 		0218B4F0242E091C0083A847 /* Media+MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4EF242E091C0083A847 /* Media+MediaType.swift */; };
 		0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0218B4F1242E09E80083A847 /* MediaTypeTests.swift */; };
@@ -388,6 +392,10 @@
 		0212AC61242C68B600C51F6C /* ResultsController+SortProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultsController+SortProducts.swift"; sourceTree = "<group>"; };
 		0212AC63242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductStore+ProductsSortOrderTests.swift"; sourceTree = "<group>"; };
 		0212AC66242C799B00C51F6C /* ResultsController+StorageProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultsController+StorageProductTests.swift"; sourceTree = "<group>"; };
+		02137900270AB204006430F7 /* MockUserActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserActionHandler.swift; sourceTree = "<group>"; };
+		02137902270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnnouncementsActionHandler.swift; sourceTree = "<group>"; };
+		02137904270AC39C006430F7 /* MockPaymentGatewayAccountActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentGatewayAccountActionHandler.swift; sourceTree = "<group>"; };
+		02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReceiptActionHandler.swift; sourceTree = "<group>"; };
 		0218B4ED242E08B20083A847 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		0218B4EF242E091C0083A847 /* Media+MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+MediaType.swift"; sourceTree = "<group>"; };
 		0218B4F1242E09E80083A847 /* MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeTests.swift; sourceTree = "<group>"; };
@@ -931,6 +939,10 @@
 				247CE8432582F3BB00F9D9D1 /* MockSettingActionHandler.swift */,
 				247CE86B25832D5800F9D9D1 /* MockShipmentActionHandler.swift */,
 				247CE86725832BEE00F9D9D1 /* MockShippingLabelActionHandler.swift */,
+				02137900270AB204006430F7 /* MockUserActionHandler.swift */,
+				02137902270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift */,
+				02137904270AC39C006430F7 /* MockPaymentGatewayAccountActionHandler.swift */,
+				02137906270AC5A0006430F7 /* MockReceiptActionHandler.swift */,
 			);
 			path = ActionHandlers;
 			sourceTree = "<group>";
@@ -1768,6 +1780,7 @@
 				247CE83C2582F36800F9D9D1 /* MockOrderActionHandler.swift in Sources */,
 				45E462142684C92D00011BF2 /* DataStore.swift in Sources */,
 				02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */,
+				02137905270AC39C006430F7 /* MockPaymentGatewayAccountActionHandler.swift in Sources */,
 				74643EE1221F567E00EDC51A /* ShipmentAction.swift in Sources */,
 				02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */,
 				2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */,
@@ -1779,6 +1792,7 @@
 				45ED6096257E7472007B4AC6 /* ProductAttributeStore.swift in Sources */,
 				077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */,
 				02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */,
+				02137901270AB204006430F7 /* MockUserActionHandler.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
 				D8C11A5022DF2D9400D4A88D /* StatsStoreV4.swift in Sources */,
 				D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */,
@@ -1814,6 +1828,7 @@
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,
 				02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */,
 				45AB8B1724AA4B3D00B5B36E /* ProductTagStore.swift in Sources */,
+				02137903270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift in Sources */,
 				247CE8342582F20100F9D9D1 /* MockAppSettingsActionHandler.swift in Sources */,
 				025CA2CA238F515600B05C81 /* ProductShippingClassStore.swift in Sources */,
 				3147030A2670295300EF253A /* PaymentGatewayAccountStore.swift in Sources */,
@@ -1827,6 +1842,7 @@
 				933A27352222352500C2143A /* Logging.swift in Sources */,
 				261CF1ED255B37B40090D8D3 /* PaymentGatewayAction.swift in Sources */,
 				74685D5020F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift in Sources */,
+				02137907270AC5A0006430F7 /* MockReceiptActionHandler.swift in Sources */,
 				74A7689020D45F9300F9D437 /* OrderAction.swift in Sources */,
 				D88E234525AE0EB90023F3B1 /* OrderFeeLine+ReadOnlyConvertible.swift in Sources */,
 				2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAnnouncementsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAnnouncementsActionHandler.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Storage
+
+struct MockAnnouncementsActionHandler: MockActionHandler {
+    typealias ActionType = AnnouncementsAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .synchronizeAnnouncements(let onCompletion):
+            onCompletion(.failure(AnnouncementsError.announcementNotFound))
+        case .loadSavedAnnouncement(let onCompletion):
+            onCompletion(.failure(AnnouncementsError.announcementNotFound))
+        default: unimplementedAction(action: action)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -22,7 +22,7 @@ struct MockAppSettingsActionHandler: MockActionHandler {
             case .loadProductsSettings(let siteId, let onCompletion):
                 loadProductSettings(siteId: siteId, onCompletion: onCompletion)
             case .loadEligibilityErrorInfo(let onCompletion):
-                loadEligibilityErrorInfo(onCompletion: onCompletion)
+                onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
             case .loadOrderAddOnsSwitchState(let onCompletion):
                 onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
             case .resetEligibilityErrorInfo:

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -21,6 +21,12 @@ struct MockAppSettingsActionHandler: MockActionHandler {
                 setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
             case .loadProductsSettings(let siteId, let onCompletion):
                 loadProductSettings(siteId: siteId, onCompletion: onCompletion)
+            case .loadEligibilityErrorInfo(let onCompletion):
+                loadEligibilityErrorInfo(onCompletion: onCompletion)
+            case .loadOrderAddOnsSwitchState(let onCompletion):
+                onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
+            case .resetEligibilityErrorInfo:
+                break
             default: unimplementedAction(action: action)
         }
     }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -12,7 +12,8 @@ struct MockOrderActionHandler: MockActionHandler {
         switch action {
             case .fetchFilteredAndAllOrders(let siteID, _, _, _, _, let onCompletion):
                 fetchFilteredAndAllOrders(siteID: siteID, onCompletion: onCompletion)
-
+            case .retrieveOrder(let siteID, let orderID, let onCompletion):
+                onCompletion(objectGraph.order(forSiteId: siteID, orderId: orderID), nil)
             default: unimplementedAction(action: action)
         }
     }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockPaymentGatewayAccountActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockPaymentGatewayAccountActionHandler.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Storage
+
+struct MockPaymentGatewayAccountActionHandler: MockActionHandler {
+    typealias ActionType = PaymentGatewayAccountAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .loadAccounts(_, let onCompletion):
+            onCompletion(.success(()))
+        default: unimplementedAction(action: action)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockReceiptActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockReceiptActionHandler.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Storage
+
+struct MockReceiptActionHandler: MockActionHandler {
+    typealias ActionType = ReceiptAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .loadReceipt(_, let onCompletion):
+            onCompletion(.failure(ReceiptStoreError.fileNotFound))
+        default: unimplementedAction(action: action)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockShippingLabelActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockShippingLabelActionHandler.swift
@@ -12,7 +12,8 @@ struct MockShippingLabelActionHandler: MockActionHandler {
             /// Not implemented
             case .synchronizeShippingLabels(_, _, let completion):
                 success(completion)
-
+            case .checkCreationEligibility(_, _, _, _, _, let onCompletion):
+                onCompletion(false)
             default: unimplementedAction(action: action)
         }
     }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockUserActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockUserActionHandler.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Storage
+
+struct MockUserActionHandler: MockActionHandler {
+    typealias ActionType = UserAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case .retrieveUser(let siteID, let onCompletion):
+            onCompletion(.success(User(localID: 0,
+                                       siteID: siteID,
+                                       wpcomID: 0,
+                                       email: "",
+                                       username: "",
+                                       firstName: "",
+                                       lastName: "",
+                                       nickname: "",
+                                       roles: [User.Role.administrator.rawValue])))
+        }
+    }
+}

--- a/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -18,20 +18,24 @@ public class MockStoresManager: StoresManager {
 
     /// All of our action handlers
     private let appSettingsActionHandler: MockAppSettingsActionHandler
+    private let announcementsActionHandler: MockAnnouncementsActionHandler
     private let availabilityActionHandler: MockAvailabilityActionHandler
     private let notificationActionHandler: MockNotificationActionHandler
     private let notificationCountActionHandler: MockNotificationCountActionHandler
     private let orderActionHandler: MockOrderActionHandler
     private let orderStatusActionHandler: MockOrderStatusActionHandler
     private let orderNoteActionHandler: MockOrderNoteActionHandler
+    private let paymentGatewayAccountActionHandler: MockPaymentGatewayAccountActionHandler
     private let productActionHandler: MockProductActionHandler
     private let productReviewActionHandler: MockProductReviewActionHandler
     private let productVariationActionHandler: MockProductVariationActionHandler
+    private let receiptActionHandler: MockReceiptActionHandler
     private let refundActionHandler: MockRefundActionHandler
     private let settingActionHandler: MockSettingActionHandler
     private let shipmentActionHandler: MockShipmentActionHandler
     private let shippingLabelActionHandler: MockShippingLabelActionHandler
     private let statsV4ActionHandler: MockStatsActionV4Handler
+    private let userActionHandler: MockUserActionHandler
 
 
     init(objectGraph: MockObjectGraph, storageManager: StorageManagerType) {
@@ -41,18 +45,22 @@ public class MockStoresManager: StoresManager {
         orderActionHandler = MockOrderActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         notificationCountActionHandler = MockNotificationCountActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         appSettingsActionHandler = MockAppSettingsActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        announcementsActionHandler = MockAnnouncementsActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         statsV4ActionHandler = MockStatsActionV4Handler(objectGraph: objectGraph, storageManager: storageManager)
         availabilityActionHandler = MockAvailabilityActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         settingActionHandler = MockSettingActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         orderStatusActionHandler = MockOrderStatusActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         orderNoteActionHandler = MockOrderNoteActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        paymentGatewayAccountActionHandler = MockPaymentGatewayAccountActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         productActionHandler = MockProductActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         productVariationActionHandler = MockProductVariationActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        receiptActionHandler = MockReceiptActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         refundActionHandler = MockRefundActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         shippingLabelActionHandler = MockShippingLabelActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         shipmentActionHandler = MockShipmentActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         productReviewActionHandler = MockProductReviewActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         notificationActionHandler = MockNotificationActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        userActionHandler = MockUserActionHandler(objectGraph: objectGraph, storageManager: storageManager)
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)
@@ -111,6 +119,14 @@ public class MockStoresManager: StoresManager {
                 productReviewActionHandler.handle(action: action)
             case let action as NotificationAction:
                 notificationActionHandler.handle(action: action)
+            case let action as UserAction:
+                userActionHandler.handle(action: action)
+            case let action as AnnouncementsAction:
+                announcementsActionHandler.handle(action: action)
+            case let action as PaymentGatewayAccountAction:
+                paymentGatewayAccountActionHandler.handle(action: action)
+            case let action as ReceiptAction:
+                receiptActionHandler.handle(action: action)
             default:
                 fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
         }


### PR DESCRIPTION
## Why

Since the [last screenshot generation updates](https://github.com/woocommerce/woocommerce-ios/pull/3337) in January, there have been tons of exciting changes to the app. There are a couple of new actions dispatched during the screenshots UI test, and this PR fixes the unimplemented fatal errors encountered in `WooCommerceScreenshots`.

Once the screenshots UI test is fixed, I can test https://github.com/woocommerce/woocommerce-ios/pull/5106 to make sure `BuildConfiguration` does not break the screenshot generation tests.

## Changes

Handled unimplemented actions from recent app changes for screenshot generation tests

## Testing

- In Xcode, switch to `WooCommerceScreenshots` target
- Run all tests in this target --> the screenshots UI test should run (going to the screens in the example screenshots) and pass in the end

## Example screenshots

The mock data might need some updates for some of the screenshots!

1-dark-order-dashboard | 2-dark-order-list | 3-dark-order-detail | 4-dark-order-search
-- | -- | --  | --
<img width="414" alt="iPhone 11-2-dark-order-list" src="https://user-images.githubusercontent.com/1945542/135804288-634296b5-dd97-4e79-a259-d4ae95666687.png"> | <img width="414" alt="iPhone 11-2-dark-order-list" src="https://user-images.githubusercontent.com/1945542/135804286-5189e93e-ccc7-4849-a180-028141d8fb81.png"> | <img width="414" alt="iPhone 11-3-dark-order-detail" src="https://user-images.githubusercontent.com/1945542/135804283-6293b351-3260-416d-bfdb-94f060c37231.png"> | <img width="414" alt="iPhone 11-4-dark-order-search" src="https://user-images.githubusercontent.com/1945542/135804281-dd5e7a18-fa13-44b1-a085-81f754850616.png">

5-dark-review-list | 6-dark-review-details | 7-dark-product-list | 8-dark-product-details
-- | -- | --  | --
<img width="414" alt="iPhone 11-5-dark-review-list" src="https://user-images.githubusercontent.com/1945542/135804279-7c6800d9-ba76-47a6-9f66-ca69f26438ed.png"> | <img width="414" alt="iPhone 11-6-dark-review-details" src="https://user-images.githubusercontent.com/1945542/135804276-dfafa13c-5f11-4984-a3b6-afc40a43ae61.png"> | <img width="414" alt="iPhone 11-7-dark-product-list" src="https://user-images.githubusercontent.com/1945542/135804271-dec9a15d-0236-48cb-b6e5-4a8f7b0c5cdd.png"> | <img width="414" alt="iPhone 11-8-dark-product-details" src="https://user-images.githubusercontent.com/1945542/135804258-8709120e-7374-4527-96a4-5237c10d6837.png">

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
