### PR TITLE
Shipping Labels: Replace AttributedText with button to avoid issues with htmlToAttributedString

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Fix incorrect info banner color and signature option spacing on Carrier and Rates screen. [https://github.com/woocommerce/woocommerce-ios/pull/5144]
 - [x] Fix an error where merchants were unable to connect to valid stores when they have other stores with corrupted information https://github.com/woocommerce/woocommerce-ios/pull/5161
 - [*] Shipping Labels: Fix issue with decimal values on customs form when setting the device with locales that use comma as decimal point. [https://github.com/woocommerce/woocommerce-ios/pull/5195]
+- [*] Shipping Labels: Fix crash when tapping on Learn more rows of customs form. [https://github.com/woocommerce/woocommerce-ios/pull/5207]
 - [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
 - [*] Shipping Labels: now in Carrier and Rates we always display the discounted rate instead of the retail rate if available. [https://github.com/woocommerce/woocommerce-ios/pull/5188]
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -70,7 +70,7 @@ struct ShippingLabelCustomsFormItemDetails: View {
                 .renderedIf(!viewModel.hasValidHSTariffNumber)
 
                 VStack(spacing: 0) {
-                    LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreHSTariffText)
+                    LearnMoreRow(content: Localization.learnMoreHSTariffText, contentURL: Constants.hsTariffURL)
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)
                 }
@@ -164,6 +164,7 @@ private extension ShippingLabelCustomsFormItemDetails {
     enum Constants {
         static let horizontalSpacing: CGFloat = 16
         static let verticalSpacing: CGFloat = 8
+        static let hsTariffURL: URL? = .init(string: "https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29")
     }
 
     enum Localization {
@@ -184,9 +185,8 @@ private extension ShippingLabelCustomsFormItemDetails {
         static let hsTariffNumberError = NSLocalizedString("HS Tariff Number must be 6 digits long",
                                                            comment: "Validation error for HS Tariff Number row in Customs screen of Shipping Label flow")
         static let learnMoreHSTariffText = NSLocalizedString(
-            "<a href=\"https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29\">Learn more</a> " +
-                "about HS Tariff Number",
-            comment: "A label prompting users to learn more about HS Tariff Number with an embedded hyperlink in Customs screen of Shipping Label flow")
+            "Learn more about HS Tariff Number",
+            comment: "A label prompting users to learn more about HS Tariff Number in Customs screen of Shipping Label flow")
         static let weightTitle = NSLocalizedString("Weight (%1$@ per unit)",
                                                    comment: "Title for the Weight row in item details in Customs screen of Shipping Label flow")
         static let weightError = NSLocalizedString("Item weight must be larger than 0",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -146,7 +146,7 @@ struct ShippingLabelCustomsFormInput: View {
             }
             .renderedIf(validationErrorMessageForITNRow.isNotEmpty)
 
-            LearnMoreRow(localizedStringWithHyperlink: Localization.learnMoreITNText)
+            LearnMoreRow(content: Localization.learnMoreITNText, contentURL: Constants.itnInfoURL)
         }
     }
 
@@ -166,6 +166,7 @@ private extension ShippingLabelCustomsFormInput {
     enum Constants {
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 8
+        static let itnInfoURL = URL(string: "https://pe.usps.com/text/imm/immc5_010.htm")
     }
     enum Localization {
         static let packageNumber = NSLocalizedString("Package %1$d", comment: "Package index in Customs screen of Shipping Label flow")
@@ -203,10 +204,8 @@ private extension ShippingLabelCustomsFormInput {
                                                                         "Customs screen of Shipping Label flow")
         static let itnInvalidFormat = NSLocalizedString("Invalid ITN format",
                                                         comment: "Error message for invalid format of ITN in Customs screen of Shipping Label flow")
-        static let learnMoreITNText = NSLocalizedString("<a href=\"https://pe.usps.com/text/imm/immc5_010.htm\">" +
-                                                            "Learn more</a> about Internal Transaction Number",
-                                                        comment: "A label prompting users to learn more about internal " +
-                                                            "transaction number with an embedded hyperlink")
+        static let learnMoreITNText = NSLocalizedString("Learn more about Internal Transaction Number",
+                                                        comment: "A label prompting users to learn more about internal transaction number")
         static let packageContentSection = NSLocalizedString("Package Content",
                                                              comment: "Title of Package Content section in Customs screen of Shipping Label flow")
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreRow.swift
@@ -1,31 +1,21 @@
 import SwiftUI
 
 struct LearnMoreRow: View {
-    let localizedStringWithHyperlink: String
-    @State private var learnMoreURL: URL? = nil
+    let content: String
+    let contentURL: URL?
+    @State private var displayedURL: URL?
 
     var body: some View {
-        AttributedText(learnMoreAttributedString)
-            .font(.subheadline)
-            .attributedTextForegroundColor(Color(.textSubtle))
-            .attributedTextLinkColor(Color(.textLink))
-            .customOpenURL(binding: $learnMoreURL)
-            .padding(.horizontal, Constants.horizontalPadding)
-            .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
-            .safariSheet(url: $learnMoreURL)
-    }
-
-    private var learnMoreAttributedString: NSAttributedString {
-        let learnMoreAttributes: [NSAttributedString.Key: Any] = [
-            .underlineStyle: 0
-        ]
-
-        let learnMoreAttrText = NSMutableAttributedString()
-        learnMoreAttrText.append(localizedStringWithHyperlink.htmlToAttributedString)
-        let range = NSRange(location: 0, length: learnMoreAttrText.length)
-        learnMoreAttrText.addAttributes(learnMoreAttributes, range: range)
-
-        return learnMoreAttrText
+        Button(action: {
+            displayedURL = contentURL
+        }, label: {
+            Text(content)
+                .font(.subheadline)
+                .foregroundColor(Color(.textLink))
+        })
+        .padding(.horizontal, Constants.horizontalPadding)
+        .frame(maxWidth: .infinity, minHeight: Constants.rowHeight, alignment: .leading)
+        .safariSheet(url: $displayedURL)
     }
 }
 
@@ -38,6 +28,6 @@ private extension LearnMoreRow {
 
 struct LearnMoreRow_Previews: PreviewProvider {
     static var previews: some View {
-        LearnMoreRow(localizedStringWithHyperlink: "<a href=\"https://pe.usps.com/text/imm/immc5_010.htm\">Learn more</a> about Internal Transaction Number")
+        LearnMoreRow(content: "Learn more about Internal Transaction Number", contentURL: URL(string: "https://pe.usps.com/text/imm/immc5_010.htm"))
     }
 }


### PR DESCRIPTION
Fixes #5203 and #5202

# Description
There is a [known issue](https://github.com/woocommerce/woocommerce-ios/issues/5031) that htmlToAttributedString can cause crashes when called to render SwiftUI view, so this PR replaces `AttributedText` with a button in the `LearnMoreRow` to avoid the need to use the problematic method.

When we're ready to build with Xcode 13, we'll need to update the row with option to use the shiny new ✨ markdown syntax ✨ for iOS 15.

# Testing
1. Make sure that your test store has configured WCShip plugin.
2. On Orders tab, select an international order that's eligible for creating shipping label.
3. Select Create Shipping Label, confirm Ship From, Ship To, Package Details.
4. On Customs form, input a valid ITN, e.g: AES X11111111111111. 
5. Tap on the chevron in the Package Content → Custom Line 1. Make sure that app doesn't crash.
6. Tap on the Learn more about Internal Transaction Number row - make sure that the web view shows up only once. Close the view, notice that no other view is presented.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
