### PR TITLE
Shipping Labels: Add unique ID for package attributes to better align with other models

### DIFF
--- a/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageAttributes.swift
@@ -7,7 +7,10 @@ struct ShippingLabelPackageAttributes: Equatable {
     /// Default box ID for boxes shipping in original packaging.
     static let originalPackagingBoxID = "individual"
 
-    /// ID of the selected package.
+    /// Unique ID of the package.
+    let id: String = UUID().uuidString
+
+    /// Name of the package.
     let packageID: String
 
     /// Total weight of the package in string value.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -75,7 +75,6 @@ final class ShippingLabelFormViewModel {
             for option in packagesResponse.predefinedOptions {
                 if let predefinedPackage = option.predefinedPackages.first(where: { $0.id == package.packageID }) {
                     let boxID = predefinedPackage.id
-                    let customsForm = customsForms.first(where: { $0.packageID == package.id })
                     return ShippingLabelPackageSelected(id: package.id,
                                                         boxID: boxID,
                                                         length: predefinedPackage.getLength(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -56,13 +56,13 @@ final class ShippingLabelFormViewModel {
             return []
         }
 
-        return selectedPackagesDetails.enumerated().compactMap { (index, package) -> ShippingLabelPackageSelected? in
+        return selectedPackagesDetails.compactMap { package -> ShippingLabelPackageSelected? in
             let weight = Double(package.totalWeight) ?? .zero
+            let customsForm = customsForms.first(where: { $0.packageID == package.id })
 
             if let customPackage = packagesResponse.customPackages.first(where: { $0.title == package.packageID }) {
                 let boxID = customPackage.title
-                let customsForm = customsForms.first(where: { $0.packageID == boxID })
-                return ShippingLabelPackageSelected(id: "\(index)-custom-package",
+                return ShippingLabelPackageSelected(id: package.id,
                                                     boxID: boxID,
                                                     length: customPackage.getLength(),
                                                     width: customPackage.getWidth(),
@@ -75,8 +75,8 @@ final class ShippingLabelFormViewModel {
             for option in packagesResponse.predefinedOptions {
                 if let predefinedPackage = option.predefinedPackages.first(where: { $0.id == package.packageID }) {
                     let boxID = predefinedPackage.id
-                    let customsForm = customsForms.first(where: { $0.packageID == boxID })
-                    return ShippingLabelPackageSelected(id: "\(index)-predefined-package",
+                    let customsForm = customsForms.first(where: { $0.packageID == package.id })
+                    return ShippingLabelPackageSelected(id: package.id,
                                                         boxID: boxID,
                                                         length: predefinedPackage.getLength(),
                                                         width: predefinedPackage.getWidth(),
@@ -88,14 +88,14 @@ final class ShippingLabelFormViewModel {
             }
 
             if package.isOriginalPackaging, let item = package.items.first {
-                return ShippingLabelPackageSelected(id: "\(index)-individual-package",
-                                                    boxID: "\(index)-individual-package",
+                return ShippingLabelPackageSelected(id: package.id,
+                                                    boxID: package.packageID,
                                                     length: Double(item.dimensions.length) ?? 0,
                                                     width: Double(item.dimensions.width) ?? 0,
                                                     height: Double(item.dimensions.height) ?? 0,
                                                     weight: item.weight,
                                                     isLetter: false,
-                                                    customsForm: customsForms.first(where: { $0.packageID == package.packageID }))
+                                                    customsForm: customsForm)
             }
 
             return nil
@@ -676,7 +676,7 @@ private extension ShippingLabelFormViewModel {
                       originCountry: SiteAddress().countryCode,
                       productID: item.productOrVariationID)
             }
-            return ShippingLabelCustomsForm(packageID: package.packageID, packageName: packageName, items: items)
+            return ShippingLabelCustomsForm(packageID: package.id, packageName: packageName, items: items)
         }
     }
 
@@ -807,8 +807,8 @@ extension ShippingLabelFormViewModel {
         }
 
         let packages = selectedPackages.enumerated().compactMap { (index, package) -> ShippingLabelPackagePurchase? in
-            guard let selectedRate = selectedRates[safe: index],
-                  let details = selectedPackagesDetails[safe: index] else {
+            guard let selectedRate = selectedRates.first(where: { $0.packageID == package.id }),
+                  let details = selectedPackagesDetails.first(where: { $0.id == package.id }) else {
                 return nil
             }
             return ShippingLabelPackagePurchase(package: package,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -122,9 +122,9 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
         viewModel.packageListViewModel.confirmPackageSelection()
 
         // Then
-        XCTAssertEqual(packageToTest, ShippingLabelPackageAttributes(packageID: customPackage.title,
-                                                                     totalWeight: "",
-                                                                     items: []))
+        XCTAssertEqual(packageToTest?.packageID, customPackage.title)
+        XCTAssertEqual(packageToTest?.totalWeight, "")
+        XCTAssertEqual(packageToTest?.items, [])
     }
 
     func test_showCustomPackagesHeader_returns_the_expected_value() {
@@ -274,15 +274,17 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
                                                           weightUnit: "kg")
 
         // Then
-        let expectedPackage1 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "10", items: items)
-        XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage1)
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.packageID, "Test Box")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.totalWeight, "10")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.items, items)
 
         // When
         viewModel.totalWeight = "12"
 
         // Then
-        let expectedPackage2 = ShippingLabelPackageAttributes(packageID: "Test Box", totalWeight: "12", items: items)
-        XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage2)
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.packageID, "Test Box")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.totalWeight, "12")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.items, items)
     }
 
     func test_validatedPackageAttributes_returns_nil_when_the_totalWeight_is_not_valid() {
@@ -365,8 +367,9 @@ class ShippingLabelSinglePackageViewModelTests: XCTestCase {
                                                             weightUnit: "kg")
 
         // Then
-        let expectedPackage = ShippingLabelPackageAttributes(packageID: "invividual", totalWeight: "60", items: items)
-        XCTAssertEqual(viewModel.validatedPackageAttributes, expectedPackage)
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.packageID, "invividual")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.totalWeight, "60")
+        XCTAssertEqual(viewModel.validatedPackageAttributes?.items, items)
     }
 
     func test_originalPackageDimensions_returns_correctly_when_package_has_no_dimensions() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -234,9 +234,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
                                                                     destinationAddress: nil)
-        let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id", totalWeight: expectedPackageWeight, items: [])
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -256,7 +255,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         shippingLabelFormViewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
-        XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, expectedPackageID)
+        XCTAssertEqual(shippingLabelFormViewModel.customsForms.first?.packageID, selectedPackage.id)
         XCTAssertTrue(shippingLabelFormViewModel.selectedRates.isEmpty)
 
         let rows = shippingLabelFormViewModel.state.sections.first?.rows
