### PR TITLE
[Mobile Payments] Add coupons and shipping to receipts

### DIFF
--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -22,6 +22,11 @@ extension ReceiptContent {
 
 public extension ReceiptContent {
     enum Localization {
+        public static let shippingLineDescription = NSLocalizedString(
+            "Shipping",
+            comment: "Line description for 'Shipping' cart total on the receipt. Only shown when >0"
+        )
+
         public static let totalTaxLineDescription = NSLocalizedString(
             "Taxes",
             comment: "Line description for tax charged on the whole cart. Only shown when >0")

--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -24,16 +24,16 @@ public extension ReceiptContent {
     enum Localization {
         public static let discountLineDescription = NSLocalizedString(
             "Discount %1$@",
-            comment: "Line description for 'Discount' cart total on the receipt. Only shown when >0. %1$@ is the coupon code(s)")
+            comment: "Line description for 'Discount' cart total on the receipt. Only shown when non-zero. %1$@ is the coupon code(s)")
 
         public static let shippingLineDescription = NSLocalizedString(
             "Shipping",
-            comment: "Line description for 'Shipping' cart total on the receipt. Only shown when >0"
+            comment: "Line description for 'Shipping' cart total on the receipt. Only shown when non-zero"
         )
 
         public static let totalTaxLineDescription = NSLocalizedString(
             "Taxes",
-            comment: "Line description for tax charged on the whole cart. Only shown when >0"
+            comment: "Line description for tax charged on the whole cart. Only shown when non-zero"
         )
 
         public static let amountPaidLineDescription = NSLocalizedString(

--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -22,6 +22,10 @@ extension ReceiptContent {
 
 public extension ReceiptContent {
     enum Localization {
+        public static let discountLineDescription = NSLocalizedString(
+            "Discount %1$@",
+            comment: "Line description for 'Discount' cart total on the receipt. Only shown when >0. %1$@ is the coupon code(s)")
+
         public static let shippingLineDescription = NSLocalizedString(
             "Shipping",
             comment: "Line description for 'Shipping' cart total on the receipt. Only shown when >0"
@@ -29,7 +33,8 @@ public extension ReceiptContent {
 
         public static let totalTaxLineDescription = NSLocalizedString(
             "Taxes",
-            comment: "Line description for tax charged on the whole cart. Only shown when >0")
+            comment: "Line description for tax charged on the whole cart. Only shown when >0"
+        )
 
         public static let amountPaidLineDescription = NSLocalizedString(
             "Amount Paid",

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -58,6 +58,24 @@ public class ReceiptStore: Store {
 
 
 private extension ReceiptStore {
+    func print(order: Order, parameters: CardPresentReceiptParameters, completion: @escaping (PrintingResult) -> Void) {
+        let content = generateReceiptContent(order: order, parameters: parameters)
+        receiptPrinterService.printReceipt(content: content, completion: completion)
+    }
+
+    func generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
+        let content = generateReceiptContent(order: order, parameters: parameters)
+        let renderer = ReceiptRenderer(content: content)
+        onContent(renderer.htmlContent())
+    }
+
+    func generateReceiptContent(order: Order, parameters: CardPresentReceiptParameters) -> ReceiptContent {
+        let lineItems = generateLineItems(order: order)
+        let cartTotals = generateCartTotals(order: order, parameters: parameters)
+
+        return ReceiptContent(parameters: parameters, lineItems: lineItems, cartTotals: cartTotals)
+    }
+
     func generateLineItems(order: Order) -> [ReceiptLineItem] {
         order.items.map { item in
             ReceiptLineItem(
@@ -76,24 +94,6 @@ private extension ReceiptStore {
         }
         totalLines.append(ReceiptTotalLine(description: ReceiptContent.Localization.amountPaidLineDescription, amount: parameters.formattedAmount))
         return totalLines
-    }
-
-    func generateReceiptContent(order: Order, parameters: CardPresentReceiptParameters) -> ReceiptContent {
-        let lineItems = generateLineItems(order: order)
-        let cartTotals = generateCartTotals(order: order, parameters: parameters)
-
-        return ReceiptContent(parameters: parameters, lineItems: lineItems, cartTotals: cartTotals)
-    }
-
-    func print(order: Order, parameters: CardPresentReceiptParameters, completion: @escaping (PrintingResult) -> Void) {
-        let content = generateReceiptContent(order: order, parameters: parameters)
-        receiptPrinterService.printReceipt(content: content, completion: completion)
-    }
-
-    func generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: @escaping (String) -> Void) {
-        let content = generateReceiptContent(order: order, parameters: parameters)
-        let renderer = ReceiptRenderer(content: content)
-        onContent(renderer.htmlContent())
     }
 
     func loadReceipt(order: Order, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -87,13 +87,17 @@ private extension ReceiptStore {
     }
 
     func generateCartTotals(order: Order, parameters: CardPresentReceiptParameters) -> [ReceiptTotalLine] {
-        var totalLines = [ReceiptTotalLine]()
-        if NSDecimalNumber(apiAmount: order.totalTax).decimalValue > 0.00 {
-            totalLines.append(ReceiptTotalLine(description: ReceiptContent.Localization.totalTaxLineDescription,
-                                          amount: order.totalTax))
-        }
-        totalLines.append(ReceiptTotalLine(description: ReceiptContent.Localization.amountPaidLineDescription, amount: parameters.formattedAmount))
-        return totalLines
+        let subtotalLines = [ReceiptTotalLine(description: ReceiptContent.Localization.shippingLineDescription,
+                                              amount: order.shippingTotal),
+                             ReceiptTotalLine(description: ReceiptContent.Localization.totalTaxLineDescription,
+                                              amount: order.totalTax)]
+            .filter {
+                NSDecimalNumber(apiAmount: $0.amount).decimalValue > 0.00
+            }
+        let totalLine = [ReceiptTotalLine(description: ReceiptContent.Localization.amountPaidLineDescription,
+                                         amount: parameters.formattedAmount)]
+
+        return subtotalLines + totalLine
     }
 
     func loadReceipt(order: Order, onCompletion: @escaping (Result<CardPresentReceiptParameters, Error>) -> Void) {

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -100,11 +100,12 @@ private extension ReceiptStore {
     }
 
     func discountLine(order: Order) -> ReceiptTotalLine? {
-        if NSDecimalNumber(apiAmount: order.discountTotal).decimalValue == 0 &&
-            order.coupons.isEmpty {
+        let discountValue = NSDecimalNumber(apiAmount: order.discountTotal).decimalValue
+        if discountValue == 0 && order.coupons.isEmpty {
             return nil
         }
-        return ReceiptTotalLine(description: discountLineDescription(order: order), amount: order.discountTotal)
+        return ReceiptTotalLine(description: discountLineDescription(order: order),
+                                amount: discountLineAmount(order: order, value: discountValue))
     }
 
     func discountLineDescription(order: Order) -> String {
@@ -117,6 +118,14 @@ private extension ReceiptStore {
             couponCodes = "(\(couponCodes))"
         }
         return String.localizedStringWithFormat(ReceiptContent.Localization.discountLineDescription, couponCodes)
+    }
+
+    func discountLineAmount(order: Order, value: Decimal) -> String {
+        if value > 0 {
+            return "-\(order.discountTotal)"
+        } else {
+            return order.discountTotal
+        }
     }
 
     func lineIfNonZero(description: String, amount: String) -> ReceiptTotalLine? {

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -202,7 +202,7 @@ final class ReceiptStoreTests: XCTestCase {
         let actualDiscountLine = receiptPrinterService.contentProvided?.cartTotals.first {
             $0.description.starts(with: expectedDiscountLineDescription())
         }
-        XCTAssertEqual(mockOrder.discountTotal, actualDiscountLine?.amount)
+        XCTAssertEqual(actualDiscountLine?.amount, "-5.00")
     }
 
     func test_print_OrderWithoutDiscountOrCoupons_DoesNotIncludeDiscountInReceiptContent() throws {


### PR DESCRIPTION
Resolves #4440 
Resolves #4438 

## Description
Adds the "Discounts" and "Shipping" lines to In Person Payment receipts.

![All lines populated](https://user-images.githubusercontent.com/2472348/135868597-4e25c119-16e8-44e4-9549-4a4ca189a3ae.jpg)

Shipping and Tax are shown whenever they are non-zero. I've changed behaviour here to check for 0 specifically, rather than use `<=`, in order to take account of potential for refund receipts in future having negative values here.

Discounts are shown when there are coupons applied to the order, or when the discount is non-zero. This is to account for coupons which don't have a discount value, e.g. free shipping coupons.

## Testing
To test, an In Person Payment setup is required. See PdfdoF-D-p2 for info.

### Shipping
1. Go to the Orders tab
2. Open an unpaid "Pay on Delivery" order with non-zero shipping
3. Take card payment
4. Tap "Print Receipt"
5. Observe that the order lines include a "Shipping" line.
6. Repeat with an order that has zero shipping, observe that the "Shipping" line is not shown.

![Shipping line](https://user-images.githubusercontent.com/2472348/135871985-8bd6ae5e-83d6-4ca7-9e7a-feec431a11d6.jpg)

### Coupons
1. Go to the Orders tab
2. Open an unpaid "Pay on Delivery" order with a coupon that provides a dollar or percentage discount
3. Take card payment
4. Tap "Print Receipt"
5. Observe that the order lines include a "Discount" line, including the coupon codes.
6. Repeat with an order that has a free shipping coupon, observe that the "Discount" line is still shown even though it's 0.00.
7. Repeat with an order that has no coupons, observe that the "Discount" line is not shown.

![Free shipping coupon](https://user-images.githubusercontent.com/2472348/135872027-570acabd-0e21-4b73-8183-cb9e0e598104.jpg)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
