### PR TITLE
Shipping Labels: Fix issue inputting decimal values on customs form when using locale with comma as decimal point

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix: Navigation bar buttons are now consistently pink on iOS 15. [https://github.com/woocommerce/woocommerce-ios/pull/5139]
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161
+- [*] Shipping Labels: Fix issue with decimal values on customs form when setting the device with locales that use comma as decimal point. [https://github.com/woocommerce/woocommerce-ios/pull/5195]
 - [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
 
 7.7

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -83,8 +83,8 @@ final class ShippingLabelCustomsFormItemDetailsViewModel: ObservableObject {
         self.quantity = item.quantity
         self.productID = item.productID
         self.description = item.description
-        self.value = String(item.value)
-        self.weight = String(item.weight)
+        self.value = NumberFormatter.localizedString(from: NSNumber(value: item.value)) ?? String(item.value)
+        self.weight = NumberFormatter.localizedString(from: NSNumber(value: item.weight)) ?? String(item.weight)
         self.hsTariffNumber = item.hsTariffNumber
         self.allCountries = countries
         self.currency = currency
@@ -129,14 +129,14 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
     }
 
     func getValidatedValue(from value: String) -> Double? {
-        guard let numericValue = Double(value), numericValue > 0 else {
+        guard let numericValue = NumberFormatter.double(from: value), numericValue > 0 else {
             return nil
         }
         return numericValue
     }
 
     func getValidatedWeight(from weight: String) -> Double? {
-        guard let numericWeight = Double(weight), numericWeight > 0 else {
+        guard let numericWeight = NumberFormatter.double(from: weight), numericWeight > 0 else {
             return nil
         }
         return numericWeight


### PR DESCRIPTION
Fixes #5187 

# Description
This PR makes sure to use `NumberFormatter`'s extension methods to handle decimal values.

# Testing
1. Make sure that your test store has configured WCShip plugin.
2. Set up the locale for your device to a region that uses comma as decimal point (e.g Italy).
3. Select an international order that's eligible for creating shipping labels.
4. Select Create Shipping Label and input Ship From, Ship To and Package Details.
5. In Customs, try entering a decimal value for weight or value of an item. Notice that you no longer gets validation error for values with comma as decimal point. Tap Done.
6. Get back to Customs form again, notice that the decimal values are presented on the form properly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
