### PR TITLE
Order Editing: Rename EditAddress types

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -23,7 +23,7 @@ final class EditOrderAddressHostingController: UIHostingController<EditOrderAddr
     ///
     private let systemNoticePresenter: NoticePresenter
 
-    init(viewModel: EditAddressFormViewModel, systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+    init(viewModel: EditOrderAddressFormViewModel, systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.systemNoticePresenter = systemNoticePresenter
         super.init(rootView: EditOrderAddressForm(viewModel: viewModel))
 
@@ -107,13 +107,13 @@ struct EditOrderAddressForm: View {
     ///
     var dismiss: (() -> Void) = {}
 
-    @ObservedObject private(set) var viewModel: EditAddressFormViewModel
+    @ObservedObject private(set) var viewModel: EditOrderAddressFormViewModel
 
     /// Set it to `true` to present the country selector.
     ///
     @State var showCountrySelector: Bool = false
 
-    init(viewModel: EditAddressFormViewModel) {
+    init(viewModel: EditOrderAddressFormViewModel) {
         self.viewModel = viewModel
     }
 
@@ -354,7 +354,7 @@ private extension EditOrderAddressForm {
 
         static let success = NSLocalizedString("Address successfully updated.", comment: "Notice text after updating the shipping or billing address")
 
-        static func useAddressAs(for type: EditAddressFormViewModel.AddressType) -> String {
+        static func useAddressAs(for type: EditOrderAddressFormViewModel.AddressType) -> String {
             switch type {
             case .shipping:
                 return NSLocalizedString("Use as Billing Address", comment: "Title for the Use as Billing Address switch in the Address form")
@@ -410,7 +410,7 @@ struct EditAddressForm_Previews: PreviewProvider {
                                        phone: "333-333-3333",
                                        email: "scrambled@scrambled.com")
 
-    static let sampleViewModel = EditAddressFormViewModel(order: sampleOrder, type: .shipping)
+    static let sampleViewModel = EditOrderAddressFormViewModel(order: sampleOrder, type: .shipping)
 
     static var previews: some View {
         NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -3,9 +3,9 @@ import Combine
 import SwiftUI
 import UIKit
 
-/// Hosting controller that wraps an `EditAddressForm`.
+/// Hosting controller that wraps an `EditOrderAddressForm`.
 ///
-final class EditAddressHostingController: UIHostingController<EditAddressForm> {
+final class EditOrderAddressHostingController: UIHostingController<EditOrderAddressForm> {
 
     /// References to keep the Combine subscriptions alive within the lifecycle of the object.
     ///
@@ -25,7 +25,7 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
     init(viewModel: EditAddressFormViewModel, systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.systemNoticePresenter = systemNoticePresenter
-        super.init(rootView: EditAddressForm(viewModel: viewModel))
+        super.init(rootView: EditOrderAddressForm(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
@@ -60,7 +60,7 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
                 switch notice {
                 case .success:
-                    self?.systemNoticePresenter.enqueue(notice: .init(title: EditAddressForm.Localization.success, feedbackType: .error))
+                    self?.systemNoticePresenter.enqueue(notice: .init(title: EditOrderAddressForm.Localization.success, feedbackType: .error))
 
                 case .error(let error):
                     switch error {
@@ -82,7 +82,7 @@ final class EditAddressHostingController: UIHostingController<EditAddressForm> {
 
 /// Intercepts to the dismiss drag gesture.
 ///
-extension EditAddressHostingController: UIAdaptivePresentationControllerDelegate {
+extension EditOrderAddressHostingController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         !rootView.viewModel.hasPendingChanges()
     }
@@ -101,7 +101,7 @@ extension EditAddressHostingController: UIAdaptivePresentationControllerDelegate
 
 /// Allows merchant to edit the customer provided address of an order.
 ///
-struct EditAddressForm: View {
+struct EditOrderAddressForm: View {
 
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
@@ -299,7 +299,7 @@ struct EditAddressForm: View {
 }
 
 // MARK: Constants
-private extension EditAddressForm {
+private extension EditOrderAddressForm {
 
     var viewTitle: String {
         switch viewModel.type {
@@ -414,7 +414,7 @@ struct EditAddressForm_Previews: PreviewProvider {
 
     static var previews: some View {
         NavigationView {
-            EditAddressForm(viewModel: sampleViewModel)
+            EditOrderAddressForm(viewModel: sampleViewModel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -2,7 +2,7 @@ import Yosemite
 import Storage
 import Combine
 
-final class EditAddressFormViewModel: ObservableObject {
+final class EditOrderAddressFormViewModel: ObservableObject {
 
     enum AddressType {
         case shipping
@@ -220,7 +220,7 @@ final class EditAddressFormViewModel: ObservableObject {
     }
 }
 
-extension EditAddressFormViewModel {
+extension EditOrderAddressFormViewModel {
     /// Representation of possible navigation bar trailing buttons
     ///
     enum NavigationItem: Equatable {
@@ -310,7 +310,7 @@ extension EditAddressFormViewModel {
     }
 }
 
-private extension EditAddressFormViewModel {
+private extension EditOrderAddressFormViewModel {
     /// Set initial values from `originalAddress` using the stored countries to compute the current selected country & state.
     ///
     func setFieldsInitialValues() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -97,7 +97,7 @@ private extension BillingInformationViewController {
     /// Presents EditOrderAddressForm modal view
     ///
     func editBillingAddress() {
-        let viewModel = EditAddressFormViewModel(order: order, type: .billing) { [weak self] updatedOrder in
+        let viewModel = EditOrderAddressFormViewModel(order: order, type: .billing) { [weak self] updatedOrder in
             self?.order = updatedOrder
             self?.reloadSections()
             self?.tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -94,7 +94,7 @@ private extension BillingInformationViewController {
         }
     }
 
-    /// Presents EditAddressForm modal view
+    /// Presents EditOrderAddressForm modal view
     ///
     func editBillingAddress() {
         let viewModel = EditAddressFormViewModel(order: order, type: .billing) { [weak self] updatedOrder in
@@ -102,7 +102,7 @@ private extension BillingInformationViewController {
             self?.reloadSections()
             self?.tableView.reloadData()
         }
-        let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
+        let editAddressViewController = EditOrderAddressHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: editAddressViewController)
         present(navigationController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -675,7 +675,7 @@ private extension OrderDetailsViewController {
 
     func editShippingAddressTapped() {
         let viewModel = EditAddressFormViewModel(order: viewModel.order, type: .shipping)
-        let editAddressViewController = EditAddressHostingController(viewModel: viewModel)
+        let editAddressViewController = EditOrderAddressHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: editAddressViewController)
         present(navigationController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -674,7 +674,7 @@ private extension OrderDetailsViewController {
     }
 
     func editShippingAddressTapped() {
-        let viewModel = EditAddressFormViewModel(order: viewModel.order, type: .shipping)
+        let viewModel = EditOrderAddressFormViewModel(order: viewModel.order, type: .shipping)
         let editAddressViewController = EditOrderAddressHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: editAddressViewController)
         present(navigationController, animated: true, completion: nil)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -840,7 +840,7 @@
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
 		AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */; };
 		AEE2610F26E664CE00B142A0 /* EditAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */; };
-		AEE2611126E6785400B142A0 /* EditAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2611026E6785400B142A0 /* EditAddressFormViewModelTests.swift */; };
+		AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -2283,7 +2283,7 @@
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
 		AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressFormViewModel.swift; sourceTree = "<group>"; };
-		AEE2611026E6785400B142A0 /* EditAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressFormViewModelTests.swift; sourceTree = "<group>"; };
+		AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -3979,7 +3979,7 @@
 			isa = PBXGroup;
 			children = (
 				26C6E8E226E2D85300C7BB0F /* CountrySelector */,
-				AEE2611026E6785400B142A0 /* EditAddressFormViewModelTests.swift */,
+				AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */,
 			);
 			path = Addresses;
 			sourceTree = "<group>";
@@ -8115,7 +8115,7 @@
 				02279594237A60FD00787C63 /* AztecHeaderFormatBarCommandTests.swift in Sources */,
 				0259EF77246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift in Sources */,
 				4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */,
-				AEE2611126E6785400B142A0 /* EditAddressFormViewModelTests.swift in Sources */,
+				AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */,
 				0212683724C049F000F8A892 /* ProductListMultiSelectorDataSourceTests.swift in Sources */,
 				DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */,
 				5768315126694ADC00FDFB6C /* AuthenticationManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
 		AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */; };
-		AEE2610F26E664CE00B142A0 /* EditAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */; };
+		AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */; };
 		AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
@@ -2282,7 +2282,7 @@
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
 		AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommandTests.swift; sourceTree = "<group>"; };
-		AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressFormViewModel.swift; sourceTree = "<group>"; };
+		AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
@@ -4931,7 +4931,7 @@
 			isa = PBXGroup;
 			children = (
 				AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */,
-				AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */,
+				AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */,
 				2662D90926E16B3600E25611 /* FilterListSelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
 				26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */,
@@ -7287,7 +7287,7 @@
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,
 				451A9973260E39270059D135 /* ShippingLabelPackageNumberRow.swift in Sources */,
-				AEE2610F26E664CE00B142A0 /* EditAddressFormViewModel.swift in Sources */,
+				AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */,
 				025C00BA25514A7100FAC222 /* BarcodeScannerFrameScaler.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				E15F163126C5117300D3059B /* InPersonPaymentsNoConnectionView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -834,7 +834,7 @@
 		A655725D258B91AE008AE7CA /* OrderListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */; };
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
-		AECD57D226DFDF7500A3B580 /* EditAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */; };
+		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
@@ -2277,7 +2277,7 @@
 		A655725C258B91AE008AE7CA /* OrderListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModelTests.swift; sourceTree = "<group>"; };
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
-		AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressForm.swift; sourceTree = "<group>"; };
+		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
@@ -4930,7 +4930,7 @@
 		AECD57D026DFDF3E00A3B580 /* Address Edit */ = {
 			isa = PBXGroup;
 			children = (
-				AECD57D126DFDF7500A3B580 /* EditAddressForm.swift */,
+				AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */,
 				AEE2610E26E664CE00B142A0 /* EditAddressFormViewModel.swift */,
 				2662D90926E16B3600E25611 /* FilterListSelector.swift */,
 				2662D90726E15D6E00E25611 /* CountrySelectorCommand.swift */,
@@ -7405,7 +7405,7 @@
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
-				AECD57D226DFDF7500A3B580 /* EditAddressForm.swift in Sources */,
+				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,
 				45E9A6E724DAE23300A600E8 /* ProductReviewsViewModel.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -27,7 +27,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_creating_with_address_prefills_fields_with_correct_data() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -54,7 +54,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_updating_fields_enables_done_button() {
         // Given
         let address = sampleAddress()
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
@@ -67,7 +67,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_updating_fields_back_to_original_values_disables_done_button() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
         XCTAssertEqual(viewModel.navigationTrailingItem, .done(enabled: false))
 
         // When
@@ -83,7 +83,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_creating_without_address_disables_done_button() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: nil), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: nil), type: .shipping, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -95,7 +95,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_creating_with_address_with_empty_nullable_fields_disables_done_button() {
         // Given
         let address = sampleAddressWithEmptyNullableFields()
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: address), type: .shipping, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -106,7 +106,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_loading_indicator_gets_enabled_during_network_request() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -118,7 +118,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
 
         // When
         viewModel.onLoadTrigger.send()
@@ -135,7 +135,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_starting_view_model_without_stored_countries_fetches_them_remotely() {
         // Given
         testingStorage.reset()
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()),
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()),
                                                  type: .shipping,
                                                  storageManager: testingStorage,
                                                  stores: testingStores)
@@ -166,7 +166,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()),
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()),
                                                  type: .shipping,
                                                  storageManager: testingStorage,
                                                  stores: testingStores)
@@ -192,7 +192,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newCountry = Self.sampleCountries[0]
 
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
         viewModel.onLoadTrigger.send()
 
         // When
@@ -207,7 +207,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_only_updates_shipping_address_field() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, stores: stores)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, stores: stores)
 
         // When
         viewModel.fields.firstName = "Tester"
@@ -231,7 +231,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_updates_shipping_and_billing_address_fields_when_use_as_toggle_is_on() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, stores: stores)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, stores: stores)
 
         // When
         viewModel.fields.firstName = "Tester"
@@ -258,7 +258,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_only_updates_billing_address_field() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = EditAddressFormViewModel(order: order(withBillingAddress: sampleAddress()), type: .billing, stores: stores)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withBillingAddress: sampleAddress()), type: .billing, stores: stores)
 
         // When
         viewModel.fields.firstName = "Tester"
@@ -283,7 +283,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         // Given
         let newState = StateOfACountry(code: "CA", name: "California")
 
-        let viewModel = EditAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
         viewModel.onLoadTrigger.send()
 
         // When
@@ -298,7 +298,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_updates_billing_and_shipping_address_fields_when_use_as_toggle_is_on() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = EditAddressFormViewModel(order: order(withBillingAddress: sampleAddress()), type: .billing, stores: stores)
+        let viewModel = EditOrderAddressFormViewModel(order: order(withBillingAddress: sampleAddress()), type: .billing, stores: stores)
 
         // When
         viewModel.fields.firstName = "Tester"
@@ -324,7 +324,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_view_model_fires_success_notice_after_updating_address_successfully() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, stores: testingStores)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, stores: testingStores)
         testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .updateOrder(_, order, _, onCompletion):
@@ -347,7 +347,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_view_model_fires_error_notice_after_failing_to_update_address() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, stores: testingStores)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, stores: testingStores)
         testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case let .updateOrder(_, _, _, onCompletion):
@@ -378,7 +378,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, storageManager: testingStorage, stores: testingStores)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, storageManager: testingStorage, stores: testingStores)
         viewModel.onLoadTrigger.send()
 
         // Then
@@ -387,7 +387,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_copying_empty_shipping_address_for_billing_does_not_sends_an_empty_email_field() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, storageManager: testingStorage, stores: testingStores)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, storageManager: testingStorage, stores: testingStores)
         viewModel.onLoadTrigger.send()
         viewModel.fields.useAsToggle = true
 
@@ -411,7 +411,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_shipping_view_model_does_not_shows_email_field() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping)
 
         // When & Then
         XCTAssertFalse(viewModel.showEmailField)
@@ -419,7 +419,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_billing_view_model_does_shows_email_field() {
         // Given
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .billing)
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing)
 
         // When & Then
         XCTAssertTrue(viewModel.showEmailField)
@@ -428,7 +428,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_success_after_updating_shipping_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(),
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(),
                                                  type: .shipping,
                                                  stores: testingStores,
                                                  analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -456,7 +456,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_success_after_updating_billing_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(),
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(),
                                                  type: .billing,
                                                  stores: testingStores,
                                                  analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -484,7 +484,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_failure_after_updating_shipping_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(),
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(),
                                                  type: .shipping,
                                                  stores: testingStores,
                                                  analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -512,7 +512,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_failure_after_updating_billing_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(),
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(),
                                                  type: .billing,
                                                  stores: testingStores,
                                                  analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -540,7 +540,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_cancel_flow_for_shipping_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When
         viewModel.userDidCancelFlow()
@@ -553,7 +553,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_cancel_flow_for_billing_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .billing, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When
         viewModel.userDidCancelFlow()
@@ -566,7 +566,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_started_flow_for_shipping_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .shipping, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When
         viewModel.onLoadTrigger.send()
@@ -579,7 +579,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
     func test_view_model_tracks_started_flow_for_billing_address() {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
-        let viewModel = EditAddressFormViewModel(order: Order.fake(), type: .billing, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .billing, analytics: WooAnalytics(analyticsProvider: analyticsProvider))
 
         // When
         viewModel.onLoadTrigger.send()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -4,7 +4,7 @@ import TestKit
 import Combine
 @testable import WooCommerce
 
-final class EditAddressFormViewModelTests: XCTestCase {
+final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     let sampleSiteID: Int64 = 123
 
@@ -590,7 +590,7 @@ final class EditAddressFormViewModelTests: XCTestCase {
     }
 }
 
-private extension EditAddressFormViewModelTests {
+private extension EditOrderAddressFormViewModelTests {
     func order(withShippingAddress shippingAddress: Address?) -> Order {
         Order.fake().copy(siteID: 123, orderID: 1234, shippingAddress: shippingAddress)
     }
@@ -628,7 +628,7 @@ private extension EditAddressFormViewModelTests {
     }
 }
 
-private extension EditAddressFormViewModelTests {
+private extension EditOrderAddressFormViewModelTests {
     static let sampleCountries: [Country] = {
         return Locale.isoRegionCodes.map { regionCode in
             let name = Locale.current.localizedString(forRegionCode: regionCode) ?? ""


### PR DESCRIPTION
# Why

We started these types aiming them to be reusable for other parts of the app. However, In the development process, we ended up coupling it with some "Order Details" peculiarities.

This PR renames "EditAddress" types to "EditOrderAddress" types so consumers are aware that these are specific to the order module.

We can rename them back if we manage to decouple them in an efficient way.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
