### PR TITLE
Quick Pay: Launch QuickPay from orders list & format amount

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -23,6 +23,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pushNotificationsForAllStores:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .quickPayPrototype:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -45,4 +45,8 @@ public enum FeatureFlag: Int {
     /// Push notifications for all stores
     ///
     case pushNotificationsForAllStores
+
+    /// Allows to create quick pay orders
+    ///
+    case quickPayPrototype
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -106,6 +106,12 @@ final class DashboardViewController: UIViewController {
         configureNavigation()
         configureView()
         configureDashboardUIContainer()
+
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            let vc = QuickPayAmountHostingController()
+            let nav = WooNavigationController(rootViewController: vc)
+            self.present(nav, animated: true)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -106,12 +106,6 @@ final class DashboardViewController: UIViewController {
         configureNavigation()
         configureView()
         configureDashboardUIContainer()
-
-        DispatchQueue.main.asyncAfter(deadline: .now()) {
-            let vc = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel())
-            let nav = WooNavigationController(rootViewController: vc)
-            self.present(nav, animated: true)
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -108,7 +108,7 @@ final class DashboardViewController: UIViewController {
         configureDashboardUIContainer()
 
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            let vc = QuickPayAmountHostingController()
+            let vc = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel())
             let nav = WooNavigationController(rootViewController: vc)
             self.present(nav, animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -93,7 +93,12 @@ private extension OrdersRootViewController {
     /// For `viewDidLoad` only, set up `navigationItem` buttons.
     ///
     func configureNavigationButtons() {
-        navigationItem.rightBarButtonItem = ordersViewController.createSearchBarButtonItem()
+        let isQuickPayEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickPayPrototype)
+        let buttons: [UIBarButtonItem?] = [
+            ordersViewController.createSearchBarButtonItem(),
+            isQuickPayEnabled ? ordersViewController.createAddQuickPayOrderItem() : nil
+        ]
+        navigationItem.rightBarButtonItems = buttons.compactMap { $0 }
     }
 
     func configureContainerView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -193,10 +193,14 @@ extension OrdersTabbedViewController {
     /// Create a `UIBarButtonItem` to be used as a way to create a new quick pay order.
     ///
     func createAddQuickPayOrderItem() -> UIBarButtonItem {
-        UIBarButtonItem(image: .plusBarButtonItemImage,
-                        style: .plain,
-                        target: self,
-                        action: #selector(presentQuickPayAmountController))
+        let button = UIBarButtonItem(image: .plusBarButtonItemImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(presentQuickPayAmountController))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = NSLocalizedString("Add quick pay order", comment: "Navigates to a screen to create a quick pay order")
+        button.accessibilityIdentifier = "quick-pay-add-button"
+        return button
     }
 
     /// Creates the view controllers to be shown in tabs.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -85,6 +85,14 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         present(navigationController, animated: true, completion: nil)
     }
 
+    /// Presents `QuickPayAmountHostingController`.
+    ///
+    @objc private func presentQuickPayAmountController() {
+        let viewController = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel())
+        let navigationController = WooNavigationController(rootViewController: viewController)
+        present(navigationController, animated: true)
+    }
+
     // MARK: - ButtonBarPagerTabStripViewController Conformance
 
     /// Return the ViewControllers for "Processing" and "All Orders".
@@ -180,6 +188,15 @@ extension OrdersTabbedViewController {
         button.accessibilityIdentifier = "order-search-button"
 
         return button
+    }
+
+    /// Create a `UIBarButtonItem` to be used as a way to create a new quick pay order.
+    ///
+    func createAddQuickPayOrderItem() -> UIBarButtonItem {
+        UIBarButtonItem(image: .plusBarButtonItemImage,
+                        style: .plain,
+                        target: self,
+                        action: #selector(presentQuickPayAmountController))
     }
 
     /// Creates the view controllers to be shown in tabs.

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -27,10 +27,6 @@ struct QuickPayAmount: View {
     ///
     var dismiss: (() -> Void) = {}
 
-    /// Temporary store for the typed amount
-    ///
-    @State private var amount: String = ""
-
     /// Keeps track of the current content scale due to accessibility changes
     ///
     @ScaledMetric private var scale: CGFloat = 1.0
@@ -49,7 +45,7 @@ struct QuickPayAmount: View {
                 .secondaryBodyStyle()
 
             // Amount Textfield
-            TextField(Localization.amountPlaceholder, text: $amount)
+            TextField(Localization.amountPlaceholder, text: $viewModel.amount)
                 .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
                 .foregroundColor(Color(.text))
                 .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -5,8 +5,8 @@ import SwiftUI
 ///
 final class QuickPayAmountHostingController: UIHostingController<QuickPayAmount> {
 
-    init() {
-        super.init(rootView: QuickPayAmount())
+    init(viewModel: QuickPayAmountViewModel) {
+        super.init(rootView: QuickPayAmount(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
@@ -34,6 +34,10 @@ struct QuickPayAmount: View {
     /// Keeps track of the current content scale due to accessibility changes
     ///
     @ScaledMetric private var scale: CGFloat = 1.0
+
+    /// ViewModel to drive the view content
+    ///
+    @ObservedObject private(set) var viewModel: QuickPayAmountViewModel
 
     var body: some View {
         VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
@@ -86,13 +90,5 @@ private extension QuickPayAmount {
         static func amountFontSize(scale: CGFloat) -> CGFloat {
             56 * scale
         }
-    }
-}
-
-// MARK: Previews
-private struct QuickPayAmount_Preview: PreviewProvider {
-    static var previews: some View {
-        QuickPayAmount()
-            .environment(\.colorScheme, .light)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -76,7 +76,7 @@ private extension QuickPayAmount {
     enum Localization {
         static let title = NSLocalizedString("Take Payment", comment: "Title for the quick pay screen")
         static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the quick pay screen")
-        static let amountPlaceholder = NSLocalizedString("$0.00", comment: "Placeholder for the amount textfield in the quick pay screen")
+        static let amountPlaceholder = "$0.00" // Not localized for now as the prototype does not supporting multiple currencies.
         static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick pay screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick pay screen")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -18,6 +18,7 @@ final class QuickPayAmountViewModel: ObservableObject {
 private extension QuickPayAmountViewModel {
 
     /// Formats a received value by making sure the `$` symbol is present and trimming content to two decimal places.
+    /// TODO: Update to support multiple currencies
     ///
     func formatAmount(_ amount: String) -> String {
         guard amount.isNotEmpty else { return amount }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// View Model for the `QuickPayAmount` view.
+///
+final class QuickPayAmountViewModel: ObservableObject {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -4,4 +4,40 @@ import Foundation
 ///
 final class QuickPayAmountViewModel: ObservableObject {
 
+    /// Stores amount entered by the merchant.
+    ///
+    @Published var amount: String = "" {
+        didSet {
+            guard amount != oldValue else { return }
+            amount = formatAmount(amount)
+        }
+    }
+}
+
+// MARK: Helpers
+private extension QuickPayAmountViewModel {
+
+    /// Formats a received value by making sure the `$` symbol is present and trimming content to two decimal places.
+    ///
+    func formatAmount(_ amount: String) -> String {
+        guard amount.isNotEmpty else { return amount }
+
+        // Removes any unwanted character
+        var formattedAmount = amount.filter { $0.isNumber || $0.isCurrencySymbol || $0 == "." }
+
+        // Prepend the `$` symbol if needed.
+        if formattedAmount.first != "$" {
+            formattedAmount.insert("$", at: formattedAmount.startIndex)
+        }
+
+        // Trims to two decimal places
+        guard let separatorIndex = formattedAmount.firstIndex(of: "."),
+              let thirdDecimalIndex = formattedAmount.index(separatorIndex, offsetBy: 3, limitedBy: formattedAmount.endIndex) else {
+            return formattedAmount
+        }
+        let unwantedDecimalsRange = thirdDecimalIndex..<formattedAmount.endIndex
+        formattedAmount.removeSubrange(unwantedDecimalsRange)
+
+        return formattedAmount
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -30,14 +30,20 @@ private extension QuickPayAmountViewModel {
             formattedAmount.insert("$", at: formattedAmount.startIndex)
         }
 
-        // Trims to two decimal places
-        guard let separatorIndex = formattedAmount.firstIndex(of: "."),
-              let thirdDecimalIndex = formattedAmount.index(separatorIndex, offsetBy: 3, limitedBy: formattedAmount.endIndex) else {
-            return formattedAmount
+        // Trim to two decimals & remove any extra "."
+        let components = formattedAmount.split(separator: ".")
+        switch components.count {
+        case 1 where formattedAmount.contains("."):
+            return components[0] + "."
+        case 1:
+            return "\(components[0])"
+        case 2...Int.max:
+            let number = components[0]
+            let decimals = components[1]
+            let trimmedDecimals = decimals.count > 2 ? decimals.prefix(2) : decimals
+            return "\(number).\(trimmedDecimals)"
+        default:
+            fatalError("Should not happen, components can't be 0 or negative")
         }
-        let unwantedDecimalsRange = thirdDecimalIndex..<formattedAmount.endIndex
-        formattedAmount.removeSubrange(unwantedDecimalsRange)
-
-        return formattedAmount
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
+		262AF387271114CC00E39AFF /* QuickPayAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -1821,6 +1822,7 @@
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
+		262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPayAmountViewModel.swift; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
@@ -3910,6 +3912,7 @@
 			isa = PBXGroup;
 			children = (
 				2678897B270E6E8B00BD249E /* QuickPayAmount.swift */,
+				262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */,
 			);
 			path = QuickPay;
 			sourceTree = "<group>";
@@ -7421,6 +7424,7 @@
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
+				262AF387271114CC00E39AFF /* QuickPayAmountViewModel.swift in Sources */,
 				CC254F3426C4113B005F3C82 /* ShippingLabelPackageSelection.swift in Sources */,
 				AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */,
 				26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
 		262AF387271114CC00E39AFF /* QuickPayAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */; };
+		262AF38A2713B67600E39AFF /* QuickPayAmountViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AF3892713B67600E39AFF /* QuickPayAmountViewModelTests.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -1823,6 +1824,7 @@
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
 		262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPayAmountViewModel.swift; sourceTree = "<group>"; };
+		262AF3892713B67600E39AFF /* QuickPayAmountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPayAmountViewModelTests.swift; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
@@ -3840,6 +3842,14 @@
 			path = "View Modifiers";
 			sourceTree = "<group>";
 		};
+		262AF3882713B65700E39AFF /* QuickPay */ = {
+			isa = PBXGroup;
+			children = (
+				262AF3892713B67600E39AFF /* QuickPayAmountViewModelTests.swift */,
+			);
+			path = QuickPay;
+			sourceTree = "<group>";
+		};
 		265284002624933B00F91BA1 /* AddOns */ = {
 			isa = PBXGroup;
 			children = (
@@ -4677,6 +4687,7 @@
 				265284072624ACAF00F91BA1 /* AddOns */,
 				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
+				262AF3882713B65700E39AFF /* QuickPay */,
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
 				57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */,
 				5767E93F256D9A4A00CFA652 /* OrderListViewModelTests.swift */,
@@ -8269,6 +8280,7 @@
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
+				262AF38A2713B67600E39AFF /* QuickPayAmountViewModelTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				578195FC25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+
+@testable import WooCommerce
+
+final class QuickPayAmountViewModelTests: XCTestCase {
+
+    func test_view_model_prepends_currency_symbol() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "12"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$12")
+    }
+
+    func test_view_model_removes_non_digit_characters() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "hi:11.30-"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$11.30")
+    }
+
+    func test_view_model_trims_more_than_two_decimal_numbers() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "$67.321432432"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$67.32")
+    }
+
+    func test_view_model_removes_duplicated_decimal_separators() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "$6.7.3"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$6.7")
+    }
+
+    func test_view_model_removes_consecutive_decimal_separators() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "$6..."
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$6.")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -5,9 +5,11 @@ import XCTest
 
 final class QuickPayAmountViewModelTests: XCTestCase {
 
+    let usLocale = Locale(identifier: "en_US")
+
     func test_view_model_prepends_currency_symbol() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(locale: usLocale)
 
         // When
         viewModel.amount = "12"
@@ -18,7 +20,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_non_digit_characters() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(locale: usLocale)
 
         // When
         viewModel.amount = "hi:11.30-"
@@ -29,7 +31,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_trims_more_than_two_decimal_numbers() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(locale: usLocale)
 
         // When
         viewModel.amount = "$67.321432432"
@@ -40,7 +42,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_duplicated_decimal_separators() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(locale: usLocale)
 
         // When
         viewModel.amount = "$6.7.3"
@@ -51,7 +53,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_consecutive_decimal_separators() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(locale: usLocale)
 
         // When
         viewModel.amount = "$6..."


### PR DESCRIPTION
# Why

Following the QuickPay prototype development, after adding the plain view in #5179, this PR makes sure the view can be launch from the orders list and adds some basic formatting to the amount provided by the merchant.

# How

- Launch `QuickPayAmountHostingController` from the orders list using a navigation bar item behind a feature flag.

- Adds a `QuickPayAmountViewModel` to prevent merchants to enter an invalid amount.

# Demo

https://user-images.githubusercontent.com/562080/136805755-830ef980-76dc-405f-a10a-8ad82c39aa21.mov

# Testing steps

- Launch the app and navigate to the orders list
- See that you can't enter an invalid amount or more than two decimals

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
