### PR TITLE
[Mobile Payments] Always show IPP in settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -81,10 +81,6 @@ final class SettingsViewController: UIViewController {
     ///
     private var storePickerCoordinator: StorePickerCoordinator?
 
-    /// Flag indicating whether the currently selected store is eligible
-    /// for card present payments
-    private var canCollectPayments: Bool = false
-
     /// Announcement for the current app version
     ///
     private var announcement: Announcement?
@@ -204,21 +200,6 @@ private extension SettingsViewController {
         sites = sitesResultsController.fetchedObjects
     }
 
-    /// Determine if any payment gateway account for this site supports card present payments
-    ///
-    private func checkAvailabilityForPayments() {
-        paymentGatewayAccounts = paymentGatewayAccountsResultsController?.fetchedObjects ?? []
-        canCollectPayments = paymentGatewayAccounts.contains(where: \.isCardPresentEligible)
-    }
-
-    private var storeSettingsRows: [Row] {
-        var result = [Row]()
-        if canCollectPayments {
-            result.append(.inPersonPayments)
-        }
-        return result
-    }
-
     func configureTableViewFooter() {
         // `tableView.tableFooterView` can't handle a footerView that uses autolayout only.
         // Hence the container view with a defined frame.
@@ -239,7 +220,6 @@ private extension SettingsViewController {
 
     func refreshViewContent() {
         updateSites()
-        checkAvailabilityForPayments()
         configureSections()
         tableView.reloadData()
     }
@@ -299,14 +279,12 @@ private extension SettingsViewController {
             sections.append(Section(title: pluginsTitle, rows: [.plugins], footerHeight: UITableView.automaticDimension))
         }
 
-        // Store Settings
-        if storeSettingsRows.isNotEmpty {
-            sections.append(
-                Section(title: storeSettingsTitle,
-                        rows: storeSettingsRows,
-                        footerHeight: UITableView.automaticDimension)
+        sections.append(
+            Section(title: storeSettingsTitle,
+                rows: [.inPersonPayments],
+                footerHeight: UITableView.automaticDimension
             )
-        }
+        )
 
         // Help & Feedback
         if couldShowBetaFeaturesRow() {


### PR DESCRIPTION
Fixes #5260 

Changes:
- Removes `checkAvailabilityForPayments` from `SettingsViewController`
- Simplifies adding section and row

To test:
- Test as administrator to avoid being blocked by #4960 
- With WooCommerce Payments not installed, ensure you can go to Settings (gear) and see In-Person Payments. Ensure that tapping on it prompts you to "Install WooCommerce Payments"
- With 2.3.3 installed but not active, ensure you can go to Settings (gear) and see In-Person Payments. Ensure that tapping on it prompts you to update your "Unsupported WooCommerce Payments version"
- With 2.3.3 installed AND active, ensure you can go to Settings (gear) and see In-Person Payments. Ensure that tapping on it prompts you to update your "Unsupported WooCommerce Payments version"
- With 2.5.0 installed AND active, ensure you can go to Settings (gear) and see In-Person Payments. Ensure that tapping on it gives you rows to Order, Manage, or view the Manual.
- With 3.1.0 installed AND active, ensure you can go to Settings (gear) and see In-Person Payments. Ensure that tapping on it gives you rows to Order, Manage, or view the Manual.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
