### PR TITLE
Show items at full price on receipts

### DIFF
--- a/Hardware/Hardware/Printer/ReceiptContent.swift
+++ b/Hardware/Hardware/Printer/ReceiptContent.swift
@@ -22,6 +22,10 @@ extension ReceiptContent {
 
 public extension ReceiptContent {
     enum Localization {
+        public static let productTotalLineDescription = NSLocalizedString(
+            "Subtotal",
+            comment: "Line description for 'Subtotal' cart total on the receipt. The subtotal of the products purchased before discounts.")
+
         public static let discountLineDescription = NSLocalizedString(
             "Discount %1$@",
             comment: "Line description for 'Discount' cart total on the receipt. Only shown when non-zero. %1$@ is the coupon code(s)")

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -88,7 +88,7 @@ private extension ReceiptStore {
 
     func generateCartTotals(order: Order, parameters: CardPresentReceiptParameters) -> [ReceiptTotalLine] {
         let subtotalLines = [
-            subtotalLine(order: order),
+            productTotalLine(order: order),
             discountLine(order: order),
             lineIfNonZero(description: ReceiptContent.Localization.feesLineDescription, amount: feesLineAmount(fees: order.fees)),
             lineIfNonZero(description: ReceiptContent.Localization.shippingLineDescription, amount: order.shippingTotal),
@@ -100,7 +100,7 @@ private extension ReceiptStore {
         return subtotalLines + totalLine
     }
 
-    func subtotalLine(order: Order) -> ReceiptTotalLine {
+    func productTotalLine(order: Order) -> ReceiptTotalLine {
         let lineItemsTotal = order.items.reduce(into: Decimal(0)) { result, item in
             result += NSDecimalNumber(apiAmount: item.subtotal).decimalValue
         }

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -87,18 +87,25 @@ private extension ReceiptStore {
     }
 
     func generateCartTotals(order: Order, parameters: CardPresentReceiptParameters) -> [ReceiptTotalLine] {
-        let subtotalLines = [discountLine(order: order),
-                             lineIfNonZero(description: ReceiptContent.Localization.feesLineDescription,
-                                           amount: feesLineAmount(fees: order.fees)),
-                             lineIfNonZero(description: ReceiptContent.Localization.shippingLineDescription,
-                                           amount: order.shippingTotal),
-                             lineIfNonZero(description: ReceiptContent.Localization.totalTaxLineDescription,
-                                           amount: order.totalTax)]
-            .compactMap { $0 }
+        let subtotalLines = [
+            subtotalLine(order: order),
+            discountLine(order: order),
+            lineIfNonZero(description: ReceiptContent.Localization.feesLineDescription, amount: feesLineAmount(fees: order.fees)),
+            lineIfNonZero(description: ReceiptContent.Localization.shippingLineDescription, amount: order.shippingTotal),
+            lineIfNonZero(description: ReceiptContent.Localization.totalTaxLineDescription, amount: order.totalTax)
+        ].compactMap { $0 }
         let totalLine = [ReceiptTotalLine(description: ReceiptContent.Localization.amountPaidLineDescription,
                                          amount: parameters.formattedAmount)]
 
         return subtotalLines + totalLine
+    }
+
+    func subtotalLine(order: Order) -> ReceiptTotalLine {
+        let lineItemsTotal = order.items.reduce(into: Decimal(0)) { result, item in
+            result += NSDecimalNumber(apiAmount: item.subtotal).decimalValue
+        }
+        return ReceiptTotalLine(description: ReceiptContent.Localization.productTotalLineDescription,
+                                amount: receiptNumberFormatter.string(from: lineItemsTotal as NSNumber) ?? "")
     }
 
     func discountLine(order: Order) -> ReceiptTotalLine? {

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -81,7 +81,7 @@ private extension ReceiptStore {
             ReceiptLineItem(
                 title: item.name,
                 quantity: item.quantity.description,
-                amount: receiptNumberFormatter.string(from: item.price) ?? ""
+                amount: item.subtotal
             )
         }
     }


### PR DESCRIPTION
Resolves #5141 

## Prerequisites
#5178 is a separate PR still awaiting review, which this was based off. I've changed the base branch to that, to avoid doubling up that PR review... but it'll need to be merged before this is.

## Description
During review of #5127, we discovered that the discounted amounts were used for each line item on an IPP receipt. This meant that it was difficult to check the totals of the receipt because the totals lines did not sum up to the grand total. In particular, this was a problem on orders with a coupon discount.

This change matches the web and email receipts, by showing the item lines at full price, then a subtotal for all the items at full price, and after that subtracting the discount from the coupon.

## Testing
To test, an In Person Payment setup is required. See PdfdoF-D-p2 for info.

1. Go to the Orders tab
2. Open an unpaid "Pay on Delivery" order with multiple lines and a percentage-off coupon applied.
3. Take card payment
4. Tap "Print Receipt"
5. Observe that the item lines show the product full price, and there is a `Subtotal` line summing them up correctly

![multi-line discounted](https://user-images.githubusercontent.com/2472348/136814963-f9670683-bde7-4d21-9120-25b03b087047.jpg)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
