### PR TITLE
Order Editing: clear billing email

### DIFF
--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -70,6 +70,36 @@ public struct Address: Codable, GeneratedFakeable, GeneratedCopiable {
                   email: email)
     }
 
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(firstName, forKey: .firstName)
+        try container.encode(lastName, forKey: .lastName)
+        try container.encodeIfPresent(company, forKey: .company)
+        try container.encode(address1, forKey: .address1)
+        try container.encodeIfPresent(address2, forKey: .address2)
+        try container.encode(city, forKey: .city)
+        try container.encode(state, forKey: .state)
+        try container.encode(postcode, forKey: .postcode)
+        try container.encode(country, forKey: .country)
+        try container.encodeIfPresent(phone, forKey: .phone)
+
+        /// Encoding an `email` has some special conditions.
+        /// - Encode the content to update the value.
+        /// - Encode `nil` to clear the value
+        /// - Don't encode to leave the value unaltered.
+        /// PS: Encoding an empty string will produce an error due to server validations.
+        ///
+        switch email {
+        case .some(let content) where content.isEmpty:
+            try container.encodeNil(forKey: .email)
+        case .some(let content):
+            try container.encode(content, forKey: .email)
+        case .none:
+            break
+        }
+    }
+
     public static var empty: Address {
         self.init(firstName: "",
                   lastName: "",

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -166,6 +166,7 @@ private extension NoticeView {
 
         if let message = notice.message {
             messageLabel.text = message
+            messageLabel.numberOfLines = 0
         } else {
             titleLabel.numberOfLines = 2
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -69,7 +69,9 @@ final class EditOrderAddressHostingController: UIHostingController<EditOrderAddr
                         self?.dismiss(animated: true) // Dismiss VC because we need country information to continue.
 
                     case .unableToUpdateAddress:
-                        self?.modalNoticePresenter.enqueue(notice: .init(title: error.errorDescription ?? "", feedbackType: .error))
+                        self?.modalNoticePresenter.enqueue(notice: .init(title: error.errorDescription ?? "",
+                                                                         message: error.recoverySuggestion,
+                                                                         feedbackType: .error))
                     }
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -199,6 +199,9 @@ final class EditOrderAddressFormViewModel: ObservableObject {
 
             case .failure(let error):
                 DDLogError("⛔️ Error updating order: \(error)")
+                if self.type == .billing, updatedAddress.hasEmailAddress == false {
+                    DDLogError("⛔️ Email is nil in address. It won't work in WC < 5.9.0 (https://git.io/J68Gl)")
+                }
                 self.presentNotice = .error(.unableToUpdateAddress)
                 self.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowFailed(subject: self.analyticsFlowType()))
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -250,8 +250,18 @@ extension EditOrderAddressFormViewModel {
                 return NSLocalizedString("Unable to fetch country information, please try again later.",
                                          comment: "Error notice when we fail to load country information in the edit address screen.")
             case .unableToUpdateAddress:
-                return NSLocalizedString("Unable to update address, please try again later.",
-                                         comment: "Error notice when we fail to update an address in the edit address screen.")
+                return NSLocalizedString("Unable to update address.",
+                                         comment: "Error notice title when we fail to update an address in the edit address screen.")
+            }
+        }
+
+        var recoverySuggestion: String? {
+            switch self {
+            case .unableToLoadCountries:
+                return nil
+            case .unableToUpdateAddress:
+                return NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
+                                         comment: "Error notice recovery suggestion when we fail to update an address in the edit address screen.")
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -446,7 +446,7 @@ private extension EditOrderAddressFormViewModel {
 
 private extension Address {
     /// Sets the email value to `nil` when it is empty.
-    /// Needed because core has a validation where a billing address can have a valid email or `nil`.
+    /// Needed because core has a validation where a billing address can only be a valid email or `nil`(instead of empty).
     ///
     func removingEmptyEmail() -> Yosemite.Address {
         guard let email = email, email.isEmpty else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -166,19 +166,21 @@ final class EditOrderAddressFormViewModel: ObservableObject {
     /// Update the address remotely and invoke a completion block when finished
     ///
     func updateRemoteAddress(onFinish: @escaping (Bool) -> Void) {
-        let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState).removingEmptyEmail()
+        let updatedAddress = fields.toAddress(country: selectedCountry, state: selectedState)
         let orderFields: [OrderUpdateField]
 
         let modifiedOrder: Yosemite.Order
         switch type {
         case .shipping where fields.useAsToggle:
-            modifiedOrder = order.copy(billingAddress: updatedAddress, shippingAddress: updatedAddress)
+            modifiedOrder = order.copy(billingAddress: updatedAddress.removingEmptyEmail(),
+                                       shippingAddress: updatedAddress.removingEmptyEmail())
             orderFields = [.shippingAddress, .billingAddress]
         case .shipping:
-            modifiedOrder = order.copy(shippingAddress: updatedAddress)
+            modifiedOrder = order.copy(shippingAddress: updatedAddress.removingEmptyEmail())
             orderFields = [.shippingAddress]
         case .billing where fields.useAsToggle:
-            modifiedOrder = order.copy(billingAddress: updatedAddress, shippingAddress: updatedAddress)
+            modifiedOrder = order.copy(billingAddress: updatedAddress,
+                                       shippingAddress: updatedAddress.copy(email: .some(nil)))
             orderFields = [.billingAddress, .shippingAddress]
         case .billing:
             modifiedOrder = order.copy(billingAddress: updatedAddress)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -409,6 +409,60 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertNil(billingAddress?.email)
     }
 
+    func test_copying_billing_address_for_shipping_does_not_sends_an_email_field() {
+        // Given
+        let viewModel = EditOrderAddressFormViewModel(order: order(withBillingAddress: sampleAddress()),
+                                                      type: .billing,
+                                                      storageManager: testingStorage,
+                                                      stores: testingStores)
+        viewModel.onLoadTrigger.send()
+        viewModel.fields.useAsToggle = true
+
+        // When
+        let shippingAddress: Address? = waitFor { promise in
+            self.testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, _, _):
+                    promise(order.shippingAddress)
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+
+            viewModel.updateRemoteAddress(onFinish: { _ in })
+        }
+
+        // Then
+        XCTAssertNil(shippingAddress?.email)
+    }
+
+    func test_sending_empty_email_billing_address_does_sends_an_empty_email_field() {
+        // Given
+        let viewModel = EditOrderAddressFormViewModel(order: order(withBillingAddress: sampleAddressWithEmptyNullableFields()),
+                                                      type: .billing,
+                                                      storageManager: testingStorage,
+                                                      stores: testingStores)
+        viewModel.onLoadTrigger.send()
+        viewModel.fields.useAsToggle = true
+
+        // When
+        let billingAddress: Address? = waitFor { promise in
+            self.testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .updateOrder(_, order, _, _):
+                    promise(order.billingAddress)
+                default:
+                    XCTFail("Unsupported Action")
+                }
+            }
+
+            viewModel.updateRemoteAddress(onFinish: { _ in })
+        }
+
+        // Then
+        XCTAssertEqual(billingAddress?.email, "")
+    }
+
     func test_shipping_view_model_does_not_shows_email_field() {
         // Given
         let viewModel = EditOrderAddressFormViewModel(order: Order.fake(), type: .shipping)


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/5115.

## Description

This PR adds support for clearing email in billing address, since support for it have been merged into core.
Before this change iOS were sending empty string as cleared email and this field was silently ignored by the backend. But all other changed fields saved fine in same request.

### Considerations

On WC <= 5.8.1 this change will result in error (code: `rest_invalid_param` message: `billing`) when email is cleared. This will be a blocker to save other fields as well.

Since email field is required for billing address (in normal checkout flow) and removing data is not a common action - so we'll keep the blocking error. To simplify debugging (for failed request with empty email) additional log line added with link to this PR.

WC 5.9.0 is scheduled to release on November 9 2021. WC 5.9.0 beta 1 is available now.

## Screenshots

WC 5.9.0 dev:

https://user-images.githubusercontent.com/3132438/137879226-9b699568-b19b-4028-a691-1798b99e7daa.mp4

WC 5.8.1:

<img width=350 src="https://user-images.githubusercontent.com/3132438/137879207-235c2461-1d07-408c-aa4f-b33de5aebce3.png">

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
