### PR TITLE
Quick Pay: Add Yosemite actions

### DIFF
--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a FeeLine Entity within an Order.
 ///
-public struct OrderFeeLine: Equatable, Decodable, GeneratedFakeable {
+public struct OrderFeeLine: Equatable, Codable, GeneratedFakeable {
     public let feeID: Int64
     public let name: String
     public let taxClass: String
@@ -34,6 +34,19 @@ public struct OrderFeeLine: Equatable, Decodable, GeneratedFakeable {
     }
 }
 
+// MARK: Codable
+extension OrderFeeLine {
+    /// Encodes OrderFeeLine writable fields.
+    ///
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(name, forKey: .name)
+        try container.encode(taxClass, forKey: .taxClass)
+        try container.encode(taxStatus, forKey: .taxStatus)
+        try container.encode(total, forKey: .total)
+    }
+}
 
 /// Defines all of the OrderFeeLine's CodingKeys.
 ///

--- a/Networking/Networking/Model/OrderFeeTaxStatus.swift
+++ b/Networking/Networking/Model/OrderFeeTaxStatus.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents a OrderFeeTaxStatus Entity.
 ///
 
-public enum OrderFeeTaxStatus: Decodable, Hashable, GeneratedFakeable {
+public enum OrderFeeTaxStatus: Codable, Hashable, GeneratedFakeable {
     case taxable
     case none
 }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -108,6 +108,30 @@ public class OrdersRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Creates an order using the specified fields of a given order
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the Order.
+    ///     - order: Order to be created.
+    ///     - fields: Fields of the order to be created.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createOrder(siteID: Int64, order: Order, fields: [CreateOrderField], completion: @escaping (Result<Order, Error>) -> Void) {
+        let path = Constants.ordersPath
+        let mapper = OrderMapper(siteID: siteID)
+        let parameters: [String: Any] = {
+            fields.reduce(into: [:]) { params, field in
+                switch field {
+                case .total:
+                    params[Order.CodingKeys.total.rawValue] = order.total
+                }
+            }
+        }()
+
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Updates the `OrderStatus` of a given Order.
     ///
     /// - Parameters:
@@ -228,5 +252,11 @@ public extension OrdersRemote {
         case customerNote
         case shippingAddress
         case billingAddress
+    }
+
+    /// Order fields supported for create
+    ///
+    enum CreateOrderField {
+        case total
     }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -248,10 +248,13 @@ final class OrdersRemoteTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
-        let feeLine = try XCTUnwrap((request.parameters["fee_lines"] as? [[String: String]])?.first)
-        XCTAssertEqual(feeLine["name"], fee.name)
-        XCTAssertEqual(feeLine["tax_status"], fee.taxStatus.rawValue)
-        XCTAssertEqual(feeLine["tax_class"], fee.taxClass)
-        XCTAssertEqual(feeLine["total"], fee.total)
+        let received = try XCTUnwrap(request.parameters["fee_lines"] as? [[String: String]]).first
+        let expected = [
+            "name": fee.name,
+            "tax_status": fee.taxStatus.rawValue,
+            "tax_class": fee.taxClass,
+            "total": fee.total
+        ]
+        assertEqual(received, expected)
     }
 }

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -236,4 +236,22 @@ final class OrdersRemoteTests: XCTestCase {
         }
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    func test_create_order_properly_encodes_fee_lines() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let fee = OrderFeeLine(feeID: 0, name: "Line", taxClass: "", taxStatus: .none, total: "12.34", totalTax: "", taxes: [], attributes: [])
+        let order = Order.fake().copy(fees: [fee])
+
+        // When
+        remote.createOrder(siteID: 123, order: order, fields: [.feeLines]) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let feeLine = try XCTUnwrap((request.parameters["fee_lines"] as? [[String: String]])?.first)
+        XCTAssertEqual(feeLine["name"], fee.name)
+        XCTAssertEqual(feeLine["tax_status"], fee.taxStatus.rawValue)
+        XCTAssertEqual(feeLine["tax_class"], fee.taxClass)
+        XCTAssertEqual(feeLine["total"], fee.total)
+    }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		265BCA0024301ACD004E53EE /* ProductCategoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */; };
 		2665034D2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */; };
 		266503512620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */; };