@@ -883,7 +882,6 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
     func test_customsForms_returns_correctly_when_updating_selectedPackageID() {
         // Given
         let expectedProductID: Int64 = 123
-        let expectedPackageID = "Food Package"
         let orderItem = OrderItem.fake().copy(productID: expectedProductID)
         let order = MockOrders().makeOrder(items: [orderItem])
         let viewModel = ShippingLabelFormViewModel(order: order, originAddress: nil, destinationAddress: nil)
@@ -892,13 +890,13 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "VN"), validated: true)
         let item = ShippingLabelPackageItem.fake(id: expectedProductID)
-        let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: "55", items: [item])
+        let selectedPackage = ShippingLabelPackageAttributes(packageID: "Food Package", totalWeight: "55", items: [item])
         viewModel.handlePackageDetailsValueChanges(details: [selectedPackage])
 
         // Then
         let defaultForms = viewModel.customsForms
         XCTAssertEqual(defaultForms.count, 1)
-        XCTAssertEqual(defaultForms.first?.packageID, expectedPackageID)
+        XCTAssertEqual(defaultForms.first?.packageID, selectedPackage.id)
         XCTAssertEqual(defaultForms.first?.items.count, 1)
         XCTAssertEqual(defaultForms.first?.items.first?.productID, expectedProductID)
         XCTAssertEqual(defaultForms.first?.items.first?.weight, item.weight)


### PR DESCRIPTION
⚠️ This PR depends on #5125, so please make sure to merge that PR first! ⚠️ 

# Description
This PR adds new unique identifier for each `ShippingLabelPackageAttributes`, which will then be used as package ID for `ShippingLabelPackageSelected`, `ShippingLabelCustomsForm`, and `ShippingLabelSelectedRate`.

This identifier makes it easier to find customs form and selected rate for each package.

# Testing
1. Make sure that your test store has installed and activated WCShip plugin.
2. Create an order with 10 items of the same product. This should be an international order so that we can test customs form too.
3. On Orders tab, select the new order and select Create Shipping Label.
4. Configure Ship From and Ship To. 
5. On Package Details screen, move some items to another package.
6. Proceed to complete other fields and purchase the labels.
7. Navigate to Order Details, make sure that all purchased labels are correct in terms of item details, customs form, rate.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
