### PR TITLE
Shipping Labels: Fix issue validating string with thousand separator

### DIFF
--- a/WooCommerce/Classes/Extensions/NumberFormatter+Localized.swift
+++ b/WooCommerce/Classes/Extensions/NumberFormatter+Localized.swift
@@ -6,6 +6,12 @@ extension NumberFormatter {
     static func double(from string: String, locale: Locale = .current) -> Double? {
         let formatter = NumberFormatter()
         formatter.locale = locale
+        formatter.usesGroupingSeparator = true
+        formatter.groupingSize = 3
+        formatter.formatterBehavior = .behavior10_4
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.roundingMode = .halfUp
         let number = formatter.number(from: string)
         return number?.doubleValue
     }

--- a/WooCommerce/WooCommerceTests/Extensions/NumberFormatter+LocalizedTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NumberFormatter+LocalizedTests.swift
@@ -21,6 +21,13 @@ class NumberFormatter_LocalizedTests: XCTestCase {
         // Then
         XCTAssertNil(NumberFormatter.double(from: valueWithComma, locale: usLocale))
         XCTAssertEqual(NumberFormatter.double(from: valueWithComma, locale: itLocale), Double(1.2))
+
+        // When
+        let valueWithThousandSeparator = "1,000"
+
+        // Then
+        XCTAssertEqual(NumberFormatter.double(from: valueWithThousandSeparator, locale: usLocale), Double(1000))
+        XCTAssertEqual(NumberFormatter.double(from: valueWithThousandSeparator, locale: itLocale), Double(1))
     }
 
     func test_string_from_number_returns_correctly_depending_on_locale() {


### PR DESCRIPTION
Fixes #5197 

# Description
This PR updates the formatter used for getting double value from string, to make sure that it uses the same styles as the formatter that converts double values to localized strings.

# Testing
1. Make sure that your test store has configured WCShip plugin.
2. Set up the locale for your device to a region that uses comma as decimal point (e.g Italy).
3. Select an international order that's eligible for creating shipping labels and has at least one product that is above 1,000 units of your store's weight unit. (For example, if your store is set to grams as the weight unit, make sure the order has at least one product that is 1,000 g.)
4. Select Create Shipping Label and input Ship From and Ship To.
5. In Package Details, notice that the Total package weight is valid with the thousand separator present.
6. In Customs, notice that the Weight for the item above 1,000 is valid with the thousand separator present.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
