### PR TITLE
Added the new optional parameter `after` when fetching orders

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -9,7 +9,9 @@ public class OrdersRemote: Remote {
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote orders.
     ///     - status: Filters the Orders by the specified Status, if any.
-    ///     - before: If given, exclude orders created before this date/time. Passing a local date is fine. This
+    ///     - after: If given, limit response to orders published after a given compliant date.  Passing a local date is fine. This
+    ///               method will convert it to UTC ISO 8601 before calling the REST API.
+    ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of Orders to be retrieved per page.
@@ -17,6 +19,7 @@ public class OrdersRemote: Remote {
     ///
     public func loadAllOrders(for siteID: Int64,
                               statusKey: String? = nil,
+                              after: Date? = nil,
                               before: Date? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
@@ -31,6 +34,9 @@ public class OrdersRemote: Remote {
                 ParameterKeys.fields: ParameterValues.listFieldValues,
             ]
 
+            if let after = after {
+                parameters[ParameterKeys.after] = utcDateFormatter.string(from: after)
+            }
             if let before = before {
                 parameters[ParameterKeys.before] = utcDateFormatter.string(from: before)
             }
@@ -233,6 +239,7 @@ public extension OrdersRemote {
         static let perPage: String          = "per_page"
         static let statusKey: String        = "status"
         static let fields: String           = "_fields"
+        static let after: String            = "after"
         static let before: String           = "before"
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -34,7 +34,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -59,7 +59,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -85,7 +85,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -110,7 +110,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredAndAllOrders(_, let statusKey, _, _, let deleteAllBeforeSaving, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -131,7 +131,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statusKey, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statusKey, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -153,7 +153,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statusKey, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statusKey, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -18,12 +18,15 @@ public enum OrderAction: Action {
     ///                  all orders list will be fetched. See `OrderStatusEnum` for possible values.
     ///     - deleteAllBeforeSaving: If true, all the orders in the db will be deleted before any
     ///                  order from the fetch requests will be saved.
+    ///     - after: Only include orders created after this date. The time zone of the `Date`
+    ///               doesn't matter. It will be converted to UTC later.
     ///     - before: Only include orders created before this date. The time zone of the `Date`
     ///               doesn't matter. It will be converted to UTC later.
     ///
     case fetchFilteredAndAllOrders(
         siteID: Int64,
         statusKey: String?,
+        after: Date? = nil,
         before: Date? = nil,
         deleteAllBeforeSaving: Bool,
         pageSize: Int,
@@ -33,11 +36,14 @@ public enum OrderAction: Action {
     /// Synchronizes the Orders matching the specified criteria.
     ///
     /// - Parameters:
+    ///     - after: Only include orders created after this date. The time zone of the `Date`
+    ///               doesn't matter. It will be converted to UTC later.
     ///     - before: Only include orders created before this date. The time zone of the `Date`
     ///               doesn't matter. It will be converted to UTC later.
     ///
     case synchronizeOrders(siteID: Int64,
                            statusKey: String?,
+                           after: Date? = nil,
                            before: Date? = nil,
                            pageNumber: Int,
                            pageSize: Int,

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -10,7 +10,7 @@ struct MockOrderActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-            case .fetchFilteredAndAllOrders(let siteID, _, _, _, _, let onCompletion):
+            case .fetchFilteredAndAllOrders(let siteID, _, _, _, _, _, let onCompletion):
                 fetchFilteredAndAllOrders(siteID: siteID, onCompletion: onCompletion)
             case .retrieveOrder(let siteID, let orderID, let onCompletion):
                 onCompletion(objectGraph.order(forSiteId: siteID, orderId: orderID), nil)

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -40,16 +40,18 @@ public class OrderStore: Store {
             retrieveOrder(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
         case .searchOrders(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .fetchFilteredAndAllOrders(let siteID, let statusKey, let before, let deleteAllBeforeSaving, let pageSize, let onCompletion):
+        case .fetchFilteredAndAllOrders(let siteID, let statusKey, let after, let before, let deleteAllBeforeSaving, let pageSize, let onCompletion):
             fetchFilteredAndAllOrders(siteID: siteID,
                                       statusKey: statusKey,
+                                      after: after,
                                       before: before,
                                       deleteAllBeforeSaving: deleteAllBeforeSaving,
                                       pageSize: pageSize,
                                       onCompletion: onCompletion)
-        case .synchronizeOrders(let siteID, let statusKey, let before, let pageNumber, let pageSize, let onCompletion):
+        case .synchronizeOrders(let siteID, let statusKey, let after, let before, let pageNumber, let pageSize, let onCompletion):
             synchronizeOrders(siteID: siteID,
                               statusKey: statusKey,
+                              after: after,
                               before: before,
                               pageNumber: pageNumber,
                               pageSize: pageSize,
@@ -111,6 +113,7 @@ private extension OrderStore {
     ///
     func fetchFilteredAndAllOrders(siteID: Int64,
                                    statusKey: String?,
+                                   after: Date?,
                                    before: Date?,
                                    deleteAllBeforeSaving: Bool,
                                    pageSize: Int,
@@ -151,6 +154,7 @@ private extension OrderStore {
             }
             self.remote.loadAllOrders(for: siteID,
                                  statusKey: statusKey,
+                                 after: after,
                                  before: before,
                                  pageNumber: pageNumber,
                                  pageSize: pageSize) { [weak self] result in
@@ -202,6 +206,7 @@ private extension OrderStore {
     ///
     func synchronizeOrders(siteID: Int64,
                            statusKey: String?,
+                           after: Date?,
                            before: Date?,
                            pageNumber: Int,
                            pageSize: Int,
@@ -209,6 +214,7 @@ private extension OrderStore {
         let startTime = Date()
         remote.loadAllOrders(for: siteID,
                              statusKey: statusKey,
+                             after: after,
                              before: before,
                              pageNumber: pageNumber,
                              pageSize: pageSize) { [weak self] result in


### PR DESCRIPTION
Part of #5243 

Added the parameter `after` inside the methods for fetching the orders (Networking + Yosemite layers).
From Woo API doc about the parameter `after`: `Limit response to resources published after a given ISO8601 compliant date.`
 This will be useful for completing #5243 where we will integrate the functionality for filtering orders in a range of dates. 

## Testing
- Just CI, still not used in our code.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
