### PR TITLE
Quick Pay: Use the store decimal separator when creating an order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmount.swift
@@ -76,7 +76,7 @@ struct QuickPayAmount: View {
                 .secondaryBodyStyle()
 
             // Amount Textfield
-            TextField(Localization.amountPlaceholder, text: $viewModel.amount)
+            TextField(viewModel.amountPlaceholder, text: $viewModel.amount)
                 .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold, design: .default))
                 .foregroundColor(Color(.text))
                 .multilineTextAlignment(.center)
@@ -108,7 +108,6 @@ private extension QuickPayAmount {
     enum Localization {
         static let title = NSLocalizedString("Take Payment", comment: "Title for the quick pay screen")
         static let instructions = NSLocalizedString("Enter Amount", comment: "Short instructions label in the quick pay screen")
-        static let amountPlaceholder = "$0.00" // Not localized for now as the prototype does not supporting multiple currencies.
         static let buttonTitle = NSLocalizedString("Done", comment: "Title for the button to confirm the amount in the quick pay screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Title for the button to cancel the quick pay screen")
         static let error = NSLocalizedString("There was an error creating the order", comment: "Notice text after failing to create a quick pay order.")

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayAmountViewModel.swift
@@ -34,6 +34,12 @@ final class QuickPayAmountViewModel: ObservableObject {
         amount.count < 2
     }
 
+    /// Dynamically builds the amount placeholder based on the store decimal separator.
+    ///
+    lazy var amountPlaceholder: String = {
+        "$0\(storeCurrencySettings.decimalSeparator)00" // Not localized for now as the prototype does not supporting multiple currencies.
+    }()
+
     /// Current store ID
     ///
     private let siteID: Int64
@@ -46,10 +52,18 @@ final class QuickPayAmountViewModel: ObservableObject {
     ///
     private let userLocale: Locale
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, locale: Locale = Locale.autoupdatingCurrent) {
+    /// Current store currency settings
+    ///
+    private let storeCurrencySettings: CurrencySettings
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         locale: Locale = Locale.autoupdatingCurrent,
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.stores = stores
         self.userLocale = locale
+        self.storeCurrencySettings = storeCurrencySettings
     }
 
     /// Called when the view taps the done button.
@@ -83,9 +97,13 @@ private extension QuickPayAmountViewModel {
     func formatAmount(_ amount: String) -> String {
         guard amount.isNotEmpty else { return amount }
 
-        // Removes any unwanted character
-        let separatorCharacter = userLocale.decimalSeparator ?? "."
-        var formattedAmount = amount.filter { $0.isNumber || $0.isCurrencySymbol || "\($0)" == separatorCharacter }
+        let deviceDecimalSeparator = userLocale.decimalSeparator ?? "."
+        let storeDecimalSeparator = storeCurrencySettings.decimalSeparator
+
+        // Removes any unwanted character & makes sure to use the store decimal separator
+        var formattedAmount = amount
+            .replacingOccurrences(of: deviceDecimalSeparator, with: storeDecimalSeparator)
+            .filter { $0.isNumber || $0.isCurrencySymbol || "\($0)" == storeDecimalSeparator }
 
         // Prepend the `$` symbol if needed.
         if formattedAmount.first != "$" {
@@ -93,17 +111,17 @@ private extension QuickPayAmountViewModel {
         }
 
         // Trim to two decimals & remove any extra "."
-        let components = formattedAmount.components(separatedBy: separatorCharacter)
+        let components = formattedAmount.components(separatedBy: storeDecimalSeparator)
         switch components.count {
-        case 1 where formattedAmount.contains(separatorCharacter):
-            return components[0] + separatorCharacter
+        case 1 where formattedAmount.contains(storeDecimalSeparator):
+            return components[0] + storeDecimalSeparator
         case 1:
             return components[0]
         case 2...Int.max:
             let number = components[0]
             let decimals = components[1]
             let trimmedDecimals = decimals.count > 2 ? "\(decimals.prefix(2))" : decimals
-            return number + separatorCharacter + trimmedDecimals
+            return number + storeDecimalSeparator + trimmedDecimals
         default:
             fatalError("Should not happen, components can't be 0 or negative")
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/QuickPay/QuickPayAmountViewModelTests.swift
@@ -98,6 +98,40 @@ final class QuickPayAmountViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldDisableDoneButton)
     }
 
+    func test_view_model_changes_coma_separator_for_dot_separator_when_the_store_requires_it() {
+        // Given
+        let comaSeparatorLocale = Locale(identifier: "es_AR")
+        let storeSettings = CurrencySettings() // Default is US settings
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, locale: comaSeparatorLocale, storeCurrencySettings: storeSettings)
+
+        // When
+        viewModel.amount = "10,25"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "$10.25")
+    }
+
+    func test_view_model_uses_the_store_currency_symbol() {
+        // Given
+        let storeSettings = CurrencySettings(currencyCode: .EUR, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
+
+        // When
+        viewModel.amount = "10.25"
+
+        // Then
+        XCTAssertEqual(viewModel.amount, "€10.25")
+    }
+
+    func test_amount_placeholder_is_formatted_with_store_currency_settings() {
+        // Given
+        let storeSettings = CurrencySettings(currencyCode: .EUR, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ",", numberOfDecimals: 2)
+        let viewModel = QuickPayAmountViewModel(siteID: sampleSiteID, locale: usLocale, storeCurrencySettings: storeSettings)
+
+        // When & Then
+        XCTAssertEqual(viewModel.amountPlaceholder, "€0,00")
+    }
+
     func test_view_model_enables_loading_state_while_performing_network_operations() {
         // Given
         let testingStore = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
# Why

For the quick pay prototype, I was using the user's locale decimal separator in order to format the amount provided by the merchant. 

This has a problem when the user's locale has a decimal coma separator but the store setting uses a decimal dot separator because it will interpret that coma as a thousand separator.

This PR fixes that and additionally, it grabs the currency symbol from the store settings rather than forcing a "$". Keep in mind that this prototype is still only meant to be used in the US.

# How

- When entering formatting an amount, replace locale's decimal separator occurrences with the store decimal separator.

- Use the store currency symbol to format the amount instead of hardcoding "$"

- Build the amount placeholder based on the store currency settings.

# Demo
https://user-images.githubusercontent.com/562080/137209600-6cbff0b5-947d-4cbc-9cf2-3d04b5d1d298.mov

# Testing Step

- Change your device/simulator to a region like Argentina(Don't worry this doesn't change the language)
- Create a quick pay order (note that the keyboard shows a comma separator but the app formats the amount with a dot)
- See that the order is created with the correct amount.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
