### PR TITLE
Quick Pay: Hide quick pay behind the beta features screen

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -9,12 +9,14 @@ extension GeneralAppSettings {
         installationDate: NullableCopiableProp<Date> = .copy,
         feedbacks: CopiableProp<[FeedbackType: FeedbackSettings]> = .copy,
         isViewAddOnsSwitchEnabled: CopiableProp<Bool> = .copy,
+        isQuickPaySwitchEnabled: CopiableProp<Bool> = .copy,
         knownCardReaders: CopiableProp<[String]> = .copy,
         lastEligibilityErrorInfo: NullableCopiableProp<EligibilityErrorInfo> = .copy
     ) -> GeneralAppSettings {
         let installationDate = installationDate ?? self.installationDate
         let feedbacks = feedbacks ?? self.feedbacks
         let isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled ?? self.isViewAddOnsSwitchEnabled
+        let isQuickPaySwitchEnabled = isQuickPaySwitchEnabled ?? self.isQuickPaySwitchEnabled
         let knownCardReaders = knownCardReaders ?? self.knownCardReaders
         let lastEligibilityErrorInfo = lastEligibilityErrorInfo ?? self.lastEligibilityErrorInfo
 
@@ -22,6 +24,7 @@ extension GeneralAppSettings {
             installationDate: installationDate,
             feedbacks: feedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+            isQuickPaySwitchEnabled: isQuickPaySwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -89,6 +89,7 @@ extension GeneralAppSettings {
         self.installationDate = try container.decodeIfPresent(Date.self, forKey: .installationDate)
         self.feedbacks = try container.decodeIfPresent([FeedbackType: FeedbackSettings].self, forKey: .feedbacks) ?? [:]
         self.isViewAddOnsSwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isViewAddOnsSwitchEnabled) ?? false
+        self.isQuickPaySwitchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isQuickPaySwitchEnabled) ?? false
         self.knownCardReaders = try container.decodeIfPresent([String].self, forKey: .knownCardReaders) ?? []
         self.lastEligibilityErrorInfo = try container.decodeIfPresent(EligibilityErrorInfo.self, forKey: .lastEligibilityErrorInfo)
 

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -24,6 +24,10 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let isViewAddOnsSwitchEnabled: Bool
 
+    /// The state(`true` or `false`) for the Quick Pay feature switch.
+    ///
+    public let isQuickPaySwitchEnabled: Bool
+
     /// A list (possibly empty) of known card reader IDs - i.e. IDs of card readers that should be reconnected to automatically
     /// e.g. ["CHB204909005931"]
     ///
@@ -36,11 +40,13 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
     public init(installationDate: Date?,
                 feedbacks: [FeedbackType: FeedbackSettings],
                 isViewAddOnsSwitchEnabled: Bool,
+                isQuickPaySwitchEnabled: Bool,
                 knownCardReaders: [String],
                 lastEligibilityErrorInfo: EligibilityErrorInfo? = nil) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
         self.isViewAddOnsSwitchEnabled = isViewAddOnsSwitchEnabled
+        self.isQuickPaySwitchEnabled = isQuickPaySwitchEnabled
         self.knownCardReaders = knownCardReaders
         self.lastEligibilityErrorInfo = lastEligibilityErrorInfo
     }
