### PR TITLE
Clarify 404 errors for plugins endpoints

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -4,6 +4,7 @@ import Gridicons
 import Yosemite
 import MessageUI
 import Combine
+import enum Networking.DotcomError
 
 final class OrderDetailsViewModel {
     private let paymentOrchestrator = PaymentCaptureOrchestrator()
@@ -408,7 +409,11 @@ extension OrderDetailsViewModel {
                 onCompletion?(nil)
             case .failure(let error):
                 ServiceLocator.analytics.track(event: .shippingLabelsAPIRequest(result: .failed(error: error)))
-                DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
+                if error as? DotcomError == .noRestRoute {
+                    DDLogError("⚠️ Endpoint for synchronizing shipping labels is unreachable. WC Shipping plugin may be missing.")
+                } else {
+                    DDLogError("⛔️ Error synchronizing shipping labels: \(error)")
+                }
                 onCompletion?(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -69,8 +69,12 @@ private extension AppCoordinator {
             switch result {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
-            case.failure(let error):
-                DDLogError("⛔️ Failed to synchronize announcements: \(error.localizedDescription)")
+            case .failure(let error):
+                if error as? AnnouncementsError == .announcementNotFound {
+                    DDLogInfo("📣 Announcements synced, but nothing received.")
+                } else {
+                    DDLogError("⛔️ Failed to synchronize announcements: \(error.localizedDescription)")
+                }
             }
             self.showWhatsNewIfNeeded()
         }))

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -374,7 +374,7 @@ private extension DefaultStoresManager {
     func synchronizeSystemPlugins(siteID: Int64) {
         let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID) { result in
             if let error = result.failure {
-                DDLogError("⛔️ Failed to sync sytem plugins for siteID: \(siteID). Error: \(error)")
+                DDLogError("⛔️ Failed to sync system plugins for siteID: \(siteID). Error: \(error)")
             }
         }
         dispatch(action)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import Yosemite
 import Observables
+import enum Networking.DotcomError
 
 // MARK: - DefaultStoresManager
 //
@@ -358,7 +359,11 @@ private extension DefaultStoresManager {
     func synchronizeAddOnsGroups(siteID: Int64) {
         let action = AddOnGroupAction.synchronizeAddOnGroups(siteID: siteID) { result in
             if let error = result.failure {
-                DDLogError("⛔️ Failed to sync add-on groups for siteID: \(siteID). Error: \(error)")
+                if error as? DotcomError == .noRestRoute {
+                    DDLogError("⚠️ Endpoint for add-on groups is unreachable for siteID: \(siteID). WC Product Add-Ons plugin may be missing.")
+                } else {
+                    DDLogError("⛔️ Failed to sync add-on groups for siteID: \(siteID). Error: \(error)")
+                }
             }
         }
         dispatch(action)

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -219,6 +219,6 @@ enum AnnouncementsStorageError: Error {
     case announcementAlreadyExists
 }
 
-enum AnnouncementsError: Error {
+public enum AnnouncementsError: Error {
     case announcementNotFound
 }

--- a/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Yosemite/Yosemite/Stores/ShippingLabelStore.swift
@@ -162,7 +162,11 @@ private extension ShippingLabelStore {
                 }
                 onCompletion(eligibility.isEligible)
             case .failure(let error):
-                DDLogError("⛔️ Error checking shipping label creation eligibility for order \(orderID): \(error)")
+                if error as? DotcomError == .noRestRoute {
+                    DDLogError("⚠️ Endpoint for shipping label creation eligibility is unreachable for order: \(orderID). WC Shipping plugin may be missing.")
+                } else {
+                    DDLogError("⛔️ Error checking shipping label creation eligibility for order \(orderID): \(error)")
+                }
                 onCompletion(false)
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAnnouncementsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAnnouncementsRemote.swift
@@ -35,7 +35,7 @@ extension MockAnnouncementsRemote: AnnouncementsRemoteProtocol {
         numberOfTimesGetAnnouncementWasCalled += 1
         requestedAppId = appId
         if let result = self.loadAnnouncementResults[appVersion] {
-            completion(.success((try? result.get()) ?? []))
+            completion(result)
         } else {
             XCTFail("\(String(describing: self)) Could not find Announcement for \(appVersion)")
         }

--- a/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -88,15 +88,15 @@ final class AnnouncementsStoreTests: XCTestCase {
         remote.whenLoadingAnnouncements(for: UserAgent.bundleShortVersion, thenReturn: .failure(error))
 
         // Act
-        let resultError: AnnouncementsError? = waitFor { [weak self] promise in
+        let resultError: NSError? = waitFor { [weak self] promise in
             let action = AnnouncementsAction.synchronizeAnnouncements { result in
-                promise(result.failure as? AnnouncementsError)
+                promise(result.failure as NSError?)
             }
             self?.subject?.onAction(action)
         }
 
         // Assert
-        XCTAssertEqual(resultError, .announcementNotFound)
+        XCTAssertEqual(resultError, error)
     }
 
     func test_load_saved_announcement_without_saved_data_returns_error() {


### PR DESCRIPTION
## Description

We have some endpoints that are expected to be 404 when related plugin is missing - Shipping Labels, Add-Ons.
But they produce scary error messages in app log that may confuse HEs looking for unrelated problems:
```
⛔️ Failed to sync add-on groups for siteID: 196010018. Error: Dotcom Invalid REST Route
```

This PR adds clarifications on some endpoints failure handlers to transform message from above to:
```
⚠️ Endpoint for add-on groups is unreachable for siteID: 196010018. WC Product Add-Ons plugin may be missing.
```

Also included related change - announcements sync shouldn't log error on successful sync with 0 items.

### Updated logs

- Global Add-Ons sync
- Announcements sync
- Shipping labels sync in order details
- Shipping label creation eligibility in order details

---
Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
