### PR TITLE
Shipping Labels: Fix incorrect item quantity in purchased label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -811,9 +811,17 @@ extension ShippingLabelFormViewModel {
                   let details = selectedPackagesDetails[safe: index] else {
                 return nil
             }
+            let productIDs: [Int64] = {
+                var ids: [Int64] = []
+                details.items.forEach { item in
+                    let quantity = item.quantity.intValue
+                    ids.append(contentsOf: Array(repeating: item.productOrVariationID, count: quantity))
+                }
+                return ids
+            }()
             return ShippingLabelPackagePurchase(package: package,
                                                 rate: selectedRate.rate,
-                                                productIDs: details.items.map { $0.productOrVariationID },
+                                                productIDs: productIDs,
                                                 customsForm: package.customsForm)
         }
 


### PR DESCRIPTION
Fixes #5153 
⚠️ This PR depends on #5125, so please make sure to merge that PR first ⚠️

# Description
Currently when purchasing labels we're not taking into account the quantity of each item. Therefore the purchased labels are not containing the correct number of items.

This PR updates the product ID list sent to the purchase request to make sure the list reflects correctly the quantity of each product associating with the label.

# Demo
https://user-images.githubusercontent.com/5533851/136362173-e7cd1c07-0d53-463b-931d-7fc994eb9653.mp4

# Testing
1. Make sure that your test store has installed and activated WCShip plugin.
2. Create an order with 10 items of the same product.
3. On Orders tab, select the new order and select Create Shipping Label.
4. Configure Ship From and Ship To. 
5. On Package Details screen, move some items to another package.
6. Proceed to complete other fields and purchase the labels.
7. Navigate to Order Details, notice that the number of items on both labels are correct.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
