### PR TITLE
Shipping Labels: enable support for multi-package support for all the merchants

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -18,7 +18,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .shippingLabelsAddCustomPackages:
             return true
         case .shippingLabelsMultiPackage:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .whatsNewOnWooCommerce:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pushNotificationsForAllStores:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 7.8
 -----
+- [***] Shipping Labels: merchants can create packages directly from the app, the labels can also contain multiple packages.
 - [*] Fix: Navigation bar buttons are now consistently pink on iOS 15. [https://github.com/woocommerce/woocommerce-ios/pull/5139]
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.8
 -----
-- [***] Shipping Labels: merchants can create packages directly from the app, the labels can also contain multiple packages.
+- [***] Shipping Labels: merchants can create multiple packages for the same order, moving the items between different packages. [https://github.com/woocommerce/woocommerce-ios/pull/5190]
 - [*] Fix: Navigation bar buttons are now consistently pink on iOS 15. [https://github.com/woocommerce/woocommerce-ios/pull/5139]
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161


### PR DESCRIPTION
Closes #4599 

This PR enables shipping labels M4 features, which include the multi-packages support.

## Testing
- Install & activate the WooCommerce Shipping & Tax plugin.
- Add at least two new packages.
- Create more than one shipping label for the same order.
- Create more than one shipping label for the same order for an international address.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
