### PR TITLE
Add accessibility announcement when offline banner appears or disappears

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Shipping Labels: Fix crash when tapping on Learn more rows of customs form. [https://github.com/woocommerce/woocommerce-ios/pull/5207]
 - [*] Shipping Labels: The shipping address now prefills the phone number from the billing address if a shipping phone number is not available. [https://github.com/woocommerce/woocommerce-ios/pull/5177]
 - [*] Shipping Labels: now in Carrier and Rates we always display the discounted rate instead of the retail rate if available. [https://github.com/woocommerce/woocommerce-ios/pull/5188]
+- [*] Accessibility: notify when offline mode banner appears or disappears. [https://github.com/woocommerce/woocommerce-ios/pull/5225]
 
 7.7
 -----

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -143,6 +143,7 @@ private extension WooNavigationControllerDelegate {
             offlineBannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -extraBottomSpace)
         ])
         viewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: OfflineBannerView.height, right: 0)
+        UIAccessibility.post(notification: .announcement, argument: Localization.offlineAnnouncement)
     }
 
     /// Removes the offline banner from the view controller if it exists.
@@ -153,5 +154,15 @@ private extension WooNavigationControllerDelegate {
         }
         offlineBanner.removeFromSuperview()
         viewController.additionalSafeAreaInsets = .zero
+        UIAccessibility.post(notification: .announcement, argument: Localization.onlineAnnouncement)
+    }
+}
+
+private extension WooNavigationControllerDelegate {
+    enum Localization {
+        static let offlineAnnouncement = NSLocalizedString("Offline - using cached data",
+                                                           comment: "Accessibility announcement message when device goes offline")
+        static let onlineAnnouncement = NSLocalizedString("Back online",
+                                                          comment: "Accessibility announcement message when device goes back online")
     }
 }


### PR DESCRIPTION
Fixes #5164 

# Description
Since offline banner is at the bottom of the screen, offline mode may be hard to noticed for users using voice over. This PR adds accessibility notification of type announcement to notify users of connectivity status.

# Testing
- Build the changes to a physical device.
- Turn on Voice Over on the device.
- Simulate network connectivity changes (e.g using airplane mode), notice that network state is correctly announced.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
