### PR TITLE
Update notice title after switching stores based on feature flag

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -7,11 +7,14 @@ final class SwitchStoreNoticePresenter {
 
     private let sessionManager: SessionManagerProtocol
     private let noticePresenter: NoticePresenter
+    private let featureFlagService: FeatureFlagService
 
     init(sessionManager: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
-         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.sessionManager = sessionManager
         self.noticePresenter = noticePresenter
+        self.featureFlagService = featureFlagService
     }
 
     /// Present the switch notice to the user, with the new configured store name.
@@ -24,13 +27,25 @@ final class SwitchStoreNoticePresenter {
             return
         }
 
-        let messageFormat = NSLocalizedString("Switched to %1$@. You will only receive notifications from this store.",
-                                              comment: "Message presented after users switch to a new store. "
-                                                + "Reads like: Switched to {store name}. You will only receive notifications from this store. "
-                                                + "Parameters: %1$@ - store name")
-        let message = String.localizedStringWithFormat(messageFormat, newStoreName)
-        let notice = Notice(title: message, feedbackType: .success)
+        let titleFormat = featureFlagService.isFeatureFlagEnabled(.pushNotificationsForAllStores) ?
+            Localization.titleFormat: Localization.titleFormatWithPushNotificationsForAllStoresDisabled
+        let title = String.localizedStringWithFormat(titleFormat, newStoreName)
+        let notice = Notice(title: title, feedbackType: .success)
 
         noticePresenter.enqueue(notice: notice)
+    }
+}
+
+extension SwitchStoreNoticePresenter {
+    enum Localization {
+        static let titleFormatWithPushNotificationsForAllStoresDisabled =
+            NSLocalizedString("Switched to %1$@. You will only receive notifications from this store.",
+                              comment: "Message presented after users switch to a new store when multi-store push notifications are not supported. "
+                                + "Reads like: Switched to {store name}. You will only receive notifications from this store. "
+                                + "Parameters: %1$@ - store name")
+        static let titleFormat = NSLocalizedString("Switched to %1$@.",
+                                                   comment: "Message presented after users switch to a new store. "
+                                                    + "Reads like: Switched to {store name}. You will only receive notifications from this store. "
+                                                    + "Parameters: %1$@ - store name")
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -45,7 +45,7 @@ extension SwitchStoreNoticePresenter {
                                 + "Parameters: %1$@ - store name")
         static let titleFormat = NSLocalizedString("Switched to %1$@.",
                                                    comment: "Message presented after users switch to a new store. "
-                                                    + "Reads like: Switched to {store name}. You will only receive notifications from this store. "
+                                                    + "Reads like: Switched to {store name}. "
                                                     + "Parameters: %1$@ - store name")
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -6,17 +6,20 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsPaymentMethodCreationOn: Bool
     private let isShippingLabelsPackageCreationOn: Bool
     private let isShippingLabelsMultiPackageOn: Bool
+    private let isPushNotificationsForAllStoresOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
          isShippingLabelsPaymentMethodCreationOn: Bool = false,
          isShippingLabelsPackageCreationOn: Bool = false,
-         isShippingLabelsMultiPackageOn: Bool = false) {
+         isShippingLabelsMultiPackageOn: Bool = false,
+         isPushNotificationsForAllStoresOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
         self.isShippingLabelsPackageCreationOn = isShippingLabelsPackageCreationOn
         self.isShippingLabelsMultiPackageOn = isShippingLabelsMultiPackageOn
+        self.isPushNotificationsForAllStoresOn = isPushNotificationsForAllStoresOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -31,6 +34,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShippingLabelsPackageCreationOn
         case .shippingLabelsMultiPackage:
             return isShippingLabelsMultiPackageOn
+        case .pushNotificationsForAllStores:
+            return isPushNotificationsForAllStoresOn
         default:
             return false
         }


### PR DESCRIPTION
Part of #5032 

## Why

When we support multi-store push notifications, we no longer want to show the message `You will only receive notifications from this store` in the notice after switching stores. This PR shows a different notice message based on the feature flag.

## Changes

- In `SwitchStoreNoticePresenter`, updated store-switching notice title based on `pushNotificationsForAllStores` feature flag with a test case on the notice title. The plan is to delete the new test case after the feature is fully launched.

## Testing

### Feature flag is on (default in debug builds)

- Launch the app from PR branch
- Switch to another store --> after switching stores, should see a notice that just says `Switched to \(siteName).`

### Feature flag is off

- In Xcode, disable the feature flag by returning `false` for `pushNotificationsForAllStores` in `DefaultFeatureFlagService`
- Launch the app from PR branch
- Switch to another store --> after switching stores, should see a notice that just says `Switched to \(siteName). You will only receive notifications from this store.`

## Example screenshots

feature flag off | feature flag on
-- | -- 
![Simulator Screen Shot - iPhone 11 - 2021-10-05 at 15 02 47](https://user-images.githubusercontent.com/1945542/135979127-7fd35979-ae36-485a-9dcc-b8dce6f77808.png) | ![Simulator Screen Shot - iPhone 11 - 2021-10-05 at 14 30 52](https://user-images.githubusercontent.com/1945542/135979141-ad98e2a3-3bb8-42e2-9179-55d0447b2d63.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
