### PR TITLE
Quick Pay: Adds protocol for CardPresentPaymentsOnboardingUseCase

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -6,10 +6,36 @@ import Yosemite
 private typealias SitePlugin = Yosemite.SitePlugin
 private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
 
-final class CardPresentPaymentsOnboardingUseCase: ObservableObject {
+/// Protocol for `CardPresentPaymentsOnboardingUseCase`.
+/// Right now, only used for testing.
+///
+protocol IPPOnboardingUseCaseProtocol {
+    /// Current store onboarding state.
+    ///
+    var state: CardPresentPaymentOnboardingState { get set }
+
+    /// Store onboarding state publisher.
+    ///
+    var statePublisher: Published<CardPresentPaymentOnboardingState>.Publisher { get }
+
+    /// Resynchronize the onboarding state if needed.
+    ///
+    func refresh()
+
+    /// Update the onboarding state with the latest synced values.
+    ///
+    func updateState()
+}
+
+final class CardPresentPaymentsOnboardingUseCase: IPPOnboardingUseCaseProtocol, ObservableObject {
     let storageManager: StorageManagerType
     let stores: StoresManager
+
     @Published var state: CardPresentPaymentOnboardingState = .loading
+
+    var statePublisher: Published<CardPresentPaymentOnboardingState>.Publisher {
+        $state
+    }
 
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -9,7 +9,7 @@ private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
 /// Protocol for `CardPresentPaymentsOnboardingUseCase`.
 /// Right now, only used for testing.
 ///
-protocol IPPOnboardingUseCaseProtocol {
+protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     /// Current store onboarding state.
     ///
     var state: CardPresentPaymentOnboardingState { get set }
@@ -27,7 +27,7 @@ protocol IPPOnboardingUseCaseProtocol {
     func updateState()
 }
 
-final class CardPresentPaymentsOnboardingUseCase: IPPOnboardingUseCaseProtocol, ObservableObject {
+final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol, ObservableObject {
     let storageManager: StorageManagerType
     let stores: StoresManager
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
+		26100B202722FCAD00473045 /* MockIPPOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
@@ -1822,6 +1823,7 @@
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
+		26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIPPOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
@@ -6304,6 +6306,7 @@
 				E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */,
 				D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */,
 				31E906A226CC91A70099A985 /* CardReaderConnectionControllerTests.swift */,
+				26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -8134,6 +8137,7 @@
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
+				26100B202722FCAD00473045 /* MockIPPOnboardingUseCase.swift in Sources */,
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
-		26100B202722FCAD00473045 /* MockIPPOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */; };
+		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
@@ -1823,7 +1823,7 @@
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
-		26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIPPOnboardingUseCase.swift; sourceTree = "<group>"; };
+		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
@@ -6306,7 +6306,7 @@
 				E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */,
 				D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */,
 				31E906A226CC91A70099A985 /* CardReaderConnectionControllerTests.swift */,
-				26100B1F2722FCAD00473045 /* MockIPPOnboardingUseCase.swift */,
+				26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -8137,7 +8137,7 @@
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
-				26100B202722FCAD00473045 /* MockIPPOnboardingUseCase.swift in Sources */,
+				26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */,
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
@@ -2,9 +2,9 @@ import Combine
 @testable import WooCommerce
 @testable import Yosemite
 
-/// Simple mock for `IPPOnboardingUseCaseProtocol`
+/// Simple mock for `CardPresentPaymentsOnboardingUseCaseProtocol`
 ///
-final class MockIPPOnboardingUseCase: IPPOnboardingUseCaseProtocol {
+final class MockCardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol {
     // MARK: Protocol properties
     @Published var state: CardPresentPaymentOnboardingState
     var statePublisher: Published<CardPresentPaymentOnboardingState>.Publisher {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockIPPOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockIPPOnboardingUseCase.swift
@@ -1,0 +1,33 @@
+import Combine
+@testable import WooCommerce
+@testable import Yosemite
+
+/// Simple mock for `IPPOnboardingUseCaseProtocol`
+///
+final class MockIPPOnboardingUseCase: IPPOnboardingUseCaseProtocol {
+    // MARK: Protocol properties
+    @Published var state: CardPresentPaymentOnboardingState
+    var statePublisher: Published<CardPresentPaymentOnboardingState>.Publisher {
+        $state
+    }
+
+    // MARK: Protocol Methods
+    func refresh() {
+        // No op
+    }
+
+    func updateState() {
+        // No op
+    }
+
+    // MARK: Convenience Initializer
+    init(initial: CardPresentPaymentOnboardingState, publisher: AnyPublisher<CardPresentPaymentOnboardingState, Never>? = nil) {
+        self.state = initial
+
+        /// Assign the publisher if provided
+        ///
+        if let publisher = publisher {
+            publisher.assign(to: &$state)
+        }
+    }
+}


### PR DESCRIPTION
# Why 

For the Quick Pay(Quick Order) experiment we are adding showing some banners conditionally when a store is onboarded for IPP.

To know if a store is onboarded we are using `CardPresentPaymentsOnboardingUseCase` but in order to unit test those conditions it is convenient to have a way to mock that use case instead of having to set the internal storage to the correct state.

# How 

- Creates a simple protocol to wrap the properties and functions that `CardPresentPaymentsOnboardingUseCase` exposes.

As `CardPresentPaymentsOnboardingUseCase` uses a `@Published` property wrapper, the protocol has to expose `state` and `statePublisher` due to swift unability to use `@Published` in protocols.

- Creates a Mock type for the new protocol to be used on tests.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
