### PR TITLE
What's New: Add tracks event for What's New component

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -351,3 +351,20 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - What's New Component
+//
+extension WooAnalyticsEvent {
+    /// Possible sources for the What's New component
+    ///
+    enum Source: String {
+        fileprivate static let key = "source"
+
+        case appUpgrade = "app_upgrade"
+        case appSettings = "app_settings"
+    }
+
+    static func featureAnnouncementShown(source: Source) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .featureAnnouncementShown, properties: [Source.key: source.rawValue])
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -506,6 +506,10 @@ public enum WooAnalyticsStat: String {
     case removeProductAttributeButtonTapped = "remove_product_attribute_button_tapped"
     case editProductVariationAttributeOptionsRowTapped = "edit_product_variation_attribute_options_row_tapped"
     case editProductVariationAttributeOptionsDoneButtonTapped = "edit_product_variation_attribute_options_done_button_tapped"
+
+    // MARK: What's New Component events
+    //
+    case featureAnnouncementShown = "feature_announcement_shown"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -84,6 +84,7 @@ private extension AppCoordinator {
             guard let (announcement, displayed) = try? result.get(), !displayed else {
                 return DDLogInfo("📣 There are no announcements to show!")
             }
+            ServiceLocator.analytics.track(event: .featureAnnouncementShown(source: .appUpgrade))
             let whatsNewViewController = WhatsNewFactory.whatsNew(announcement) { [weak self] in
                 self?.tabBarController.dismiss(animated: true)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -607,6 +607,7 @@ private extension SettingsViewController {
     }
 
     func whatsNewWasPressed() {
+        ServiceLocator.analytics.track(event: .featureAnnouncementShown(source: .appSettings))
         guard let announcement = announcement else { return }
         let viewController = WhatsNewFactory.whatsNew(announcement) { [weak self] in
             self?.dismiss(animated: true)


### PR DESCRIPTION
Closes: #4864

## Description

Adds a tracks event when the What's New component is shown, with a `source` property to track whether it is shown after upgrading the app or opened from app settings:

* `*_feature_announcement_shown` with property `source: (app_upgrade|app_settings)` 

## Testing

⚠️ **Prerequisite** ⚠️ 
Make the following changes to display the test announcement:

<img width="562" alt="Screen Shot 2021-10-20 at 12 00 39 PM" src="https://user-images.githubusercontent.com/8658164/138081225-97e8bbf4-983d-4f58-b35f-f7ad3e512746.png">

<img width="1171" alt="Screen Shot 2021-10-20 at 12 00 06 PM" src="https://user-images.githubusercontent.com/8658164/138081226-8b274895-1981-40ef-9b0c-2c84dd9f49e3.png">

1. Build the app in debug mode (to ensure the feature flag is enabled).
2. What's New component should be displayed upon app launch
3. Notice that event `feature_announcement_shown` appears in console with `source` property and value `app_upgrade`.
4. Tap Continue to dismiss the modal.
5. Open app settings.
6. Tap the "What's New in WooCommerce" row in settings to display the What's New component again.
7. Notice that event `feature_announcement_shown` appears in console with `source` property and value `app_settings`.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
