### PR TITLE
What's New: Prevent scrolling/scroll bounce when the feature list fits on screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -43,8 +43,6 @@ struct IconListItem: View {
             }
             Spacer()
         }
-        .padding(.horizontal, Layout.horizontalPadding)
-        .padding(.vertical, Layout.verticalPadding)
     }
 }
 
@@ -53,8 +51,6 @@ private extension IconListItem {
         static let iconSize = CGSize(width: 40, height: 40)
         static let contentSpacing: CGFloat = 16
         static let innerSpacing: CGFloat = 2
-        static let horizontalPadding: CGFloat = 40
-        static let verticalPadding: CGFloat = 16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -43,6 +43,7 @@ struct IconListItem: View {
             }
             Spacer()
         }
+        .padding(.horizontal, Layout.horizontalPadding)
     }
 }
 
@@ -51,6 +52,7 @@ private extension IconListItem {
         static let iconSize = CGSize(width: 40, height: 40)
         static let contentSpacing: CGFloat = 16
         static let innerSpacing: CGFloat = 2
+        static let horizontalPadding: CGFloat = 40
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
@@ -23,17 +23,17 @@ struct ReportList: View {
     @Environment(\.horizontalSizeClass) var sizeClass: UserInterfaceSizeClass?
 
     var body: some View {
-        VStack {
-            Spacer(minLength: Layout.topSpaceLength(sizeClass))
+        Spacer(minLength: Layout.topSpaceLength(sizeClass))
+        VStack(spacing: Layout.listTopSpacerLength(sizeClass)) {
             LargeTitle(text: viewModel.title)
-            Spacer(minLength: Layout.listTopSpacerLength(sizeClass))
-            ScrollView {
+            VStack {
                 ForEach(viewModel.items, id: \.id) {
                     IconListItem(title: $0.title,
                                  subtitle: $0.subtitle,
                                  icon: $0.icon)
                 }
             }
+            .scrollVerticallyIfNeeded()
             Spacer()
             Button(viewModel.ctaTitle, action: viewModel.onDismiss)
                 .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
@@ -23,10 +23,11 @@ struct ReportList: View {
     @Environment(\.horizontalSizeClass) var sizeClass: UserInterfaceSizeClass?
 
     var body: some View {
-        Spacer(minLength: Layout.topSpaceLength(sizeClass))
-        VStack(spacing: Layout.listTopSpacerLength(sizeClass)) {
+        VStack {
             LargeTitle(text: viewModel.title)
-            VStack {
+                .padding(.top, Layout.titleTopPadding(sizeClass))
+                .padding(.bottom, Layout.listVerticalPadding(sizeClass))
+            VStack(spacing: Layout.listSpacing) {
                 ForEach(viewModel.items, id: \.id) {
                     IconListItem(title: $0.title,
                                  subtitle: $0.subtitle,
@@ -34,34 +35,28 @@ struct ReportList: View {
                 }
             }
             .scrollVerticallyIfNeeded()
-            Spacer()
+            Spacer(minLength: Layout.listVerticalPadding(sizeClass))
             Button(viewModel.ctaTitle, action: viewModel.onDismiss)
                 .buttonStyle(PrimaryButtonStyle())
-                .padding(.horizontal, Layout.buttonHorizontalPadding(sizeClass))
-                .padding(.bottom, Layout.buttonVerticalPadding(sizeClass))
         }
         .onAppear(perform: viewModel.onAppear)
+        .padding(Layout.padding)
     }
 }
 
 private extension ReportList {
     enum Layout {
 
-        static func topSpaceLength(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 40 : 75
+        static func titleTopPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+            sizeClass == .regular ? 0 : 35
         }
 
-        static func listTopSpacerLength(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        static func listVerticalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
             sizeClass == .regular ? 32 : 40
         }
 
-        static func buttonHorizontalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 40 : 24
-        }
-
-        static func buttonVerticalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 40 : 60
-        }
+        static let padding: CGFloat = 40
+        static let listSpacing: CGFloat = 32
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
@@ -25,9 +25,8 @@ struct ReportList: View {
     var body: some View {
         VStack {
             LargeTitle(text: viewModel.title)
-                .padding(.top, Layout.titleTopPadding(sizeClass))
-                .padding(.bottom, Layout.listVerticalPadding(sizeClass))
-            VStack(spacing: Layout.listSpacing) {
+                .padding(.bottom, Layout.titleBottomPadding(sizeClass))
+            VStack(spacing: Layout.listSpacing(sizeClass)) {
                 ForEach(viewModel.items, id: \.id) {
                     IconListItem(title: $0.title,
                                  subtitle: $0.subtitle,
@@ -35,28 +34,39 @@ struct ReportList: View {
                 }
             }
             .scrollVerticallyIfNeeded()
-            Spacer(minLength: Layout.listVerticalPadding(sizeClass))
+            Spacer()
             Button(viewModel.ctaTitle, action: viewModel.onDismiss)
                 .buttonStyle(PrimaryButtonStyle())
+                .padding(.horizontal, Layout.buttonHorizontalPadding(sizeClass))
         }
         .onAppear(perform: viewModel.onAppear)
-        .padding(Layout.padding)
+        .padding(.top, Layout.topPadding(sizeClass))
+        .padding(.bottom, Layout.bottomPadding(sizeClass))
     }
 }
 
 private extension ReportList {
     enum Layout {
 
-        static func titleTopPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 0 : 35
+        static func topPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+            sizeClass == .regular ? 40 : 75
         }
 
-        static func listVerticalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        static func bottomPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+            sizeClass == .regular ? 40 : 60
+        }
+
+        static func titleBottomPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
             sizeClass == .regular ? 32 : 40
         }
 
-        static let padding: CGFloat = 40
-        static let listSpacing: CGFloat = 32
+        static func buttonHorizontalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+            sizeClass == .regular ? 40 : 24
+        }
+
+        static func listSpacing(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+            sizeClass == .regular ? 24 : 32
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: #4915

## Description

On the What's New screen, when the feature list fits on screen it shouldn't scroll (or have any scroll bounce). This changes the layout to avoid that extra scroll/scroll bounce.

It also fixes a small issue with the spacing of list items on iPad (reduces the spacing to match designs).

## Changes

* Replaces the feature list `ScrollView` with a `VStack` using our modifier `scrollVerticallyIfNeeded()`. This allows the VStack to be scrolled when the list doesn't fit on the screen, but otherwise prevents scrolling.
* Replaces some of the `Spacer()` views with padding, to maintain the expected layout. (The `Spacer()` approach works with a `ScrollView` but not a `VStack`, since those views' heights are not the same.)
* Removes the vertical padding from `IconListItem` and replaces it with `Layout.listSpacing` on the list `VStack`. This allows the spacing between list items to be adjusted depending on the screen size, to better match the iPad design. This change also allows more list items to appear on screen in iPhone landscape mode.

![Simulator Screen Recording - iPhone 12 Pro - 2021-10-22 at 15 47 07](https://user-images.githubusercontent.com/8658164/138477298-55a1003f-235f-4f0a-9d1b-14ff0c9946c5.gif)


Before|After
-|-
![Before-iphone-portrait](https://user-images.githubusercontent.com/8658164/138477120-f57eaced-ca81-4cb3-8d5c-d4e903183746.png)|![After-iphone-portrait](https://user-images.githubusercontent.com/8658164/138477118-f73263c2-cd0e-46ce-8d6c-146a0c853391.png)
![Before-iphone-landscape](https://user-images.githubusercontent.com/8658164/138477127-7431fcdb-8ccd-44fd-8ea1-09a3535fce10.png)|![After-iphone-landscape](https://user-images.githubusercontent.com/8658164/138477116-1f123186-180a-43fa-9d67-e4424966b021.png)
![Before-ipad-portrait](https://user-images.githubusercontent.com/8658164/138477125-23f045de-a4db-4196-beb5-c15730e1cca1.png)|![After-ipad-portrait](https://user-images.githubusercontent.com/8658164/138477112-a4554881-e43f-456f-a4a1-2f158494c200.png)
![Before-ipad-landscape](https://user-images.githubusercontent.com/8658164/138477122-7e787c21-1a08-4b47-b5a6-9b754cdb3d86.png)|![After-ipad-landscape](https://user-images.githubusercontent.com/8658164/138477109-97c1b652-df0e-4338-b93b-27e292726344.png)



## Testing

⚠️ **Prerequisite** ⚠️ 
Make the following changes to display the test announcement:

<img width="562" alt="Screen Shot 2021-10-20 at 12 00 39 PM" src="https://user-images.githubusercontent.com/8658164/138081225-97e8bbf4-983d-4f58-b35f-f7ad3e512746.png">

<img width="1171" alt="Screen Shot 2021-10-20 at 12 00 06 PM" src="https://user-images.githubusercontent.com/8658164/138081226-8b274895-1981-40ef-9b0c-2c84dd9f49e3.png">

1. Build the app in debug mode (to ensure the feature flag is enabled) on an iPhone.
2. What's New component should be displayed upon app launch. (If not, you can go to Settings > What's New in WooCommerce to view it.)
3. With all the list items visible on screen (i.e. in iPhone portrait mode) confirm you _can't_ scroll the list.
4. With all the list items **not** visible on screen (i.e. in iPhone landscape mode) confirm you _can_ scroll the list.
5. Repeat steps 1-4 on an iPad and confirm the list doesn't scroll when all the items are visible on screen.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
