### PR TITLE
Shipping Labels: Update background color for Package Details and Carriers screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -40,7 +40,7 @@ struct ShippingLabelCarriers: View {
                                                               shippingCost: viewModel.shippingCost).renderedIf(viewModel.shouldDisplayTopBanner)
                         ForEach(Array(viewModel.sections.enumerated()), id: \.offset) { index, sectionVM in
                             ShippingLabelCarriersSection(section: sectionVM, safeAreaInsets: geometry.safeAreaInsets)
-                                .background(Color(.systemBackground))
+                                .background(Color(.listForeground))
                             Spacer().frame(height: Constants.spaceBetweenSections)
                         }
                     case .error:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelSinglePackage.swift
@@ -48,7 +48,7 @@ struct ShippingLabelSinglePackage: View {
                     .padding(.trailing, Constants.horizontalPadding)
                 }
                 .padding(.horizontal, insets: safeAreaInsets)
-                .background(Color(.systemBackground))
+                .background(Color(.listForeground))
                 Divider()
                     .padding(.horizontal, insets: safeAreaInsets)
                     .padding(.leading, Constants.horizontalPadding)
@@ -69,7 +69,7 @@ struct ShippingLabelSinglePackage: View {
                         ShippingLabelPackageSelection(viewModel: viewModel.packageListViewModel)
                     })
                 }
-                .background(Color(.systemBackground))
+                .background(Color(.listForeground))
                 .renderedIf(!viewModel.isOriginalPackaging)
 
                 VStack(spacing: 0) {
@@ -89,7 +89,7 @@ struct ShippingLabelSinglePackage: View {
                                     subtitle: Localization.individuallyShipped)
                     .padding(.horizontal, insets: safeAreaInsets)
             }
-            .background(Color(.systemBackground))
+            .background(Color(.listForeground))
             .renderedIf(viewModel.isOriginalPackaging)
 
             VStack(spacing: 0) {
@@ -101,7 +101,7 @@ struct ShippingLabelSinglePackage: View {
                                     isError: !viewModel.hasValidPackageDimensions)
                     .padding(.horizontal, insets: safeAreaInsets)
             }
-            .background(Color(.systemBackground))
+            .background(Color(.listForeground))
             .renderedIf(viewModel.isOriginalPackaging)
 
             ValidationErrorRow(errorMessage: Localization.invalidDimensions)
@@ -122,7 +122,7 @@ struct ShippingLabelSinglePackage: View {
 
                 Divider()
             }
-            .background(Color(.systemBackground))
+            .background(Color(.listForeground))
 
             if viewModel.isValidTotalWeight {
                 ListHeaderView(text: Localization.footer, alignment: .left)


### PR DESCRIPTION
# Description
This PR updates the background color for rows in Package Details and Carriers screens to use `listForeground` instead of `.systemBackground` to make sure the color looks correct in dark mode.

# Screenshots
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/136886213-692d6668-8ffa-4674-8242-119c6b829155.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/136886255-167fb61b-1bb8-4c1d-827a-c4dc4e709d6d.png" width=320 /> |
| <img src="https://user-images.githubusercontent.com/5533851/136886311-9dac65ef-5f8d-4bc9-b536-6a4d0f053f37.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/136886340-f275e5ea-0edd-4fe3-91f7-b2b00d488f1e.png" width=320 /> |

# Testing
1. Configure your test store with WCShip plugin.
2. Switch device to dark mode if you haven't already.
3. On Orders tab, select an order that's eligible for creating shipping labels.
4. Select Create Shipping Label and configure info for for the purchase form. Notice that all views have correct background color.
5. Switch device to light mode, make sure that everything still looks good.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
