### PR TITLE
Order list: feature flag and top bar that display order filters

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -25,6 +25,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .quickPayPrototype:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .orderListFilters:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -49,4 +49,8 @@ public enum FeatureFlag: Int {
     /// Allows to create quick pay orders
     ///
     case quickPayPrototype
+    
+    /// Display the bar for displaying the filters in the Order List
+    ///
+    case orderListFilters
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -49,7 +49,7 @@ public enum FeatureFlag: Int {
     /// Allows to create quick pay orders
     ///
     case quickPayPrototype
-    
+
     /// Display the bar for displaying the filters in the Order List
     ///
     case orderListFilters

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -8,23 +8,28 @@ final class FilteredOrdersHeaderBar: UIView {
     @IBOutlet private weak var mainLabel: UILabel!
     @IBOutlet private weak var filtersView: UIView!
     @IBOutlet private weak var filtersButtonLabel: UILabel!
+    @IBOutlet private weak var filtersNumberView: UIView!
     @IBOutlet private weak var filtersNumberLabel: UILabel!
 
     /// The number of filters applied
     ///
-    private var numberOfFilters = 0
+    private var numberOfFilters = 4 {
+        didSet {
+            filtersNumberLabel.text = "\(numberOfFilters)"
+        }
+    }
 
     var onAction: (() -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
-        configureFiltersView()
-        configureLabels()
+        configureViews()
     }
 
     func setNumberOfFilters(_ filters: Int) {
         numberOfFilters = filters
+        filtersNumberView.isHidden = numberOfFilters == 0
         configureLabels()
     }
 
@@ -40,15 +45,17 @@ private extension FilteredOrdersHeaderBar {
         backgroundColor = .listForeground
     }
 
-    /// Setup: Filters View
+    /// Setup: Views
     ///
-    func configureFiltersView() {
+    func configureViews() {
         filtersView.layer.cornerRadius = 14.0
         filtersView.layer.borderWidth = 1.0
         filtersView.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
-
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
         filtersView.addGestureRecognizer(recognizer)
+
+        filtersNumberView.backgroundColor = .accent
+        filtersNumberView.layer.cornerRadius = filtersNumberView.frame.height/2
     }
 
     /// Setup: Labels
@@ -59,8 +66,6 @@ private extension FilteredOrdersHeaderBar {
         filtersButtonLabel.applySubheadlineStyle()
         filtersButtonLabel.text = Localization.filters
         filtersNumberLabel.applyFootnoteStyle()
-        filtersNumberLabel.isHidden = numberOfFilters == 0
-        filtersNumberLabel.text = "\(numberOfFilters)"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -10,7 +10,7 @@ final class FilteredOrdersHeaderBar: UIView {
 
     /// The number of filters applied
     ///
-    private var numberOfFilters = 4
+    private var numberOfFilters = 0
 
     var onAction: (() -> Void)?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -16,7 +16,6 @@ final class FilteredOrdersHeaderBar: UIView {
         configureLabels()
     }
 
-
 }
 
 // MARK: - Setup

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -6,36 +6,30 @@ import UIKit
 final class FilteredOrdersHeaderBar: UIView {
 
     @IBOutlet private weak var mainLabel: UILabel!
-    @IBOutlet private weak var filtersView: UIView!
-    @IBOutlet private weak var filtersButtonLabel: UILabel!
-    @IBOutlet private weak var filtersNumberView: UIView!
-    @IBOutlet private weak var filtersNumberLabel: UILabel!
+    @IBOutlet private weak var filterButton: UIButton!
 
     /// The number of filters applied
     ///
-    private var numberOfFilters = 4 {
-        didSet {
-            filtersNumberLabel.text = "\(numberOfFilters)"
-        }
-    }
+    private var numberOfFilters = 4
 
     var onAction: (() -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        configureBackground()
-        configureViews()
+        configureLabels()
+        configureButtons()
     }
 
     func setNumberOfFilters(_ filters: Int) {
         numberOfFilters = filters
-        filtersNumberView.isHidden = numberOfFilters == 0
         configureLabels()
+        configureButtons()
     }
 
-    @objc private func viewTapped() {
+    @IBAction func filterButtonTapped(_ sender: Any) {
         onAction?()
     }
+
 }
 
 // MARK: - Setup
@@ -45,27 +39,22 @@ private extension FilteredOrdersHeaderBar {
         backgroundColor = .listForeground
     }
 
-    /// Setup: Views
-    ///
-    func configureViews() {
-        filtersView.layer.cornerRadius = 14.0
-        filtersView.layer.borderWidth = 1.0
-        filtersView.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
-        filtersView.addGestureRecognizer(recognizer)
-
-        filtersNumberView.backgroundColor = .accent
-        filtersNumberView.layer.cornerRadius = filtersNumberView.frame.height/2
-    }
-
     /// Setup: Labels
     ///
     func configureLabels() {
         mainLabel.applyHeadlineStyle()
         mainLabel.text = numberOfFilters == 0 ? Localization.noFiltersApplied : Localization.filtersApplied
-        filtersButtonLabel.applySubheadlineStyle()
-        filtersButtonLabel.text = Localization.filters
-        filtersNumberLabel.applyFootnoteStyle()
+    }
+
+    /// Setup: Buttons
+    ///
+    func configureButtons() {
+        filterButton.applyLinkButtonStyle()
+        let title =  numberOfFilters == 0 ?
+        Localization.buttonWithoutActiveFilters :
+        String.localizedStringWithFormat(Localization.buttonWithActiveFilters, numberOfFilters)
+
+        filterButton.setTitle(title, for: .normal)
     }
 
     enum Localization {
@@ -75,5 +64,11 @@ private extension FilteredOrdersHeaderBar {
                                                       comment: "Header bar label on top of order list when filters are applied")
         static let filters = NSLocalizedString("Filters",
                                                comment: "Filters button text on header bar on top of order list")
+        static let buttonWithoutActiveFilters =
+            NSLocalizedString("Filter",
+                              comment: "Title of the toolbar button to filter orders without filters applied.")
+        static let buttonWithActiveFilters =
+            NSLocalizedString("Filter (%ld)",
+                              comment: "Title of the toolbar button to filter orders with filters applied.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -36,7 +36,16 @@ private extension FilteredOrdersHeaderBar {
     ///
     func configureLabels() {
         mainLabel.applyHeadlineStyle()
+        mainLabel.text = Localization.mainLabel
         filtersButtonLabel.applySubheadlineStyle()
+        filtersButtonLabel.text = Localization.filters
         filtersNumberLabel.applyFootnoteStyle()
+    }
+
+    enum Localization {
+        static let mainLabel = NSLocalizedString("Filtered Orders",
+                                                 comment: "Filtered Orders header bar label on top of order list")
+        static let filters = NSLocalizedString("Filters",
+                                               comment: "Filters button text on header bar on top of order list")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -10,6 +10,10 @@ final class FilteredOrdersHeaderBar: UIView {
     @IBOutlet private weak var filtersButtonLabel: UILabel!
     @IBOutlet private weak var filtersNumberLabel: UILabel!
 
+    /// The number of filters applied
+    ///
+    private var numberOfFilters = 0
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -18,12 +22,8 @@ final class FilteredOrdersHeaderBar: UIView {
     }
 
     func setNumberOfFilters(_ filters: Int) {
-        guard filters != 0 else {
-            filtersNumberLabel.isHidden = true
-            return
-        }
-        filtersNumberLabel.isHidden = false
-        filtersNumberLabel.text = "\(filters)"
+        numberOfFilters = filters
+        configureLabels()
     }
 }
 
@@ -44,15 +44,19 @@ private extension FilteredOrdersHeaderBar {
     ///
     func configureLabels() {
         mainLabel.applyHeadlineStyle()
-        mainLabel.text = Localization.mainLabel
+        mainLabel.text = numberOfFilters == 0 ? Localization.noFiltersApplied : Localization.filtersApplied
         filtersButtonLabel.applySubheadlineStyle()
         filtersButtonLabel.text = Localization.filters
         filtersNumberLabel.applyFootnoteStyle()
+        filtersNumberLabel.isHidden = numberOfFilters == 0
+        filtersNumberLabel.text = "\(numberOfFilters)"
     }
 
     enum Localization {
-        static let mainLabel = NSLocalizedString("Filtered Orders",
-                                                 comment: "Filtered Orders header bar label on top of order list")
+        static let noFiltersApplied = NSLocalizedString("All Orders",
+                                                        comment: "Header bar label on top of order list when no filters are applied")
+        static let filtersApplied = NSLocalizedString("Filtered Orders",
+                                                      comment: "Header bar label on top of order list when filters are applied")
         static let filters = NSLocalizedString("Filters",
                                                comment: "Filters button text on header bar on top of order list")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -17,6 +17,14 @@ final class FilteredOrdersHeaderBar: UIView {
         configureLabels()
     }
 
+    func setNumberOfFilters(_ filters: Int) {
+        guard filters != 0 else {
+            filtersNumberLabel.isHidden = true
+            return
+        }
+        filtersNumberLabel.isHidden = false
+        filtersNumberLabel.text = "\(filters)"
+    }
 }
 
 // MARK: - Setup

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -40,6 +40,8 @@ private extension FilteredOrdersHeaderBar {
         backgroundColor = .listForeground
     }
 
+    /// Setup: Filters View
+    ///
     func configureFiltersView() {
         filtersView.layer.cornerRadius = 14.0
         filtersView.layer.borderWidth = 1.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -26,7 +26,7 @@ final class FilteredOrdersHeaderBar: UIView {
         configureButtons()
     }
 
-    @IBAction func filterButtonTapped(_ sender: Any) {
+    @IBAction private func filterButtonTapped(_ sender: Any) {
         onAction?()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -6,13 +6,14 @@ import UIKit
 final class FilteredOrdersHeaderBar: UIView {
 
     @IBOutlet private weak var mainLabel: UILabel!
+    @IBOutlet private weak var filtersView: UIView!
     @IBOutlet private weak var filtersButtonLabel: UILabel!
     @IBOutlet private weak var filtersNumberLabel: UILabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
         configureBackground()
+        configureFiltersView()
         configureLabels()
     }
 
@@ -23,6 +24,12 @@ final class FilteredOrdersHeaderBar: UIView {
 private extension FilteredOrdersHeaderBar {
     func configureBackground() {
         backgroundColor = .listForeground
+    }
+
+    func configureFiltersView() {
+        filtersView.layer.cornerRadius = 14.0
+        filtersView.layer.borderWidth = 1.0
+        filtersView.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
     }
 
     /// Setup: Labels

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -14,6 +14,8 @@ final class FilteredOrdersHeaderBar: UIView {
     ///
     private var numberOfFilters = 0
 
+    var onAction: (() -> Void)?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -24,6 +26,10 @@ final class FilteredOrdersHeaderBar: UIView {
     func setNumberOfFilters(_ filters: Int) {
         numberOfFilters = filters
         configureLabels()
+    }
+
+    @objc private func viewTapped() {
+        onAction?()
     }
 }
 
@@ -38,6 +44,9 @@ private extension FilteredOrdersHeaderBar {
         filtersView.layer.cornerRadius = 14.0
         filtersView.layer.borderWidth = 1.0
         filtersView.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
+
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+        filtersView.addGestureRecognizer(recognizer)
     }
 
     /// Setup: Labels

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+/// A view with a title on the left side, and tappable component on the right side showing how many filters are applied to the order list.
+/// Used on top of the Order List screen.
+///
+final class FilteredOrdersHeaderBar: UIView {
+
+    @IBOutlet private weak var mainLabel: UILabel!
+    @IBOutlet private weak var filtersButtonLabel: UILabel!
+    @IBOutlet private weak var filtersNumberLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureBackground()
+        configureLabels()
+    }
+
+
+}
+
+// MARK: - Setup
+
+private extension FilteredOrdersHeaderBar {
+    func configureBackground() {
+        backgroundColor = .listForeground
+    }
+
+    /// Setup: Labels
+    ///
+    func configureLabels() {
+        mainLabel.applyHeadlineStyle()
+        filtersButtonLabel.applySubheadlineStyle()
+        filtersNumberLabel.applyFootnoteStyle()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.swift
@@ -55,6 +55,7 @@ private extension FilteredOrdersHeaderBar {
         String.localizedStringWithFormat(Localization.buttonWithActiveFilters, numberOfFilters)
 
         filterButton.setTitle(title, for: .normal)
+        filterButton.contentEdgeInsets = .zero
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -23,37 +23,49 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
-                    <rect key="frame" x="276" y="0.0" width="83" height="44"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="34c-zg-V3z">
+                    <rect key="frame" x="260" y="8" width="99" height="28"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
-                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="44"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
-                            <rect key="frame" x="41.5" y="0.0" width="41.5" height="44"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
+                            <rect key="frame" x="8" y="4" width="83" height="20.5"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
+                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
+                                    <rect key="frame" x="41.5" y="0.0" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
                     </subviews>
-                </stackView>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="P55-TE-oxY" firstAttribute="leading" secondItem="34c-zg-V3z" secondAttribute="leading" constant="8" id="6aM-sM-MR0"/>
+                        <constraint firstItem="P55-TE-oxY" firstAttribute="centerY" secondItem="34c-zg-V3z" secondAttribute="centerY" id="Qaj-Ua-xWs"/>
+                        <constraint firstAttribute="height" constant="28" id="t8e-fB-Ai6"/>
+                        <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="8" id="u1L-jA-nHA"/>
+                    </constraints>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="DSK-6z-QUa"/>
             <constraints>
-                <constraint firstItem="P55-TE-oxY" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="I97-ZJ-Njt"/>
-                <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="16" id="UyD-zE-enW"/>
+                <constraint firstItem="34c-zg-V3z" firstAttribute="centerY" secondItem="eDg-Zp-eCF" secondAttribute="centerY" id="Dxb-3k-0d0"/>
+                <constraint firstAttribute="trailing" secondItem="34c-zg-V3z" secondAttribute="trailing" constant="16" id="IqR-eo-3Ec"/>
                 <constraint firstItem="r3U-zo-uYF" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Vq0-Yg-FRD"/>
                 <constraint firstAttribute="bottom" secondItem="r3U-zo-uYF" secondAttribute="bottom" id="W7n-Hy-Hyd"/>
                 <constraint firstItem="r3U-zo-uYF" firstAttribute="leading" secondItem="eDg-Zp-eCF" secondAttribute="leading" constant="16" id="pG9-uN-iXD"/>
-                <constraint firstItem="DSK-6z-QUa" firstAttribute="bottom" secondItem="P55-TE-oxY" secondAttribute="bottom" id="t98-KC-Y4V"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="filtersButtonLabel" destination="Y4N-fM-glL" id="slT-Fb-M5m"/>
                 <outlet property="filtersNumberLabel" destination="QuU-Io-Dz9" id="HBo-dZ-pYI"/>
+                <outlet property="filtersView" destination="34c-zg-V3z" id="PrQ-7k-vYX"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>
             <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,69 +23,33 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="34c-zg-V3z">
-                    <rect key="frame" x="47.5" y="8" width="311.5" height="28"/>
-                    <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
-                            <rect key="frame" x="12" y="-50" width="287.5" height="128"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
-                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="128"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6eS-cm-nck">
-                                    <rect key="frame" x="47.5" y="0.0" width="240" height="128"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
-                                            <rect key="frame" x="6" y="54" width="228" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstItem="QuU-Io-Dz9" firstAttribute="centerY" secondItem="6eS-cm-nck" secondAttribute="centerY" id="DqI-lO-mNj"/>
-                                        <constraint firstItem="QuU-Io-Dz9" firstAttribute="leading" secondItem="6eS-cm-nck" secondAttribute="leading" constant="6" id="OFj-Af-Vpj"/>
-                                        <constraint firstAttribute="trailing" secondItem="QuU-Io-Dz9" secondAttribute="trailing" constant="6" id="y5I-wi-aXG"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
+                    <rect key="frame" x="305" y="0.0" width="54" height="44"/>
                     <constraints>
-                        <constraint firstItem="P55-TE-oxY" firstAttribute="leading" secondItem="34c-zg-V3z" secondAttribute="leading" constant="12" id="6aM-sM-MR0"/>
-                        <constraint firstItem="P55-TE-oxY" firstAttribute="centerY" secondItem="34c-zg-V3z" secondAttribute="centerY" id="Qaj-Ua-xWs"/>
-                        <constraint firstAttribute="height" constant="28" id="t8e-fB-Ai6"/>
-                        <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="12" id="u1L-jA-nHA"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
                     </constraints>
-                </view>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" title="Button"/>
+                    <connections>
+                        <action selector="filterButtonTapped:" destination="eDg-Zp-eCF" eventType="touchUpInside" id="8Et-eL-Ur8"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="DSK-6z-QUa"/>
             <constraints>
-                <constraint firstItem="34c-zg-V3z" firstAttribute="centerY" secondItem="eDg-Zp-eCF" secondAttribute="centerY" id="Dxb-3k-0d0"/>
-                <constraint firstAttribute="trailing" secondItem="34c-zg-V3z" secondAttribute="trailing" constant="16" id="IqR-eo-3Ec"/>
+                <constraint firstItem="3R4-Zy-CEM" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Gqp-AK-j9u"/>
+                <constraint firstItem="DSK-6z-QUa" firstAttribute="bottom" secondItem="3R4-Zy-CEM" secondAttribute="bottom" id="VSR-Qd-Cs2"/>
                 <constraint firstItem="r3U-zo-uYF" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Vq0-Yg-FRD"/>
                 <constraint firstAttribute="bottom" secondItem="r3U-zo-uYF" secondAttribute="bottom" id="W7n-Hy-Hyd"/>
                 <constraint firstItem="r3U-zo-uYF" firstAttribute="leading" secondItem="eDg-Zp-eCF" secondAttribute="leading" constant="16" id="pG9-uN-iXD"/>
+                <constraint firstAttribute="trailing" secondItem="3R4-Zy-CEM" secondAttribute="trailing" constant="16" id="sfp-QN-QDn"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="filtersButtonLabel" destination="Y4N-fM-glL" id="slT-Fb-M5m"/>
-                <outlet property="filtersNumberLabel" destination="QuU-Io-Dz9" id="HBo-dZ-pYI"/>
-                <outlet property="filtersNumberView" destination="6eS-cm-nck" id="zyG-U2-eJE"/>
-                <outlet property="filtersView" destination="34c-zg-V3z" id="PrQ-7k-vYX"/>
+                <outlet property="filterButton" destination="3R4-Zy-CEM" id="Cah-6b-bfB"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>
             <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -24,10 +24,10 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="34c-zg-V3z">
-                    <rect key="frame" x="254" y="8" width="105" height="28"/>
+                    <rect key="frame" x="246" y="8" width="113" height="28"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
-                            <rect key="frame" x="8" y="4" width="89" height="20.5"/>
+                            <rect key="frame" x="12" y="4" width="89" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
                                     <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -46,10 +46,10 @@
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="P55-TE-oxY" firstAttribute="leading" secondItem="34c-zg-V3z" secondAttribute="leading" constant="8" id="6aM-sM-MR0"/>
+                        <constraint firstItem="P55-TE-oxY" firstAttribute="leading" secondItem="34c-zg-V3z" secondAttribute="leading" constant="12" id="6aM-sM-MR0"/>
                         <constraint firstItem="P55-TE-oxY" firstAttribute="centerY" secondItem="34c-zg-V3z" secondAttribute="centerY" id="Qaj-Ua-xWs"/>
                         <constraint firstAttribute="height" constant="28" id="t8e-fB-Ai6"/>
-                        <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="8" id="u1L-jA-nHA"/>
+                        <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="12" id="u1L-jA-nHA"/>
                     </constraints>
                 </view>
             </subviews>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="eDg-Zp-eCF" customClass="FilteredOrdersHeaderBar" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
+                    <rect key="frame" x="16" y="0.0" width="41.5" height="44"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="44" id="nJf-yc-v2W"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
+                    <rect key="frame" x="276" y="0.0" width="83" height="44"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
+                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="44"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
+                            <rect key="frame" x="41.5" y="0.0" width="41.5" height="44"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="DSK-6z-QUa"/>
+            <constraints>
+                <constraint firstItem="P55-TE-oxY" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="I97-ZJ-Njt"/>
+                <constraint firstAttribute="trailing" secondItem="P55-TE-oxY" secondAttribute="trailing" constant="16" id="UyD-zE-enW"/>
+                <constraint firstItem="r3U-zo-uYF" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Vq0-Yg-FRD"/>
+                <constraint firstAttribute="bottom" secondItem="r3U-zo-uYF" secondAttribute="bottom" id="W7n-Hy-Hyd"/>
+                <constraint firstItem="r3U-zo-uYF" firstAttribute="leading" secondItem="eDg-Zp-eCF" secondAttribute="leading" constant="16" id="pG9-uN-iXD"/>
+                <constraint firstItem="DSK-6z-QUa" firstAttribute="bottom" secondItem="P55-TE-oxY" secondAttribute="bottom" id="t98-KC-Y4V"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="filtersButtonLabel" destination="Y4N-fM-glL" id="slT-Fb-M5m"/>
+                <outlet property="filtersNumberLabel" destination="QuU-Io-Dz9" id="HBo-dZ-pYI"/>
+                <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
+            </connections>
+            <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,23 +25,34 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="34c-zg-V3z">
-                    <rect key="frame" x="246" y="8" width="113" height="28"/>
+                    <rect key="frame" x="47.5" y="8" width="311.5" height="28"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
-                            <rect key="frame" x="12" y="4" width="89" height="20.5"/>
+                            <rect key="frame" x="12" y="-50" width="287.5" height="128"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
-                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="128"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
-                                    <rect key="frame" x="47.5" y="0.0" width="41.5" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6eS-cm-nck">
+                                    <rect key="frame" x="47.5" y="0.0" width="240" height="128"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
+                                            <rect key="frame" x="6" y="54" width="228" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstItem="QuU-Io-Dz9" firstAttribute="centerY" secondItem="6eS-cm-nck" secondAttribute="centerY" id="DqI-lO-mNj"/>
+                                        <constraint firstItem="QuU-Io-Dz9" firstAttribute="leading" secondItem="6eS-cm-nck" secondAttribute="leading" constant="6" id="OFj-Af-Vpj"/>
+                                        <constraint firstAttribute="trailing" secondItem="QuU-Io-Dz9" secondAttribute="trailing" constant="6" id="y5I-wi-aXG"/>
+                                    </constraints>
+                                </view>
                             </subviews>
                         </stackView>
                     </subviews>
@@ -65,10 +77,16 @@
             <connections>
                 <outlet property="filtersButtonLabel" destination="Y4N-fM-glL" id="slT-Fb-M5m"/>
                 <outlet property="filtersNumberLabel" destination="QuU-Io-Dz9" id="HBo-dZ-pYI"/>
+                <outlet property="filtersNumberView" destination="6eS-cm-nck" id="zyG-U2-eJE"/>
                 <outlet property="filtersView" destination="34c-zg-V3z" id="PrQ-7k-vYX"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>
             <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filter bar/FilteredOrdersHeaderBar.xib
@@ -24,10 +24,10 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="34c-zg-V3z">
-                    <rect key="frame" x="260" y="8" width="99" height="28"/>
+                    <rect key="frame" x="254" y="8" width="105" height="28"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
-                            <rect key="frame" x="8" y="4" width="83" height="20.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="P55-TE-oxY">
+                            <rect key="frame" x="8" y="4" width="89" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4N-fM-glL">
                                     <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -36,7 +36,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QuU-Io-Dz9">
-                                    <rect key="frame" x="41.5" y="0.0" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="47.5" y="0.0" width="41.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -27,10 +27,14 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
     ///
     @IBOutlet weak var topStackView: UIStackView!
 
-    /// The top bar for apply a filter, that will be embedded inside the stackview, on top of everything.
+    /// The top bar for apply filters, that will be embedded inside the stackview, on top of everything.
     ///
     private var filteredOrdersBar: FilteredOrdersHeaderBar = {
-        return FilteredOrdersHeaderBar.instantiateFromNib()
+        let filteredOrdersBar: FilteredOrdersHeaderBar = FilteredOrdersHeaderBar.instantiateFromNib()
+        filteredOrdersBar.onAction = {
+            // TODO: handle action
+        }
+        return filteredOrdersBar
     }()
 
     private lazy var analytics = ServiceLocator.analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -23,6 +23,16 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
     ///
     @IBOutlet private var buttonBarBackgroundView: UIView!
 
+    /// The stack view that will embed the headers (filtered orders bar and tab strip)
+    ///
+    @IBOutlet weak var topStackView: UIStackView!
+
+    /// The top bar for apply a filter, that will be embedded inside the stackview, on top of everything.
+    ///
+    private var filteredOrdersBar: FilteredOrdersHeaderBar = {
+        return FilteredOrdersHeaderBar.instantiateFromNib()
+    }()
+
     private lazy var analytics = ServiceLocator.analytics
 
     private lazy var viewModel = OrdersTabbedViewModel(siteID: siteID)
@@ -39,6 +49,12 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
     }
 
     override func viewDidLoad() {
+
+        let isOrderListFiltersEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderListFilters)
+        if isOrderListFiltersEnabled {
+            topStackView.addArrangedSubview(filteredOrdersBar)
+        }
+
         // `configureTabStrip` must be called before `super.viewDidLoad()` or else the selection
         // highlight will be black. ¯\_(ツ)_/¯
         configureTabStrip()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -50,6 +50,8 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
 
     override func viewDidLoad() {
 
+        // Display the filtered orders bar
+        // if the feature flag is enabled
         let isOrderListFiltersEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderListFilters)
         if isOrderListFiltersEnabled {
             topStackView.addArrangedSubview(filteredOrdersBar)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
@@ -23,19 +23,16 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wqX-zR-Ley">
+                    <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nqW-eP-g9y">
                     <rect key="frame" x="0.0" y="44" width="414" height="0.0"/>
                     <constraints>
                         <constraint firstAttribute="height" priority="100" id="05s-ZC-Zgk"/>
                     </constraints>
                 </stackView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wqX-zR-Ley">
-                    <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="44" id="G6J-ed-pDG"/>
-                    </constraints>
-                </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="7lu-ed-U2a" customClass="ButtonBarView" customModule="XLPagerTabStrip">
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -58,18 +55,19 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="1oC-b9-sf9"/>
+                <constraint firstItem="wqX-zR-Ley" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="4EI-Hm-Ndo"/>
                 <constraint firstAttribute="trailing" secondItem="VD7-Yu-YwE" secondAttribute="trailing" id="9vb-3t-PWE"/>
-                <constraint firstItem="wqX-zR-Ley" firstAttribute="top" secondItem="nqW-eP-g9y" secondAttribute="bottom" id="A3q-N1-Fwo"/>
                 <constraint firstItem="7lu-ed-U2a" firstAttribute="top" secondItem="nqW-eP-g9y" secondAttribute="bottom" id="F32-cv-57F"/>
+                <constraint firstAttribute="trailing" secondItem="wqX-zR-Ley" secondAttribute="trailing" id="F8T-7Z-XKi"/>
+                <constraint firstItem="VD7-Yu-YwE" firstAttribute="top" secondItem="wqX-zR-Ley" secondAttribute="bottom" id="GMd-fY-hoa"/>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="top" secondItem="7lu-ed-U2a" secondAttribute="bottom" id="L4N-Ce-OKC"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="bottom" secondItem="VD7-Yu-YwE" secondAttribute="bottom" id="LZC-0z-fDh"/>
-                <constraint firstItem="wqX-zR-Ley" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="Lo6-gd-Emr"/>
-                <constraint firstAttribute="trailing" secondItem="wqX-zR-Ley" secondAttribute="trailing" id="SAn-A3-97p"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="nqW-eP-g9y" secondAttribute="trailing" id="TZF-MH-fH4"/>
                 <constraint firstItem="nqW-eP-g9y" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="XCG-Mm-PUt"/>
                 <constraint firstItem="nqW-eP-g9y" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="YPO-jO-rX3"/>
                 <constraint firstItem="7lu-ed-U2a" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="Zdd-er-iM1"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="7lu-ed-U2a" secondAttribute="trailing" id="lJ7-pc-DWf"/>
+                <constraint firstItem="wqX-zR-Ley" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="w0i-dw-rEZ"/>
             </constraints>
             <point key="canvasLocation" x="-317.39130434782612" y="152.67857142857142"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,6 +14,7 @@
                 <outlet property="buttonBarBackgroundView" destination="wqX-zR-Ley" id="n0e-zz-Fag"/>
                 <outlet property="buttonBarView" destination="7lu-ed-U2a" id="CeJ-gT-RxY"/>
                 <outlet property="containerView" destination="VD7-Yu-YwE" id="3vO-sb-eUc"/>
+                <outlet property="topStackView" destination="nqW-eP-g9y" id="qrA-O3-bDo"/>
                 <outlet property="view" destination="xuO-pm-Bnd" id="21G-dF-888"/>
             </connections>
         </placeholder>
@@ -21,6 +23,12 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nqW-eP-g9y">
+                    <rect key="frame" x="0.0" y="44" width="414" height="0.0"/>
+                    <constraints>
+                        <constraint firstAttribute="height" priority="100" id="05s-ZC-Zgk"/>
+                    </constraints>
+                </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wqX-zR-Ley">
                     <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -51,16 +59,19 @@
             <constraints>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="1oC-b9-sf9"/>
                 <constraint firstAttribute="trailing" secondItem="VD7-Yu-YwE" secondAttribute="trailing" id="9vb-3t-PWE"/>
+                <constraint firstItem="wqX-zR-Ley" firstAttribute="top" secondItem="nqW-eP-g9y" secondAttribute="bottom" id="A3q-N1-Fwo"/>
+                <constraint firstItem="7lu-ed-U2a" firstAttribute="top" secondItem="nqW-eP-g9y" secondAttribute="bottom" id="F32-cv-57F"/>
                 <constraint firstItem="VD7-Yu-YwE" firstAttribute="top" secondItem="7lu-ed-U2a" secondAttribute="bottom" id="L4N-Ce-OKC"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="bottom" secondItem="VD7-Yu-YwE" secondAttribute="bottom" id="LZC-0z-fDh"/>
                 <constraint firstItem="wqX-zR-Ley" firstAttribute="leading" secondItem="xuO-pm-Bnd" secondAttribute="leading" id="Lo6-gd-Emr"/>
-                <constraint firstItem="7lu-ed-U2a" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="Rct-WJ-OQP"/>
                 <constraint firstAttribute="trailing" secondItem="wqX-zR-Ley" secondAttribute="trailing" id="SAn-A3-97p"/>
+                <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="nqW-eP-g9y" secondAttribute="trailing" id="TZF-MH-fH4"/>
+                <constraint firstItem="nqW-eP-g9y" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="XCG-Mm-PUt"/>
+                <constraint firstItem="nqW-eP-g9y" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="YPO-jO-rX3"/>
                 <constraint firstItem="7lu-ed-U2a" firstAttribute="leading" secondItem="rGE-vr-B04" secondAttribute="leading" id="Zdd-er-iM1"/>
                 <constraint firstItem="rGE-vr-B04" firstAttribute="trailing" secondItem="7lu-ed-U2a" secondAttribute="trailing" id="lJ7-pc-DWf"/>
-                <constraint firstItem="wqX-zR-Ley" firstAttribute="top" secondItem="rGE-vr-B04" secondAttribute="top" id="nZy-cJ-0KO"/>
             </constraints>
-            <point key="canvasLocation" x="-317" y="153"/>
+            <point key="canvasLocation" x="-317.39130434782612" y="152.67857142857142"/>
         </view>
     </objects>
     <resources>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -610,6 +610,8 @@
 		4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4541D889270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift */; };
 		45455E322657C3F300BBB0C4 /* Shimmer in Frameworks */ = {isa = PBXBuildFile; productRef = 45455E312657C3F300BBB0C4 /* Shimmer */; };
 		45455EFA26580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45455EF926580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift */; };
+		4546E09A271F0942003836F3 /* FilteredOrdersHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4546E098271F0942003836F3 /* FilteredOrdersHeaderBar.swift */; };
+		4546E09B271F0942003836F3 /* FilteredOrdersHeaderBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4546E099271F0942003836F3 /* FilteredOrdersHeaderBar.xib */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
 		4552085B25829091001CF873 /* AddAttributeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4552085A25829091001CF873 /* AddAttributeViewModelTests.swift */; };
 		45527A412472C6160078D609 /* SwitchStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45527A402472C6160078D609 /* SwitchStoreUseCase.swift */; };
@@ -2011,6 +2013,8 @@
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		4541D889270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarriersSectionViewModel.swift; sourceTree = "<group>"; };
 		45455EF926580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCarrierRowViewModel.swift; sourceTree = "<group>"; };
+		4546E098271F0942003836F3 /* FilteredOrdersHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteredOrdersHeaderBar.swift; sourceTree = "<group>"; };
+		4546E099271F0942003836F3 /* FilteredOrdersHeaderBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilteredOrdersHeaderBar.xib; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		4552085A25829091001CF873 /* AddAttributeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeViewModelTests.swift; sourceTree = "<group>"; };
 		45527A402472C6160078D609 /* SwitchStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreUseCase.swift; sourceTree = "<group>"; };
@@ -4223,6 +4227,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		4546E095271F08CD003836F3 /* Order Filter bar */ = {
+			isa = PBXGroup;
+			children = (
+				4546E098271F0942003836F3 /* FilteredOrdersHeaderBar.swift */,
+				4546E099271F0942003836F3 /* FilteredOrdersHeaderBar.xib */,
+			);
+			path = "Order Filter bar";
+			sourceTree = "<group>";
+		};
 		455208592582907C001CF873 /* Add Product Variation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5741,6 +5754,7 @@
 				57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */,
 				57C5FF7D250925000074EC26 /* OrderListViewModel.swift */,
 				57A49127250A7EB2000FEF21 /* OrderListViewController.swift */,
+				4546E095271F08CD003836F3 /* Order Filter bar */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -6968,6 +6982,7 @@
 				CE37C04522984E81008DCB39 /* PickListTableViewCell.xib in Resources */,
 				31C21FA626D994B700916E2E /* SeveralReadersFoundViewController.xib in Resources */,
 				D85B8334222FABD1002168F3 /* StatusListTableViewCell.xib in Resources */,
+				4546E09B271F0942003836F3 /* FilteredOrdersHeaderBar.xib in Resources */,
 				5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */,
 				45B9C63F23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib in Resources */,
 				B5F571A621BEC92A0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.xib in Resources */,
@@ -7672,6 +7687,7 @@
 				B57C5C9421B80E4700FF82B2 /* Data+Woo.swift in Sources */,
 				453A907925EFB6D6006EE892 /* ButtonActivityIndicator.swift in Sources */,
 				E1C5E78426C2B8E8008D4C47 /* Site+Woo.swift in Sources */,
+				4546E09A271F0942003836F3 /* FilteredOrdersHeaderBar.swift in Sources */,
 				B554E17B2152F27200F31188 /* UILabel+Appearance.swift in Sources */,
 				020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */,
 				7441EBC9226A71AA008BF83D /* TitleBodyTableViewCell.swift in Sources */,


### PR DESCRIPTION
Part of #5243

## Description
As part of the Order List filters project, I added a new feature flag that will be useful to hide/show the new top bar in the Order List that will be useful for displaying and editing the filters on the order list.

## Testing
1. Open the app, and press the "Orders" tab.
2. You should see the new top bar that displays the label "All Orders" on the left, and a button "Filter" on the right.
3. Go into the code, and edit the feature flag `orderListFilters` under `DefaultFeatureFlagService`, changing the return to `false`.
4. Repeat from the beginning. This time, the top bar should be hidden.

## Screenshots
| Light mode             |  Dark mode |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 13 Pro - 2021-10-20 at 15 57 59](https://user-images.githubusercontent.com/495617/138108109-afbb6f51-afdc-4a15-9f75-768bbd99c3c8.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-10-20 at 15 57 50](https://user-images.githubusercontent.com/495617/138108120-edccff40-674a-4056-a2d2-396852fbd2a0.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
