### PR TITLE
Fix multiple instances of `ProductsViewController` in memory after switching stores

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -65,7 +65,9 @@ final class ProductsViewController: UIViewController {
     ///
     private lazy var resultsController: ResultsController<StorageProduct> = {
         let resultsController = createResultsController(siteID: siteID)
-        configureResultsController(resultsController, onReload: reloadTableAndView)
+        configureResultsController(resultsController, onReload: { [weak self] in
+            self?.reloadTableAndView()
+        })
         return resultsController
     }()
 
@@ -716,7 +718,9 @@ private extension ProductsViewController {
     func removePlaceholderProducts() {
         tableView.removeGhostContent()
         // Assign again the original closure
-        setClosuresToResultController(resultsController, onReload: reloadTableAndView)
+        setClosuresToResultController(resultsController, onReload: { [weak self] in
+            self?.reloadTableAndView()
+        })
         tableView.reloadData()
     }
 


### PR DESCRIPTION
Fixes #5272 

## Why

When passing a closure that references `self`, if `self` isn't specified as weak it causes a retain cycle, and thus `ProductsViewController` is not deallocated after switching stores.

For example, after switching stores twice there are 3 instances of `ProductsViewController` and two of them are from the previous two stores:

<img width="1552" alt="Screen Shot 2021-10-25 at 11 22 37 AM" src="https://user-images.githubusercontent.com/1945542/138634342-00aa242a-7fd0-4f70-8499-cd341f8ca443.png">

## Changes

Weak self when setting `ResultsController`'s callbacks.

## Testing

Prerequisite: the app account is connected to more than 1 store

- Launch the app in logged-in state
- Go to the products tab
- In Xcode, run memory debugger and filter by "ProductsViewController" --> there is one `ProductsViewController` instance
- Go to Settings > Switch Store, and switch to a different store
- In Xcode, run memory debugger and filter by "ProductsViewController" --> there should be only one `ProductsViewController` instance

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
