### PR TITLE
Use Fakeable and Copiable for `ProductReviewFromNoteParcel`

### DIFF
--- a/CodeGeneration/Sourcery/Copiable/Models+Copiable.swifttemplate
+++ b/CodeGeneration/Sourcery/Copiable/Models+Copiable.swifttemplate
@@ -103,8 +103,6 @@ let matchingTypes = types.based["GeneratedCopiable"].filter {
 let modulesToGenerateImports: [String] = {
     let modulesFromType: [String] =  matchingTypes.flatMap { type in
         type.imports.map { $0.description }
-        // Importing a protocol (e.g. `import protocol Storage.StorageType`) generates a type "protocol" that is not needed
-        .filter { $0 != "protocol" }
     }
 
     let modulesFromProperties: [String] = matchingTypes.flatMap { type in 

--- a/CodeGeneration/Sourcery/Copiable/Models+Copiable.swifttemplate
+++ b/CodeGeneration/Sourcery/Copiable/Models+Copiable.swifttemplate
@@ -103,6 +103,8 @@ let matchingTypes = types.based["GeneratedCopiable"].filter {
 let modulesToGenerateImports: [String] = {
     let modulesFromType: [String] =  matchingTypes.flatMap { type in
         type.imports.map { $0.description }
+        // Importing a protocol (e.g. `import protocol Storage.StorageType`) generates a type "protocol" that is not needed
+        .filter { $0 != "protocol" }
     }
 
     let modulesFromProperties: [String] = matchingTypes.flatMap { type in 

--- a/WooCommerce/WooCommerceTests/Mocks/ProductReviewFromNoteParcelFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/ProductReviewFromNoteParcelFactory.swift
@@ -1,3 +1,4 @@
+import Codegen
 import XCTest
 import Yosemite
 
@@ -32,9 +33,6 @@ final class ProductReviewFromNoteParcelFactory {
                         header: Data(),
                         body: Data(),
                         meta: metaAsData)
-        let product = Product.fake()
-        let review = ProductReview.fake()
-
-        return ProductReviewFromNoteParcel(note: note, review: review, product: product)
+        return ProductReviewFromNoteParcel.fake().copy(note: note)
     }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		021EAA5C25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */; };
 		0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */; };
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
+		02291735270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02291734270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift */; };
 		022F00BE24725BAF008CD97F /* NotificationCountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F00BD24725BAF008CD97F /* NotificationCountStore.swift */; };
 		022F00C024725BC6008CD97F /* NotificationCountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F00BF24725BC6008CD97F /* NotificationCountAction.swift */; };
 		022F00C224726090008CD97F /* SiteNotificationCountFileContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F00C124726090008CD97F /* SiteNotificationCountFileContents.swift */; };
@@ -395,6 +396,7 @@
 		021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Date.swift"; sourceTree = "<group>"; };
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
+		02291734270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcel.swift; sourceTree = "<group>"; };
 		022F00BD24725BAF008CD97F /* NotificationCountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCountStore.swift; sourceTree = "<group>"; };
 		022F00BF24725BC6008CD97F /* NotificationCountAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCountAction.swift; sourceTree = "<group>"; };
 		022F00C124726090008CD97F /* SiteNotificationCountFileContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteNotificationCountFileContents.swift; sourceTree = "<group>"; };
@@ -981,6 +983,7 @@
 			isa = PBXGroup;
 			children = (
 				570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */,
+				02291734270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift */,
 			);
 			path = ProductReview;
 			sourceTree = "<group>";
@@ -1807,6 +1810,7 @@
 				45739F372437680F00480C95 /* ProductSettings.swift in Sources */,
 				247CE88725833F1200F9D9D1 /* MockObjectGraph.swift in Sources */,
 				741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */,
+				02291735270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift in Sources */,
 				74B260212188B5F30041793A /* Note+ReadOnlyType.swift in Sources */,
 				B505254C20EE6491008090F5 /* Site+ReadOnlyConvertible.swift in Sources */,
 				26E5A07E25A6640E000DF8F6 /* ProductAttributeTermAction.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */; };
 		02E7FFD52562226B00C53030 /* ShippingLabelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFD42562226B00C53030 /* ShippingLabelStoreTests.swift */; };
 		02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */; };
+		02F6AAAC270556A4002425D0 /* Models+Copiable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6AAAB270556A4002425D0 /* Models+Copiable.generated.swift */; };
 		02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054523D983F30058E6E7 /* MediaFileManager.swift */; };
 		02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054623D983F30058E6E7 /* MediaImageExporter.swift */; };
 		02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054723D983F30058E6E7 /* FileManager+URL.swift */; };
