### PR TITLE
`DefaultNoticePresenter` - Ignore the `notice` and don't enqueue it, if the `notice` is already being presented.

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -28,7 +28,12 @@ class DefaultNoticePresenter: NoticePresenter {
     /// Enqueues the specified Notice for display.
     ///
     func enqueue(notice: Notice) {
-        guard !notices.contains(notice) else { return }
+        guard
+            noticeOnScreen != notice, // Ignore if we are already presenting this notice.
+            !notices.contains(notice) // Ignore if this notice is already enqueued and waiting for presentation.
+        else {
+            return
+        }
         notices.append(notice)
         presentNextNoticeIfPossible()
     }


### PR DESCRIPTION
Closes #5111 

# Description

It has been identified and reported at #5111 that we are presenting duplicate notices, when trying to edit an Order's shipping address, while in offline mode.
The root cause for those duplicate notices were that `DefaultNoticePresenter` was not preventing duplicate notices properly.

# Solution

`DefaultNoticePresenter` tries to prevent duplicate notices, by comparing the new notice with the `notices` that are already enqueued and waiting to be presented. If `notices` contains the "new notice" then the "new notice" is ignored.

But, to ensure that duplicate notices are not presented `DefaultNoticePresenter` should also compare the new notice with the `notice` that is already being presented.

# Demo

https://user-images.githubusercontent.com/524475/136665218-27560525-42cb-4859-afbc-20a1ec011cb8.mov

# Testing

1. Make sure that there is an order with a shipping address available for editing.
1. Navigate to Orders tab, and select the Order from the list.
1. In the Order detail screen, scroll down to Shipping Details and tap on the pencil button to edit the address.
1. Land in the Edit address screen.
1. Make any change to the address and observe that the `Done` button it enabled.
1. Tap on done button multiple times and observe that you see the offline notice only once.


Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
