### PR TITLE
Shipping Labels: Fix corrupted navigation view for SelectionList

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -75,6 +75,7 @@ struct ShippingLabelCarriers: View {
                     .disabled(!viewModel.isDoneButtonEnabled())
                 }
             }
+            .wooNavigationBarStyle()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -39,6 +39,7 @@ struct ShippingLabelCustomsFormList: View {
                 }).disabled(!viewModel.doneButtonEnabled)
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesForm.swift
@@ -43,6 +43,7 @@ struct ShippingLabelPackagesForm: View {
                 .disabled(!viewModel.doneButtonEnabled)
             }
         }
+        .wooNavigationBarStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -133,6 +133,7 @@ struct ShippingLabelPaymentMethods: View {
                     .disabled(!viewModel.isDoneButtonEnabled())
                 }
             }
+            .wooNavigationBarStyle()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectionList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectionList.swift
@@ -69,6 +69,7 @@ struct SelectionList<T: Hashable>: View {
                     }
                 })
             }
+            .navigationViewStyle(StackNavigationViewStyle())
             .wooNavigationBarStyle()
         }
     }


### PR DESCRIPTION
Fixes #5200 

# Description
On devices with regular width for horizontal size class (e.g iPad, iPhone Pro Max / Plus), navigation views that embed a list or scroll view will default to use column style. This style without proper setup can mess up the UI.

Since our `SelectionList` doesn't show any view on selection, I updated it to explicitly use stack style instead.

Extra: Add missing `wooNavigationBarStyle` for Package Details, Customs, Carriers and Rates, Payment method screens to make sure all Done buttons are pink on iOS 15.

# Screenshot
| Before | After |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/137122726-082dd25d-f732-4d98-b313-ef2181fa7603.png" /> | <img src="https://user-images.githubusercontent.com/5533851/137122792-4814164e-9fc0-4192-b602-7a4be0cc4cc0.png" />

# Testing
1. Make sure your test store has configured WCShip plugin.
2. Build the fix on an iPad / iPhone with Pro Max or Plus model.
3. Select an order that's eligible for creating shipping labels, select Create Shipping Label.
4. Configure Ship From and Ship To. On Package Details, select Package Selected > Add New Package > Custom Package > Package Type. Notice that the package type list is displayed properly on iPad and on landscape mode of iPhone with Pro Max or Plus models.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
