### PR TITLE
Product screen: Fix `Sort by` and `Filter` toolbar's visibility on first time login or after switching stores. 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -875,6 +875,7 @@ private extension ProductsViewController {
             ensureFooterSpinnerIsStopped()
             removePlaceholderProducts()
             showTopBannerViewIfNeeded()
+            showOrHideToolBar()
         case .results:
             break
         }


### PR DESCRIPTION
Closes #5250 

## Description
The toolbar which consists of `Sort by` and `Filter` options isn't visible, when we load products from a store for the first time. 

We load products for the first time in the following scenarios,
1. After logging in for the first time
1.  After switching stores. 

## Observations
I took a look and identified that `func showOrHideToolBar()` is not being called after the products are loaded by the `resultsController`.
```swift
    func showOrHideToolBar() {
        toolbar.isHidden = filters.numberOfActiveFilters == 0 ? isEmpty : false
    }
```

This is happening because `reloadTableAndView()` function is not being called as we directly reload the tableView using `tableView.reloadData()` from `func removePlaceholderProducts()`.

Even though we set back the `onDidChangeContent` and `onDidResetContent` closures by calling `setClosuresToResultController(resultsController, onReload: reloadTableAndView)` in `func removePlaceholderProducts()`, the `func reloadTableAndView()` is not called because the content is already loaded before we set those closures.

Also, this issue occurs only when we fetch products for the first time because, `showOrHideToolBar()` is called from `viewDidLoad()` as well. When we relaunch the app `resultsController.isEmpty` will be false because of the cached/stored products, which makes the `toolBar` visible.

## Fix
To fix this, I am calling `showOrHideToolBar()` for `.syncing` case in the following function.

This makes sure that toolBar's visibility is updated every time syncing is finished. i.e. When products are loaded.

## Demo
https://user-images.githubusercontent.com/524475/138455971-5c310576-95e9-4024-8fb5-2a7bf0378d2f.mov

## Testing
1. Do a fresh install and login into the app using a woocommerce account, preferably with more than one store.
1. Go to `Products` tab and wait for the products to load for the first time.
1. Observe that `Sort by` and `Filter` options are visible.
1. Go to settings and switch the store.
1. Go back to Products tab and observe that `Sort by` and `Filter` options are visible after switching stores.

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.