### PR TITLE
Issue/5159 add product category filter

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -27,6 +27,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .orderListFilters:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .filterProductsByCategory:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -53,4 +53,8 @@ public enum FeatureFlag: Int {
     /// Display the bar for displaying the filters in the Order List
     ///
     case orderListFilters
+
+    /// Allows to filter products by a product category, persisting it so the filter can remain after restarting the app
+    ///
+    case filterProductsByCategory
 }

--- a/Networking/Networking/Model/Product/StoredProductSettings.swift
+++ b/Networking/Networking/Model/Product/StoredProductSettings.swift
@@ -12,17 +12,20 @@ public struct StoredProductSettings: Codable, Equatable, GeneratedFakeable {
         public let stockStatusFilter: ProductStockStatus?
         public let productStatusFilter: ProductStatus?
         public let productTypeFilter: ProductType?
+        public let productCategoryFilter: ProductCategory?
 
         public init(siteID: Int64,
                     sort: String?,
                     stockStatusFilter: ProductStockStatus?,
                     productStatusFilter: ProductStatus?,
-                    productTypeFilter: ProductType?) {
+                    productTypeFilter: ProductType?,
+                    productCategoryFilter: ProductCategory?) {
             self.siteID = siteID
             self.sort = sort
             self.stockStatusFilter = stockStatusFilter
             self.productStatusFilter = productStatusFilter
             self.productTypeFilter = productTypeFilter
+            self.productCategoryFilter = productCategoryFilter
         }
 
         public func numberOfActiveFilters() -> Int {
@@ -36,6 +39,11 @@ public struct StoredProductSettings: Codable, Equatable, GeneratedFakeable {
             if productTypeFilter != nil {
                 total += 1
             }
+
+            if productCategoryFilter != nil {
+                total += 1
+            }
+
             return total
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -227,7 +227,7 @@ private extension FilterListViewController {
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
             case .categories:
-                // WIP https://github.com/woocommerce/woocommerce-ios/issues/5159: Show filter products by category view controller
+                // TODO-5159: Show filter products by category view controller
                 break
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -53,7 +53,7 @@ enum FilterListValueSelectorConfig {
     // Standard list selector with fixed options
     case staticOptions(options: [FilterType])
     // Filter list selector for categories, retrieved dynamically
-    case categories
+    case productCategories
 }
 
 /// Contains data for rendering a filter type row.
@@ -226,7 +226,7 @@ private extension FilterListViewController {
                 }
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
-            case .categories:
+            case .productCategories:
                 // TODO-5159: Show filter products by category view controller
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Observables
+import Yosemite
 
 /// The view model protocol for filtering a list of models with generic filters.
 ///
@@ -51,8 +52,8 @@ final class FilterTypeViewModel {
 enum FilterListValueSelectorConfig {
     // Standard list selector with fixed options
     case staticOptions(options: [FilterType])
-    // Example: Categories
-    case custom
+    // Filter list selector for categories, retrieved dynamically
+    case categories
 }
 
 /// Contains data for rendering a filter type row.
@@ -225,7 +226,7 @@ private extension FilterListViewController {
                 }
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
-            case .custom:
+            case .categories:
                 break
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -227,6 +227,7 @@ private extension FilterListViewController {
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
             case .categories:
+                // WIP https://github.com/woocommerce/woocommerce-ios/issues/5159: Show filter products by category view controller
                 break
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import Experiments
 
 /// `FilterListViewModel` for filtering a list of products.
 final class FilterProductListViewModel: FilterListViewModel {
@@ -50,9 +51,13 @@ final class FilterProductListViewModel: FilterListViewModel {
     private let productTypeFilterViewModel: FilterTypeViewModel
     private let productCategoryFilterViewModel: FilterTypeViewModel
 
+    private let featureFlagService: FeatureFlagService
+
     /// - Parameters:
     ///   - filters: the filters to be applied initially.
-    init(filters: Filters) {
+    init(filters: Filters, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.featureFlagService = featureFlagService
+
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
         self.productStatusFilterViewModel = ProductListFilter.productStatus.createViewModel(filters: filters)
         self.productTypeFilterViewModel = ProductListFilter.productType.createViewModel(filters: filters)
@@ -64,7 +69,7 @@ final class FilterProductListViewModel: FilterListViewModel {
             productTypeFilterViewModel
         ]
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
+        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
             filterTypeViewModels.append(productCategoryFilterViewModel)
         }
 
@@ -77,7 +82,7 @@ final class FilterProductListViewModel: FilterListViewModel {
         let productType = productTypeFilterViewModel.selectedValue as? ProductType ?? nil
         var productCategory: ProductCategory? = nil
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory),
+        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory),
            let selectedProductCategory = productCategoryFilterViewModel.selectedValue as? ProductCategory {
             productCategory = selectedProductCategory
         }
@@ -101,7 +106,7 @@ final class FilterProductListViewModel: FilterListViewModel {
         let clearedProductType: ProductType? = nil
         productTypeFilterViewModel.selectedValue = clearedProductType
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
+        if featureFlagService.isFeatureFlagEnabled(.filterProductsByCategory) {
             let clearedProductCategory: ProductCategory? = nil
             productCategoryFilterViewModel.selectedValue = clearedProductCategory
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -159,7 +159,7 @@ extension FilterProductListViewModel.ProductListFilter {
                                        selectedValue: filters.productType)
         case .productCategory:
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .categories,
+                                       listSelectorConfig: .productCategories,
                                        selectedValue: filters.productCategory)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
@@ -28,3 +28,13 @@ extension ProductType: FilterType {
         return true
     }
 }
+
+extension ProductCategory: FilterType {
+    var description: String {
+        return name
+    }
+
+    var isActive: Bool {
+        return true
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -836,6 +836,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                 self?.filters = FilterProductListViewModel.Filters(stockStatus: settings.stockStatusFilter,
                                                                    productStatus: settings.productStatusFilter,
                                                                    productType: settings.productTypeFilter,
+                                                                   productCategory: settings.productCategoryFilter,
                                                                    numberOfActiveFilters: settings.numberOfActiveFilters())
             case .failure:
                 break

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -819,7 +819,8 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                                               sort: sort?.rawValue,
                                                               stockStatusFilter: filters.stockStatus,
                                                               productStatusFilter: filters.productStatus,
-                                                              productTypeFilter: filters.productType) { (error) in
+                                                              productTypeFilter: filters.productType,
+                                                              productCategoryFilter: filters.productCategory) { (error) in
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
+/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
 "#%@ %@" = "#%1$@ %2$@";
 
 /* In Shipping Labels Package Details, the pattern used to show the weight of a product. For example, “1lbs”. */
@@ -2465,6 +2465,9 @@
 
 /* Row title for filtering products by product type. */
 "Product Type" = "Product Type";
+
+/* Row title for filtering products by product category. */
+"Product Category" = "Product Category";
 
 /* Title of the Product Type row on Product main screen */
 "Product type" = "Product type";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
+﻿/* In Order List, the pattern to show the order number. For example, “#123456”. The %@ placeholder is the order number. */
 "#%@ %@" = "#%1$@ %2$@";
 
 /* In Shipping Labels Package Details, the pattern used to show the weight of a product. For example, “1lbs”. */
@@ -2465,9 +2465,6 @@
 
 /* Row title for filtering products by product type. */
 "Product Type" = "Product Type";
-
-/* Row title for filtering products by product category. */
-"Product Category" = "Product Category";
 
 /* Title of the Product Type row on Product main screen */
 "Product type" = "Product type";

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -8,19 +8,22 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isShippingLabelsPackageCreationOn: Bool
     private let isShippingLabelsMultiPackageOn: Bool
     private let isPushNotificationsForAllStoresOn: Bool
+    private let isFilterProductsByCategoryOn: Bool
 
     init(isShippingLabelsM2M3On: Bool = false,
          isInternationalShippingLabelsOn: Bool = false,
          isShippingLabelsPaymentMethodCreationOn: Bool = false,
          isShippingLabelsPackageCreationOn: Bool = false,
          isShippingLabelsMultiPackageOn: Bool = false,
-         isPushNotificationsForAllStoresOn: Bool = false) {
+         isPushNotificationsForAllStoresOn: Bool = false,
+         isFilterProductsByCategoryOn: Bool = false) {
         self.isShippingLabelsM2M3On = isShippingLabelsM2M3On
         self.isInternationalShippingLabelsOn = isInternationalShippingLabelsOn
         self.isShippingLabelsPaymentMethodCreationOn = isShippingLabelsPaymentMethodCreationOn
         self.isShippingLabelsPackageCreationOn = isShippingLabelsPackageCreationOn
         self.isShippingLabelsMultiPackageOn = isShippingLabelsMultiPackageOn
         self.isPushNotificationsForAllStoresOn = isPushNotificationsForAllStoresOn
+        self.isFilterProductsByCategoryOn = isFilterProductsByCategoryOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -37,6 +40,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShippingLabelsMultiPackageOn
         case .pushNotificationsForAllStores:
             return isPushNotificationsForAllStoresOn
+        case .filterProductsByCategory:
+            return isFilterProductsByCategoryOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
@@ -9,19 +9,31 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
     }
 
     func testOneActiveFilter() {
-        let filters = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: .draft, productType: nil, numberOfActiveFilters: 0)
+        let filters = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                         productStatus: .draft,
+                                                         productType: nil,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
         XCTAssertEqual(filterTypeViewModels.numberOfActiveFilters, 1)
     }
 
     func testTwoActiveFilters() {
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .publish, productType: nil, numberOfActiveFilters: 0)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .publish,
+                                                         productType: nil,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
         XCTAssertEqual(filterTypeViewModels.numberOfActiveFilters, 2)
     }
 
     func testThreeActiveFilters() {
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .publish, productType: .variable, numberOfActiveFilters: 0)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .publish,
+                                                         productType: .variable,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 0)
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
         XCTAssertEqual(filterTypeViewModels.numberOfActiveFilters, 3)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+@testable import Yosemite
 
 final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
     func testZeroActiveFilters() {
@@ -37,6 +38,17 @@ final class FilterProductListViewModel_numberOfActiveFiltersTests: XCTestCase {
         let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
         XCTAssertEqual(filterTypeViewModels.numberOfActiveFilters, 3)
     }
+
+    func testFourActiveFilters() {
+        let filterProductCategory = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "", slug: "")
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .publish,
+                                                         productType: .variable,
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 0)
+        let filterTypeViewModels = createFilterTypeViewModels(filters: filters)
+        XCTAssertEqual(filterTypeViewModels.numberOfActiveFilters, 4)
+    }
 }
 
 private extension FilterProductListViewModel_numberOfActiveFiltersTests {
@@ -44,7 +56,8 @@ private extension FilterProductListViewModel_numberOfActiveFiltersTests {
         return [
             FilterProductListViewModel.ProductListFilter.stockStatus.createViewModel(filters: filters),
             FilterProductListViewModel.ProductListFilter.productStatus.createViewModel(filters: filters),
-            FilterProductListViewModel.ProductListFilter.productType.createViewModel(filters: filters)
+            FilterProductListViewModel.ProductListFilter.productType.createViewModel(filters: filters),
+            FilterProductListViewModel.ProductListFilter.productCategory.createViewModel(filters: filters)
         ]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -3,13 +3,15 @@ import XCTest
 @testable import Yosemite
 
 final class FilterProductListViewModelProductListFilterTests: XCTestCase {
+    let filterProductCategory = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "", slug: "")
+
     func testCreatingStockStatusFilterTypeViewModel() {
         let filterType = FilterProductListViewModel.ProductListFilter.stockStatus
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
                                                          productType: .grouped,
-                                                         productCategory: nil,
-                                                         numberOfActiveFilters: 3)
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductStockStatus, .inStock)
     }
@@ -19,8 +21,8 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
                                                          productType: .grouped,
-                                                         productCategory: nil,
-                                                         numberOfActiveFilters: 3)
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductStatus, .draft)
     }
@@ -30,9 +32,21 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
                                                          productType: .grouped,
-                                                         productCategory: nil,
-                                                         numberOfActiveFilters: 3)
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductType, .grouped)
+    }
+
+    func testCreatingProductCategoryFilterTypeViewModel() {
+        let filterType = FilterProductListViewModel.ProductListFilter.productCategory
+
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
+        let viewModel = filterType.createViewModel(filters: filters)
+        XCTAssertEqual(viewModel.selectedValue as? ProductCategory, filterProductCategory)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -5,21 +5,33 @@ import XCTest
 final class FilterProductListViewModelProductListFilterTests: XCTestCase {
     func testCreatingStockStatusFilterTypeViewModel() {
         let filterType = FilterProductListViewModel.ProductListFilter.stockStatus
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 3)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductStockStatus, .inStock)
     }
 
     func testCreatingProductStatusFilterTypeViewModel() {
         let filterType = FilterProductListViewModel.ProductListFilter.productStatus
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 3)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductStatus, .draft)
     }
 
     func testCreatingProductTypeFilterTypeViewModel() {
         let filterType = FilterProductListViewModel.ProductListFilter.productType
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 3)
         let viewModel = filterType.createViewModel(filters: filters)
         XCTAssertEqual(viewModel.selectedValue as? ProductType, .grouped)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -30,7 +30,8 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                          numberOfActiveFilters: 4)
 
         // When
