### PR TITLE
Quick Pay: Add Quick Pay View Prototype

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -46,10 +46,10 @@ struct QuickPayAmount: View {
 
             // Amount Textfield
             TextField(Localization.amountPlaceholder, text: $amount)
-                .keyboardType(.decimalPad)
-                .foregroundColor(Color(.text))
                 .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
-                .fixedSize(horizontal: true, vertical: true)
+                .foregroundColor(Color(.text))
+                .multilineTextAlignment(.center)
+                .keyboardType(.decimalPad)
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -40,9 +40,11 @@ struct QuickPayAmount: View {
 
             Spacer()
 
+            // Instructions Label
             Text(Localization.instructions)
                 .secondaryBodyStyle()
 
+            // Amount Textfield
             TextField(Localization.amountPlaceholder, text: $amount)
                 .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
                 .foregroundColor(Color(.text))
@@ -50,6 +52,7 @@ struct QuickPayAmount: View {
 
             Spacer()
 
+            // Done button
             Button(Localization.buttonTitle) {
                 print("Done tapped")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -55,8 +55,15 @@ struct QuickPayAmount: View {
             }
             .buttonStyle(PrimaryButtonStyle())
         }
-        .navigationTitle(Localization.title)
         .padding()
+        .navigationTitle(Localization.title)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Localization.cancelTitle, action: {
+                    dismiss()
+                })
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -1,14 +1,73 @@
 import Foundation
 import SwiftUI
 
-/// View that receives an arbitrary amount for creating a quick pay order.
+/// Hosting controller that wraps an `QuickPayAmount` view.
 ///
-struct QuickPayAmount: View {
-    var body: some View {
-        Text("Holi")
+final class QuickPayAmountHostingController: UIHostingController<QuickPayAmount> {
+
+    init() {
+        super.init(rootView: QuickPayAmount())
+
+        // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 
+/// View that receives an arbitrary amount for creating a quick pay order.
+///
+struct QuickPayAmount: View {
+
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
+
+    /// Temporary store for the typed amount
+    ///
+    @State private var amount: String = ""
+
+    var body: some View {
+        VStack(alignment: .center) {
+
+            Spacer()
+
+            Text(Localization.instructions)
+                .secondaryBodyStyle()
+
+            TextField(Localization.amountPlaceholder, text: $amount)
+                .font(.system(size: 56, weight: .bold, design: .default))
+                .foregroundColor(Color(.text))
+                .fixedSize(horizontal: true, vertical: false)
+
+            Spacer()
+
+            Button(Localization.buttonTitle) {
+                print("Done tapped")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .navigationTitle(Localization.title)
+        .padding()
+    }
+}
+
+// MARK: Constants
+private extension QuickPayAmount {
+    enum Localization {
+        static let title = NSLocalizedString("Take Payment", comment: "Title for the quick pay screen")
+        static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the quick pay screen")
+        static let amountPlaceholder = NSLocalizedString("$0.00", comment: "Placeholder for the amount textfield in the quick pay screen")
+        static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick pay screen")
+        static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick pay screen")
+    }
+}
+
+// MARK: Previews
 private struct QuickPayAmount_Preview: PreviewProvider {
     static var previews: some View {
         QuickPayAmount()

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -46,9 +46,10 @@ struct QuickPayAmount: View {
 
             // Amount Textfield
             TextField(Localization.amountPlaceholder, text: $amount)
-                .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
+                .keyboardType(.decimalPad)
                 .foregroundColor(Color(.text))
-                .fixedSize(horizontal: true, vertical: false)
+                .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
+                .fixedSize(horizontal: true, vertical: true)
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftUI
+
+/// View that receives an arbitrary amount for creating a quick pay order.
+///
+struct QuickPayAmount: View {
+    var body: some View {
+        Text("Holi")
+    }
+}
+
+private struct QuickPayAmount_Preview: PreviewProvider {
+    static var previews: some View {
+        QuickPayAmount()
+            .environment(\.colorScheme, .light)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -31,8 +31,12 @@ struct QuickPayAmount: View {
     ///
     @State private var amount: String = ""
 
+    /// Keeps track of the current content scale due to accessibility changes
+    ///
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     var body: some View {
-        VStack(alignment: .center) {
+        VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
 
             Spacer()
 
@@ -40,7 +44,7 @@ struct QuickPayAmount: View {
                 .secondaryBodyStyle()
 
             TextField(Localization.amountPlaceholder, text: $amount)
-                .font(.system(size: 56, weight: .bold, design: .default))
+                .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
                 .foregroundColor(Color(.text))
                 .fixedSize(horizontal: true, vertical: false)
 
@@ -64,6 +68,13 @@ private extension QuickPayAmount {
         static let amountPlaceholder = NSLocalizedString("$0.00", comment: "Placeholder for the amount textfield in the quick pay screen")
         static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick pay screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick pay screen")
+    }
+
+    enum Layout {
+        static let mainVerticalSpacing: CGFloat = 8
+        static func amountFontSize(scale: CGFloat) -> CGFloat {
+            56 * scale
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */; };
 		2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */; };
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
+		2678897C270E6E8B00BD249E /* QuickPayAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* QuickPayAmount.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1846,6 +1847,7 @@
 		2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCase.swift; sourceTree = "<group>"; };
 		2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundCoordinatingController.swift; sourceTree = "<group>"; };
+		2678897B270E6E8B00BD249E /* QuickPayAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPayAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -3900,6 +3902,14 @@
 			path = "Issue Refund";
 			sourceTree = "<group>";
 		};
+		2678897A270E6E3C00BD249E /* QuickPay */ = {
+			isa = PBXGroup;
+			children = (
+				2678897B270E6E8B00BD249E /* QuickPayAmount.swift */,
+			);
+			path = QuickPay;
+			sourceTree = "<group>";
+		};
 		268EC45D26CEA4E500716F5C /* Customer Note */ = {
 			isa = PBXGroup;
 			children = (
@@ -5702,6 +5712,7 @@
 			children = (
 				CEE006022077D0F80079161F /* Cells */,
 				CE35F1092343E482007B2A6B /* Order Details */,
+				2678897A270E6E3C00BD249E /* QuickPay */,
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				57C503DB23E8C70C00EC0790 /* OrdersTabbedViewController.swift */,
 				57C503DD23E8CE0D00EC0790 /* OrdersTabbedViewController.xib */,
@@ -7882,6 +7893,7 @@
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
+				2678897C270E6E8B00BD249E /* QuickPayAmount.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,


### PR DESCRIPTION
# Why

This PR adds the view to enter an arbitrary amount for the quick pay prototype.

# How

- Added SwiftUI `QuickPayAmount` view.

# Screenshots

Normal | Dark | Big Font
--- | --- | ---
<img width="435" alt="portrait" src="https://user-images.githubusercontent.com/562080/136588071-5bc23e9e-6e78-4393-9a88-5033eca5479a.png"> | <img width="412" alt="darkmode" src="https://user-images.githubusercontent.com/562080/136588085-53f93fce-f604-467e-a921-8df5be1756b1.png"> | <img width="429" alt="portrait-big" src="https://user-images.githubusercontent.com/562080/136588080-406329b7-e25c-4f4a-87f2-cba692f6ad24.png">


Landscape | Landscape Big Font
--- | --- 
<img width="885" alt="lanscape" src="https://user-images.githubusercontent.com/562080/136588123-9381bb62-5cf2-457a-93f2-c0f1f1a27e72.png"> | <img width="869" alt="landscape-big" src="https://user-images.githubusercontent.com/562080/136588126-d36eedd9-4703-45a6-86b0-b66841a53c52.png">

**Note:** Accessibility does not work correctly in all orientations and sizes, but as the fix is not trivial and this is a prototype, I'll leave that for later.

# Testing Steps

- Modify `DashboardViewController.viewDidLoad` to look like
```swift
override func viewDidLoad() {
    super.viewDidLoad()
    configureNavigation()
    configureView()
    configureDashboardUIContainer()

    DispatchQueue.main.asyncAfter(deadline: .now()) {
        let vc = QuickPayAmountHostingController()
        let nav = WooNavigationController(rootViewController: vc)
        self.present(nav, animated: true)
    }
}
```
- Launch the app
- See the view presented.

# Next

- In the next PR I'll be working on adding the view model support & making sure the amount added is properly formatted.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
