### PR TITLE
Shipping Labels: Update ITN placeholder text when it's required in customs form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -133,7 +133,7 @@ struct ShippingLabelCustomsFormInput: View {
     private var itnRows: some View {
         VStack(spacing: 0) {
             TitleAndTextFieldRow(title: Localization.itnTitle,
-                                 placeholder: viewModel.missingITNForDestination ? Localization.itnRequiredPlaceholder : Localization.itnPlaceholder,
+                                 placeholder: viewModel.missingITNForDestination || viewModel.missingITNForClassesAbove2500usd ? Localization.itnRequiredPlaceholder : Localization.itnPlaceholder,
                                  text: $viewModel.itn)
             Divider()
                 .padding(.leading, Constants.horizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -133,7 +133,9 @@ struct ShippingLabelCustomsFormInput: View {
     private var itnRows: some View {
         VStack(spacing: 0) {
             TitleAndTextFieldRow(title: Localization.itnTitle,
-                                 placeholder: viewModel.missingITNForDestination || viewModel.missingITNForClassesAbove2500usd ? Localization.itnRequiredPlaceholder : Localization.itnPlaceholder,
+                                 placeholder: viewModel.missingITNForDestination || viewModel.missingITNForClassesAbove2500usd
+                                    ? Localization.itnRequiredPlaceholder
+                                    : Localization.itnPlaceholder,
                                  text: $viewModel.itn)
             Divider()
                 .padding(.leading, Constants.horizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -133,7 +133,7 @@ struct ShippingLabelCustomsFormInput: View {
     private var itnRows: some View {
         VStack(spacing: 0) {
             TitleAndTextFieldRow(title: Localization.itnTitle,
-                                 placeholder: Localization.itnPlaceholder,
+                                 placeholder: viewModel.missingITNForDestination ? Localization.itnRequiredPlaceholder : Localization.itnPlaceholder,
                                  text: $viewModel.itn)
             Divider()
                 .padding(.leading, Constants.horizontalPadding)
@@ -196,6 +196,8 @@ private extension ShippingLabelCustomsFormInput {
                                                 comment: "Title for the ITN row in Customs screen of Shipping Label flow")
         static let itnPlaceholder = NSLocalizedString("Enter ITN (Optional)",
                                                       comment: "Placeholder for the ITN row in Customs screen of Shippling Label flow")
+        static let itnRequiredPlaceholder = NSLocalizedString("Enter ITN",
+                                                              comment: "Placeholder for the required ITN row in Customs screen of Shipping Label flow")
         static let itnMissingForDestination = NSLocalizedString("ITN is required for shipments to %1$@",
                                                                 comment: "Error message for missing ITN for destination country in" +
                                                                     "Customs screen of Shipping Label flow. The placeholder is the destination country.")


### PR DESCRIPTION
Fixes: #4972

## Description

In the Shipping Label creation flow, when the ITN field is required on a customs form, the placeholder text is updated to remove `(optional)`.

## Changes

* In `ShippingLabelCustomsFormInput`, checks whether the ITN is missing for the destination and uses that to determine whether the placeholder text will be set to `Enter ITN` (when required) or `Enter ITN (Optional)` (when optional).

Required ITN|Optional ITN
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-10-15 at 14 09 29](https://user-images.githubusercontent.com/8658164/137493546-8a3852fa-dac5-4b91-bbca-0deded5ebfa2.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-10-15 at 14 10 08](https://user-images.githubusercontent.com/8658164/137493561-afdc5220-0892-4ffd-9c20-16f1982b3146.png)

## Testing

1. Make sure that your test store has the WCShip plugin installed and activated.
2. Create an order that requires international shipping (origin country different from destination country) where the destination country requires an Internal Transaction Number (ITN) on the customs form (for example, Iran).
3. Open the app, select the Orders tab, and select the created order.
4. Select Create Shipping Label.
5. Go through Ship From, Ship To, Package Details to configure Customs.
6. On the Customs screen, confirm you see the ITN row with the placeholder `Enter ITN` and the validation message below it noting that the ITN is required.
7. Change the destination country to a country that does NOT require an ITN on the customs form (for example, UK).
8. Go back to Customs, confirm you see the ITN row with the placeholder `Enter ITN (Optional)`.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
