### PR TITLE
Shipping Labels: Fix incorrect total weight for locales with comma as decimal point

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -57,7 +57,7 @@ final class ShippingLabelFormViewModel {
         }
 
         return selectedPackagesDetails.compactMap { package -> ShippingLabelPackageSelected? in
-            let weight = Double(package.totalWeight) ?? .zero
+            let weight = NumberFormatter.double(from: package.totalWeight) ?? .zero
             let customsForm = customsForms.first(where: { $0.packageID == package.id })
 
             if let customPackage = packagesResponse.customPackages.first(where: { $0.title == package.packageID }) {
@@ -321,7 +321,7 @@ final class ShippingLabelFormViewModel {
 
         let formatter = WeightFormatter(weightUnit: packagesResponse?.storeOptions.weightUnit ?? "")
         let totalWeight = selectedPackagesDetails
-            .map { Double($0.totalWeight) ?? 0 }
+            .map { NumberFormatter.double(from: ($0.totalWeight)) ?? 0 }
             .reduce(0, { $0 + $1 })
         let packageWeight = formatter.formatWeight(weight: totalWeight)
 


### PR DESCRIPTION
Fixes #5184 

# Description
Currently there are two places in `ShippingLabelsFormViewModel` where we're converting from string to double without taking locale into consideration:
- When calculating total weight of all packages to display on Package Details row.
- When getting the total weight of each package to set to `ShippingLabelPackageSelected` for fetching carriers and rates.

This causes issue with incorrect weights displayed and passed to carrier list requests when running the app with locales that use comma as decimal point. This PR fixes that by using `NumberFormatter` to convert string to double values instead of the naive way of converting to Double directly.

# Testing
1. Make sure that your test store has configured WCShip plugin.
2. Set locale for your device to a region that uses comma for decimal point (e.g Italy).
3. Select an order eligible for creating shipping labels.
4. Select Create Shipping Label, configure Ship From and Ship To.
5. In Package Details, update the total weight of the package to a decimal value and tap Done. Notice that the total weight displayed on Package Details row is correct.
6. Proceed to select Carriers and Rates. Notice that the list can be fetched properly with appropriate package size and weight.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
