### PR TITLE
Shipping Labels: Auto select new package on new Package Details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackageViewModel.swift
@@ -202,7 +202,6 @@ extension ShippingLabelSinglePackageViewModel: ShippingLabelPackageSelectionDele
 
     func didSyncPackages(packagesResponse: ShippingLabelPackagesResponse?) {
         self.packagesResponse = packagesResponse
-        packageListViewModel = .init(siteID: order.siteID, packagesResponse: packagesResponse)
         onPackagesSync(packagesResponse)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
@@ -115,21 +115,27 @@ extension ShippingLabelPackageListViewModel {
         guard let packagesResponse = packagesResponse else {
             return
         }
-
+        let shouldNotifyDelegate = !hasCustomOrPredefinedPackages
         self.packagesResponse = packagesResponse
+        delegate?.didSyncPackages(packagesResponse: packagesResponse)
+
         addNewPackageViewModel = .init(siteID: siteID,
                                        packagesResponse: packagesResponse,
                                        onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
                                          guard let self = self else { return }
                                          self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                        })
+
         if let customPackage = customPackage {
             selectCustomPackage(customPackage.title)
-        }
-        else if let servicePackage = servicePackage {
+            if shouldNotifyDelegate {
+                delegate?.didSelectPackage(id: customPackage.title)
+            }
+        } else if let servicePackage = servicePackage {
             selectPredefinedPackage(servicePackage.id)
+            if shouldNotifyDelegate {
+                delegate?.didSelectPackage(id: servicePackage.id)
+            }
         }
-
-        delegate?.didSyncPackages(packagesResponse: packagesResponse)
     }
 }


### PR DESCRIPTION
Fixes #5140 

# Description
The new package details screen has incorrect logic when syncing packages:
- New view model for the package list is created every time new packages are synced - this is redundant because the package list already updates its packages response; and this also causes the loss of selected package in the list.
- Packages response is not updated in the packages form view model, so new package details cannot be updated on UI.

# Changes
- Removes redundant recreation of package list view model when syncing packages
- Updates packages response in packages form view model.

# Demo
https://user-images.githubusercontent.com/5533851/136179841-034e3dca-e34d-4849-b90a-c11216472023.mp4

# Testing
1. Make sure your test store has configured WCShip plugin.
2. On Orders tab, select an order that's eligible for creating shipping label.
3. Select Create Shipping Label and configure Ship From, Ship To.
4. On the Package Details screen, select the "Package Selected" row.
5. On the Add New Package screen, create a custom package or select a service package.
6. Tap Done, notice that on the packages list the new package is listed and selected. Tap Done again, notice that the correct package name is displayed on the Package Details screen.
7. If there are more than one packages, select "Package Selected" row on another package. Notice that the new package is listed in the packages list.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