@@ -66,6 +72,7 @@ public struct GeneralAppSettings: Codable, Equatable, GeneratedCopiable {
             installationDate: installationDate,
             feedbacks: updatedFeedbacks,
             isViewAddOnsSwitchEnabled: isViewAddOnsSwitchEnabled,
+            isQuickPaySwitchEnabled: isQuickPaySwitchEnabled,
             knownCardReaders: knownCardReaders,
             lastEligibilityErrorInfo: lastEligibilityErrorInfo
         )

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -78,6 +78,7 @@ class GeneralAppSettingsTests: XCTestCase {
         let previousSettings = GeneralAppSettings(installationDate: currentDate,
                                                   feedbacks: feedbackSettings,
                                                   isViewAddOnsSwitchEnabled: true,
+                                                  isQuickPaySwitchEnabled: true,
                                                   knownCardReaders: readers,
                                                   lastEligibilityErrorInfo: eligibilityInfo)
 
@@ -95,5 +96,6 @@ class GeneralAppSettingsTests: XCTestCase {
         assertEqual(newSettings.knownCardReaders, readers)
         assertEqual(newSettings.lastEligibilityErrorInfo, eligibilityInfo)
         assertEqual(newSettings.isViewAddOnsSwitchEnabled, false)
+        assertEqual(newSettings.isQuickPaySwitchEnabled, true)
     }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -6,7 +6,11 @@ class GeneralAppSettingsTests: XCTestCase {
     func test_it_returns_the_correct_status_of_a_stored_feedback() {
         // Given
         let feedback = FeedbackSettings(name: .general, status: .dismissed)
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: feedback], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
+        let settings = GeneralAppSettings(installationDate: nil,
+                                          feedbacks: [.general: feedback],
+                                          isViewAddOnsSwitchEnabled: false,
+                                          isQuickPaySwitchEnabled: false,
+                                          knownCardReaders: [])
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -17,7 +21,11 @@ class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_returns_pending_status_of_a_non_stored_feedback() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
+        let settings = GeneralAppSettings(installationDate: nil,
+                                          feedbacks: [:],
+                                          isViewAddOnsSwitchEnabled: false,
+                                          isQuickPaySwitchEnabled: false,
+                                          knownCardReaders: [])
 
         // When
         let loadedStatus = settings.feedbackStatus(of: .general)
@@ -33,6 +41,7 @@ class GeneralAppSettingsTests: XCTestCase {
             installationDate: nil,
             feedbacks: [.general: existingFeedback],
             isViewAddOnsSwitchEnabled: false,
+            isQuickPaySwitchEnabled: false,
             knownCardReaders: []
         )
 
@@ -46,7 +55,11 @@ class GeneralAppSettingsTests: XCTestCase {
 
     func test_it_adds_new_feedback_when_replacing_empty_feedback_store() {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
+        let settings = GeneralAppSettings(installationDate: nil,
+                                          feedbacks: [:],
+                                          isViewAddOnsSwitchEnabled: false,
+                                          isQuickPaySwitchEnabled: false,
+                                          knownCardReaders: [])
 
         // When
         let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -73,13 +73,19 @@ private extension BetaFeaturesViewController {
     ///
     func configureSections() {
         self.sections = [
-            productsSection()
+            productsSection(),
+            ordersSection()
         ]
     }
 
     func productsSection() -> Section {
         return Section(rows: [.orderAddOns,
                               .orderAddOnsDescription])
+    }
+
+    func ordersSection() -> Section {
+        Section(rows: [.quickPay,
+                       .quickPayDescription])
     }
 
     /// Register table cells.
@@ -104,6 +110,11 @@ private extension BetaFeaturesViewController {
             configureOrderAddOnsSwitch(cell: cell)
         case let cell as BasicTableViewCell where row == .orderAddOnsDescription:
             configureOrderAddOnsDescription(cell: cell)
+        // Orders
+        case let cell as SwitchTableViewCell where row == .quickPay:
+            configureQuickPaySwitch(cell: cell)
+        case let cell as BasicTableViewCell where row == .quickPayDescription:
+            configureQuickPayDescription(cell: cell)
         default:
             fatalError()
         }
@@ -142,6 +153,16 @@ private extension BetaFeaturesViewController {
     func configureOrderAddOnsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
         cell.textLabel?.text = Localization.orderAddOnsDescription
+    }
+
+    func configureQuickPaySwitch(cell: SwitchTableViewCell) {
+        configureCommonStylesForSwitchCell(cell)
+        cell.title = Localization.quickPayTitle
+    }
+
+    func configureQuickPayDescription(cell: BasicTableViewCell) {
+        configureCommonStylesForDescriptionCell(cell)
+        cell.textLabel?.text = Localization.quickPayDescription
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -17,6 +17,10 @@ class BetaFeaturesViewController: UIViewController {
     ///
     private var sections = [Section]()
 
+    /// Use case to tell us if the store is enrolled in the in-person payments program.
+    ///
+    private let paymentsStoreUseCase = CardPresentPaymentsOnboardingUseCase()
+
     init() {
         super.init(nibName: nil, bundle: nil)
     }
@@ -74,7 +78,7 @@ private extension BetaFeaturesViewController {
     func configureSections() {
         self.sections = [
             productsSection(),
-            ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickPayPrototype) ? ordersSection() : nil
+            ordersSection()
         ].compactMap { $0 }
     }
 
@@ -83,9 +87,15 @@ private extension BetaFeaturesViewController {
                               .orderAddOnsDescription])
     }
 
-    func ordersSection() -> Section {
-        Section(rows: [.quickPay,
-                       .quickPayDescription])
+    /// A section is returned only when the store is ready to receive payments
+    ///
+    func ordersSection() -> Section? {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickPayPrototype), paymentsStoreUseCase.state == .completed else {
+            return nil
+        }
+
+        return Section(rows: [.quickPay,
+                              .quickPayDescription])
     }
 
     /// Register table cells.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -74,8 +74,8 @@ private extension BetaFeaturesViewController {
     func configureSections() {
         self.sections = [
             productsSection(),
-            ordersSection()
-        ]
+            ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickPayPrototype) ? ordersSection() : nil
+        ].compactMap { $0 }
     }
 
     func productsSection() -> Section {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -158,6 +158,29 @@ private extension BetaFeaturesViewController {
     func configureQuickPaySwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
         cell.title = Localization.quickPayTitle
+
+        // Fetch switch's state stored value.
+        let action = AppSettingsAction.loadQuickPaySwitchState() { result in
+            guard let isEnabled = try? result.get() else {
+                return cell.isOn = false
+            }
+            cell.isOn = isEnabled
+        }
+        ServiceLocator.stores.dispatch(action)
+
+        // Change switch's state stored value
+        cell.onChange = { isSwitchOn in
+            // TODO: Add analytics
+
+            let action = AppSettingsAction.setQuickPayFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
+                // Roll back toggle if an error occurred
+                if result.isFailure {
+                    cell.isOn.toggle()
+                }
+            })
+            ServiceLocator.stores.dispatch(action)
+        }
+        cell.accessibilityIdentifier = "beta-features-order-quick-pay-cell"
     }
 
     func configureQuickPayDescription(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -207,11 +207,15 @@ private enum Row: CaseIterable {
     case orderAddOns
     case orderAddOnsDescription
 
+    // Orders.
+    case quickPay
+    case quickPayDescription
+
     var type: UITableViewCell.Type {
         switch self {
-        case .orderAddOns:
+        case .orderAddOns, .quickPay:
             return SwitchTableViewCell.self
-        case .orderAddOnsDescription:
+        case .orderAddOnsDescription, .quickPayDescription:
             return BasicTableViewCell.self
         }
     }
@@ -226,5 +230,9 @@ private extension BetaFeaturesViewController {
         static let orderAddOnsTitle = NSLocalizedString("View Add-Ons", comment: "Cell title on the beta features screen to enable the order add-ons feature")
         static let orderAddOnsDescription = NSLocalizedString("Test out viewing Order Add-Ons as we get ready to launch",
                                                               comment: "Cell description on the beta features screen to enable the order add-ons feature")
+
+        static let quickPayTitle = NSLocalizedString("Quick Order", comment: "Cell title on the beta features screen to enable the Quick Pay feature")
+        static let quickPayDescription = NSLocalizedString("Test out creating orders with minimal information as we get ready to launch",
+                                                              comment: "Cell description on the beta features screen to enable the Quick Pay feature")
     }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -101,6 +101,14 @@ public enum AppSettingsAction: Action {
     ///
     case loadOrderAddOnsSwitchState(onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Loads the most recent state for the Quick Pay beta feature switch
+    ///
+    case loadQuickPaySwitchState(onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Sets the state for the Quick Pay beta feature switch.
+    ///
+    case setQuickPayFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void)
+
     /// Remember the given card reader (to support automatic reconnection)
     /// where `cardReaderID` is a String e.g. "CHB204909005931"
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -130,6 +130,10 @@ public class AppSettingsStore: Store {
             setOrderAddOnsFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
         case .loadOrderAddOnsSwitchState(onCompletion: let onCompletion):
             loadOrderAddOnsSwitchState(onCompletion: onCompletion)
+        case .setQuickPayFeatureSwitchState(isEnabled: let isEnabled, onCompletion: let onCompletion):
+            setQuickPayFeatureSwitchState(isEnabled: isEnabled, onCompletion: onCompletion)
+        case .loadQuickPaySwitchState(onCompletion: let onCompletion):
+            loadQuickPaySwitchState(onCompletion: onCompletion)
         case .rememberCardReader(cardReaderID: let cardReaderID, onCompletion: let onCompletion):
             rememberCardReader(cardReaderID: cardReaderID, onCompletion: onCompletion)
         case .forgetCardReader(onCompletion: let onCompletion):
@@ -217,6 +221,26 @@ private extension AppSettingsStore {
         onCompletion(.success(settings.isViewAddOnsSwitchEnabled))
     }
 
+    /// Loads the current QuickPay beta feature switch state from `GeneralAppSettings`
+    ///
+    func loadQuickPaySwitchState(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        onCompletion(.success(settings.isQuickPaySwitchEnabled))
+    }
+
+    /// Sets the provided QuickPay beta feature switch state into `GeneralAppSettings`
+    ///
+    func setQuickPayFeatureSwitchState(isEnabled: Bool, onCompletion: (Result<Void, Error>) -> Void) {
+        do {
+            let settings = loadOrCreateGeneralAppSettings().copy(isQuickPaySwitchEnabled: isEnabled)
+            try saveGeneralAppSettings(settings)
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+
+    }
+
     /// Loads the last persisted eligibility error information from `GeneralAppSettings`
     ///
     func loadEligibilityErrorInfo(onCompletion: (Result<EligibilityErrorInfo, Error>) -> Void) {
@@ -245,6 +269,7 @@ private extension AppSettingsStore {
             return GeneralAppSettings(installationDate: nil,
                                       feedbacks: [:],
                                       isViewAddOnsSwitchEnabled: false,
+                                      isQuickPaySwitchEnabled: false,
                                       knownCardReaders: [],
                                       lastEligibilityErrorInfo: nil)
         }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -157,7 +157,10 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM5_is_true_if_no_settings_are_found() throws {
         // Given
-        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:], isViewAddOnsSwitchEnabled: false, knownCardReaders: [])
+        let settings = GeneralAppSettings(installationDate: nil,
+                                          feedbacks: [:], isViewAddOnsSwitchEnabled: false,
+                                          isQuickPaySwitchEnabled: false,
+                                          knownCardReaders: [])
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsVariations)
 
         // When
@@ -221,6 +224,7 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
             installationDate: instalationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
+            isQuickPaySwitchEnabled: false,
             knownCardReaders: []
         )
         return settings

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -446,6 +446,42 @@ final class AppSettingsStoreTests: XCTestCase {
         let isEnabled = try result.get()
         XCTAssertTrue(isEnabled)
     }
+
+    func test_loadQuickPaySwitchState_returns_false_on_new_generalAppSettings() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadQuickPaySwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_loadQuickPaySwitchState_returns_true_after_updating_switch_state_to_true() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.setQuickPayFeatureSwitchState(isEnabled: true, onCompletion: { _ in })
+        subject?.onAction(updateAction)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = AppSettingsAction.loadQuickPaySwitchState { result in
+                promise(result)
+            }
+            self.subject?.onAction(action)
+        }
+
+        // Then
+        let isEnabled = try result.get()
+        XCTAssertTrue(isEnabled)
+    }
 }
 
 // MARK: - Utils
@@ -462,6 +498,7 @@ private extension AppSettingsStoreTests {
             installationDate: installationDate,
             feedbacks: [feedback.name: feedback],
             isViewAddOnsSwitchEnabled: false,
+            isQuickPaySwitchEnabled: false,
             knownCardReaders: []
         )
         return (settings, feedback)


### PR DESCRIPTION
# Why

We will be releasing the Quick Pay prototype under an experimental flag. This PR enables that.
PS: It is still under the local feature flag, which will be removed later.

# How

- Update `GeneralAppSettings` to add a field to store the value of the feature toggle.

- Add Yosemite actions to save and load the feature toggle state.

- Update `BetaFeaturesViewController` to render and modify the state of the toggle(when the local feature flag is enabled)  

- Update `OrdersRootViewController` to check the toggle value on `ViewWillAppear` and render the appropriate navigation buttons.

# Demo

https://user-images.githubusercontent.com/562080/138187514-2aeec3dc-f501-47c8-b976-c35cca4b8769.mov


# Testing Steps

- Launch the app and see that the "+" button in the orders list is not present.
- Go to the beta features screen and enable the "Quick Pay" toggle. 
- Go back to the orders list and see that the "+" button in the orders list is present.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
