### PR TITLE
Update GeneralAppSettings with a custom decoding

### DIFF
--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -71,3 +71,18 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
         )
     }
 }
+
+// MARK: Custom Decoding
+extension GeneralAppSettings {
+    /// We need a custom decoding to make sure decoding doesn't fail when this type is updated (eg: when adding new properties)
+    /// Otherwise we risk to lose previously stored information
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.installationDate = try container.decodeIfPresent(Date.self, forKey: .installationDate)
+        self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
+        self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
+        self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
+        self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
+    }
+}

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -72,10 +72,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     }
 }
 
-// MARK: Custom Decoding
+//// MARK: Custom Decoding
 extension GeneralAppSettings {
-    /// We need a custom decoding to make sure decoding doesn't fail when this type is updated (eg: when adding new properties)
-    /// Otherwise we risk to lose previously stored information
+    /// We need a custom decoding to make sure it doesn't fails when this type is updated (eg: when adding/removing new properties)
+    /// Otherwise we will lose previously stored information.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -84,5 +84,7 @@ extension GeneralAppSettings {
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
+
+        // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -55,4 +55,32 @@ class GeneralAppSettingsTests: XCTestCase {
         // Then
         XCTAssertEqual(newSettings.feedbacks[.general], newFeedback)
     }
+
+    func test_updating_properties_to_generalAppSettings_does_not_breaks_decoding() throws {
+        // Given
+        let currentDate = Date()
+        let feedbackSettings = [FeedbackType.general: FeedbackSettings(name: .general, status: .pending)]
+        let readers = ["aaaaa", "bbbbbb"]
+        let eligibilityInfo = EligibilityErrorInfo(name: "user", roles: ["admin"])
+        let previousSettings = GeneralAppSettings(installationDate: currentDate,
+                                                  feedbacks: feedbackSettings,
+                                                  isViewAddOnsSwitchEnabled: true,
+                                                  knownCardReaders: readers,
+                                                  lastEligibilityErrorInfo: eligibilityInfo)
+
+        let previousEncodedSettings = try JSONEncoder().encode(previousSettings)
+        var previousSettingsJson = try JSONSerialization.jsonObject(with: previousEncodedSettings, options: .allowFragments) as? [String: Any]
+
+        // When
+        previousSettingsJson?.removeValue(forKey: "isViewAddOnsSwitchEnabled")
+        let newEncodedSettings = try JSONSerialization.data(withJSONObject: previousSettingsJson as Any, options: .fragmentsAllowed)
+        let newSettings = try JSONDecoder().decode(GeneralAppSettings.self, from: newEncodedSettings)
+
+        // Then
+        assertEqual(newSettings.installationDate, currentDate)
+        assertEqual(newSettings.feedbacks, feedbackSettings)
+        assertEqual(newSettings.knownCardReaders, readers)
+        assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
+        assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
+    }
 }


### PR DESCRIPTION
# Why

While working on adding the quick pay prototype behind the experimental features screen I noticed that at some point my "View Add-Ons" feature switch value got lost.

After inspecting, I noticed that adding(or updating/removing) a property to `GeneralAppSettings` makes the previously-stored `GeneralAppSettings` decoding fail because the data structure does not match the new type definition. Then a new `GeneralAppSettings` is created and stored with default values.

# How

To fix this, a custom decoding for `GeneralAppSettings` has been added, where if a property is not present or is different a default value is given but without aborting the whole decoding process.

# Testing Steps

- Launch the app, navigate to the experimental features screen and make sure the view add-ons feature is on.

- Modify `GeneralAppSettings` to include a new property.
```swift
public var someValue: String = "dsa"
```

- Launch the app and make sure the view add-ons feature is still on.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
