### PR TITLE
Update badge number to be 1 when there are notifications from currently selected site

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -109,7 +109,7 @@ extension PushNotificationsManager {
     }
 
 
-    /// Registers the Application for Remote Notifgications.
+    /// Registers the Application for Remote Notifications.
     ///
     func registerForRemoteNotifications() {
         DDLogInfo("📱 Registering for Remote Notifications...")
@@ -151,7 +151,9 @@ extension PushNotificationsManager {
 
     func resetBadgeCountForAllStores(onCompletion: @escaping () -> Void) {
         let action = NotificationCountAction.resetForAllSites() { [weak self] in
-            self?.configuration.application.applicationIconBadgeNumber = AppIconBadgeNumber.clearsBadgeAndAllPushNotifications
+            guard let self = self else { return }
+            self.configuration.application.applicationIconBadgeNumber = AppIconBadgeNumber.clearsBadgeAndAllPushNotifications
+            self.removeAllNotifications()
             onCompletion()
         }
         stores.dispatch(action)
@@ -289,6 +291,10 @@ private extension PushNotificationsManager {
         default:
             break
         }
+    }
+
+    func removeAllNotifications() {
+        configuration.userNotificationsCenter.removeAllNotifications()
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -152,7 +152,7 @@ extension PushNotificationsManager {
     func resetBadgeCountForAllStores(onCompletion: @escaping () -> Void) {
         let action = NotificationCountAction.resetForAllSites() { [weak self] in
             guard let self = self else { return }
-            self.configuration.application.applicationIconBadgeNumber = AppIconBadgeNumber.clearsBadgeAndAllPushNotifications
+            self.configuration.application.applicationIconBadgeNumber = AppIconBadgeNumber.clearsBadgeAndPotentiallyAllPushNotifications
             self.removeAllNotifications()
             onCompletion()
         }
@@ -533,8 +533,8 @@ enum AppIconBadgeNumber {
     static let hasUnreadPushNotifications = 1
     /// An unofficial workaround to clear the app icon badge without clearing all push notifications in Notification Center.
     static let clearsBadgeOnly = -1
-    /// Clears the app icon badge and all push notifications in Notification Center.
-    static let clearsBadgeAndAllPushNotifications = 0
+    /// Clears the app icon badge and potentially all push notifications in Notification Center.
+    static let clearsBadgeAndPotentiallyAllPushNotifications = 0
 }
 
 // MARK: - Private Types

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -218,8 +218,9 @@ extension PushNotificationsManager {
         // Badge: Update
         if let typeString = userInfo.string(forKey: APNSKey.type),
             let type = Note.Kind(rawValue: typeString),
-            let siteID = userInfo[APNSKey.siteID] as? Int64 {
-            incrementNotificationCount(siteID: siteID, type: type, incrementCount: 1) { [weak self] in
+            let siteID = siteID,
+            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
+            incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
                 self?.loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: type)
                 onBadgeUpdateCompletion()
             }
@@ -519,6 +520,17 @@ private extension PushNotification {
     }
 }
 
+// MARK: - App Icon Badge Number
+
+enum AppIconBadgeNumber {
+    /// Indicates that there are unread push notifications in Notification Center.
+    static let hasUnreadPushNotifications = 1
+    /// An unofficial workaround to clear the app icon badge without clearing all push notifications in Notification Center.
+    static let clearsBadgeOnly = -1
+    /// Clears the app icon badge and all push notifications in Notification Center.
+    static let clearsBadgeAndAllPushNotifications = 0
+}
+
 // MARK: - Private Types
 //
 private enum APNSKey {
@@ -527,15 +539,6 @@ private enum APNSKey {
     static let identifier = "note_id"
     static let type = "type"
     static let siteID = "blog"
-}
-
-private enum AppIconBadgeNumber {
-    /// Indicates that there are unread push notifications in Notification Center.
-    static let hasUnreadPushNotifications = 1
-    /// An unofficial workaround to clear the app icon badge without clearing all push notifications in Notification Center.
-    static let clearsBadgeOnly = -1
-    /// Clears the app icon badge and all push notifications in Notification Center.
-    static let clearsBadgeAndAllPushNotifications = 0
 }
 
 private enum AnalyticKey {

--- a/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
+++ b/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
@@ -13,6 +13,9 @@ protocol UserNotificationsCenterAdapter {
     /// Requests Push Notifications Authorization
     ///
     func requestAuthorization(queue: DispatchQueue, completion: @escaping (Bool) -> Void)
+
+    /// Removes all push notifications that have been delivered or scheduled
+    func removeAllNotifications()
 }
 
 
@@ -38,5 +41,10 @@ extension UNUserNotificationCenter: UserNotificationsCenterAdapter {
                 completion(allowed)
             }
         }
+    }
+
+    func removeAllNotifications() {
+        removeAllDeliveredNotifications()
+        removeAllPendingNotificationRequests()
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotificationsCenterAdapter.swift
@@ -5,7 +5,7 @@ import UserNotifications
 
 /// MockUserNotificationsCenterAdapter: UNUserNotificationCenter Mock
 ///
-class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
+final class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
 
     /// User Notifications Authorization Status
     ///
@@ -19,6 +19,9 @@ class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
     ///
     var requestAuthorizationIsSuccessful = false
 
+    /// Indicates if `removeAllNotifications` was called
+    ///
+    var removeAllNotificationsWasCalled = false
 
     /// "Simulates" an UNUserNotificationCenter Load Status OP
     ///
@@ -31,6 +34,10 @@ class MockUserNotificationsCenterAdapter: UserNotificationsCenterAdapter {
     func requestAuthorization(queue: DispatchQueue, completion: @escaping (Bool) -> Void) {
         requestAuthorizationWasCalled = true
         completion(requestAuthorizationIsSuccessful)
+    }
+
+    func removeAllNotifications() {
+        removeAllNotificationsWasCalled = true
     }
 
     /// Restores the initial state

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -514,7 +514,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         // Assert
-        XCTAssertEqual(application.applicationIconBadgeNumber, AppIconBadgeNumber.clearsBadgeAndAllPushNotifications)
+        XCTAssertEqual(application.applicationIconBadgeNumber, AppIconBadgeNumber.clearsBadgeAndPotentiallyAllPushNotifications)
         XCTAssertTrue(userNotificationCenter.removeAllNotificationsWasCalled)
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -409,11 +409,10 @@ final class PushNotificationsManagerTests: XCTestCase {
                                                                userNotificationsCenter: self.userNotificationCenter)
             return PushNotificationsManager(configuration: configuration)
         }()
-        ServiceLocator.setPushNotesManager(manager)
         stores.authenticate(credentials: SessionSettings.credentials)
         let siteID = Int64(123)
         stores.updateDefaultStore(storeID: siteID)
-        XCTAssertEqual(application.applicationIconBadgeNumber, AppIconBadgeNumber.clearsBadgeOnly)
+        XCTAssertEqual(application.applicationIconBadgeNumber, .min)
 
         // Action
         let userInfo = notificationPayload(badgeCount: 10, type: .comment, siteID: siteID)
@@ -427,8 +426,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertEqual(application.applicationIconBadgeNumber, AppIconBadgeNumber.hasUnreadPushNotifications)
     }
 
-    /// Verifies that `handleNotification` does not update app badge number when the notification is from a different site.
-    func test_receiving_notification_from_a_different_site_does_not_change_app_badge_number() {
+    /// Verifies that `handleNotification` clears app badge number without clearing push notifications when the notification is from a different site.
+    func test_receiving_notification_from_a_different_site_clears_app_badge_number_only() {
         // Arrange
         // A site ID and the default stores are required to update the application badge number.
         let stores = DefaultStoresManager.testingInstance
@@ -440,10 +439,9 @@ final class PushNotificationsManagerTests: XCTestCase {
                                                                userNotificationsCenter: self.userNotificationCenter)
             return PushNotificationsManager(configuration: configuration)
         }()
-        ServiceLocator.setPushNotesManager(manager)
         stores.authenticate(credentials: SessionSettings.credentials)
         stores.updateDefaultStore(storeID: 123)
-        XCTAssertEqual(application.applicationIconBadgeNumber, AppIconBadgeNumber.clearsBadgeOnly)
+        XCTAssertEqual(application.applicationIconBadgeNumber, .min)
 
         // Action
         let userInfo = notificationPayload(badgeCount: 10, type: .comment, siteID: 556)

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -320,7 +320,8 @@ final class PushNotificationsManagerTests: XCTestCase {
             handleNotificationCallbackWasExecuted = true
         }
 
-        guard case let .synchronizeNotifications(onCompletion) = storesManager.receivedActions.first as! NotificationAction else {
+        guard case let .synchronizeNotifications(onCompletion) =
+                storesManager.receivedActions.compactMap { $0 as? NotificationAction }.first else {
             XCTFail()
             return
         }
@@ -344,7 +345,8 @@ final class PushNotificationsManagerTests: XCTestCase {
             handleNotificationCallbackWasExecuted = true
         }
 
-        guard case let .synchronizeNotifications(onCompletion) = storesManager.receivedActions.first as! NotificationAction else {
+        guard case let .synchronizeNotifications(onCompletion) =
+                storesManager.receivedActions.compactMap({ $0 as? NotificationAction }).first else {
             XCTFail()
             return
         }
@@ -466,14 +468,15 @@ private extension PushNotificationsManagerTests {
 
     /// Returns a Sample Notification Payload
     ///
-    func notificationPayload(badgeCount: Int = 0, noteID: Int64 = 1234, type: Note.Kind = .comment) -> [String: Any] {
+    func notificationPayload(badgeCount: Int = 0, noteID: Int64 = 1234, type: Note.Kind = .comment, siteID: Int64 = 134) -> [String: Any] {
         return [
             "aps": [
                 "badge": badgeCount,
                 "alert": Sample.defaultMessage
             ],
             "note_id": noteID,
-            "type": type.rawValue
+            "type": type.rawValue,
+            "blog": siteID
         ]
     }
 }


### PR DESCRIPTION
Part of #5032 
p2 discussion p91TBi-66O-p2

## Why

Before this PR, we've been showing a badge number on the app icon that might not reflect the exact count for the push notifications. After some feedback on p91TBi-66O-p2 for multi-store push notifications, we are updating the app badge number to be **1** when the app has received any push notifications for the **currently selected site**. The logic for clearing the badge count remains the same (when loading the Orders or Reviews tab). We are applying this change without a feature flag, most likely the multi-store push notifications feature will be enabled in the upcoming release.

### Workaround: clearing app badge number without deleting all push notifications

As mentioned in p91TBi-66O-p2, setting the badge number to 0 has an undocumented side effect that _sometimes_ clears all the outstanding notifications in Notification Center 😓. This isn't ideal, especially when there are notifications from other sites when we support multi-store push notifications. I stumbled upon a workaround on [Apple Dev forum](https://developer.apple.com/forums/thread/7598) and [StackOverflow](https://stackoverflow.com/a/55949027/9185596) to set the badge number to `-1` so that it clears the number but not the push notifications. I tested on a device (iPhone XR, iOS 14.5.1) and this works. A side effect from this workaround is when we reset the badge count when the user logs out, setting the badge number back to `0` does not clear push notifications in Notification Center anymore 🤦🏻‍♀️. That's why in this PR, I called [`UNUserNotificationCenter` API](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter) to remove all delivered and scheduled notifications when the user logs out.

## Changes

- In `PushNotificationsManager`:
  - Incremented the notification count for the site ID in notification payload instead of the currently selected site ID
  - Set `applicationIconBadgeNumber` to one of the `AppIconBadgeNumber` values: `-1` when we don't want to clear all push notifications, `0` when the user logs out (even though it stops clearing push notifications when we've set `-1` before), and `1` when the app has received non-zero push notifications for the selected site
  - When resetting badge count for all sites (user logging out), also called `UNUserNotificationCenter` API to [remove all delivered](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649502-removealldeliverednotifications) and [scheduled notifications](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649509-removeallpendingnotificationrequ) since setting `applicationIconBadgeNumber` to `0` no longer clears push notifications in Notification Center
- Added `removeAllNotifications` to `UserNotificationsCenterAdapter` protocol to clear all push notifications (delivered and scheduled) in Notification Center. Implemented in `UNUserNotificationCenter` extension
- Updated unit tests for new changes

## Testing

Prerequisites: the logged-in user has more than one site connected to the app.
If you are testing with your a8c WP.com account, you can resend previous new order/review notifications from the **MC Push Notifications Debug Console** (MC > Push Notifications > Debug Console > WP.com Notification, or with this path `/mobile/push-notifications/debug/?type=wpcom-notification`).

Please test push notifications on a device, since simulators cannot register for remote notifications from WP.com. You might need a developer sandbox for receiving push notifications in a debug build. If you don't have one, please check out the first step in p99K0U-1qz-p2

### Multi-store push notifications feature flag on

- Start from a clean slate by logging out and in to an account with multiple sites --> the app icon should have no badge
- Put the app in the background
- Place an order or leave a review **on a different site** (you can also resend a notification in the MC Debug Console) --> a new push notification should show up, but the app icon should still have no badge because it's not from the selected site
- Place an order or leave a review **on the selected site** --> a new push notification should show up, and the app icon should have badge number `1`
- Place an order or leave a review **on the selected site** again --> a new push notification should show up, and the app icon should keep the badge number at `1`
- Tap on one of the latest 2 push notifications from the selected site --> it should navigate to the order/review details, and the other 2 push notifications should remain in Notification Center
- Tap on the other push notification from the selected site --> it should navigate to the order/review details, and the push notification from a different site should remain in Notification Center
- Log out from the app --> the push notification from a different site should be cleared from Notification Center so that there are no notifications from Woo

### Multi-store push notifications feature flag off

I am testing this flow, code reviewers feel free to skip this scenario.

- In Xcode, disable the feature flag by returning `false` for `pushNotificationsForAllStores` in `DefaultFeatureFlagService`
- Start from a clean slate by logging out and in to an account with multiple sites --> the app icon should have no badge
- Put the app in the background
- Place an order or leave a review **on a different site** (you can also resend a notification in the MC Debug Console) --> no new push notification should show up, and the app icon should have no badge
- Place an order or leave a review **on the selected site** --> a new push notification should show up, and the app icon should have badge number `1`
- Place an order or leave a review **on the selected site** again --> a new push notification should show up, and the app icon should keep the badge number at `1`
- Tap on one of the latest 2 push notifications from the selected site --> it should navigate to the order/review details, and the other push notification should remain in Notification Center
- Log out from the app --> the push notification from a different site should be cleared from Notification Center so that there are no notifications from Woo

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.