### PR TITLE
Shipping Labels: Make name optional for local address validation when company is specified

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */; };
 		D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */; };
 		D8FBFF2922D52AFB006E3336 /* order-stats-v4-year.json in Resources */ = {isa = PBXBuildFile; fileRef = D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */; };
+		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
@@ -1087,6 +1088,7 @@
 		D8FBFF2322D52815006E3336 /* order-stats-v4-daily.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-daily.json"; sourceTree = "<group>"; };
 		D8FBFF2622D529F2006E3336 /* order-stats-v4-month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-month.json"; sourceTree = "<group>"; };
 		D8FBFF2822D52AFA006E3336 /* order-stats-v4-year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year.json"; sourceTree = "<group>"; };
+		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1663,6 +1665,7 @@
 				CC9A253B26442C71005DE56E /* shipping-label-eligibility-success.json */,
 				CC9A254526442CA7005DE56E /* shipping-label-eligibility-failure.json */,
 				45A4B85525D2E75200776FB4 /* shipping-label-address-validation-success.json */,
+				DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */,
 				45A4B85B25D2FAB500776FB4 /* shipping-label-address-validation-error.json */,
 				CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */,
 				CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */,
@@ -2156,6 +2159,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
+				DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
 				31054710262E2EE400C5C02B /* wcpay-payment-intent-succeeded.json in Resources */,
 				02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */,

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -54,11 +54,36 @@ public struct ShippingLabelAddress: GeneratedCopiable, Equatable, GeneratedFakea
 
 // MARK: Codable
 extension ShippingLabelAddress: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        let company = try container.decode(String.self, forKey: .company)
