### PR TITLE
Shipping Labels: Fix flaky customs form list test

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Customs/ShippingLabelCustomsFormListViewModelTests.swift
@@ -8,7 +8,7 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
 
     func test_done_button_is_enabled_when_all_fields_are_valid() {
         // Given
-        let item = ShippingLabelCustomsForm.Item.fake()
+        let item = ShippingLabelCustomsForm.Item.fake().copy(quantity: 1)
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", items: [item])
 
@@ -38,7 +38,7 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
 
     func test_done_button_is_disable_when_not_all_fields_are_valid() {
         // Given
-        let item = ShippingLabelCustomsForm.Item.fake()
+        let item = ShippingLabelCustomsForm.Item.fake().copy(quantity: 1)
         let order = MockOrders().makeOrder().copy(siteID: sampleSiteID)
         let customsForm = ShippingLabelCustomsForm(packageID: "Custom package", packageName: "Custom package", items: [item])
 
@@ -64,8 +64,6 @@ class ShippingLabelCustomsFormListViewModelTests: XCTestCase {
         firstItem?.hsTariffNumber = "111111"
 
         // Then
-        DispatchQueue.main.async {
-            XCTAssertFalse(viewModel.doneButtonEnabled)
-        }
+        XCTAssertFalse(viewModel.doneButtonEnabled)
     }
 }


### PR DESCRIPTION
# Description
A missing quantity in the fake instance of `ShippingLabelCustomsForm` in the `test_done_button_is_disable_when_not_all_fields_are_valid` test of customs form list view model causes the test to fail. 

This PR fixes the test by adding a non-zero quantity to the fake model, to make sure that the total value of the test item is larger than zero.

# Testing
Run the test a few times to make sure that it always passes.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
