### PR TITLE
[Mobile Payments] Allow collection of payment on orders where it was interrupted by an error

### DIFF
--- a/WooCommerce/Classes/Model/OrderPaymentMethod.swift
+++ b/WooCommerce/Classes/Model/OrderPaymentMethod.swift
@@ -3,6 +3,9 @@ enum OrderPaymentMethod: RawRepresentable {
     /// Cash on Delivery
     case cod
 
+    /// WooCommerce Payments
+    case woocommercePayments
+
     /// No payment method assigned.
     case none
 
@@ -15,6 +18,8 @@ enum OrderPaymentMethod: RawRepresentable {
         switch rawValue {
         case Keys.cod:
             self = .cod
+        case Keys.woocommercePayments:
+            self = .woocommercePayments
         case Keys.none:
             self = .none
         default:
@@ -26,6 +31,8 @@ enum OrderPaymentMethod: RawRepresentable {
         switch self {
         case .cod:
             return Keys.cod
+        case .woocommercePayments:
+            return Keys.woocommercePayments
         case .none:
             return Keys.none
         default:
@@ -37,6 +44,7 @@ enum OrderPaymentMethod: RawRepresentable {
 
 private enum Keys {
     static let cod = "cod"
+    static let woocommercePayments = "woocommerce_payments"
     static let none = ""
     static let unknown = "unknown"
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1490,7 +1490,7 @@ private extension OrderDetailsDataSource {
 
     func isOrderPaymentMethodEligibleForCardPayment() -> Bool {
         let paymentMethod = OrderPaymentMethod(rawValue: order.paymentMethodID)
-        return paymentMethod == .cod || paymentMethod == .none
+        return paymentMethod == .cod || paymentMethod == .woocommercePayments || paymentMethod == .none
     }
 
     func hasCardPresentEligiblePaymentGatewayAccount() -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -127,13 +127,35 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         XCTAssertNil(row(row: .markCompleteButton(style: .secondary, showsBottomSpacing: false), in: productsSection))
     }
 
-    func test_collect_payment_button_is_visible_and_primary_style_if_order_is_eligible_for_cash_on_delivery() throws {
+    func test_collect_payment_button_is_visible_and_primary_style_if_order_status_is_processing_and_method_is_cash_on_delivery() throws {
         // Setup
         let account = storageManager.insertCardPresentEligibleAccount()
         storageManager.viewStorage.saveIfNeeded()
 
         // Given
         let order = makeOrder().copy(status: .processing, datePaid: .some(nil), paymentMethodID: "cod")
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
+        dataSource.configureResultsControllers { }
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        XCTAssertNotNil(row(row: .collectCardPaymentButton, in: paymentSection))
+
+        // Clean up
+        storageManager.viewStorage.deleteObject(account)
+        storageManager.viewStorage.saveIfNeeded()
+    }
+
+    func test_collect_payment_button_is_visible_and_primary_style_if_order_status_is_on_hold_and_method_is_woocommerce_payments() throws {
+        // Setup
+        let account = storageManager.insertCardPresentEligibleAccount()
+        storageManager.viewStorage.saveIfNeeded()
+
+        // Given
+        let order = makeOrder().copy(status: .onHold, datePaid: .some(nil), paymentMethodID: "woocommerce_payments")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager)
         dataSource.configureResultsControllers { }
 

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -166,8 +166,8 @@ public enum PaymentGatewayAccountError: Error, LocalizedError {
 
     enum Localizations {
         static let defaultMessage = NSLocalizedString(
-            "Unknown error",
-            comment: "Message presented when no error message is available."
+            "An unexpected error occurred with the store's payment gateway when capturing payment for the order",
+            comment: "Message presented when an unexpected error occurs with the store's payment gateway."
         )
     }
 }

--- a/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentGatewayAccountStore.swift
@@ -96,7 +96,7 @@ private extension PaymentGatewayAccountStore {
 
                 onCompletion(.success(()))
             case .failure(let error):
-                onCompletion(.failure(error))
+                onCompletion(.failure(PaymentGatewayAccountError(underlyingError: error)))
                 return
             }
         })
@@ -121,5 +121,53 @@ private extension PaymentGatewayAccountStore {
 
         storage.deleteObject(storageAccount)
         storage.saveIfNeeded()
+    }
+}
+
+/// Models errors thrown by the PaymentGatewayAccountStore. Not to be confused with
+/// errors originating from the card readers. Those are defined in CardReaderServiceError.
+///
+public enum PaymentGatewayAccountError: Error, LocalizedError {
+    case orderPaymentCaptureError(message: String?)
+    case otherError(error: AnyError)
+
+    init(underlyingError error: Error) {
+        guard case let DotcomError.unknown(code, message) = error else {
+            self = .otherError(error: error.toAnyError)
+            return
+        }
+
+        /// See if we recognize this DotcomError code
+        ///
+        self = ErrorCode(rawValue: code)?.error(message: message ?? Localizations.defaultMessage) ?? .otherError(error: error.toAnyError)
+    }
+
+    enum ErrorCode: String {
+        case wcpayCaptureError = "wcpay_capture_error"
+
+        func error(message: String) -> PaymentGatewayAccountError {
+            switch self {
+            case .wcpayCaptureError:
+                return .orderPaymentCaptureError(message: message)
+            }
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .orderPaymentCaptureError(let message):
+            /// Return the message directly from the store, e.g. in the case of fractional quantities, which are not allowed
+            /// "Payment capture failed to complete with the following message: Error: Invalid integer: 2.5"
+            return message
+        case .otherError(let error):
+            return error.localizedDescription
+        }
+    }
+
+    enum Localizations {
+        static let defaultMessage = NSLocalizedString(
+            "Unknown error",
+            comment: "Message presented when no error message is available."
+        )
     }
 }


### PR DESCRIPTION
Closes #4655

NOTE: This picks up #5244 at https://github.com/woocommerce/woocommerce-ios/pull/5244/commits/e26293c7a18e6796ac3c65bb4c3e3aa3cbdb61ce but targeting `develop` (changing the base on 5244 unleashed the kraken, so it will be closed without committing)

Changes:
- If collecting a payment fails and the payment method ID is changed to `woocommerce_payments` the logic prior to this PR would treat it as ineligible for in-person payments
- This PR adds `woocommerce_payments` as an acceptable payment method ID on an order. Coupled with the status of processing, on-hold, or none makes sense and continues to avoids the problem of collecting payments on orders which already have payment collected
- This PR also presents any error message provided from the backend during order payment capture directly to the user (e.g. "Payment capture failed to complete with the following message: Error: Invalid integer: 2.5") if preferred we could just show something simpler like "Payment capture failed to complete" - it would also avoid the risk of localization differences but would impart less information to the user. 

To test:
- Use the fractional quantity plugin described in @designsimply 's original report in #4655 to reproduce the error during payment collection
- Ensure that after pulling to refresh the order the Collect Payment button continues to be presented

Note: The backend does NOT emit different codes for different capture failures from Stripe, however. They all have the same code: `wcpay_capture_error`. See https://github.com/Automattic/woocommerce-payments/blob/6b2e9a5c9f372fdf9d585220846ac0154e83dea6/includes/admin/class-wc-rest-payments-orders-controller.php#L125-L139

Note: We could add coverage for other errors like wcpay_payment_uncapturable and wcpay_refunded_order_uncapturable and the less likely wcpay_missing_order  if desired. I can open separate issues for any of those. See that same part of the plugin linked above for those. See below for a screenshot of how other errors are presented (i.e. no change)

Screenshots:

Error when we attempt to process a fractional quantity:

![IMG_0204](https://user-images.githubusercontent.com/1595739/137977158-a0c8d023-a84f-458a-b48c-fd97539e1b30.PNG)

Error when the endpoint simply doesn't exist (edit includes/admin/class-wc-rest-payments-orders-controller.php and rename the path):

![IMG_0205](https://user-images.githubusercontent.com/1595739/137977148-b656fa14-a221-49ce-a959-a05dad359d2a.PNG)

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.