### PR TITLE
Quick Pay: Navigate to order & Inform errors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -1,6 +1,7 @@
 
 import UIKit
 import XLPagerTabStrip
+import struct Yosemite.Order
 import struct Yosemite.OrderStatus
 import enum Yosemite.OrderStatusEnum
 import struct Yosemite.Note
@@ -85,10 +86,30 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         present(navigationController, animated: true, completion: nil)
     }
 
+    /// Pushes an `OrderDetailsViewController` onto the navigation stack.
+    ///
+    private func navigateToOrderDetail(_ order: Order) {
+        guard let orderViewController = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else { return }
+        orderViewController.viewModel = OrderDetailsViewModel(order: order)
+        show(orderViewController, sender: self)
+
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID, "status": order.status.rawValue])
+    }
+
     /// Presents `QuickPayAmountHostingController`.
     ///
     @objc private func presentQuickPayAmountController() {
-        let viewController = QuickPayAmountHostingController(viewModel: QuickPayAmountViewModel(siteID: siteID))
+        let viewModel = QuickPayAmountViewModel(siteID: siteID)
+        viewModel.onOrderCreated = { [weak self] order in
+            guard let self = self else { return }
+
+            self.moveToViewController(at: 1, animated: false) // AllOrders list is at index 2
+            self.dismiss(animated: true) {
+                self.navigateToOrderDetail(order)
+            }
+        }
+
+        let viewController = QuickPayAmountHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: viewController)
         present(navigationController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -103,7 +103,7 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         viewModel.onOrderCreated = { [weak self] order in
             guard let self = self else { return }
 
-            self.moveToViewController(at: 1, animated: false) // AllOrders list is at index 2
+            self.moveToViewController(at: 1, animated: false) // AllOrders list is at index 1
             self.dismiss(animated: true) {
                 self.navigateToOrderDetail(order)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -55,11 +55,7 @@ struct QuickPayAmount: View {
 
             // Done button
             Button(Localization.buttonTitle) {
-                viewModel.createQuickPayOrder { success  in
-                    if success {
-                        dismiss()
-                    }
-                }
+                viewModel.createQuickPayOrder()
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.loading))
             .disabled(viewModel.shouldDisableDoneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -1,9 +1,22 @@
 import Foundation
 import SwiftUI
+import Combine
 
 /// Hosting controller that wraps an `QuickPayAmount` view.
 ///
 final class QuickPayAmountHostingController: UIHostingController<QuickPayAmount> {
+
+    /// References to keep the Combine subscriptions alive within the lifecycle of the object.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
+    /// Presents notices in the current modal presentation context
+    ///
+    private lazy var modalNoticePresenter: NoticePresenter = {
+        let presenter = DefaultNoticePresenter()
+        presenter.presentingViewController = self
+        return presenter
+    }()
 
     init(viewModel: QuickPayAmountViewModel) {
         super.init(rootView: QuickPayAmount(viewModel: viewModel))
@@ -12,6 +25,24 @@ final class QuickPayAmountHostingController: UIHostingController<QuickPayAmount>
         rootView.dismiss = { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }
+
+        // Observe the present notice intent and set it back to `nil` after presented.
+        viewModel.$presentNotice
+            .compactMap { $0 }
+            .sink { [weak self] notice in
+
+                // To prevent keyboard to hide the notice
+                self?.view.endEditing(true)
+
+                switch notice {
+                case .error:
+                    self?.modalNoticePresenter.enqueue(notice: .init(title: QuickPayAmount.Localization.error, feedbackType: .error))
+                }
+
+                // Nullify the presentation intent.
+                viewModel.presentNotice = nil
+            }
+            .store(in: &subscriptions)
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -80,6 +111,7 @@ private extension QuickPayAmount {
         static let amountPlaceholder = "$0.00" // Not localized for now as the prototype does not supporting multiple currencies.
         static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick pay screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick pay screen")
+        static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a quick pay order.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -18,6 +18,11 @@ final class QuickPayAmountViewModel: ObservableObject {
     ///
     @Published private(set) var loading: Bool = false
 
+    /// Defines the current notice that should be shown.
+    /// Defaults to `nil`.
+    ///
+    @Published var presentNotice: Notice?
+
     /// Assign this closure to be notified when a new order is created
     ///
     var onOrderCreated: (Order) -> Void = { _ in }
@@ -53,15 +58,16 @@ final class QuickPayAmountViewModel: ObservableObject {
     func createQuickPayOrder() {
         loading = true
         let action = OrderAction.createQuickPayOrder(siteID: siteID, amount: amount) { [weak self] result in
-            self?.loading = false
+            guard let self = self else { return }
+            self.loading = false
 
             switch result {
             case .success(let order):
-                self?.onOrderCreated(order)
+                self.onOrderCreated(order)
 
             case .failure(let error):
+                self.presentNotice = .error
                 DDLogError("⛔️ Error creating quick pay order: \(error)")
-                // TODO: Show error notice
             }
         }
         stores.dispatch(action)
@@ -101,5 +107,13 @@ private extension QuickPayAmountViewModel {
         default:
             fatalError("Should not happen, components can't be 0 or negative")
         }
+    }
+}
+
+// MARK: Definitions
+extension QuickPayAmountViewModel {
+    /// Representation of possible notices that can be displayed
+    enum Notice: Equatable {
+        case error
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -18,6 +18,10 @@ final class QuickPayAmountViewModel: ObservableObject {
     ///
     @Published private(set) var loading: Bool = false
 
+    /// Assign this closure to be notified when a new order is created
+    ///
+    var onOrderCreated: (Order) -> Void = { _ in }
+
     /// Returns true when amount has less than two characters.
     /// Less than two, because `$` should be the first character.
     ///
@@ -46,18 +50,16 @@ final class QuickPayAmountViewModel: ObservableObject {
     /// Called when the view taps the done button.
     /// Creates a quick pay order.
     ///
-    func createQuickPayOrder(onCompletion: @escaping (Bool) -> Void) {
+    func createQuickPayOrder() {
         loading = true
         let action = OrderAction.createQuickPayOrder(siteID: siteID, amount: amount) { [weak self] result in
             self?.loading = false
 
             switch result {
-            case .success:
-                // TODO: Send order just created.
-                onCompletion(true)
+            case .success(let order):
+                self?.onOrderCreated(order)
 
             case .failure(let error):
-                onCompletion(false)
                 DDLogError("⛔️ Error creating quick pay order: \(error)")
                 // TODO: Show error notice
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -115,10 +115,35 @@ final class QuickPayAmountViewModelTests: XCTestCase {
                     XCTFail("Received unsupported action: \(action)")
                 }
             }
-            viewModel.createQuickPayOrder { _ in }
+            viewModel.createQuickPayOrder()
         }
 
         // Then
         XCTAssertTrue(isLoading)
+    }
+
+    func test_view_model_call_onOrderCreated_closure_after_an_order_is_created() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createQuickPayOrder(_, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        let onOrderCreatedCalled: Bool = waitFor { promise in
+            viewModel.onOrderCreated = { _ in
+                promise(true)
+            }
+            viewModel.createQuickPayOrder()
+        }
+
+        // Then
+        XCTAssertTrue(onOrderCreatedCalled)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -146,4 +146,25 @@ final class QuickPayAmountViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(onOrderCreatedCalled)
     }
+
+    func test_view_model_attempts_error_notice_presentation_when_failing_to_crete_order() {
+        // Given
+        let testingStore = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, stores: testingStore)
+        testingStore.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createQuickPayOrder(_, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.createQuickPayOrder()
+
+        // Then
+        XCTAssertEqual(viewModel.presentNotice, .error)
+    }
+
 }


### PR DESCRIPTION
# Why

Now that creating a quick pay order is possible #5194, this PR adds the final details for the prototype happy path:

- Navigate to the order once it has been created
- Display an error if the order creation fails.

# How

- Added an `onOrderCreated` closure to `QuickPayAmountViewModel` to inform consumers that a new order has been created.

- Update the consumer to present the new order when required.

- Added an `presentNotice` published variable to `QuickPayAmountViewModel` to inform consumers that a notice should be presented.

- Update the consumer to display the error notice.

# Demo

**Success**

https://user-images.githubusercontent.com/562080/137025874-80f1af58-93e4-4dd5-9bb8-26dcc9e77e5a.mov

**Error**

https://user-images.githubusercontent.com/562080/137025906-cc398a3f-321e-4d8f-ad1a-6ae4cdde73d8.mov

# Testing Steps

### Success

- Launch the app and navigate to the orders tab
- Tap the + button
- Enter an amount & tap done
- See that the app redirects you to the order detail

### Error

- Launch the app and navigate to the orders tab
- Tap the + button
- Disconnect from the internet
- Enter an amount & tap done
- See that an error notice is presented

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
