### PR TITLE
Shipping Labels: Fix info banner color and signature option spacing on Carrier and Rates screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.8
 -----
-
+- [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 
 7.7
 -----

--- a/WooCommerce/Classes/Styles/ColorStudio.swift
+++ b/WooCommerce/Classes/Styles/ColorStudio.swift
@@ -71,6 +71,7 @@ struct ColorStudio {
     static let green = ColorStudio(name: .green)
     static let yellow = ColorStudio(name: .yellow)
     static let orange = ColorStudio(name: .orange)
+    static let celadon = ColorStudio(name: .celadon)
 
     /// The full name of the color, with required shade value
     func assetName() -> String {

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -48,16 +48,17 @@ extension UIColor {
                        dark: .withColorStudio(.orange, shade: .shade90))
     }
 
-    /// Info. Green with Shade 50
+    /// Info. Celadon-40 (< iOS 13 and Light Mode) and Green-50 (Dark Mode)
     ///
     static var info: UIColor {
-        return .withColorStudio(.green, shade: .shade50)
+        return UIColor(light: .withColorStudio(.celadon, shade: .shade40),
+                       dark: .withColorStudio(.green, shade: .shade50))
     }
 
-    /// Info. Green-5 (< iOS 13 and Light Mode) and Green-80 (Dark Mode)
+    /// Info. Celadon-5 (< iOS 13 and Light Mode) and Green-80 (Dark Mode)
     ///
     static var infoBackground: UIColor {
-        return UIColor(light: .withColorStudio(.green, shade: .shade5),
+        return UIColor(light: .withColorStudio(.celadon, shade: .shade5),
                        dark: .withColorStudio(.green, shade: .shade80))
     }
 

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -48,18 +48,17 @@ extension UIColor {
                        dark: .withColorStudio(.orange, shade: .shade90))
     }
 
-    /// Info. Green with Shade 40
+    /// Info. Green with Shade 50
     ///
     static var info: UIColor {
-        return UIColor(light: .withColorStudio(.green, shade: .shade50),
-                       dark: .withColorStudio(.orange, shade: .shade30))
+        return .withColorStudio(.green, shade: .shade50)
     }
 
-    /// Info. Green-80 (< iOS 13 and Light Mode) and Orange-70 (Dark Mode)
+    /// Info. Green-5 (< iOS 13 and Light Mode) and Green-80 (Dark Mode)
     ///
     static var infoBackground: UIColor {
-        return UIColor(light: .withColorStudio(.green, shade: .shade80),
-                       dark: .withColorStudio(.orange, shade: .shade70))
+        return UIColor(light: .withColorStudio(.green, shade: .shade5),
+                       dark: .withColorStudio(.green, shade: .shade80))
     }
 
     /// Blue. Blue-50 (< iOS 13 and Light Mode) and Blue-30 (Dark Mode)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRow.swift
@@ -11,7 +11,7 @@ struct ShippingLabelCarrierRow: View {
 
     var body: some View {
         VStack(alignment: .leading,
-               spacing: Constants.vStackSpacing) {
+               spacing: Constants.padding) {
             HStack(alignment: .top, spacing: Constants.hStackSpacing) {
                 if viewModel.selected {
                     Image(uiImage: .checkmarkStyledImage)
@@ -47,7 +47,7 @@ struct ShippingLabelCarrierRow: View {
             if viewModel.selected {
                 HStack {
                     Spacer().frame(width: Constants.leadingSpaceSignature)
-                    VStack(alignment: .leading, spacing: Constants.vStackSpacing) {
+                    VStack(alignment: .leading, spacing: Constants.padding) {
                         if viewModel.displaySignatureRequired {
                             HStack (spacing: Constants.padding) {
                                 let image: UIImage = viewModel.signatureSelected ? UIImage.checkmarkImage : UIImage.plusImage

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -233,8 +233,6 @@ private extension TopBannerView {
             iconImageView.tintColor = .info
         }
         backgroundColor = backgroundColor(for: type)
-        titleLabel.textColor = textColor(for: type)
-        infoLabel.textColor = textColor(for: type)
     }
 
     func backgroundColor(for bannerType: TopBannerViewModel.BannerType) -> UIColor {
@@ -245,17 +243,6 @@ private extension TopBannerView {
             return .warningBackground
         case .info:
             return .infoBackground
-        }
-    }
-
-    func textColor(for bannerType: TopBannerViewModel.BannerType) -> UIColor {
-        switch bannerType {
-        case .normal:
-            return .text
-        case .warning:
-            return .text
-        case .info:
-            return .white
         }
     }
 


### PR DESCRIPTION
Fixes: #4853

## Description

This fixes two issues on the Carrier and Rates screen:

* Updates the info banner color to match designs (Celadon in light mode, Green in dark mode)
* Adds more spacing (16 px) between additional signature options

## Changes

* Adds `celadon` to the `ColorStudio` palette.
* Updates `UIColor` with correct colors for light and dark mode for info image (`.info` - Celadon-40 light mode/Green-50 dark mode) and background (`.infoBackground` - Celadon-5 light mode/Green-80 dark mode).
* Updates `ShippingLabelCarrierRow` to use more padding between the selected shipping rate and additional signature options, and between each signature option.

Before|After
-|-
<img src="https://user-images.githubusercontent.com/8658164/136069776-a38e1cfc-06c1-4943-b319-7c7e85718fd7.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/136069787-861b7f27-3693-4174-971d-aa07ab26e8be.png" width="300px">
<img src="https://user-images.githubusercontent.com/8658164/136069800-4182a27a-2201-4ba0-9aad-0b30930180b8.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/136069807-00bb6096-42cb-48de-bb86-1bde846e67de.png" width="300px">

## Testing

1. Make sure WCShip is installed and activated on your store, and you have an order that is eligible for shipping labels where the customer paid for shipping.
2. Open the Orders tab and select an order.
3. Tap the "Create Shipping Label" button.
4. Fill out the shipping label form until you get to Carrier and Rates.
5. On the Carrier and Rates screen, check both light and dark mode to confirm the banner matches the designs.
6. Select a shipping rate and confirm the signature options have additional spacing as expected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
