### PR TITLE
Shipping Labels: Use the order billing phone as a fallback if there is no shipping phone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix: Navigation bar buttons are now consistently pink on iOS 15. [https://github.com/woocommerce/woocommerce-ios/pull/5139]
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161
+- [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
 
 7.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -181,7 +181,7 @@ final class ShippingLabelFormViewModel {
                                                                company: company,
                                                                siteAddress: SiteAddress(),
                                                                account: defaultAccount)
-        self.destinationAddress = ShippingLabelFormViewModel.fromAddressToShippingLabelAddress(address: destinationAddress)
+        self.destinationAddress = ShippingLabelFormViewModel.getDestinationAddress(order: order, address: destinationAddress)
 
         self.stores = stores
         self.storageManager = storageManager
@@ -568,6 +568,17 @@ private extension ShippingLabelFormViewModel {
                               country: siteAddress.countryCode,
                               phone: "",
                               email: account?.email)
+        return fromAddressToShippingLabelAddress(address: address)
+    }
+
+    /// Gets the destination address as a `ShippingLabelAddress`.
+    /// The order's billing phone is used as a fallback if there is no shipping phone.
+    ///
+    static func getDestinationAddress(order: Order, address: Address?) -> ShippingLabelAddress? {
+        guard let phone = address?.phone, phone.isNotEmpty else {
+            let destinationAddress = address?.copy(phone: order.billingAddress?.phone)
+            return fromAddressToShippingLabelAddress(address: destinationAddress)
+        }
         return fromAddressToShippingLabelAddress(address: address)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -905,6 +905,33 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(defaultForms.first?.items.first?.value, item.value)
         XCTAssertEqual(defaultForms.first?.items.first?.originCountry, "")
     }
+
+    func test_getDestinationAddress_uses_shipping_phone_if_available() {
+        // Given
+        let billingAddress = Address.fake().copy(phone: "555-555-5555")
+        let shippingAddress = Address.fake().copy(phone: "333-333-3333")
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: Order.fake().copy(billingAddress: billingAddress),
+                                                   originAddress: nil,
+                                                   destinationAddress: shippingAddress)
+
+        // Then
+        XCTAssertEqual(viewModel.destinationAddress?.phone, shippingAddress.phone)
+    }
+
+    func test_getDestinationAddress_uses_billing_phone_when_no_shipping_phone_available() {
+        // Given
+        let billingAddress = Address.fake().copy(phone: "555-555-5555")
+
+        // When
+        let viewModel = ShippingLabelFormViewModel(order: Order.fake().copy(billingAddress: billingAddress),
+                                                   originAddress: nil,
+                                                   destinationAddress: Address.fake())
+
+        // Then
+        XCTAssertEqual(viewModel.destinationAddress?.phone, billingAddress.phone)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Fixes: #4773

## Description

When purchasing a shipping label, we want to use the phone number from the customer's billing address as a fallback in the "Ship to" address if there is no shipping address phone number. (This aligns with [the plugin's web behavior](https://github.com/Automattic/woocommerce-services/blob/2028479c4b2c75e09258843dd8563b0d60dc152a/woocommerce-services.php#L1558-L1565).)

## Changes

When initializing `ShippingLabelFormViewModel`, we were taking the destination address and using `fromAddressToShippingLabelAddress` to convert it from an `Address` to a `ShippingLabelAddress`. This PR adds a method `getDestinationAddress` that checks if there is a phone number and, if there isn't one, adds the phone number from `order.billingAddress` before converting the address to a `ShippingLabelAddress`.

Before|After
-|-
![Simulator Screen Shot - iPhone 12 Pro - 2021-10-08 at 15 28 02](https://user-images.githubusercontent.com/8658164/136574565-c4efaff5-f81f-4934-aaca-addcdc920f60.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-10-08 at 15 25 36](https://user-images.githubusercontent.com/8658164/136574587-c6d8964c-42f4-4dff-aa75-44ac6ae9cb4e.png)

## Testing

1. Make sure you have WCShip installed and activated on your store.
2. Create an order with a phone number in the billing address, and **no** phone number in the shipping address.
3. Go to Orders and select that order.
4. Select "Create Shipping Label."
5. Confirm the "Ship from" address and then edit the "Ship to" address.
6. In the "Ship to" address form, confirm the billing address phone number appears.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
