### PR TITLE
Shipping Labels: Only set limit to number of retries for failed requests of purchase status

### DIFF
--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -257,7 +257,7 @@ private extension ShippingLabelStore {
                     guard let self = self else { return }
 
                     // Poll the status of the label purchases from the response above
-                    // with a delay of 1 second each time, with a maximum of 3 retries for error
+                    // with a delay of 1 second each time, with a maximum of 3 retries for failed requests.
                     self.pollLabelStatus(withDelayInSeconds: 1.0,
                                          maxErrorRetries: 3,
                                          siteID: siteID,
@@ -415,6 +415,8 @@ private extension ShippingLabelStore {
         }
     }
 
+    /// Polls the status of the purchases for labels with given IDs,
+    /// with a delay of 1 second each time, and a maximum of 3 retries for failed requests.
     func pollLabelStatus(withDelayInSeconds delay: Double,
                          maxErrorRetries: Int64,
                          siteID: Int64,


### PR DESCRIPTION
Closes #5169 

# Description
As discussed in p1633624095107900-slack-C6H8C3G23, we should only limit the number of polling requests when fail to fetch purchase status of shipping labels. In cases when the requests succeed and status of all labels are not all successful yet, we need to keep the polling requests going.

This PR makes sure that the limit of retries applies only to failed requests:
- Renames `maxRetries` parameter of `pollLabelStatus` method to `maxErrorRetries` to clarify the intention.
- Removes the check for number of retries when a purchase status request succeeds.

# Testing
1. Make sure that your test store has installed and activated WCShip plugin.
2. On Orders tab, select an order that's eligible for creating shipping label.
3. Select Create Shipping Label and input information for all rows in the purchase form.
4. Proceed to purchase the label. Notice that the no error notice is displayed when the purchase succeeds (this may be hard to test if the backend responds with success status quickly; so I have also updated the unit test to ensure that we don't return error if the purchase status is in progress).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.