-        let viewModel = FilterProductListViewModel(filters: filters)
+        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
+        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
 
         // Then
         let expectedCriteria = filters
@@ -46,7 +47,8 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                          numberOfActiveFilters: 4)
 
         // When
-        let viewModel = FilterProductListViewModel(filters: filters)
+        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
+        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
         viewModel.clearAll()
 
         // Then
@@ -56,5 +58,45 @@ final class FilterProductListViewModelTests: XCTestCase {
                                                                   productCategory: nil,
                                                                   numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
+    }
+
+    func testCriteriaWithNonNilFiltersAndFilterProductByCategoryIsDisabled() {
+        // Given
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
+        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+
+        // Then
+        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: filters.stockStatus,
+                                                                  productStatus: filters.productStatus,
+                                                                  productType: filters.productType,
+                                                                  productCategory: nil,
+                                                                  numberOfActiveFilters: 3)
+        XCTAssertEqual(viewModel.criteria, expectedCriteria)
+    }
+
+    func testViewModelsWhenFilterProductByCategoryIsDisabled() {
+        // Given
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
+        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+
+        // Then
+        let productCategoryFilterTypeViewModels = viewModel.filterTypeViewModels.compactMap { $0.selectedValue as? ProductCategory }
+
+        XCTAssertTrue(productCategoryFilterTypeViewModels.isEmpty)
+        XCTAssertEqual(viewModel.filterTypeViewModels.count, 3)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -21,7 +21,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
-    func testCriteriaWithNonNilFilters() {
+    func test_criteria_with_non_nil_filters_then_it_returns_all_active_filters() {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
@@ -38,7 +38,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
-    func testCriteriaAfterClearingAllNonNilFilters() {
+    func test_criteria_after_clearing_all_non_nil_filters_then_it_returns_no_active_filter() {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
@@ -60,7 +60,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
-    func testCriteriaWithNonNilFiltersAndFilterProductByCategoryIsDisabled() {
+    func test_criteria_with_non_nil_filters_and_isFilterProductsByCategoryOff_then_it_returns_all_active_filters_minus_filterProductCategory() {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
@@ -81,7 +81,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
-    func testViewModelsWhenFilterProductByCategoryIsDisabled() {
+    func test_viewModels_when_isFilterProductsByCategoryOff_then_it_returns_viewModels_except_filterProductCategory() {
         // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -1,7 +1,10 @@
 import XCTest
 @testable import WooCommerce
+@testable import Yosemite
 
 final class FilterProductListViewModelTests: XCTestCase {
+    let filterProductCategory = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "", slug: "")
+
     func testCriteriaWithDefaultFilters() {
         // Given
         let filters = FilterProductListViewModel.Filters()
@@ -23,8 +26,8 @@ final class FilterProductListViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
                                                          productType: .grouped,
-                                                         productCategory: nil,
-                                                         numberOfActiveFilters: 3)
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
 
         // When
         let viewModel = FilterProductListViewModel(filters: filters)
@@ -39,8 +42,8 @@ final class FilterProductListViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,
                                                          productType: .grouped,
-                                                         productCategory: nil,
-                                                         numberOfActiveFilters: 3)
+                                                         productCategory: filterProductCategory,
+                                                         numberOfActiveFilters: 4)
 
         // When
         let viewModel = FilterProductListViewModel(filters: filters)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -10,13 +10,21 @@ final class FilterProductListViewModelTests: XCTestCase {
         let viewModel = FilterProductListViewModel(filters: filters)
 
         // Then
-        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
+        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                                  productStatus: nil,
+                                                                  productType: nil,
+                                                                  productCategory: nil,
+                                                                  numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
     func testCriteriaWithNonNilFilters() {
         // Given
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 3)
 
         // When
         let viewModel = FilterProductListViewModel(filters: filters)
@@ -28,14 +36,22 @@ final class FilterProductListViewModelTests: XCTestCase {
 
     func testCriteriaAfterClearingAllNonNilFilters() {
         // Given
-        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
+                                                         productStatus: .draft,
+                                                         productType: .grouped,
+                                                         productCategory: nil,
+                                                         numberOfActiveFilters: 3)
 
         // When
         let viewModel = FilterProductListViewModel(filters: filters)
         viewModel.clearAll()
 
         // Then
-        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
+        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil,
+                                                                  productStatus: nil,
+                                                                  productType: nil,
+                                                                  productCategory: nil,
+                                                                  numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -68,6 +68,7 @@ public enum AppSettingsAction: Action {
                                 stockStatusFilter: ProductStockStatus? = nil,
                                 productStatusFilter: ProductStatus? = nil,
                                 productTypeFilter: ProductType? = nil,
+                                productCategoryFilter: ProductCategory? = nil,
                                 onCompletion: (Error?) -> Void)
 
     /// Clears all the products settings

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -44,7 +44,12 @@ struct MockAppSettingsActionHandler: MockActionHandler {
     }
 
     func loadProductSettings(siteId: Int64, onCompletion: (Result<StoredProductSettings.Setting, Error>) -> Void) {
-        let emptySetting = StoredProductSettings.Setting(siteID: siteId, sort: nil, stockStatusFilter: nil, productStatusFilter: nil, productTypeFilter: nil)
+        let emptySetting = StoredProductSettings.Setting(siteID: siteId,
+                                                         sort: nil,
+                                                         stockStatusFilter: nil,
+                                                         productStatusFilter: nil,
+                                                         productTypeFilter: nil,
+                                                         productCategoryFilter: nil)
         onCompletion(.success(emptySetting))
     }
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -117,12 +117,19 @@ public class AppSettingsStore: Store {
             loadFeedbackVisibility(type: type, onCompletion: onCompletion)
         case .loadProductsSettings(let siteID, let onCompletion):
             loadProductsSettings(siteID: siteID, onCompletion: onCompletion)
-        case .upsertProductsSettings(let siteID, let sort, let stockStatusFilter, let productStatusFilter, let productTypeFilter, let onCompletion):
+        case .upsertProductsSettings(let siteID,
+                                     let sort,
+                                     let stockStatusFilter,
+                                     let productStatusFilter,
+                                     let productTypeFilter,
+                                     let productCategoryFilter,
+                                     let onCompletion):
             upsertProductsSettings(siteID: siteID,
                                    sort: sort,
                                    stockStatusFilter: stockStatusFilter,
                                    productStatusFilter: productStatusFilter,
                                    productTypeFilter: productTypeFilter,
+                                   productCategoryFilter: productCategoryFilter,
                                    onCompletion: onCompletion)
         case .resetProductsSettings:
             resetProductsSettings()
@@ -573,6 +580,7 @@ private extension AppSettingsStore {
                                 stockStatusFilter: ProductStockStatus? = nil,
                                 productStatusFilter: ProductStatus? = nil,
                                 productTypeFilter: ProductType? = nil,
+                                productCategoryFilter: ProductCategory? = nil,
                                 onCompletion: (Error?) -> Void) {
         var existingSettings: [Int64: StoredProductSettings.Setting] = [:]
         if let storedSettings: StoredProductSettings = try? fileStorage.data(for: productsSettingsURL) {
@@ -583,7 +591,8 @@ private extension AppSettingsStore {
                                                        sort: sort,
                                                        stockStatusFilter: stockStatusFilter,
                                                        productStatusFilter: productStatusFilter,
-                                                       productTypeFilter: productTypeFilter)
+                                                       productTypeFilter: productTypeFilter,
+                                                       productCategoryFilter: productCategoryFilter)
         existingSettings[siteID] = newSetting
 
         let newStoredProductSettings = StoredProductSettings(settings: existingSettings)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
@@ -42,7 +42,8 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                             sort: ProductsSortOrder.dateAscending.rawValue,
                                                             stockStatusFilter: .outOfStock,
                                                             productStatusFilter: .pending,
-                                                            productTypeFilter: .simple)
+                                                            productTypeFilter: .simple,
+                                                            productCategoryFilter: nil)
 
         // When
         let result: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
@@ -84,12 +85,14 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                              sort: ProductsSortOrder.dateAscending.rawValue,
                                                              stockStatusFilter: .outOfStock,
                                                              productStatusFilter: .pending,
-                                                             productTypeFilter: .simple)
+                                                             productTypeFilter: .simple,
+                                                             productCategoryFilter: nil)
         let productSettings2 = StoredProductSettings.Setting(siteID: siteID2,
                                                              sort: ProductsSortOrder.nameAscending.rawValue,
                                                              stockStatusFilter: .inStock,
                                                              productStatusFilter: .draft,
-                                                             productTypeFilter: .grouped)
+                                                             productTypeFilter: .grouped,
+                                                             productCategoryFilter: nil)
 
         // When
         let writeAction1 = AppSettingsAction.upsertProductsSettings(siteID: siteID1,

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
@@ -38,12 +38,13 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
     func test_productsSettings_actions_returns_values_after_being_set() throws {
         // Given
         let siteID: Int64 = 134
+        let filterProductCategory = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "", slug: "")
         let productSettings = StoredProductSettings.Setting(siteID: siteID,
                                                             sort: ProductsSortOrder.dateAscending.rawValue,
                                                             stockStatusFilter: .outOfStock,
                                                             productStatusFilter: .pending,
                                                             productTypeFilter: .simple,
-                                                            productCategoryFilter: nil)
+                                                            productCategoryFilter: filterProductCategory)
 
         // When
         let result: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
@@ -59,7 +60,8 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                                    sort: productSettings.sort,
                                                                    stockStatusFilter: productSettings.stockStatusFilter,
                                                                    productStatusFilter: productSettings.productStatusFilter,
-                                                                   productTypeFilter: productSettings.productTypeFilter) { (error) in
+                                                                   productTypeFilter: productSettings.productTypeFilter,
+                                                                   productCategoryFilter: productSettings.productCategoryFilter) { (error) in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction)
@@ -81,25 +83,30 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
         // Given
         let siteID1: Int64 = 134
         let siteID2: Int64 = 268
+
+        let filterProductCategory1 = ProductCategory(categoryID: 0, siteID: 0, parentID: 0, name: "category1", slug: "")
+        let filterProductCategory2 = ProductCategory(categoryID: 1, siteID: 1, parentID: 1, name: "category2", slug: "")
+
         let productSettings1 = StoredProductSettings.Setting(siteID: siteID1,
                                                              sort: ProductsSortOrder.dateAscending.rawValue,
                                                              stockStatusFilter: .outOfStock,
                                                              productStatusFilter: .pending,
                                                              productTypeFilter: .simple,
-                                                             productCategoryFilter: nil)
+                                                             productCategoryFilter: filterProductCategory1)
         let productSettings2 = StoredProductSettings.Setting(siteID: siteID2,
                                                              sort: ProductsSortOrder.nameAscending.rawValue,
                                                              stockStatusFilter: .inStock,
                                                              productStatusFilter: .draft,
                                                              productTypeFilter: .grouped,
-                                                             productCategoryFilter: nil)
+                                                             productCategoryFilter: filterProductCategory2)
 
         // When
         let writeAction1 = AppSettingsAction.upsertProductsSettings(siteID: siteID1,
                                                                     sort: productSettings1.sort,
                                                                     stockStatusFilter: productSettings1.stockStatusFilter,
                                                                     productStatusFilter: productSettings1.productStatusFilter,
-                                                                    productTypeFilter: productSettings1.productTypeFilter) { (error) in
+                                                                    productTypeFilter: productSettings1.productTypeFilter,
+                                                                    productCategoryFilter: productSettings1.productCategoryFilter) { (error) in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction1)
@@ -108,7 +115,8 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                                     sort: productSettings2.sort,
                                                                     stockStatusFilter: productSettings2.stockStatusFilter,
                                                                     productStatusFilter: productSettings2.productStatusFilter,
-                                                                    productTypeFilter: productSettings2.productTypeFilter) { (error) in
+                                                                    productTypeFilter: productSettings2.productTypeFilter,
+                                                                    productCategoryFilter: productSettings2.productCategoryFilter) { (error) in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction2)


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5159

## Description
In the context of https://github.com/woocommerce/woocommerce-ios/issues/5159, we implement the UI for the  product filter list view, and the logic behind. We add a new row for Product Category filtering in the `FilterListViewController`, so the user can access the product categories list and select a category so the products list can be filter by category as well. However, please note that the `ProductCategoryFilterListViewController` that should hold the product categories list is not added yet, to keep the PR size in an acceptable level.
Furthermore, in this PR the product category filter logic is added to the relevant elements (filter view models, product list and storage) and the `ProductCategory` type is adapted to play as a filter. Existing unit tests are enhanced and new ones added, covering the new features added (feature flag, product category filter)
Lastly, a feature flag is added so the feature can be hidden in Release builds, as the feature is not yet finished.

## Changes
- Add feature flag for this case
- Make `ProductCategory` conform to `FilterType`
- Add a view model for Product Category in FilterListViewController so the row can be shown if the feature flag is enabled
- Handle clear filter logic also for Product Category
- Add a case for categories in `FilterListValueSelectorConfig`, so it can react to the selection (for now a no-op until the UI for the product categories is added)
- Add string to localizable strings
- Add `ProductCategory` parameter to `AppSettingStore`

## Testing
With feature flag enabled:
- Open the app
- Go to Products tab
- Open Filter
- Product Category row should be shown at the end, without any specific category selected (Any):

<img src="https://user-images.githubusercontent.com/1864060/138415960-8b36e51e-af52-467b-9bad-4e3b6db889a4.png" width="320" height="693">

Please check that the existing filter flow works as expected, and the new addition did not break anything:
- Adding a filter option
- Clearing filter options
- Showing products with filters

With the feature flag disabled:
- Disable the filter by categories feature by doing it in `DefaultFeatureFlagService` on by running the app in a release version
- Open the app
- Go to Products tab
- Open Filter
- Product Category row should **not** be shown

<img src="https://user-images.githubusercontent.com/1864060/138417076-9ee4e7bf-7706-4e10-9d44-bd18cb161756.png" width="320" height="693">

As in the previous case, please check that the existing filter flow works as expected, and the new addition did not break anything:
- Adding a filter option
- Clearing filter options
- Showing products with filters

## Next Steps
- Show filter product category list view
- Handle selection: UI, storage
- Filter product list by category: networking


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
