### PR TITLE
Shipping Labels: Get shipping phone from order metadata if it isn't part of shipping address

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */; };
 		CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */; };
 		CC0786C9267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */; };
+		CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
 		CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */; };
@@ -987,6 +988,7 @@
 		CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusMapper.swift; sourceTree = "<group>"; };
 		CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-status-success.json"; sourceTree = "<group>"; };
 		CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusMapperTests.swift; sourceTree = "<group>"; };
+		CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderMetaData.swift; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CC9A24A22641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationEligibilityResponse.swift; sourceTree = "<group>"; };
@@ -1517,6 +1519,7 @@
 				B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */,
 				021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */,
 				CE430671234B9EB20073CBFF /* OrderItemTax.swift */,
+				CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */,
 				74C8F06320EEB44800B6EDC9 /* OrderNote.swift */,
 				CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */,
 				CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */,
@@ -2417,6 +2420,7 @@
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
 				B53EF53C21814900003E146F /* SuccessResultMapper.swift in Sources */,
 				D8EDFE2625EE8A60003D2213 /* WCPayConnectionTokenMapper.swift in Sources */,
+				CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */,
 				02C254A4256371B200A04423 /* ShippingLabelSettings.swift in Sources */,
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -30,7 +30,7 @@ struct OrderMetaData: Decodable {
 ///
 private extension OrderMetaData {
     enum CodingKeys: String, CodingKey {
-        case key = "key"
-        case value = "value"
+        case key
+        case value
     }
 }

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Codegen
+
+/// Represents the metadata within an Order
+/// Currently only handles `String` metadata values
+///
+struct OrderMetaData: Decodable {
+    public let key: String
+    public let value: String
+
+    /// OrderMetaData struct initializer.
+    ///
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+
+    /// The public initializer for OrderMetaData.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let key = try container.decode(String.self, forKey: .key)
+        let value = container.failsafeDecodeIfPresent(String.self, forKey: .value) ?? ""
+
+        self.init(key: key, value: value)
+    }
+}
+
+/// Defines all of the OrderMetaData's CodingKeys.
+///
+private extension OrderMetaData {
+    enum CodingKeys: String, CodingKey {
+        case key = "key"
+        case value = "value"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -71,7 +71,7 @@ final class OrderMapperTests: XCTestCase {
     ///
     func test_Order_shipping_phone_is_correctly_parsed_from_metadata() {
         guard let order = mapLoadFullyRefundedOrderResponse(), let shippingAddress = order.shippingAddress else {
-            XCTFail()
+            XCTFail("Expected a mapped order response with a non-nil shipping address.")
             return
         }
 

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -63,7 +63,19 @@ final class OrderMapperTests: XCTestCase {
             XCTAssertEqual(address.state, "NY")
             XCTAssertEqual(address.postcode, "14304")
             XCTAssertEqual(address.country, "US")
+            XCTAssertEqual(address.phone, "333-333-3333")
         }
+    }
+
+    /// Verifies that Order shipping phone is parsed correctly from metadata.
+    ///
+    func test_Order_shipping_phone_is_correctly_parsed_from_metadata() {
+        guard let order = mapLoadFullyRefundedOrderResponse(), let shippingAddress = order.shippingAddress else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(shippingAddress.phone, "555-666-7777")
     }
 
     /// Verifies that all of the Order Items are parsed correctly.


### PR DESCRIPTION
Part of: #4773

## Description

Currently in Shipping Labels, the phone number is not pre-filled on the Ship To form unless it is sent as part of the shipping address (available in Core since version 5.6.0).

This updates the Order networking model to try to parse the shipping phone from the order metadata (`_shipping_phone`) if the phone number isn't part of the shipping address. (Another PR will include the billing phone number as a fallback if there is no shipping phone number.)

## Changes

* Adds an `OrderMetaData` model to decode the metadata within an order (currently only parses `String` values).
* In the `Order` model, if the shipping address has a `nil` phone number it tries getting the phone number from the metadata.

## Testing

1. Make sure WCShip is installed and activated on your store, and you have at least one order eligible for shipping labels that includes a shipping address with a phone number.
2. Open the Orders tab and select the order.
3. Select "Create Shipping Label."
4. Confirm the "Ship from" address.
5. Edit the "Ship to" address and confirm the phone number is included.

If you have a store that sends the phone number as metadata on the order, please test using that store. I wasn't able to reproduce that behavior on my store but I included a unit test to confirm the phone number is parsed correctly when sent as metadata.

<img src="https://user-images.githubusercontent.com/8658164/136432132-b6069bbf-fed8-4f37-8fcd-0ad6ba8f69be.png" width="300px">

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
