### PR TITLE
4439 Add total fees to In Person Payment receipts

### DIFF
--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -26,6 +26,11 @@ public extension ReceiptContent {
             "Discount %1$@",
             comment: "Line description for 'Discount' cart total on the receipt. Only shown when non-zero. %1$@ is the coupon code(s)")
 
+        public static let feesLineDescription = NSLocalizedString(
+            "Fees",
+            comment: "Line description for 'Fees' cart total on the receipt. Only shown when non-zero."
+        )
+
         public static let shippingLineDescription = NSLocalizedString(
             "Shipping",
             comment: "Line description for 'Shipping' cart total on the receipt. Only shown when non-zero"

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -88,6 +88,8 @@ private extension ReceiptStore {
 
     func generateCartTotals(order: Order, parameters: CardPresentReceiptParameters) -> [ReceiptTotalLine] {
         let subtotalLines = [discountLine(order: order),
+                             lineIfNonZero(description: ReceiptContent.Localization.feesLineDescription,
+                                           amount: feesLineAmount(fees: order.fees)),
                              lineIfNonZero(description: ReceiptContent.Localization.shippingLineDescription,
                                            amount: order.shippingTotal),
                              lineIfNonZero(description: ReceiptContent.Localization.totalTaxLineDescription,
@@ -126,6 +128,13 @@ private extension ReceiptStore {
         } else {
             return order.discountTotal
         }
+    }
+
+    func feesLineAmount(fees: [OrderFeeLine]) -> String {
+        let feeTotal = fees.reduce(into: Decimal(0)) { result, fee in
+            result += NSDecimalNumber(apiAmount: fee.total).decimalValue
+        }
+        return receiptNumberFormatter.string(from: feeTotal as NSNumber) ?? ""
     }
 
     func lineIfNonZero(description: String, amount: String) -> ReceiptTotalLine? {


### PR DESCRIPTION
Resolves #4439 

## Description
Fees are used by some WC stores to cover various non-product services. They aren't really exposed in the core UI, and seem to generally be applied using plug ins, but they form part of the order total and when they're present it's important that we show them on the receipts so that the grand total makes sense.

## Context for review
The handling of numbers here and inability to use `CurrencyFormatter` for the receipts is a known issue that we're going to resolve. #5108 

Additionally, I'm looking in to improvements in how we might interpret numbers from the API (which often come to us as strings) in order to use them with more confidence for logic in the app. Any thoughts on this are very much welcome (saves me some time!) but I'll be looking to improve it in a future change rather than this PR.

## Testing
To test, an In Person Payment setup is required. See PdfdoF-D-p2 for info.

There are some plugins which can add fees, but the most direct route I found was to add the following to `functions.php` or in a snippet on your store:
```
add_action('woocommerce_cart_calculate_fees', function() {
	WC()->cart->add_fee('Extra-careful handling', 5);
});
```

This will add a $5 fee (for a US store) to every order.

1. Add the above snippet to a store
2. Checkout an In-Person Payment order
3. Go to the Orders tab
4. Open an unpaid "Pay on Delivery" order with fees
5. Take card payment
6. Tap "Print Receipt"
7. Observe that the order lines include a "Fees" line.
8. Repeat with an order that has no fees, observe that the "Fees" line is not shown.


![Fees](https://user-images.githubusercontent.com/2472348/136583454-4742e55c-19a6-4273-b0d5-20f489b5f9ea.jpg)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
