### PR TITLE
Shipping Label: display loading state when syncing user account after adding a new payment method

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -188,7 +188,7 @@ private extension ShippingLabelPaymentMethods {
                                                             comment: "Title of the webview of adding a payment method in Shipping Labels")
         static let doneButtonAddPayment = NSLocalizedString("Done",
                                                             comment: "Done navigation button in Shipping Label add payment webview")
-        static let paymentMethodAddedNotice = NSLocalizedString("No payment method found",
+        static let paymentMethodAddedNotice = NSLocalizedString("Payment method added",
                                                                 comment: "Notice that will be displayed after adding a new Shipping Label payment method")
         static let pleaseAddPaymentMethodMessage = NSLocalizedString("Please, add a new payment method",
                                                                      comment: "Message that will be displayed if there are no Shipping Label payment methods.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
@@ -6,7 +6,7 @@ import protocol Storage.StorageManagerType
 ///
 final class ShippingLabelPaymentMethodsViewModel: ObservableObject {
 
-    /// Indicates if the view model is updating the remote account settings
+    /// Indicates if the view model is updating the remote account settings or fetching remote account settings
     ///
     @Published var isUpdating: Bool = false
 
@@ -83,9 +83,11 @@ extension ShippingLabelPaymentMethodsViewModel {
     /// Syncs account settings specific to shipping labels, such as the last selected package and payment methods.
     ///
     func syncShippingLabelAccountSettings() {
+        isUpdating = true
         let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: accountSettings.siteID) { [weak self] result in
             guard let self = self else { return }
 
+            self.isUpdating = false
             switch result {
             case .success(let value):
                 self.accountSettings = value


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5037

## Description
In this PR, the `Done` button will display the loading indicator after adding a new payment method. Before, nothing was shown, and there were no indicators that we were waiting for a response syncing the user accounts.
Plus, I fixed a localized string that display a wrong message after adding a payment method.

## Testing
**Important testing notes:**
1) For testing this PR I suggest you disable the proxy on your Mac. More info here: pMz3w-bAI#comment-80199
2) For configuring your sandbox environment on the app, you should search for `Store Sandbox Cookie Secret` from the Secret Store, and put it under `AuthenticatedWebView`, substituting the string `[secret]`. Otherwise, you will not be able to test it with a fake credit card.
3) You can use one of the fake credit cards included in the post called `Testing the Store` under the Field Guide.


1. Open an order eligible for shipping label creation.
2. Click on Create shipping label.
3. Pass all steps until you reach the payment step.
4. Click on edit.
5. Click on Add credit card.
6. Enter the card details and save.
9. Notice that the webview will be dismissed and that the top right button will become a loader until the new account data are fetched.

## Video
https://user-images.githubusercontent.com/495617/136389202-c16de7ce-f110-47a3-81bf-8d3a9482c592.mp4



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
