### PR TITLE
[Mobile Payments] Add manual to in-person payments menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -28,7 +28,8 @@ private extension InPersonPaymentsMenuViewController {
     func configureRows() {
         rows = [
             .orderCardReader,
-            .manageCardReader
+            .manageCardReader,
+            .bbposChipper2XBTManual
         ]
     }
 
@@ -53,6 +54,8 @@ private extension InPersonPaymentsMenuViewController {
             configureOrderCardReader(cell: cell)
         case let cell as BasicTableViewCell where row == .manageCardReader:
             configureManageCardReader(cell: cell)
+        case let cell as BasicTableViewCell where row == .bbposChipper2XBTManual:
+            configureBBPOSChipper2XBTManual(cell: cell)
         default:
             fatalError()
         }
@@ -68,6 +71,12 @@ private extension InPersonPaymentsMenuViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Manage card reader", comment: "Navigates to Card Reader management screen")
+    }
+
+    func configureBBPOSChipper2XBTManual(cell: UITableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Card reader manual", comment: "Navigates to Card Reader manual")
     }
 }
 
@@ -95,6 +104,10 @@ extension InPersonPaymentsMenuViewController {
         let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList()
         viewController.configure(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
+    }
+
+    func bbposChipper2XBTManualWasPressed() {
+        WebviewHelper.launch(Constants.bbposChipper2XBTManualURL, with: self)
     }
 }
 
@@ -129,6 +142,8 @@ extension InPersonPaymentsMenuViewController {
             orderCardReaderWasPressed()
         case .manageCardReader:
             manageCardReaderWasPressed()
+        case .bbposChipper2XBTManual:
+            bbposChipper2XBTManualWasPressed()
         }
     }
 }
@@ -136,11 +151,15 @@ extension InPersonPaymentsMenuViewController {
 private enum Row: CaseIterable {
     case orderCardReader
     case manageCardReader
+    case bbposChipper2XBTManual
+
     var type: UITableViewCell.Type {
         switch self {
         case .orderCardReader:
             return BasicTableViewCell.self
         case .manageCardReader:
+            return BasicTableViewCell.self
+        case .bbposChipper2XBTManual:
             return BasicTableViewCell.self
         }
     }
@@ -152,6 +171,7 @@ private enum Row: CaseIterable {
 
 private enum Constants {
     static let woocommercePurchaseCardReaderURL = URL(string: "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader")!
+    static let bbposChipper2XBTManualURL = URL(string: "https://developer.bbpos.com/quick_start_guide/Chipper%202X%20BT%20Quick%20Start%20Guide.pdf")!
 }
 
 // MARK: - SwiftUI compatibility


### PR DESCRIPTION
Closes #5199 

@joshheald  or @ctarda - just one review is needed for this urgent fix to the 7.7 code freeze branch

cc @jkmassel 

To test:
- Tap on Settings, In-Person Payments, Card Reader Manual
- Ensure manual is displayed including FCC section

Screenshots:

![1](https://user-images.githubusercontent.com/1595739/137016358-f2b7d4dc-4817-4411-b55e-f4296e0f17db.png)

![2](https://user-images.githubusercontent.com/1595739/137016368-8457bea9-238d-4249-b116-3b61b1c38a8f.png)

![3](https://user-images.githubusercontent.com/1595739/137016377-32b5701e-70bc-4ca4-8126-a9d6f037b4eb.png)

![tada](https://user-images.githubusercontent.com/1595739/137016382-1aad18f6-4415-4dc7-b54f-380a849b5017.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
