### PR TITLE
Order Editing: Add empty shipping address state

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+TitleAndImage.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+TitleAndImage.swift
@@ -10,11 +10,13 @@ extension UIButton {
 
         switch layoutDirection {
         case .rightToLeft:
-            imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets.top, left: insetAmount, bottom: imageEdgeInsets.bottom, right: imageEdgeInsets.right)
-            titleEdgeInsets = UIEdgeInsets(top: titleEdgeInsets.top, left: titleEdgeInsets.left, bottom: titleEdgeInsets.bottom, right: insetAmount)
+            imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets.top, left: insetAmount, bottom: imageEdgeInsets.bottom, right: -insetAmount)
+            titleEdgeInsets = UIEdgeInsets(top: titleEdgeInsets.top, left: -insetAmount, bottom: titleEdgeInsets.bottom, right: insetAmount)
+            contentEdgeInsets = UIEdgeInsets(top: contentEdgeInsets.top, left: -insetAmount, bottom: contentEdgeInsets.bottom, right: -insetAmount)
         default:
-            imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets.top, left: imageEdgeInsets.left, bottom: imageEdgeInsets.bottom, right: insetAmount)
-            titleEdgeInsets = UIEdgeInsets(top: titleEdgeInsets.top, left: insetAmount, bottom: titleEdgeInsets.bottom, right: titleEdgeInsets.right)
+            imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets.top, left: -insetAmount, bottom: imageEdgeInsets.bottom, right: insetAmount)
+            titleEdgeInsets = UIEdgeInsets(top: titleEdgeInsets.top, left: insetAmount, bottom: titleEdgeInsets.bottom, right: -insetAmount)
+            contentEdgeInsets = UIEdgeInsets(top: contentEdgeInsets.top, left: insetAmount, bottom: contentEdgeInsets.bottom, right: insetAmount)
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -787,12 +787,20 @@ private extension OrderDetailsDataSource {
 
         cell.title = Title.shippingAddress
         cell.name = shippingAddress?.fullNameWithCompany
-        cell.address = shippingAddress?.formattedPostalAddress ?? Title.shippingAddressEmptyAction
 
-        cell.onEditTapped = { [weak self] in
-            self?.onCellAction?(.editShippingAddress, nil)
+        if let formattedPostalAddress = shippingAddress?.formattedPostalAddress {
+            cell.address = formattedPostalAddress
+            cell.onEditTapped = { [weak self] in
+                self?.onCellAction?(.editShippingAddress, nil)
+            }
+        } else {
+            cell.address = nil
+            cell.onAddTapped = { [weak self] in
+                self?.onCellAction?(.editShippingAddress, nil)
+            }
         }
 
+        cell.addButtonTitle = NSLocalizedString("Add Shipping Address", comment: "Title for the button to add the Shipping Address in Order Details")
         cell.editButtonAccessibilityLabel = NSLocalizedString(
             "Update Address",
             comment: "Accessibility Label for the edit button to change the Customer Shipping Address in Order Details")
@@ -1246,10 +1254,6 @@ extension OrderDetailsDataSource {
             NSLocalizedString("Don’t know how to print from your mobile device?",
                               comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
                                 "a shipping label on the mobile device.")
-        static let shippingAddressEmptyAction =
-            NSLocalizedString("No address specified.",
-                              comment: "Order details > customer info > shipping details. " +
-                                "This is where the address would normally display.")
     }
 
     enum Footer {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -382,6 +382,7 @@ private extension OrderDetailsDataSource {
             }
         }
 
+        cell.addButtonTitle = NSLocalizedString("Add Customer Note", comment: "Title for the button to add the Customer Provided Note in Order Details")
         cell.editButtonAccessibilityLabel = NSLocalizedString(
             "Update Note",
             comment: "Accessibility Label for the edit button to change the Customer Provided Note in Order Details")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.swift
@@ -19,6 +19,8 @@ class CustomerInfoTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var editButton: UIButton!
 
+    @IBOutlet private weak var addButton: UIButton!
+
     var title: String? {
         get {
             return titleLabel.text
@@ -56,6 +58,16 @@ class CustomerInfoTableViewCell: UITableViewCell {
         }
     }
 
+    /// Closure to be invoked when the add button is tapped
+    /// Setting a value makes the button visible
+    ///
+    var onAddTapped: (() -> Void)? {
+        didSet {
+            let shouldHideAddButton = onAddTapped == nil
+            addButton.isHidden = shouldHideAddButton
+        }
+    }
+
     /// Accessibility label to be used on the edit button, when shown
     ///
     var editButtonAccessibilityLabel: String? {
@@ -67,11 +79,23 @@ class CustomerInfoTableViewCell: UITableViewCell {
         }
     }
 
+    /// Title to be used on the add button, when shown
+    ///
+    var addButtonTitle: String? {
+        get {
+            addButton.currentTitle
+        }
+        set {
+            addButton.setTitle(newValue, for: .normal)
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         configureBackground()
         configureEditButton()
+        configureAddButton()
     }
 
     override func prepareForReuse() {
@@ -80,6 +104,7 @@ class CustomerInfoTableViewCell: UITableViewCell {
         nameLabel.text = nil
         addressLabel.text = nil
         onEditTapped = nil
+        onAddTapped = nil
         editButton.accessibilityLabel = nil
     }
 }
@@ -95,8 +120,22 @@ private extension CustomerInfoTableViewCell {
         editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
     }
 
+    func configureAddButton() {
+        addButton.applyLinkButtonStyle()
+        addButton.setImage(.plusImage, for: .normal)
+        addButton.contentHorizontalAlignment = .leading
+        addButton.contentVerticalAlignment = .bottom
+        addButton.contentEdgeInsets = .zero
+        addButton.distributeTitleAndImage(spacing: Constants.buttonTitleAndImageSpacing)
+        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+    }
+
     @objc func editButtonTapped() {
         onEditTapped?()
+    }
+
+    @objc func addButtonTapped() {
+        onAddTapped?()
     }
 }
 
@@ -112,5 +151,11 @@ extension CustomerInfoTableViewCell {
 
     func getAddressLabel() -> UILabel {
         return addressLabel
+    }
+}
+
+private extension CustomerInfoTableViewCell {
+    enum Constants {
+        static let buttonTitleAndImageSpacing: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
@@ -64,10 +64,19 @@
                                     </button>
                                 </subviews>
                             </stackView>
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PXt-fH-GM8">
+                                <rect key="frame" x="0.0" y="92" width="288" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="1vO-Pa-Rrp"/>
+                                </constraints>
+                                <state key="normal" title="Add Customer Note"/>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="ROw-w5-B5y" firstAttribute="leading" secondItem="KmX-Sc-g7S" secondAttribute="leading" id="748-v2-bRN"/>
                             <constraint firstAttribute="trailing" secondItem="ROw-w5-B5y" secondAttribute="trailing" id="HEe-FX-fCQ"/>
+                            <constraint firstAttribute="trailing" secondItem="PXt-fH-GM8" secondAttribute="trailing" id="gQG-Rd-zLW"/>
+                            <constraint firstItem="PXt-fH-GM8" firstAttribute="leading" secondItem="KmX-Sc-g7S" secondAttribute="leading" id="mdw-Th-NpD"/>
                         </constraints>
                     </stackView>
                 </subviews>
@@ -80,6 +89,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="addButton" destination="PXt-fH-GM8" id="dUB-nu-XDA"/>
                 <outlet property="addressLabel" destination="KJW-Ch-VgS" id="W8H-je-t7J"/>
                 <outlet property="editButton" destination="zA3-Zq-pRC" id="Igf-KB-IhK"/>
                 <outlet property="nameLabel" destination="pQe-4r-eVj" id="vSy-Fd-TAw"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -63,6 +63,17 @@ final class CustomerNoteTableViewCell: UITableViewCell {
         }
     }
 
+    /// Title to be used on the add button, when shown
+    ///
+    var addButtonTitle: String? {
+        get {
+            addButton.currentTitle
+        }
+        set {
+            addButton.setTitle(newValue, for: .normal)
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/5114.

## Description

Instead of showing "No address specified" with edit icon we show "+ Add Shipping Address" button.

### How

Create button is added in vertical stack, just like on `CustomerNoteTableViewCell`.

Initial issue (https://github.com/woocommerce/woocommerce-ios/issues/5114) suggests that app hides empty address and we need to display it first. I found that shipping address row is hidden when order contains only virtual products:
https://github.com/woocommerce/woocommerce-ios/blob/9c10f58bbfea741d530a751e002f9fb048838f95/WooCommerce/Classes/ViewModels/Order%20Details/OrderDetailsDataSource.swift#L962-L968

Related discussion:
- https://github.com/woocommerce/woocommerce-ios/issues/705

**Question:** should we change this logic for Quick Pay flow? To allow adding shipping address on order without products. We can differentiate "only virtual products" and "no products at all" cases.

BTW, I haven't found a way to have `nil` address. It's coming as address with all empty fields even for virtual products without shipping.

So here I've implemented different case - when shipping address is empty for a order with non-virtual products. You can do it by clearing all fields in wp-admin:
<img width="765" alt="Screenshot" src="https://user-images.githubusercontent.com/3132438/136597722-9bf244a1-2971-4dd7-b2f4-330b74366427.png">

One more thing:
I've noticed strange glitch with `UIButton.distributeTitleAndImage` helper. Small improvement inspired by [this SO answer](https://stackoverflow.com/a/25559946/840588) helped. Check second set of screenshots for comparison.

## Test

1. Navigate to order with empty shipping address (or edit shipping address to have empty content from wp-admin).
2. Verify that add button appears (instead of edit) and it opens modal view to edit address.
3. Add some address fields, save it and verify that order details view changes with new content.

## Screenshots

before | after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/136601409-4d6519d3-3faf-4dfd-bf78-355ae92b4a04.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/136601532-c7cb77be-3e20-4116-ad62-da23359e3293.png)

before UIButton alignment fix | after UIButton alignment fix
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/136601435-54ccdd8d-90bb-4887-bdf6-05b602320e5a.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/136601532-c7cb77be-3e20-4116-ad62-da23359e3293.png)

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
