### PR TITLE
Change apply button functionality

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -9,7 +9,6 @@ final class OrderStatusListViewController: UIViewController {
     /// The index of the status stored in the database when list view is presented
     ///
     private var initialStatus: IndexPath?
-    
     /// The index of (new) order status selected by the user tapping on a table row.
     ///
     private var indexOfSelectedStatus: IndexPath? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -6,11 +6,23 @@ final class OrderStatusListViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
+    /// The index of the status stored in the database when list view is presented
+    ///
+    private var storedStatus: IndexPath?
+    
     /// The index of (new) order status selected by the user tapping on a table row.
     ///
     private var indexOfSelectedStatus: IndexPath? {
         didSet {
-            activateApplyButton()
+            guard let storedStatus = storedStatus else {
+                activateApplyButton()
+                return
+            }
+            if storedStatus != indexOfSelectedStatus {
+                activateApplyButton()
+            } else {
+                deActivateApplyButton()
+            }
         }
     }
 
@@ -53,6 +65,7 @@ final class OrderStatusListViewController: UIViewController {
             return
         }
         tableView.selectRow(at: selectedStatusIndex, animated: false, scrollPosition: .none)
+        storedStatus = selectedStatusIndex
     }
 
     /// Registers all of the available TableViewCells

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -8,17 +8,13 @@ final class OrderStatusListViewController: UIViewController {
 
     /// The index of the status stored in the database when list view is presented
     ///
-    private var storedStatus: IndexPath?
+    private var initialStatus: IndexPath?
     
     /// The index of (new) order status selected by the user tapping on a table row.
     ///
     private var indexOfSelectedStatus: IndexPath? {
         didSet {
-            guard let storedStatus = storedStatus else {
-                activateApplyButton()
-                return
-            }
-            if storedStatus != indexOfSelectedStatus {
+            if initialStatus != indexOfSelectedStatus {
                 activateApplyButton()
             } else {
                 deActivateApplyButton()
@@ -65,7 +61,7 @@ final class OrderStatusListViewController: UIViewController {
             return
         }
         tableView.selectRow(at: selectedStatusIndex, animated: false, scrollPosition: .none)
-        storedStatus = selectedStatusIndex
+        initialStatus = selectedStatusIndex
     }
 
     /// Registers all of the available TableViewCells


### PR DESCRIPTION
# Overview

This PR only changes the apply button on the `OrderStatusListViewController` so it is only active for a changed status.

# How

- Added `storedStatus` as an optional indexpath variable, which keeps track of the current status of an order while the status list view is presented.
- This property is set in the `selectStatusIfPossible` method in viewDidLoad, if the order status can be set from `viewModel.indexOfCurrentOrderStatus()`, otherwise it retains a nil value.
- If the `storedStatus` property is nil when `indexOfSelectedStatus` is set, or these two values are **NOT** equal, then the apply button is activated. Otherwise, it is deactivated

# Demo

Before:

https://user-images.githubusercontent.com/51763119/137056319-a50066d7-9bc6-41c6-b4d5-fffec35b3675.mp4

After: 

https://user-images.githubusercontent.com/51763119/137056352-092bd9a6-a3f4-41c9-a40c-51a6a0e30ad9.mp4

# Testing

- Launch the app and navigate to the orders tab
- Click on an order with a status and tap the "pencil" edit button
- Test if apply button is highlighted for the stored status.
