### PR TITLE
Adds a button style that shows a progress view while the view performs a loading operation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -88,7 +88,7 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
     /// Presents `QuickPayAmountHostingController`.
     ///
     @objc private func presentQuickPayAmountController() {
-        let viewController = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel())
+        let viewController = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel(siteID: siteID))
         let navigationController = WooNavigationController(rootViewController: viewController)
         present(navigationController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -57,7 +57,7 @@ struct QuickPayAmount: View {
             Button(Localization.buttonTitle) {
                 print("Done tapped")
             }
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.amount == "$10"))
         }
         .padding()
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -55,9 +55,9 @@ struct QuickPayAmount: View {
 
             // Done button
             Button(Localization.buttonTitle) {
-                print("Done tapped")
+                viewModel.createQuickPayOrder()
             }
-            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.amount == "$10"))
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)
         }
         .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -58,6 +58,7 @@ struct QuickPayAmount: View {
                 print("Done tapped")
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.amount == "$10"))
+            .disabled(viewModel.shouldDisableDoneButton)
         }
         .padding()
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -55,7 +55,11 @@ struct QuickPayAmount: View {
 
             // Done button
             Button(Localization.buttonTitle) {
-                viewModel.createQuickPayOrder()
+                viewModel.createQuickPayOrder { success  in
+                    if success {
+                        dismiss()
+                    }
+                }
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -12,6 +12,13 @@ final class QuickPayAmountViewModel: ObservableObject {
             amount = formatAmount(amount)
         }
     }
+
+    /// Returns true when amount has less than two characters.
+    /// Less than two, because `$` should be the first character.
+    ///
+    var shouldDisableDoneButton: Bool {
+        amount.count < 2
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// View Model for the `QuickPayAmount` view.
 ///
@@ -13,11 +14,50 @@ final class QuickPayAmountViewModel: ObservableObject {
         }
     }
 
+    /// True while performing the create order operation. False otherwise.
+    ///
+    @Published private(set) var loading: Bool = false
+
     /// Returns true when amount has less than two characters.
     /// Less than two, because `$` should be the first character.
     ///
     var shouldDisableDoneButton: Bool {
         amount.count < 2
+    }
+
+    /// Current store ID
+    ///
+    private let siteID: Int64
+
+    /// Stores to dispatch actions
+    ///
+    private let stores: StoresManager
+
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+
+    /// Called when the view taps the done button.
+    /// Creates a quick pay order.
+    ///
+    func createQuickPayOrder() {
+        loading = true
+        let action = OrderAction.createQuickPayOrder(siteID: siteID, amount: amount) { [weak self] result in
+            self?.loading = false
+
+            switch result {
+            case .success:
+                break
+                // TODO: Inform about completion
+
+            case .failure(let error):
+                DDLogError("⛔️ Error creating quick pay order: \(error)")
+                // TODO: Show error notice
+                // TODO: Inform about completion
+            }
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -41,20 +41,20 @@ final class QuickPayAmountViewModel: ObservableObject {
     /// Called when the view taps the done button.
     /// Creates a quick pay order.
     ///
-    func createQuickPayOrder() {
+    func createQuickPayOrder(onCompletion: @escaping (Bool) -> Void) {
         loading = true
         let action = OrderAction.createQuickPayOrder(siteID: siteID, amount: amount) { [weak self] result in
             self?.loading = false
 
             switch result {
             case .success:
-                break
-                // TODO: Inform about completion
+                // TODO: Send order just created.
+                onCompletion(true)
 
             case .failure(let error):
+                onCompletion(false)
                 DDLogError("⛔️ Error creating quick pay order: \(error)")
                 // TODO: Show error notice
-                // TODO: Inform about completion
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -2,12 +2,15 @@ import Foundation
 import XCTest
 
 @testable import WooCommerce
+@testable import Yosemite
 
 final class QuickPayAmountViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 123
+
     func test_view_model_prepends_currency_symbol() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "12"
@@ -18,7 +21,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_non_digit_characters() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "hi:11.30-"
@@ -29,7 +32,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_trims_more_than_two_decimal_numbers() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "$67.321432432"
@@ -40,7 +43,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_duplicated_decimal_separators() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "$6.7.3"
@@ -51,7 +54,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_removes_consecutive_decimal_separators() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "$6..."
@@ -62,7 +65,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_disables_next_button_when_there_is_no_amount() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = ""
@@ -73,7 +76,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_disables_next_button_when_amount_only_has_currency_symbol() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "$"
@@ -84,12 +87,36 @@ final class QuickPayAmountViewModelTests: XCTestCase {
 
     func test_view_model_enables_next_button_when_amount_has_more_than_one_character() {
         // Given
-        let viewModel = QuickPayAmountViewModel()
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID)
 
         // When
         viewModel.amount = "$2"
 
         // Then
         XCTAssertFalse(viewModel.shouldDisableDoneButton)
+    }
+
+    func test_view_model_enables_loading_state_while_performing_network_operations() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        viewModel.amount = "$12.30"
+        XCTAssertFalse(viewModel.loading)
+
+        // When
+        let isLoading: Bool = waitFor { promise in
+            testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case .createQuickPayOrder:
+                    promise(viewModel.loading)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.createQuickPayOrder()
+        }
+
+        // Then
+        XCTAssertTrue(isLoading)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -113,7 +113,7 @@ final class QuickPayAmountViewModelTests: XCTestCase {
                     XCTFail("Received unsupported action: \(action)")
                 }
             }
-            viewModel.createQuickPayOrder()
+            viewModel.createQuickPayOrder { _ in }
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -59,4 +59,37 @@ final class QuickPayAmountViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.amount, "$6.")
     }
+
+    func test_view_model_disables_next_button_when_there_is_no_amount() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = ""
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+    }
+
+    func test_view_model_disables_next_button_when_amount_only_has_currency_symbol() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "$"
+
+        // Then
+        XCTAssertTrue(viewModel.shouldDisableDoneButton)
+    }
+
+    func test_view_model_enables_next_button_when_amount_has_more_than_one_character() {
+        // Given
+        let viewModel = QuickPayAmountViewModel()
+
+        // When
+        viewModel.amount = "$2"
+
+        // Then
+        XCTAssertFalse(viewModel.shouldDisableDoneButton)
+    }
 }


### PR DESCRIPTION
# Why

Following the Quick Pay prototype development, after the amount is correctly formatted in #5189, now it's time to properly submit that amount and create a quick pay order.

# How

- Call the `createQuickPayOrder` action from the view model when the user taps on the done button.

- Created a new `PrimaryLoadingButtonStyle` to allow a primary button to show a loading spinner while the network request is being performed

- Update ViewModel to disable the done button while no amount has been entered.

# Demo

https://user-images.githubusercontent.com/562080/136884313-262a9c1d-1dc7-40c9-bc48-75dab1b00588.mov

# Testing Steps
- Launch the app and navigate to the order list
- Tap on the plus icon
- See that the done button is disabled
- Enter an amount 
- See that the done button gets enabled
- Tap on the done button
- See that while the network call is being performed a spinner is shown within the done button
- After the operation is done, see that the view gets dismissed.
- Navigate to the All orders tab and see that the new order has been created with the correct amount.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
