### PR TITLE
Order Details: Fix outdated product variation results controller when updating order

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -204,6 +204,8 @@ final class OrderDetailsDataSource: NSObject {
 
     func update(order: Order) {
         self.order = order
+        resultsControllers.update(order: order)
+        reloadSections()
     }
 
     func configureResultsControllers(onReload: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -205,7 +205,6 @@ final class OrderDetailsDataSource: NSObject {
     func update(order: Order) {
         self.order = order
         resultsControllers.update(order: order)
-        reloadSections()
     }
 
     func configureResultsControllers(onReload: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -7,7 +7,7 @@ import protocol Storage.StorageManagerType
 final class OrderDetailsResultsControllers {
     private let storageManager: StorageManagerType
 
-    private let order: Order
+    private var order: Order
     private let siteID: Int64
 
     /// Shipment Tracking ResultsController.
@@ -147,6 +147,10 @@ final class OrderDetailsResultsControllers {
         configureShippingLabelResultsController(onReload: onReload)
         configurePaymentGatewayAccountResultsController(onReload: onReload)
         configureAddOnGroupResultsController(onReload: onReload)
+    }
+
+    func update(order: Order) {
+        self.order = order
     }
 }
 


### PR DESCRIPTION
Fixes #5170 

# Description
There is an edge case when an `OrderDetailsViewModel` is created with a storage model that has an empty list of order items. This list should be updated after syncing with remote is done, which then triggers the data source to update order with `update(order:)` method.

Currently the `resultsControllers` is created only once with the initial order, so when this edge case happens, the `resultsControllers` is tied with an order that has no items. Its `productVariationResultsController` needs the order item list to get the list of variation IDs for fetching, so if the order item list is not updated, the Order Details screen cannot display the correct item count for product variations in shipping labels.

This PR fixes the issue by forcing the data source to update the order in its `resultsControllers`.

# Testing
1. Make sure that your test store has installed and activated WCShip plugin.
2. Create an order with simple products and variable products.
3. On Orders tab, select the new order and select Create Shipping Label.
4. Complete the shipping label form and purchase the label.
5. Navigate to Order Details, notice that the number of items only includes the simple products.
6. Tap on "# items" and notice that the variable product has correct quantity.

This issue can also be tested with orders with existing shipping labels.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