+		26788979270E057900BD249E /* OrderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26788978270E057900BD249E /* OrderFactory.swift */; };
 		2685C10D263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */; };
 		2685C111263C97A800D9EE97 /* AddOnGroupAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */; };
 		2685C117263C98CF00D9EE97 /* AddOnGroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */; };
@@ -501,6 +502,7 @@
 		265BC9FF24301ACD004E53EE /* ProductCategoryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryStoreTests.swift; sourceTree = "<group>"; };
 		2665034C2620E0A90079A159 /* ProductAddOnOption+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOnOption+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		266503502620E2EB0079A159 /* ProductAddOn+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductAddOn+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		26788978270E057900BD249E /* OrderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderFactory.swift; sourceTree = "<group>"; };
 		2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddOnGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupAction.swift; sourceTree = "<group>"; };
 		2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnGroupStore.swift; sourceTree = "<group>"; };
@@ -979,6 +981,7 @@
 			isa = PBXGroup;
 			children = (
 				5726456E250BD4E4005BBD7C /* OrdersUpsertUseCase.swift */,
+				26788978270E057900BD249E /* OrderFactory.swift */,
 			);
 			path = Order;
 			sourceTree = "<group>";
@@ -1805,6 +1808,7 @@
 				749374FE2249601F007D85D1 /* ProductStore.swift in Sources */,
 				077F39E226A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift in Sources */,
 				570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */,
