### PR TITLE
5174 Fix typo on Shipping Labels refund screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Refund Shipping Label/RefundShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Refund Shipping Label/RefundShippingLabelViewController.swift
@@ -157,7 +157,7 @@ private extension RefundShippingLabelViewController {
         static let navigationBarTitle = NSLocalizedString("Request a Refund",
                                                           comment: "Navigation bar title to request a refund for a shipping label")
         static let headerText = NSLocalizedString(
-            "You can request a refund for a shipping label that has not been used to ship a package.\nIt will take a least 14 days to process.",
+            "You can request a refund for a shipping label that has not been used to ship a package.\nIt will take at least 14 days to process.",
             comment: "Header text in Refund Shipping Label screen")
         static let purchaseDateTitle = NSLocalizedString("Purchase Date",
                                                          comment: "Title of shipping label purchase date in Refund Shipping Label screen")


### PR DESCRIPTION
Fixes #5174 

Typo on the Shipping Label Request a Refund screen: "It will take a least 14 days to process" ➡️ "It will take at least 14 days to process"

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
