### PR TITLE
[Mobile Payments] [SDK 2.0] Prevent errors when canceling updates

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -472,7 +472,10 @@ extension StripeCardReaderService: BluetoothReaderDelegate {
 
     public func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
         if let error = error {
-            softwareUpdateSubject.send(.failed(error: error))
+            let underlyingError = UnderlyingError(with: error)
+            if underlyingError != .commandCancelled {
+                softwareUpdateSubject.send(.failed(error: error))
+            }
             softwareUpdateSubject.send(.available)
         } else {
             softwareUpdateSubject.send(.completed)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewController.swift
@@ -135,8 +135,8 @@ private extension CardReaderSettingsConnectedViewController {
                     tryAgain: {
                         viewModel.startCardReaderUpdate()
                     },
-                    close: { [settingsAlerts] in
-                        settingsAlerts.dismiss()
+                    close: {
+                        viewModel.dismissReaderUpdateError()
                     }
                 )
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsConnectedViewModel.swift
@@ -131,6 +131,11 @@ final class CardReaderSettingsConnectedViewModel: CardReaderSettingsPresentedVie
         })
     }
 
+    func dismissReaderUpdateError() {
+        readerUpdateError = nil
+        didUpdate?()
+    }
+
     private func completeCardReaderUpdate(success: Bool) {
         readerUpdateAvailable = !success
         readerUpdateProgress = nil


### PR DESCRIPTION
Fixes #5124 

There are two different issues being corrected in this PR:

1. When the user cancels an update, we don't treat that as an installation failure. Instead, we just leave the update as "available"
2. When an update fails and the user dismisses the error modal without retrying, we clear the error from the view model so the modal doesn't get triggered over and over.

## To test

1. Edit the WooCommerce scheme, and enable `-simulate-stripe-card-reader` in the Arguments tab.
2. In `StripeCardReaderService.start(_:)`, after the SDK has been initialized (I add this right after Terminal.shared.delegate = self), add the following line: `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .available`
2. Go to Settings > In-Person Payments > Manage Card Reader and connect to a reader
3. After the reader connects, it should show an available update
4. Tap on "Update Reader Software"
5. Tap on Cancel before it completes
6. It should show no error. Disconnecting and reconnecting should show no error

Also tested with the same steps, but simulating an SDK error instead of user cancelation. To do that, replace the `installUpdate` method in `StripeCardReaderService` with this:

```swift
    public func installUpdate() -> Void {
        softwareUpdateSubject.send(.failed(error: CardReaderServiceError.bluetoothDenied))
        softwareUpdateSubject.send(.available)
    }
```


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
