### PR TITLE
Shipping Labels: display the discounted price rate in Carrier and Rates screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161
 - [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
+- [*] Shipping Labels: now in Carrier and Rates we always display the discounted rate instead of the retail rate if available.
 
 7.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161
 - [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
-- [*] Shipping Labels: now in Carrier and Rates we always display the discounted rate instead of the retail rate if available.
+- [*] Shipping Labels: now in Carrier and Rates we always display the discounted rate instead of the retail rate if available. [https://github.com/woocommerce/woocommerce-ios/pull/5188]
 
 7.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -58,12 +58,12 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
 
         price = {
             if signatureSelected, let signatureRate = signatureRate {
-                    return currencyFormatter.formatAmount(Decimal(signatureRate.retailRate)) ?? ""
+                    return currencyFormatter.formatAmount(Decimal(signatureRate.rate)) ?? ""
                 }
                 if adultSignatureSelected, let adultSignatureRate = adultSignatureRate {
-                    return currencyFormatter.formatAmount(Decimal(adultSignatureRate.retailRate)) ?? ""
+                    return currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate)) ?? ""
                 }
-            return currencyFormatter.formatAmount(Decimal(rate.retailRate)) ?? ""
+            return currencyFormatter.formatAmount(Decimal(rate.rate)) ?? ""
         }()
 
         carrierLogo = CarrierLogo(rawValue: rate.carrierID)?.image()
@@ -92,14 +92,14 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
         displayAdultSignatureRequired = adultSignatureRate != nil
 
         if displaySignatureRequired, let signatureRate = signatureRate {
-            let amount = currencyFormatter.formatAmount(Decimal(signatureRate.retailRate - rate.retailRate)) ?? ""
+            let amount = currencyFormatter.formatAmount(Decimal(signatureRate.rate - rate.rate)) ?? ""
               signatureRequiredText = String(format: Localization.signatureRequired, amount)
         } else {
             signatureRequiredText = ""
         }
 
         if displayAdultSignatureRequired, let adultSignatureRate = adultSignatureRate {
-            let amount = currencyFormatter.formatAmount(Decimal(adultSignatureRate.retailRate - rate.retailRate)) ?? ""
+            let amount = currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate - rate.rate)) ?? ""
             adultSignatureRequiredText = String(format: Localization.adultSignatureRequired, amount)
         }
         else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -352,7 +352,7 @@ final class ShippingLabelFormViewModel {
 
         if selectedRates.count == 1, let selectedRate = selectedRates.first {
             let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-            let price = currencyFormatter.formatAmount(Decimal(selectedRate.retailRate)) ?? ""
+            let price = currencyFormatter.formatAmount(Decimal(selectedRate.totalRate)) ?? ""
 
             let formatString = selectedRate.rate.deliveryDays == 1 ? Localization.businessDaySingular : Localization.businessDaysPlural
 
@@ -365,7 +365,7 @@ final class ShippingLabelFormViewModel {
         } else {
             let ratesCount = String(format: Localization.selectedRatesCount, selectedRates.count)
 
-            let total = selectedRates.reduce(0, { $0 + $1.retailRate })
+            let total = selectedRates.reduce(0, { $0 + $1.totalRate })
             let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
             let price = currencyFormatter.formatAmount(Decimal(total)) ?? ""
             let totalRate = String(format: Localization.totalRate, price)
@@ -395,7 +395,7 @@ final class ShippingLabelFormViewModel {
         }
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         return selectedRates.map { rate in
-            currencyFormatter.formatAmount(Decimal(rate.retailRate)) ?? ""
+            currencyFormatter.formatAmount(Decimal(rate.totalRate)) ?? ""
         }
     }
 


### PR DESCRIPTION
Fixes #5156 

## Description
Previously, in Carriers and Rates, just on iOS, we were displaying the `retail_rate` instead of the discounted price rate. This creates misalignment problems between iOS and Android.

## Testing
1. Make sure that your test store has configured the WCShip plugin.
2. Select an order eligible for creating shipping labels.
3. Select Create Shipping Label, configure Ship From and Ship To.
5. Select a package.
6. Proceed to select Carriers and Rates. Notice that the price listed, it's the discounted price (if available) and not the retail rate. The prices between Android and iOS should be aligned.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
