### PR TITLE
[Mobile Payments] Log localized description

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -718,6 +718,7 @@ private extension OrderDetailsViewController {
             switch result {
             case .failure(let error):
                 ServiceLocator.analytics.track(.collectPaymentFailed, withError: error)
+                DDLogError("Failed to collect payment: \(error.localizedDescription)")
                 self.paymentAlerts.error(error: error, tryAgain: {
                     self.retryCollectPayment()
                 })


### PR DESCRIPTION
Closes #5215 

This PR is exactly the same as #5219 but targeting the release/7.7 branch

To test:
- Complete an order with cart total ending in .05
- A payment failure will result
- Ensure it appears in debugger, e.g.:

The tracking and the logging now looks like

```
2021-10-14 06:16:19.165621-0700 WooCommerce[8619:6415552] 🔵 Tracked card_present_collect_payment_failed, properties: [AnyHashable("error_domain"): "Hardware.CardReaderServiceError", AnyHashable("error_description"): "Hardware.CardReaderServiceError.paymentCapture(underlyingError: Hardware.UnderlyingError.paymentDeclinedByPaymentProcessorAPI)", AnyHashable("error_code"): "5", AnyHashable("blog_id"): 197907611, AnyHashable("is_wpcom_store"): false]
2021-10-14 06:16:19.165979-0700 WooCommerce[8619:6415488] Failed to collect payment: The card was declined by the payment processor - please try another means of payment
```

FWIW, it looks like this to the user:

![IMG_0192](https://user-images.githubusercontent.com/1595739/137220300-037762f7-a8fc-43e8-a279-63a1645874ea.PNG)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
