### PR TITLE
Shipping Labels: Use non-digit-only keyboard for international post code field

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -450,7 +450,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      text: viewModel.address?.postcode,
                                                                      placeholder: Localization.postcodeFieldPlaceholder,
                                                                      state: .normal,
-                                                                     keyboardType: .phonePad,
+                                                                     keyboardType: viewModel.isUSAddress ? .phonePad : .namePhonePad,
                                                                      textFieldAlignment: .leading) { [weak self] (newText) in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -47,6 +47,10 @@ final class ShippingLabelAddressFormViewModel {
         return state.isLoading
     }
 
+    var isUSAddress: Bool {
+        address?.country == "US"
+    }
+
     var sections: [Section] = []
 
     private(set) var countries: [Country]
@@ -220,7 +224,7 @@ extension ShippingLabelAddressFormViewModel {
         guard let phone = address?.phone, phone.isNotEmpty else {
             return false
         }
-        guard address?.country == "US" else {
+        guard isUSAddress else {
             return true
         }
         if phone.hasPrefix("1") {


### PR DESCRIPTION
Fixes #5157 

# Description
We're currently using digit keyboard for post code field - but in some country post code can also contain letters.

This PR updates the keyboard to only force digit post code for US address; otherwise use a generic keyboard with both digits and letters.

# Testing
1. Make sure your test store has configured WCShip plugin.
2. Open an international order, e.g. to the UK, without post code in the billing & shipping address.
3. Tap `Continue` through the `Ship from` screen, making any required corrections to progress.
4. On the `Ship to` screen, tap in the postcode field.
5. Notice that the keyboard showing up contains both digits and letters.
6. Repeat the same steps with an US order, notice that the post code keyboard is digit only.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
