### PR TITLE
Shipping Labels: added tracks events for multi-package support

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -243,6 +243,8 @@ public enum WooAnalyticsStat: String {
     case shippingLabelAddPackageFailed = "shipping_label_add_package_failed"
     case shippingLabelAddPaymentMethodTapped = "shipping_label_add_payment_method_tapped"
     case shippingLabelPaymentMethodAdded = "shipping_label_payment_method_added"
+    case shippingLabelMoveItemTapped = "shipping_label_move_item_tapped"
+    case shippingLabelItemMoved = "shipping_label_item_moved"
 
     // MARK: Receipt Events
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -172,6 +172,7 @@ private extension ShippingLabelPackagesFormViewModel {
                     }
                     let packageTitle = String(format: Localization.packageName, index + 1, name)
                     buttons.append(.default(Text(packageTitle), action: { [weak self] in
+                        ServiceLocator.analytics.track(.shippingLabelItemMoved, withProperties: ["destination": "existing_package"])
                         self?.moveItem(productOrVariationID: productOrVariationID, currentPackageIndex: packageIndex, newPackageIndex: index)
                     }))
                 }
@@ -182,16 +183,19 @@ private extension ShippingLabelPackagesFormViewModel {
                 if hasMultipleItems {
                     // Add option to add item to new package if current package has more than one item.
                     buttons.append(.default(Text(Localization.addToNewPackage)) { [weak self] in
+                        ServiceLocator.analytics.track(.shippingLabelItemMoved, withProperties: ["destination": "new_package"])
                         self?.addItemToNewPackage(productOrVariationID: productOrVariationID, packageIndex: packageIndex)
                     })
                 }
 
                 // Add option to ship in original package
                 buttons.append(.default(Text(Localization.shipInOriginalPackage)) { [weak self] in
+                    ServiceLocator.analytics.track(.shippingLabelItemMoved, withProperties: ["destination": "original_packaging"])
                     self?.shipInOriginalPackage(productOrVariationID: productOrVariationID, packageIndex: packageIndex)
                 })
             } else {
                 buttons.append(.default(Text(Localization.addToNewPackage)) { [weak self] in
+                    ServiceLocator.analytics.track(.shippingLabelItemMoved, withProperties: ["destination": "new_package"])
                     self?.addItemToNewPackage(productOrVariationID: productOrVariationID, packageIndex: packageIndex)
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -39,6 +39,7 @@ struct ShippingLabelSinglePackage: View {
                     Button(action: {
                         viewModel.requestMovingItem(productItemRow.productOrVariationID)
                         shouldShowMoveItemActionSheet = true
+                        ServiceLocator.analytics.track(.shippingLabelMoveItemTapped)
                     }, label: {
                         Text(Localization.moveButton)
                             .font(.footnote)


### PR DESCRIPTION
Fixes #5172 

## Description
Integrated the tracks events for multi-package support.
Added two new events:
- `*_shipping_label_move_item_tapped` -> The button "move" in the packaging step is tapped.
- `*_shipping_label_item_moved` -> A destination is selected for the item being moved. 


## Testing
1. Make sure that your test store has WCShip plugin installed and activated, with packages configured in WPAdmin > WooCommerce > Settings > Shipping > WooCommerce Shipping.
2. Select an order eligible for creating shipping label. The order item list should contain more than one item / or there should be an order item whose quantity is larger one.
3. Select Create Shipping Label and configure Ship From and Ship To.
4. Proceed to configure Package Details. Tap Move on one of the items. -> Notice that the event `shipping_label_move_item_tapped` appear in console.
5. Select Add to new package. Notice that the event `shipping_label_item_moved` appears in the console, with the property `destination` populated with the right value.
6. Repeat the process of moving other items or the same item to different packages or in original packaging. You should see the event `shipping_label_item_moved` in the console, with the property `destination` populated with the right value based on the option selected.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
