### PR TITLE
[Mobile Payments] [SDK 2] Bump minimum WCPay version, update merchant messaging

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -239,6 +239,6 @@ private extension PaymentGatewayAccount {
 
 private enum Constants {
     static let pluginName = "WooCommerce Payments"
-    static let supportedWCPayVersion = "2.5"
+    static let supportedWCPayVersion = "3.1"
     static let supportedCountryCodes = ["US"]
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -36,7 +36,7 @@ private enum Localization {
     )
 
     static let message = NSLocalizedString(
-        "The WooCommerce Payments extension is installed on your store, but the installed version does not support In-Person Payments. "
+        "The WooCommerce Payments extension is installed on your store, but needs to be updated for In-Person Payments. "
             + "Please update WooCommerce Payments to the most recent version.",
         comment: "Error message when WooCommerce Payments is installed but the version is not supported"
     )

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -371,8 +371,8 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     }
 
     enum PluginVersion: String {
-        case supported = "2.6.1"
-        case supportedExact = "2.5"
+        case supported = "3.1.1"
+        case supportedExact = "3.1"
         case unsupported = "2.4.2"
     }
 }


### PR DESCRIPTION
Closes #5077 

Changes
- Bumps minimum version to 3.1 to pick up locations API and line2 fix - see https://github.com/Automattic/woocommerce-payments/issues/3012#issuecomment-938215347
- Updates merchant facing text, which might have been confusing for existing (beta) in-person payments users

from

The WooCommerce Payments extension is installed on your store, but the installed version does not support In-Person Payments.

to

The WooCommerce Payments extension is installed on your store, but needs to be updated for In-Person Payments.

To test:

- Downgrade your store to WooCommerce Payments 3.1 and enter the mobile app settings, In-Person Payments. Ensure you see this:

![IMG_0183](https://user-images.githubusercontent.com/1595739/136475696-f3f3c8fa-5c05-4832-bb82-3e48253a36e4.PNG)

- Upgrade your store to WooCommerce Payments plugin 3.1 and ensure you are not stopped at that screen but advance or order/manage card reader instead.

cc @kidinov 

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