+				26788979270E057900BD249E /* OrderFactory.swift in Sources */,
 				B5B5C797208E49B600642956 /* Action+Internal.swift in Sources */,
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,
 				2618707C2540B6A4006522A1 /* ShippingLineTax+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -58,4 +58,8 @@ public enum OrderAction: Action {
     /// Updates the specified fields from an order.
     ///
     case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
+
+    /// Creates an order with the specified fields from a given order
+    ///
+    case createOrder(siteID: Int64, order: Order, fields: [CreateOrderField], onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -59,7 +59,7 @@ public enum OrderAction: Action {
     ///
     case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
 
-    /// Creates an order with the specified fields from a given order
+    /// Creates a quick pay order with a specific amount value and no tax,
     ///
-    case createOrder(siteID: Int64, order: Order, fields: [OrderCreateField], onCompletion: (Result<Order, Error>) -> Void)
+    case createQuickPayOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -59,7 +59,7 @@ public enum OrderAction: Action {
     ///
     case updateOrder(siteID: Int64, order: Order, fields: [OrderUpdateField], onCompletion: (Result<Order, Error>) -> Void)
 
-    /// Creates a quick pay order with a specific amount value and no tax,
+    /// Creates a quick pay order with a specific amount value and no tax.
     ///
     case createQuickPayOrder(siteID: Int64, amount: String, onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -61,5 +61,5 @@ public enum OrderAction: Action {
 
     /// Creates an order with the specified fields from a given order
     ///
-    case createOrder(siteID: Int64, order: Order, fields: [CreateOrderField], onCompletion: (Result<Order, Error>) -> Void)
+    case createOrder(siteID: Int64, order: Order, fields: [OrderCreateField], onCompletion: (Result<Order, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -46,6 +46,7 @@ public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval
 public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
 public typealias OrderUpdateField = Networking.OrdersRemote.UpdateOrderField
+public typealias OrderCreateField = Networking.OrdersRemote.CreateOrderField
 public typealias PaymentGateway = Networking.PaymentGateway
 public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Networking
+
+/// Factory to create convenience order types.
+///
+enum OrderFactory {
+    /// Creates an order suitable to be used as a quick pay order.
+    /// Under the hood it uses a fee line without taxes to create an order with the desired amount.
+    ///
+    static func quickPayOrder(amount: String) -> Order {
+        Order(siteID: 0,
+              orderID: 0,
+              parentID: 0,
+              customerID: 0,
+              number: "",
+              status: .pending,
+              currency: "",
+              customerNote: "",
+              dateCreated: Date(),
+              dateModified: Date(),
+              datePaid: Date(),
+              discountTotal: "",
+              discountTax: "",
+              shippingTotal: "",
+              shippingTax: "",
+              total: "",
+              totalTax: "",
+              paymentMethodID: "",
+              paymentMethodTitle: "",
+              items: [],
+              billingAddress: nil,
+              shippingAddress: nil,
+              shippingLines: [],
+              coupons: [],
+              refunds: [],
+              fees: [.init(feeID: 0, name: "Quick Pay", taxClass: "", taxStatus: .none, total: amount, totalTax: "", taxes: [], attributes: [])])
+    }
+}

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -59,6 +59,9 @@ public class OrderStore: Store {
 
         case let .updateOrder(siteID, order, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
+
+        case let .createOrder(siteID, order, fields, onCompletion):
+            createOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
         }
     }
 }
@@ -234,6 +237,22 @@ private extension OrderStore {
 
             self?.upsertStoredOrdersInBackground(readOnlyOrders: [order]) {
                 onCompletion(order, nil)
+            }
+        }
+    }
+
+    /// Creates an order with the specified fields from a given order
+    ///
+    // TODO: Add Unit tests
+    func createOrder(siteID: Int64, order: Order, fields: [OrderCreateField], onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        remote.createOrder(siteID: siteID, order: order, fields: fields) { [weak self] result in
+            switch result {
+            case .success(let order):
+                self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
+                    onCompletion(result)
+                })
+            case .failure:
+                onCompletion(result)
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -60,8 +60,8 @@ public class OrderStore: Store {
         case let .updateOrder(siteID, order, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
 
-        case let .createOrder(siteID, order, fields, onCompletion):
-            createOrder(siteID: siteID, order: order, fields: fields, onCompletion: onCompletion)
+        case let .createQuickPayOrder(siteID, amount, onCompletion):
+            createQuickPayOrder(siteID: siteID, amount: amount, onCompletion: onCompletion)
         }
     }
 }
@@ -241,11 +241,11 @@ private extension OrderStore {
         }
     }
 
-    /// Creates an order with the specified fields from a given order
+    /// Creates a quick pay order with a specific amount value and no tax,
     ///
-    // TODO: Add Unit tests
-    func createOrder(siteID: Int64, order: Order, fields: [OrderCreateField], onCompletion: @escaping (Result<Order, Error>) -> Void) {
-        remote.createOrder(siteID: siteID, order: order, fields: fields) { [weak self] result in
+    func createQuickPayOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        let order = OrderFactory.quickPayOrder(amount: amount)
+        remote.createOrder(siteID: siteID, order: order, fields: [.feeLines]) { [weak self] result in
             switch result {
             case .success(let order):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -241,7 +241,7 @@ private extension OrderStore {
         }
     }
 
-    /// Creates a quick pay order with a specific amount value and no tax,
+    /// Creates a quick pay order with a specific amount value and no tax.
     ///
     func createQuickPayOrder(siteID: Int64, amount: String, onCompletion: @escaping (Result<Order, Error>) -> Void) {
         let order = OrderFactory.quickPayOrder(amount: amount)


### PR DESCRIPTION
# Why 

As the Quick Pay project is about to start, this PR makes sure that we have an action available in order to create a quick pay order using custom fees as discussed in p91TBi-6aO

# How

- Update `OrderFeeLine` to add `Encodable` support.

- Added into `OrdersRemote` a function to create orders, similar to the update orders functions, here we can choose what attribute from a given order will be used to create a new order. Currently, only `fee_lines` are supported.

- Added into `OrdersStore` an action to create a quick pay order. It will take just an arbitrary amount and will create an store an order as needed.

# Testing Steps

- Modify `DashboardViewController.viewDidLoad` in order to look like 
```swift
override func viewDidLoad() {
    super.viewDidLoad()
    configureNavigation()
    configureView()
    configureDashboardUIContainer()

    DispatchQueue.main.async {
        let action = OrderAction.createQuickPayOrder(siteID: self.siteID, amount: "10.99") { result in
            print(result)
        }
        ServiceLocator.stores.dispatch(action)
    }
}
```

- Launch the app and navigate to orders
- Go to the "All Orders" tab
- See that a new Guest order is there
- Confirm the value of the order is `10.99` and that you see the `Collect Payment` button if your test store is configured to receive payments.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