+        let phone = try container.decode(String.self, forKey: .phone)
+        let country = try container.decode(String.self, forKey: .country)
+        let state = try container.decode(String.self, forKey: .state)
+        let address1 = try container.decode(String.self, forKey: .address1)
+        let address2 = try container.decode(String.self, forKey: .address2)
+        let city = try container.decode(String.self, forKey: .city)
+        let postcode = try container.decode(String.self, forKey: .postcode)
+
+        self.init(company: company,
+                  name: name,
+                  phone: phone,
+                  country: country,
+                  state: state,
+                  address1: address1,
+                  address2: address2,
+                  city: city,
+                  postcode: postcode)
+    }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(company, forKey: .company)
-        try container.encode(name, forKey: .name)
+        if !name.isEmpty {
+            try container.encode(name, forKey: .name)
+        }
         try container.encode(phone, forKey: .phone)
         try container.encode(country, forKey: .country)
         try container.encode(state, forKey: .state)

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -86,7 +86,7 @@ extension ShippingLabelAddress: Codable {
         // Make sure to only send address name if it's not empty,
         // otherwise requests to fetch rates and purchase label will fail.
         // Reference: https://git.io/JVQzC
-        if name.isNotEmpty {
+        if !name.isEmpty {
             try container.encode(name, forKey: .name)
         }
         try container.encode(phone, forKey: .phone)

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -86,7 +86,7 @@ extension ShippingLabelAddress: Codable {
         // Make sure to only send address name if it's not empty,
         // otherwise requests to fetch rates and purchase label will fail.
         // Reference: https://git.io/JVQzC
-        if !name.isEmpty {
+        if name.isNotEmpty {
             try container.encode(name, forKey: .name)
         }
         try container.encode(phone, forKey: .phone)

--- a/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Networking/Networking/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -56,6 +56,8 @@ public struct ShippingLabelAddress: GeneratedCopiable, Equatable, GeneratedFakea
 extension ShippingLabelAddress: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        // If no name is sent to validation address request, no name will be received in response.
+        // So make sure to decode it only if it's present.
         let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         let company = try container.decode(String.self, forKey: .company)
         let phone = try container.decode(String.self, forKey: .phone)
@@ -81,6 +83,9 @@ extension ShippingLabelAddress: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(company, forKey: .company)
+        // Make sure to only send address name if it's not empty,
+        // otherwise requests to fetch rates and purchase label will fail.
+        // Reference: https://git.io/JVQzC
         if !name.isEmpty {
             try container.encode(name, forKey: .name)
         }

--- a/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -126,6 +126,27 @@ final class ShippingLabelRemoteTests: XCTestCase {
         }
     }
 
+    func test_shippingAddressValidation_returns_address_without_name_on_success() throws {
+        // Given
+        let remote = ShippingLabelRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "normalize-address", filename: "shipping-label-address-without-name-validation-success")
+
+        // When
+        let result: Result<ShippingLabelAddressValidationSuccess, Error> = waitFor { promise in
+            remote.addressValidation(siteID: self.sampleSiteID, address: self.sampleShippingLabelAddressWithoutNameVerification()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        switch result {
+        case .success(let response):
+            XCTAssertEqual(response.address, sampleShippingLabelAddressWithoutName())
+        case .failure(let error):
+            XCTFail("Expected successful result, got error instead: \(error)")
+        }
+    }
+
     func test_shippingAddressValidation_returns_errors_on_failure() throws {
         // Given
         let remote = ShippingLabelRemote(network: network)
@@ -519,9 +540,26 @@ private extension ShippingLabelRemoteTests {
         return ShippingLabelAddressVerification(address: sampleShippingLabelAddress(), type: type)
     }
 
+    func sampleShippingLabelAddressWithoutNameVerification() -> ShippingLabelAddressVerification {
+        let type: ShippingLabelAddressVerification.ShipType = .destination
+        return ShippingLabelAddressVerification(address: sampleShippingLabelAddressWithoutName(), type: type)
+    }
+
     func sampleShippingLabelAddress() -> ShippingLabelAddress {
         return ShippingLabelAddress(company: "",
                                     name: "Anitaa",
+                                    phone: "41535032",
+                                    country: "US",
+                                    state: "CA",
+                                    address1: "60 29TH ST # 343",
+                                    address2: "",
+                                    city: "SAN FRANCISCO",
+                                    postcode: "94110-4929")
+    }
+
+    func sampleShippingLabelAddressWithoutName() -> ShippingLabelAddress {
+        return ShippingLabelAddress(company: "Automattic",
+                                    name: "",
                                     phone: "41535032",
                                     country: "US",
                                     state: "CA",

--- a/Networking/NetworkingTests/Responses/shipping-label-address-without-name-validation-success.json
+++ b/Networking/NetworkingTests/Responses/shipping-label-address-without-name-validation-success.json
@@ -1,0 +1,16 @@
+{
+    "data": {
+        "success": true,
+        "normalized": {
+            "address_2": "",
+            "city": "SAN FRANCISCO",
+            "state": "CA",
+            "postcode": "94110-4929",
+            "country": "US",
+            "address": "60 29TH ST # 343",
+            "company": "Automattic",
+            "phone": "41535032"
+        },
+        "is_trivial_normalization": false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -343,9 +343,10 @@ private extension ShippingLabelAddressFormViewController {
     }
 
     func configureName(cell: TitleAndTextFieldTableViewCell, row: Row) {
+        let placeholder = viewModel.nameRequired ? Localization.requiredNameFieldPlaceholder : Localization.optionalNameFieldPlaceholder
         let cellViewModel = TitleAndTextFieldTableViewCell.ViewModel(title: Localization.nameField,
                                                                      text: viewModel.address?.name,
-                                                                     placeholder: Localization.nameFieldPlaceholder,
+                                                                     placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
@@ -527,7 +528,12 @@ private extension ShippingLabelAddressFormViewController {
         static let titleViewShipTo = NSLocalizedString("Ship to", comment: "Shipping Label Address Validation navigation title")
 
         static let nameField = NSLocalizedString("Name", comment: "Text field name in Shipping Label Address Validation")
-        static let nameFieldPlaceholder = NSLocalizedString("Required", comment: "Text field placeholder in Shipping Label Address Validation")
+        static let requiredNameFieldPlaceholder = NSLocalizedString("Required",
+                                                                    comment: "Name text field placeholder in Shipping Label "
+                                                                    + "Address Validation when it's required")
+        static let optionalNameFieldPlaceholder = NSLocalizedString("Optional",
+                                                                    comment: "Name text field placeholder in Shipping Label "
+                                                                    + "Address Validation when it's optional")
         static let companyField = NSLocalizedString("Company", comment: "Text field company in Shipping Label Address Validation")
         static let companyFieldPlaceholder = NSLocalizedString("Optional", comment: "Text field placeholder in Shipping Label Address Validation")
         static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Shipping Label Address Validation")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -51,6 +51,10 @@ final class ShippingLabelAddressFormViewModel {
 
     private(set) var countries: [Country]
 
+    var nameRequired: Bool {
+        address?.company.isEmpty == true
+    }
+
     var statesOfSelectedCountry: [StateOfACountry] {
         countries.first { $0.code == address?.country }?.states.sorted { $0.name < $1.name } ?? []
     }
@@ -243,7 +247,7 @@ extension ShippingLabelAddressFormViewModel {
         var errors: [ValidationError] = []
 
         if let addressToBeValidated = address {
-            if addressToBeValidated.name.isEmpty {
+            if addressToBeValidated.name.isEmpty && nameRequired {
                 errors.append(.name)
             }
             if addressToBeValidated.address1.isEmpty {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -108,6 +108,39 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
+    func test_sections_are_returned_correctly_if_name_is_empty_while_company_is_not_empty() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(company: "Automattic",
+                                                                     name: "",
+                                                                     phone: "0111111111",
+                                                                     country: "US",
+                                                                     state: "CA",
+                                                                     address1: "13 Main street",
+                                                                     address2: "",
+                                                                     city: "California",
+                                                                     postcode: "900000")
+
+        // When
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          validationError: nil,
+                                                          countries: [])
+        viewModel.validateAddress(onlyLocally: true) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .company,
+                                                                     .phone,
+                                                                     .address,
+                                                                     .address2,
+                                                                     .city,
+                                                                     .postcode,
+                                                                     .state,
+                                                                     .country]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
     func test_sections_are_returned_correctly_if_stateOfCountry_is_not_required() {
         // Given
         let shippingAddress = MockShippingLabelAddress.sampleAddress(country: "VN")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -538,6 +538,42 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.extendedCountryName, "United States")
         XCTAssertEqual(viewModel.extendedStateName, "California")
     }
+
+    func test_correct_row_index_is_returned_in_onChange_callback() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(company: "Automattic",
+                                                                     name: "",
+                                                                     phone: "0111111111",
+                                                                     country: "US",
+                                                                     state: "CA",
+                                                                     address1: "13 Main street",
+                                                                     address2: "",
+                                                                     city: "California",
+                                                                     postcode: "900000")
+
+        // When
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          validationError: nil,
+                                                          countries: [])
+        var rowIndex: Int?
+        viewModel.onChange = { index in
+            rowIndex = index
+        }
+        viewModel.handleAddressValueChanges(row: .company, newValue: "")
+
+        // Then
+        XCTAssertNotNil(viewModel.sections.first?.rows.first(where: { $0 == .fieldError(.name) }))
+        XCTAssertEqual(rowIndex, 2)
+
+        // When
+        viewModel.handleAddressValueChanges(row: .company, newValue: "Apple")
+
+        // Then
+        XCTAssertNil(viewModel.sections.first?.rows.first(where: { $0 == .fieldError(.name) }))
+        XCTAssertEqual(rowIndex, 1)
+    }
 }
 
 private extension ShippingLabelAddressFormViewModelTests {


### PR DESCRIPTION
Fixes #4681 

# Description
This PR make name field in address validation form optional when company field is not empty. This also makes sure that name is only sent in requests to fetching carriers and rates & purchasing label when it's not empty.

# Changes
- Networking layer: 
   - Updates `ShippingLabelAddress` encoder to only encode name when it's not empty
   - Updates `ShippingLabelAddress` decoder to only decode name when the field is present.
- ShippingLabelAddressFormViewModel:
   - Adds new variable to check if name is optional
   - Updates local validation for name field
   - Fixes incorrect row index when validation error changes.
- ShippingLabelAddressFormViewController: updates correct placeholder text for Name field based on whether the field is optional.

# Demo
https://user-images.githubusercontent.com/5533851/136159595-c41a97d7-a1ee-40aa-915d-5eaf01c3591e.mp4

# Testing
1. Make sure your test store has configured WCShip plugin.
2. On Orders tab select an order that's eligible for creating shipping labels.
3. Select Create shipping label and select Ship From.
4. Clear both Name and Company fields, notice that the placeholder on Name field is Required and a validation error shows up below the field.
5. Enter value for Company field, notice that placeholder on Name field is Optional and the validation error goes away. Tap Done and notice that the validation succeeds when other fields are valid.
6. Proceed to configure other info for the shipping label. Notice that the carriers and rows list can be loaded like before.
7. Proceed to purchase the label. Make sure that it still succeeds and information on the purchased label is correct.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
