### PR TITLE
Issue/5159 show product category filter list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -52,7 +52,7 @@ final class FilterTypeViewModel {
 enum FilterListValueSelectorConfig {
     // Standard list selector with fixed options
     case staticOptions(options: [FilterType])
-    // Filter list selector for categories, retrieved dynamically
+    // Filter list selector for categories linked to that site id, retrieved dynamically
     case productCategories(siteID: Int64)
 }
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -53,7 +53,7 @@ enum FilterListValueSelectorConfig {
     // Standard list selector with fixed options
     case staticOptions(options: [FilterType])
     // Filter list selector for categories, retrieved dynamically
-    case productCategories
+    case productCategories(siteID: Int64)
 }
 
 /// Contains data for rendering a filter type row.
@@ -226,9 +226,9 @@ private extension FilterListViewController {
                 }
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
-            case .productCategories:
-                // TODO-5159: Show filter products by category view controller
-                break
+            case let .productCategories(siteID):
+                let filterProductCategoryListViewController = FilterProductCategoryListViewController(siteID: siteID)
+                self.listSelector.navigationController?.pushViewController(filterProductCategoryListViewController, animated: true)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -227,6 +227,7 @@ private extension FilterListViewController {
                 let staticListSelector = ListSelectorViewController(command: command, tableViewStyle: .plain) { _ in }
                 self.listSelector.navigationController?.pushViewController(staticListSelector, animated: true)
             case let .productCategories(siteID):
+                // TODO-5159: Handle product category filter selection
                 let filterProductCategoryListViewController = FilterProductCategoryListViewController(siteID: siteID)
                 self.listSelector.navigationController?.pushViewController(filterProductCategoryListViewController, animated: true)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryCellViewModel.swift
@@ -5,7 +5,7 @@ import Foundation
 struct ProductCategoryCellViewModel {
     /// Category ID
     ///
-    let categoryID: Int64
+    let categoryID: Int64?
 
     /// Category name
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryCellViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a row in the ProductCategoryList screen
 ///
-struct ProductCategoryCellViewModel {
+struct ProductCategoryCellViewModel: Equatable {
     /// Category ID
     ///
     let categoryID: Int64?

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -13,11 +13,8 @@ final class ProductCategoryListViewController: UIViewController {
 
     let viewModel: ProductCategoryListViewModel
 
-    private let siteID: Int64
-
-    init(siteID: Int64, selectedCategories: [ProductCategory]) {
-        viewModel = ProductCategoryListViewModel(siteID: siteID, selectedCategories: selectedCategories)
-        self.siteID = siteID
+    init(viewModel: ProductCategoryListViewModel) {
+        self.viewModel = viewModel
 
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -1,7 +1,8 @@
 import Foundation
 import Yosemite
 
-/// Classes conforming to this protocol can enrich the UI to be displayed
+/// Classes conforming to this protocol can enrich the Product Category List UI,
+/// e.g by adding extra rows
 ///
 protocol ProductCategoryListViewModelEnrichingDataSource: AnyObject {
     /// This method enriches the passed view models array so the case logic specific view models can be added
@@ -66,7 +67,7 @@ final class ProductCategoryListViewModel {
 
     /// Enriches product category cells view models
     ///
-    private weak var dataSource: ProductCategoryListViewModelEnrichingDataSource?
+    private weak var enrichingDataSource: ProductCategoryListViewModelEnrichingDataSource?
 
     /// Current  category synchronization state
     ///
@@ -89,12 +90,12 @@ final class ProductCategoryListViewModel {
     init(storesManager: StoresManager = ServiceLocator.stores,
          siteID: Int64,
          selectedCategories: [ProductCategory] = [],
-         dataSource: ProductCategoryListViewModelEnrichingDataSource? = nil,
+         enrichingDataSource: ProductCategoryListViewModelEnrichingDataSource? = nil,
          delegate: ProductCategoryListViewModelDelegate? = nil) {
         self.storesManager = storesManager
         self.siteID = siteID
         self.selectedCategories = selectedCategories
-        self.dataSource = dataSource
+        self.enrichingDataSource = enrichingDataSource
         self.delegate = delegate
     }
 
@@ -144,13 +145,13 @@ final class ProductCategoryListViewModel {
         reloadData()
     }
 
-    /// Resets the selected categories. Please note that this method that not trigger any UI reload
+    /// Resets the selected categories. This method does not trigger any UI reload
     ///
     func resetSelectedCategories() {
         selectedCategories = []
     }
 
-    /// Select or Deselect a category
+    /// Select or Deselect a category, notifying the delegate before any other action
     ///
     func selectOrDeselectCategory(index: Int) {
         delegate?.viewModel(self, didSelectRowAt: index)
@@ -170,13 +171,14 @@ final class ProductCategoryListViewModel {
         updateViewModelsArray()
     }
 
-    /// Updates  `categoryViewModels` from  the resultController's fetched objects.
+    /// Updates  `categoryViewModels` from  the resultController's fetched objects,
+    /// letting the enriching data source enrich the view models array if necessary.
     ///
     func updateViewModelsArray() {
         let fetchedCategories = resultController.fetchedObjects
         let baseViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: selectedCategories)
 
-        categoryViewModels = dataSource?.enrichCategoryViewModels( baseViewModels) ?? baseViewModels
+        categoryViewModels = enrichingDataSource?.enrichCategoryViewModels( baseViewModels) ?? baseViewModels
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -144,6 +144,8 @@ final class ProductCategoryListViewModel {
         reloadData()
     }
 
+    /// Resets the selected categories. Please note that this method that not trigger any UI reload
+    ///
     func resetSelectedCategories() {
         selectedCategories = []
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewController.swift
@@ -23,7 +23,10 @@ final class EditProductCategoryListViewController: UIViewController {
 
     init(product: Product, completion: @escaping Completion) {
         self.product = product
-        productCategoryListViewController = ProductCategoryListViewController(siteID: product.siteID, selectedCategories: product.categories)
+
+        let productCategoryListViewModel = ProductCategoryListViewModel(siteID: product.siteID,
+                                                                        selectedCategories: product.categories)
+        productCategoryListViewController = ProductCategoryListViewController(viewModel: productCategoryListViewModel)
         viewModel = EditProductCategoryListViewModel(product: product,
                                                      baseProductCategoryListViewModel: productCategoryListViewController.viewModel,
                                                      completion: completion)

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import UIKit
 import Yosemite

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -1,0 +1,58 @@
+
+import Foundation
+import UIKit
+import Yosemite
+
+/// FilterProductCategoryListViewController: Displays the list of ProductCategories associated to the active Account,
+/// and allows the selection of one of them, or any.
+///
+final class FilterProductCategoryListViewController: UIViewController {
+
+    private let siteID: Int64
+    private let productCategoryListViewController: ProductCategoryListViewController
+    private let viewModel: FilterProductCategoryListViewModel
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+        self.viewModel = FilterProductCategoryListViewModel()
+        let productCategoryListViewModel = ProductCategoryListViewModel(siteID: siteID,
+                                                                        selectedCategories: [],
+                                                                        dataSource: viewModel,
+                                                                        delegate: viewModel)
+
+        productCategoryListViewController = ProductCategoryListViewController(viewModel: productCategoryListViewModel)
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureProductCategoryListView()
+        configureNavigationBar()
+    }
+
+    func configureProductCategoryListView() {
+        addChild(productCategoryListViewController)
+        attachSubview(productCategoryListViewController.view)
+        productCategoryListViewController.didMove(toParent: self)
+    }
+
+    private func attachSubview(_ subview: UIView) {
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(subview)
+        view.pinSubviewToAllEdges(subview)
+    }
+
+    private func configureNavigationBar() {
+        configureTitle()
+    }
+
+    private func configureTitle() {
+        title = NSLocalizedString("Categories", comment: "Filter product categories screen - Screen title")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -19,7 +19,7 @@ final class FilterProductCategoryListViewController: UIViewController {
         // TODO-5159: Initialize selected categories with the stored filter categories
         let productCategoryListViewModel = ProductCategoryListViewModel(siteID: siteID,
                                                                         selectedCategories: [],
-                                                                        dataSource: viewModel,
+                                                                        enrichingDataSource: viewModel,
                                                                         delegate: viewModel)
 
         productCategoryListViewController = ProductCategoryListViewController(viewModel: productCategoryListViewModel)
@@ -37,15 +37,15 @@ final class FilterProductCategoryListViewController: UIViewController {
         configureProductCategoryListView()
         configureNavigationBar()
     }
+}
 
+private extension FilterProductCategoryListViewController {
     func configureProductCategoryListView() {
         addChild(productCategoryListViewController)
         attachSubview(productCategoryListViewController.view)
         productCategoryListViewController.didMove(toParent: self)
     }
-}
 
-private extension FilterProductCategoryListViewController {
     func attachSubview(_ subview: UIView) {
         subview.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(subview)

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -41,18 +41,20 @@ final class FilterProductCategoryListViewController: UIViewController {
         attachSubview(productCategoryListViewController.view)
         productCategoryListViewController.didMove(toParent: self)
     }
+}
 
-    private func attachSubview(_ subview: UIView) {
+private extension FilterProductCategoryListViewController {
+    func attachSubview(_ subview: UIView) {
         subview.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(subview)
         view.pinSubviewToAllEdges(subview)
     }
 
-    private func configureNavigationBar() {
+    func configureNavigationBar() {
         configureTitle()
     }
 
-    private func configureTitle() {
-        title = NSLocalizedString("Categories", comment: "Filter product categories screen - Screen title")
+    func configureTitle() {
+        title = viewModel.title
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -34,7 +34,7 @@ final class FilterProductCategoryListViewController: UIViewController {
         super.viewDidLoad()
 
         configureProductCategoryListView()
-        configureNavigationBar()
+        configureTitle()
     }
 }
 
@@ -49,10 +49,6 @@ private extension FilterProductCategoryListViewController {
         subview.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(subview)
         view.pinSubviewToAllEdges(subview)
-    }
-
-    func configureNavigationBar() {
-        configureTitle()
     }
 
     func configureTitle() {

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import Yosemite
 
-/// FilterProductCategoryListViewController: Displays the list of ProductCategories associated to the active Account,
+/// Displays the list of ProductCategories associated to the active Account,
 /// and allows the selection of one of them, or any.
 ///
 final class FilterProductCategoryListViewController: UIViewController {

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -15,6 +15,8 @@ final class FilterProductCategoryListViewController: UIViewController {
     init(siteID: Int64) {
         self.siteID = siteID
         self.viewModel = FilterProductCategoryListViewModel()
+
+        // TODO-5159: Initialize selected categories with the stored filter categories
         let productCategoryListViewModel = ProductCategoryListViewModel(siteID: siteID,
                                                                         selectedCategories: [],
                                                                         dataSource: viewModel,

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
@@ -15,7 +15,7 @@ final class FilterProductCategoryListViewModel: ProductCategoryListViewModelEnri
     /// Title for the view
     ///
     let title = Localization.title
-    
+
     /// Holds a reference to the fixed "Any" category cell selection value so it can be used when enriching category view models
     ///
     private var anyCategoryIsSelected = true

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Generates a cell view model for the "Any" selection cell, that is, when there is no category selected.
+///
+fileprivate extension ProductCategoryCellViewModel {
+    static func anyCategoryCellViewModel(isSelected: Bool) -> ProductCategoryCellViewModel {
+        ProductCategoryCellViewModel(categoryID: nil,
+                                     name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                     isSelected: isSelected,
+                                     indentationLevel: 0)
+    }
+}
+
+final class FilterProductCategoryListViewModel: ProductCategoryListViewModelEnrichingDataSource, ProductCategoryListViewModelDelegate {
+    /// Holds a reference to the fixed "Any" category cell selection value so it can be used when enriching category view models
+    ///
+    private var anyCategoryIsSelected = true
+
+    /// Enriches the category view models by adding the "Any" category row view model on top
+    ///
+    func enrichCategoryViewModels(_ viewModels: [ProductCategoryCellViewModel]) -> [ProductCategoryCellViewModel] {
+        var returningViewModels = viewModels
+        let anyCategoryViewModel = ProductCategoryCellViewModel.anyCategoryCellViewModel(isSelected: anyCategoryIsSelected)
+        returningViewModels.insert(anyCategoryViewModel, at: 0)
+
+        return returningViewModels
+    }
+
+    /// Reacts to a cell selection having into account that:
+    ///     - Only one category selection is  allowed when filtering products, that is why categories are reset everytime a selection happens
+    ///     - Because, of that, if one cell is selected (including Any on top) while selected, it stays selected.
+    ///
+    func viewModel(_ viewModel: ProductCategoryListViewModel, didSelectRowAt index: Int) {
+        viewModel.resetSelectedCategories()
+        anyCategoryIsSelected = index == 0
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewModel.swift
@@ -12,6 +12,10 @@ fileprivate extension ProductCategoryCellViewModel {
 }
 
 final class FilterProductCategoryListViewModel: ProductCategoryListViewModelEnrichingDataSource, ProductCategoryListViewModelDelegate {
+    /// Title for the view
+    ///
+    let title = Localization.title
+    
     /// Holds a reference to the fixed "Any" category cell selection value so it can be used when enriching category view models
     ///
     private var anyCategoryIsSelected = true
@@ -33,5 +37,11 @@ final class FilterProductCategoryListViewModel: ProductCategoryListViewModelEnri
     func viewModel(_ viewModel: ProductCategoryListViewModel, didSelectRowAt index: Int) {
         viewModel.resetSelectedCategories()
         anyCategoryIsSelected = index == 0
+    }
+}
+
+private extension FilterProductCategoryListViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("Categories", comment: "Filter product categories screen - Screen title")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -55,13 +55,13 @@ final class FilterProductListViewModel: FilterListViewModel {
 
     /// - Parameters:
     ///   - filters: the filters to be applied initially.
-    init(filters: Filters, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(filters: Filters, siteID: Int64, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.featureFlagService = featureFlagService
 
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
         self.productStatusFilterViewModel = ProductListFilter.productStatus.createViewModel(filters: filters)
         self.productTypeFilterViewModel = ProductListFilter.productType.createViewModel(filters: filters)
-        self.productCategoryFilterViewModel = ProductListFilter.productCategory.createViewModel(filters: filters)
+        self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
 
         var filterTypeViewModels = [
             stockStatusFilterViewModel,
@@ -120,7 +120,7 @@ extension FilterProductListViewModel {
         case stockStatus
         case productStatus
         case productType
-        case productCategory
+        case productCategory(siteID: Int64)
     }
 }
 
@@ -157,9 +157,9 @@ extension FilterProductListViewModel.ProductListFilter {
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: options),
                                        selectedValue: filters.productType)
-        case .productCategory:
+        case let .productCategory(siteID):
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .productCategories,
+                                       listSelectorConfig: .productCategories(siteID: siteID),
                                        selectedValue: filters.productCategory)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -664,7 +664,7 @@ private extension ProductsViewController {
 
     @objc func filterButtonTapped() {
         ServiceLocator.analytics.track(.productListViewFilterOptionsTapped)
-        let viewModel = FilterProductListViewModel(filters: filters)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID)
         let filterProductListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
             ServiceLocator.analytics.track(.productFilterListShowProductsButtonTapped, withProperties: ["filters": filters.analyticsDescription])
             self?.filters = filters

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -843,6 +843,8 @@
 		77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EC72510FE07003D385F /* ProductDownloadsEditableData.swift */; };
 		7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A01962725B811001668D5 /* FilterProductCategoryListViewController.swift */; };
 		7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A019E2725CD76001668D5 /* FilterProductCategoryListViewModel.swift */; };
+		7E6A01A12725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A01A02725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift */; };
+		7E6A01A32726C5D3001668D5 /* MockProductCategoryStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A01A22726C5D3001668D5 /* MockProductCategoryStoresManager.swift */; };
 		7E7C5F782719A8F800315B61 /* EditProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E7C5F752719A8F800315B61 /* EditProductCategoryListViewController.xib */; };
 		7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F762719A8F800315B61 /* EditProductCategoryListViewModel.swift */; };
 		7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F772719A8F800315B61 /* EditProductCategoryListViewController.swift */; };
@@ -2254,6 +2256,8 @@
 		77E53EC72510FE07003D385F /* ProductDownloadsEditableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadsEditableData.swift; sourceTree = "<group>"; };
 		7E6A01962725B811001668D5 /* FilterProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		7E6A019E2725CD76001668D5 /* FilterProductCategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductCategoryListViewModel.swift; sourceTree = "<group>"; };
+		7E6A01A02725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
+		7E6A01A22726C5D3001668D5 /* MockProductCategoryStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductCategoryStoresManager.swift; sourceTree = "<group>"; };
 		7E7C5F752719A8F800315B61 /* EditProductCategoryListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EditProductCategoryListViewController.xib; sourceTree = "<group>"; };
 		7E7C5F762719A8F800315B61 /* EditProductCategoryListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditProductCategoryListViewModel.swift; sourceTree = "<group>"; };
 		7E7C5F772719A8F800315B61 /* EditProductCategoryListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditProductCategoryListViewController.swift; sourceTree = "<group>"; };
@@ -3266,6 +3270,7 @@
 				02F5F80D246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift */,
 				0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */,
 				0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */,
+				7E6A01A02725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -4809,6 +4814,7 @@
 				02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */,
 				6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */,
 				57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */,
+				7E6A01A22726C5D3001668D5 /* MockProductCategoryStoresManager.swift */,
 				02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */,
 				023EC2E124DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift */,
 				45AF9DAE265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift */,
@@ -8131,6 +8137,7 @@
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
+				7E6A01A32726C5D3001668D5 /* MockProductCategoryStoresManager.swift in Sources */,
 				45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */,
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
@@ -8224,6 +8231,7 @@
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
+				7E6A01A12725DEDE001668D5 /* FilterProductCategoryListViewModelTests.swift in Sources */,
 				E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */,
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -841,6 +841,8 @@
 		77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EBE2510C153003D385F /* ProductDownloadListViewModel.swift */; };
 		77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EC42510C193003D385F /* ProductDownloadListViewController+Droppable.swift */; };
 		77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EC72510FE07003D385F /* ProductDownloadsEditableData.swift */; };
+		7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A01962725B811001668D5 /* FilterProductCategoryListViewController.swift */; };
+		7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A019E2725CD76001668D5 /* FilterProductCategoryListViewModel.swift */; };
 		7E7C5F782719A8F800315B61 /* EditProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E7C5F752719A8F800315B61 /* EditProductCategoryListViewController.xib */; };
 		7E7C5F792719A8F900315B61 /* EditProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F762719A8F800315B61 /* EditProductCategoryListViewModel.swift */; };
 		7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F772719A8F800315B61 /* EditProductCategoryListViewController.swift */; };
@@ -2250,6 +2252,8 @@
 		77E53EBE2510C153003D385F /* ProductDownloadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewModel.swift; sourceTree = "<group>"; };
 		77E53EC42510C193003D385F /* ProductDownloadListViewController+Droppable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDownloadListViewController+Droppable.swift"; sourceTree = "<group>"; };
 		77E53EC72510FE07003D385F /* ProductDownloadsEditableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadsEditableData.swift; sourceTree = "<group>"; };
+		7E6A01962725B811001668D5 /* FilterProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductCategoryListViewController.swift; sourceTree = "<group>"; };
+		7E6A019E2725CD76001668D5 /* FilterProductCategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductCategoryListViewModel.swift; sourceTree = "<group>"; };
 		7E7C5F752719A8F800315B61 /* EditProductCategoryListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EditProductCategoryListViewController.xib; sourceTree = "<group>"; };
 		7E7C5F762719A8F800315B61 /* EditProductCategoryListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditProductCategoryListViewModel.swift; sourceTree = "<group>"; };
 		7E7C5F772719A8F800315B61 /* EditProductCategoryListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditProductCategoryListViewController.swift; sourceTree = "<group>"; };
@@ -3713,6 +3717,8 @@
 			children = (
 				02C88774245036D400E4470F /* FilterProductListViewModel.swift */,
 				0295355A245ADF8100BDC42B /* FilterType+Products.swift */,
+				7E6A01962725B811001668D5 /* FilterProductCategoryListViewController.swift */,
+				7E6A019E2725CD76001668D5 /* FilterProductCategoryListViewModel.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -7343,6 +7349,7 @@
 				B5DB01B52114AB2D00A4F797 /* WooCrashLoggingStack.swift in Sources */,
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */,
+				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
@@ -7778,6 +7785,7 @@
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,
+				7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */,
 				E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */,
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductCategoryStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductCategoryStoresManager.swift
@@ -1,0 +1,35 @@
+import Yosemite
+@testable import WooCommerce
+
+/// Mock Product Category Store Manager
+///
+ final class MockProductCategoryStoresManager: DefaultStoresManager {
+
+    /// Set mock responses to be dispatched upon Product Category Actions.
+    ///
+    var productCategoryResponse: ProductCategoryActionError?
+
+    /// Indicates how many times respones where consumed
+    ///
+    private(set) var numberOfResponsesConsumed = 0
+
+    init() {
+        super.init(sessionManager: SessionManager.testingInstance)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let productCategoryAction = action as? ProductCategoryAction {
+            handleProductCategoryAction(productCategoryAction)
+        }
+    }
+
+    private func handleProductCategoryAction(_ action: ProductCategoryAction) {
+        switch action {
+        case let .synchronizeProductCategories(_, _, onCompletion):
+            numberOfResponsesConsumed = numberOfResponsesConsumed + 1
+            onCompletion(productCategoryResponse)
+        default:
+            return
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -21,6 +21,28 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         storesManager = nil
     }
 
+    func test_resetSelectedCategories_then_it_does_not_return_any_view_model() {
+        // Given
+        let exp = expectation(description: #function)
+        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, siteID: 0)
+
+        // When
+        viewModel.performFetch()
+        viewModel.observeCategoryListStateChanges { state in
+            if state == .synced {
+                viewModel.selectOrDeselectCategory(index: 0)
+                viewModel.resetSelectedCategories()
+
+                exp.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(viewModel.categoryViewModels.isEmpty)
+    }
+
     func testItTransitionsToSyncedStateAfterSynchronizingCategories() {
         // Given
         let exp = expectation(description: #function)
@@ -77,40 +99,5 @@ final class ProductCategoryListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(reloadNeededIsCalled)
-    }
-}
-
-
-
-/// Mock Product Category Store Manager
-///
-private final class MockProductCategoryStoresManager: DefaultStoresManager {
-
-    /// Set mock responses to be dispatched upon Product Category Actions.
-    ///
-    var productCategoryResponse: ProductCategoryActionError?
-
-    /// Indicates how many times respones where consumed
-    ///
-    private(set) var numberOfResponsesConsumed = 0
-
-    init() {
-        super.init(sessionManager: SessionManager.testingInstance)
-    }
-
-    override func dispatch(_ action: Action) {
-        if let productCategoryAction = action as? ProductCategoryAction {
-            handleProductCategoryAction(productCategoryAction)
-        }
-    }
-
-    private func handleProductCategoryAction(_ action: ProductCategoryAction) {
-        switch action {
-        case let .synchronizeProductCategories(_, _, onCompletion):
-            numberOfResponsesConsumed = numberOfResponsesConsumed + 1
-            onCompletion(productCategoryResponse)
-        default:
-            return
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-
+import TestKit
 @testable import WooCommerce
 @testable import Yosemite
 @testable import Networking
@@ -72,31 +72,29 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
     }
 
     func test_select_index_then_productCategoryListViewModel_reset_categories() {
-        // Given
-        let exp = expectation(description: #function)
-
         // When
         productCategoryListViewModel.performFetch()
-        productCategoryListViewModel.observeCategoryListStateChanges { [weak self] state in
-            guard let self = self else {
-                return
-            }
 
-            if state == .synced {
-                self.filterProductCategoryListViewModel.viewModel(self.productCategoryListViewModel, didSelectRowAt: 0)
+        let categoryViewModels: [ProductCategoryCellViewModel] = waitFor { [weak self] promise in
+            self?.productCategoryListViewModel.observeCategoryListStateChanges { [weak self] state in
+                guard let self = self else {
+                    return
+                }
 
-                exp.fulfill()
+                if state == .synced {
+                    self.filterProductCategoryListViewModel.viewModel(self.productCategoryListViewModel, didSelectRowAt: 0)
+
+                    promise(self.productCategoryListViewModel.categoryViewModels)
+                }
             }
         }
-
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
 
         // Then
         let expectedAnyCategoryViewModel = ProductCategoryCellViewModel(categoryID: nil,
                                                                         name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
                                                                         isSelected: true,
                                                                         indentationLevel: 0)
-        XCTAssertEqual(productCategoryListViewModel.categoryViewModels.first, expectedAnyCategoryViewModel)
-        XCTAssertEqual(productCategoryListViewModel.categoryViewModels.count, 1)
+        XCTAssertEqual(categoryViewModels.first, expectedAnyCategoryViewModel)
+        XCTAssertEqual(categoryViewModels.count, 1)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -14,7 +14,7 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
         filterProductCategoryListViewModel = FilterProductCategoryListViewModel()
         productCategoryListViewModel = ProductCategoryListViewModel(storesManager: MockProductCategoryStoresManager(),
                                                                     siteID: 0,
-                                                                    dataSource: filterProductCategoryListViewModel,
+                                                                    enrichingDataSource: filterProductCategoryListViewModel,
                                                                     delegate: filterProductCategoryListViewModel)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+@testable import Networking
+
+final class FilterProductCategoryListViewModelTests: XCTestCase {
+    private var filterProductCategoryListViewModel: FilterProductCategoryListViewModel!
+    private var productCategoryListViewModel: ProductCategoryListViewModel!
+
+    override func setUp() {
+        super.setUp()
+
+        filterProductCategoryListViewModel = FilterProductCategoryListViewModel()
+        productCategoryListViewModel = ProductCategoryListViewModel(storesManager: MockProductCategoryStoresManager(),
+                                                                    siteID: 0,
+                                                                    dataSource: filterProductCategoryListViewModel,
+                                                                    delegate: filterProductCategoryListViewModel)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        filterProductCategoryListViewModel = nil
+        productCategoryListViewModel = nil
+    }
+
+    func test_enrichCategoryViewModels_then_it_adds_the_any_category_view_model() {
+        // Given
+        let categoryViewModel = ProductCategoryCellViewModel(categoryID: 1,
+                                                              name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                                              isSelected: true,
+                                                              indentationLevel: 0)
+
+        // When
+        let enrichedViewModels = filterProductCategoryListViewModel.enrichCategoryViewModels([categoryViewModel])
+
+        // Then
+        let expectedAnyCategoryViewModel = ProductCategoryCellViewModel(categoryID: nil,
+                                                                        name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                                                        isSelected: true,
+                                                                        indentationLevel: 0)
+        XCTAssertEqual(enrichedViewModels.count, 2)
+        XCTAssertEqual(enrichedViewModels.first, expectedAnyCategoryViewModel)
+        XCTAssertEqual(enrichedViewModels.last, categoryViewModel)
+    }
+
+    func test_index_other_than_zero_is_selected_then_any_view_model_is_deselected() {
+        // When
+        filterProductCategoryListViewModel.viewModel(productCategoryListViewModel, didSelectRowAt: 1)
+
+        // Then
+        let expectedAnyCategoryViewModel = ProductCategoryCellViewModel(categoryID: nil,
+                                                                        name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                                                        isSelected: false,
+                                                                        indentationLevel: 0)
+        let enrichedViewModels = filterProductCategoryListViewModel.enrichCategoryViewModels([])
+        XCTAssertEqual(enrichedViewModels.first, expectedAnyCategoryViewModel)
+    }
+
+    func test_index_zero_is_selected_then_any_view_model_is_selected() {
+        // When
+        filterProductCategoryListViewModel.viewModel(productCategoryListViewModel, didSelectRowAt: 0)
+
+        // Then
+        let expectedAnyCategoryViewModel = ProductCategoryCellViewModel(categoryID: nil,
+                                                                        name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                                                        isSelected: true,
+                                                                        indentationLevel: 0)
+        let enrichedViewModels = filterProductCategoryListViewModel.enrichCategoryViewModels([])
+        XCTAssertEqual(enrichedViewModels.first, expectedAnyCategoryViewModel)
+    }
+
+    func test_select_index_then_productCategoryListViewModel_reset_categories() {
+        // Given
+        let exp = expectation(description: #function)
+
+        // When
+        productCategoryListViewModel.performFetch()
+        productCategoryListViewModel.observeCategoryListStateChanges { [weak self] state in
+            guard let self = self else {
+                return
+            }
+
+            if state == .synced {
+                self.filterProductCategoryListViewModel.viewModel(self.productCategoryListViewModel, didSelectRowAt: 0)
+
+                exp.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
+        // Then
+        let expectedAnyCategoryViewModel = ProductCategoryCellViewModel(categoryID: nil,
+                                                                        name: NSLocalizedString("Any", comment: "Title when there is no filter set."),
+                                                                        isSelected: true,
+                                                                        indentationLevel: 0)
+        XCTAssertEqual(productCategoryListViewModel.categoryViewModels.first, expectedAnyCategoryViewModel)
+        XCTAssertEqual(productCategoryListViewModel.categoryViewModels.count, 1)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModel+numberOfActiveFiltersTests.swift
@@ -57,7 +57,7 @@ private extension FilterProductListViewModel_numberOfActiveFiltersTests {
             FilterProductListViewModel.ProductListFilter.stockStatus.createViewModel(filters: filters),
             FilterProductListViewModel.ProductListFilter.productStatus.createViewModel(filters: filters),
             FilterProductListViewModel.ProductListFilter.productType.createViewModel(filters: filters),
-            FilterProductListViewModel.ProductListFilter.productCategory.createViewModel(filters: filters)
+            FilterProductListViewModel.ProductListFilter.productCategory(siteID: 0).createViewModel(filters: filters)
         ]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -39,7 +39,7 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
     }
 
     func testCreatingProductCategoryFilterTypeViewModel() {
-        let filterType = FilterProductListViewModel.ProductListFilter.productCategory
+        let filterType = FilterProductListViewModel.ProductListFilter.productCategory(siteID: 0)
 
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock,
                                                          productStatus: .draft,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -10,7 +10,7 @@ final class FilterProductListViewModelTests: XCTestCase {
         let filters = FilterProductListViewModel.Filters()
 
         // When
-        let viewModel = FilterProductListViewModel(filters: filters)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0)
 
         // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil,
@@ -31,7 +31,7 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // When
         let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
-        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
 
         // Then
         let expectedCriteria = filters
@@ -48,7 +48,7 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // When
         let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: true)
-        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
         viewModel.clearAll()
 
         // Then
@@ -70,7 +70,7 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // When
         let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
-        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
 
         // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: filters.stockStatus,
@@ -91,7 +91,7 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // When
         let featureFlagService = MockFeatureFlagService(isFilterProductsByCategoryOn: false)
-        let viewModel = FilterProductListViewModel(filters: filters, featureFlagService: featureFlagService)
+        let viewModel = FilterProductListViewModel(filters: filters, siteID: 0, featureFlagService: featureFlagService)
 
         // Then
         let productCategoryFilterTypeViewModels = viewModel.filterTypeViewModels.compactMap { $0.selectedValue as? ProductCategory }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/5159

## Description

In the context of https://github.com/woocommerce/woocommerce-ios/issues/5159, we implement in this PR the `FilterProductCategoryListViewController` that shows the categories plus the "Any" filter row. Furthermore, we enhance the `productCategories` case of `FilterListValueSelectorConfig` with the `siteID` `Int64` necessary to fetch the relevant categories. Likewise, we pass that `siteID` to the `FilterProductListViewModel` from the `ProductsListViewController`, so it can be passed along. While the selection UI is implemented here, the selected product category is not passed to the filter yet, so products are not filtered by category yet. (will be implemented in the next PR)

## Challenges

In https://github.com/woocommerce/woocommerce-ios/pull/5230 we extracted the `ProductCategoryListViewController` from `EditProductCategoryListViewController`, so it can be reused in other cases, like in this one. There are however few features that are only specific to the filter product category list case:
- We should show an extra row on top with the title "Any"
- Unlike the case of `EditProductCategoryListViewController` where none or multiple categories can be selected, in this case **only and always one** should be selected (or Any)

To implement this business logic, we extend the functionality of `ProductCategoryListViewModel` with two protocols, 
`ProductCategoryListViewModelEnrichingDataSource`, that can modify the UI, and `ProductCategoryListViewModelDelegate`, that reacts to the selection event. The relevant logic for our case is encapsulated in `FilterProductCategoryListViewModel`, that conforms to these two protocols. It adds an extra row on top of the product category list (Any), and reacts to the selection event by reseting the categories so only one is selected, and updating the Any row selection state.  As you can see, nothing changes for the `EditProductCategoryListViewModel`, thus keeping its behaviour exactly as it was.

## Changes
- Pass that `siteID` to the `FilterProductListViewModel` from the `ProductsListViewController`
- Enhance the `productCategories` case of `FilterListValueSelectorConfig` with the `siteID` `Int64`
- Use it to retrieve product categories linked to that `siteID`
- Create `FilterProductCategoryListViewController` to show the product categories to be filtered
- Create `FilterProductCategoryListViewModel` to handle its logic
- Extend `ProductCategoryListViewModel` with `ProductCategoryListViewModelEnrichingDataSource` and `ProductCategoryListViewModelDelegate`
- Make `FilterProductCategoryListViewModel` conform to these protocols to implement its specific business logic
- Make `categoryID` in `ProductCategoryCellViewModel` optional so we can handle the "Any" cell case, that is not linked to any particular product category
- Refactor `ProductCategoryListViewController` initializer to accept the view model as parameter instead of multiple ones that are only used in the view model
- Move `MockProductCategoryStoresManager` to its own file, make it public
- Add Unit tests, TODOs

## Test
- Open the app
- Go to Products tab
- Open Filter
- Open Product Category:
  - Loading ghost effect should be visible
  - Product Categories are shown
  - Any row is shown on top
  - Only and always one product category (or the any row) can be selected (same as other filters)
  - UI looks good for landscape and portrait

<img src="https://user-images.githubusercontent.com/1864060/138704731-97ad31f7-6869-4c05-bc26-f541e036946d.png" width="320" height="693">
<img src="https://user-images.githubusercontent.com/1864060/138704951-680260b7-3df1-4470-8e73-990397adf349.png" width="693" height="320">

## Next Steps
- Pass the selected product category along and filter the products according to it
- Remove the feature flag

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
