### PR TITLE
Shipping Labels: Fix issue with text fields not enabled on address form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -465,8 +465,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      state: .normal,
                                                                      keyboardType: .default,
                                                                      textFieldAlignment: .leading) { _ in }
-        cell.configure(viewModel: cellViewModel)
-        cell.enableTextField(viewModel.statesOfSelectedCountry.isEmpty)
+        cell.configure(viewModel: cellViewModel, textFieldEnabled: viewModel.statesOfSelectedCountry.isEmpty)
     }
 
     func configureCountry(cell: TitleAndTextFieldTableViewCell, row: Row) {
@@ -476,8 +475,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      state: .normal,
                                                                      keyboardType: .default,
                                                                      textFieldAlignment: .leading) { _ in }
-        cell.configure(viewModel: cellViewModel)
-        cell.enableTextField(false)
+        cell.configure(viewModel: cellViewModel, textFieldEnabled: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -51,7 +51,7 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         configureTapGestureRecognizer()
     }
 
-    func configure(viewModel: ViewModel) {
+    func configure(viewModel: ViewModel, textFieldEnabled: Bool = true) {
         titleLabel.text = viewModel.title
         titleLabel.textColor = viewModel.state.textColor
         textField.text = viewModel.text
@@ -59,11 +59,8 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         textField.textColor = viewModel.state.textColor
         textField.keyboardType = viewModel.keyboardType
         textField.textAlignment = viewModel.textFieldAlignment.toTextAlignment()
+        textField.isEnabled = textFieldEnabled
         onTextChange = viewModel.onTextChange
-    }
-
-    func enableTextField(_ enabled: Bool) {
-        textField.isEnabled = enabled
     }
 
     func textFieldBecomeFirstResponder() {


### PR DESCRIPTION
Fixes #5051 

# Description
There's this weird behavior that after reloading the address form a few times, some text field cannot become first responder while others can. 

The root cause of this issue is that two rows: state and country are the only ones to disable their text fields. When the cells are reused, the text fields' `isEnabled` are messed up, which makes some fields disabled although they are expected to be enabled.

# Solution
To ensure the correct behavior for all text fields, it is important to explicitly configure each text field's `isEnabled` to be either true or false:
- For minimal setup, the `enableTextField` method in `TitleAndTextFieldTableViewCell` is removed.
- Adds new parameter `textFieldEnabled` in `configure(viewModel:)` method with default value true to enable the text field.

# Demo
https://user-images.githubusercontent.com/5533851/136655625-7d443905-fc26-4cd5-8909-5c026018a7d8.mp4

# Testing
1. Make sure your test store has activated and configured WCShip plugin.
2. Build the app with Xcode 13.
3. On Orders tab, select an international order and select Create Shipping Label.
4. Select Ship From field, type in digits for the Phone field. Notice that the focus maintains on that field even when validation error changes.
5. Select any other rows, notice that all of them can accept touch properly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