@@ -435,6 +436,7 @@
 		02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOrderedSet+Array.swift"; sourceTree = "<group>"; };
 		02E7FFD42562226B00C53030 /* ShippingLabelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStoreTests.swift; sourceTree = "<group>"; };
 		02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelRemote.swift; sourceTree = "<group>"; };
+		02F6AAAB270556A4002425D0 /* Models+Copiable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Models+Copiable.generated.swift"; sourceTree = "<group>"; };
 		02FF054523D983F30058E6E7 /* MediaFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManager.swift; sourceTree = "<group>"; };
 		02FF054623D983F30058E6E7 /* MediaImageExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImageExporter.swift; sourceTree = "<group>"; };
 		02FF054723D983F30058E6E7 /* FileManager+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URL.swift"; sourceTree = "<group>"; };
@@ -854,6 +856,14 @@
 			path = ShippingSettings;
 			sourceTree = "<group>";
 		};
+		02F6AAA827055655002425D0 /* Copiable */ = {
+			isa = PBXGroup;
+			children = (
+				02F6AAAB270556A4002425D0 /* Models+Copiable.generated.swift */,
+			);
+			path = Copiable;
+			sourceTree = "<group>";
+		};
 		02FF054423D983C40058E6E7 /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -1159,6 +1169,7 @@
 		B53D89E720E6C7DC00F90866 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				02F6AAA827055655002425D0 /* Copiable */,
 				247CE7AF2582DBD000F9D9D1 /* Mocks */,
 				D8652E1A26303D0600350F37 /* Payments */,
 				45739F35243767FE00480C95 /* Products */,
@@ -1915,6 +1926,7 @@
 				D8652E2026303D4800350F37 /* PaymentIntent+ReceiptParameters.swift in Sources */,
 				453305F7245AE68C00264E50 /* SitePostStore.swift in Sources */,
 				026CF62A237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift in Sources */,
+				02F6AAAC270556A4002425D0 /* Models+Copiable.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -2,7 +2,6 @@
 // DO NOT EDIT
 import Codegen
 import Foundation
-import Networking
 
 
 extension ProductReviewFromNoteParcel {

--- a/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -1,0 +1,24 @@
+// Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import Codegen
+import Foundation
+import Networking
+
+
+extension ProductReviewFromNoteParcel {
+    public func copy(
+        note: CopiableProp<Note> = .copy,
+        review: CopiableProp<ProductReview> = .copy,
+        product: CopiableProp<Product> = .copy
+    ) -> ProductReviewFromNoteParcel {
+        let note = note ?? self.note
+        let review = review ?? self.review
+        let product = product ?? self.product
+
+        return ProductReviewFromNoteParcel(
+            note: note,
+            review: review,
+            product: product
+        )
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductReview/ProductReviewFromNoteParcel.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/ProductReviewFromNoteParcel.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Codegen
+
+/// The result from `RetrieveProductReviewFromNoteUseCase`.
+///
+public struct ProductReviewFromNoteParcel: GeneratedFakeable, GeneratedCopiable {
+    public let note: Note
+    public let review: ProductReview
+    public let product: Product
+
+    public init(note: Note, review: ProductReview, product: Product) {
+        self.note = note
+        self.review = review
+        self.product = product
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -1,22 +1,7 @@
 
 import Foundation
 import Networking
-import Codegen
 import protocol Storage.StorageType
-
-/// The result from `RetrieveProductReviewFromNoteUseCase`.
-///
-public struct ProductReviewFromNoteParcel: GeneratedFakeable, GeneratedCopiable {
-    public let note: Note
-    public let review: ProductReview
-    public let product: Product
-
-    public init(note: Note, review: ProductReview, product: Product) {
-        self.note = note
-        self.review = review
-        self.product = product
-    }
-}
 
 /// Fetches the `Note`, `ProductReview`, and `Product` in sequence from the Storage and/or API
 /// using a `noteID`.

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -6,7 +6,7 @@ import protocol Storage.StorageType
 
 /// The result from `RetrieveProductReviewFromNoteUseCase`.
 ///
-public struct ProductReviewFromNoteParcel: GeneratedFakeable {
+public struct ProductReviewFromNoteParcel: GeneratedFakeable, GeneratedCopiable {
     public let note: Note
     public let review: ProductReview
     public let product: Product


### PR DESCRIPTION
Minor improvement for #3823 

## Why

Now that we can use Fakeable in Yosemite, this PR replaces `ProductReviewFromNoteParcel`'s mock generation with fakeable and copiable to simplify our testing code.

## Changes

- Moved `ProductReviewFromNoteParcel` to its own file, otherwise the [protocol import](https://github.com/woocommerce/woocommerce-ios/blob/bfb70d2ede6afea14950a1d120e5c1d046e8bfd8/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L5) in `RetrieveProductReviewFromNoteUseCase` results in `import protocol` from the codegen script because Sourcery sees "protocol" as an import type
- In `ProductReviewFromNoteParcelFactory`, replaced `ProductReviewFromNoteParcel` instantiation with fakeable + copiable (2 fewer lines of code 😉 )

## Testing

No user-facing changes, CI passing is sufficient.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
