### PR TITLE
Quick Pay: Adds announcement banners

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -301,7 +301,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
         }
 
         transitionToSyncingState()
-        setErrorLoadingData(to: false)
+        viewModel.hasErrorLoadingData = false
 
         let action = viewModel.synchronizationAction(
             siteID: siteID,
@@ -314,7 +314,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
 
                 if let error = error {
                     DDLogError("⛔️ Error synchronizing orders: \(error)")
-                    self.setErrorLoadingData(to: true)
+                    self.viewModel.hasErrorLoadingData = true
                 } else {
                     if pageNumber == self.syncingCoordinator.pageFirstIndex {
                         // save timestamp of last successful update
@@ -330,12 +330,6 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
         }
 
         ServiceLocator.stores.dispatch(action)
-    }
-
-    /// Sets `hasErrorLoadingData` in the view model.
-    ///
-    private func setErrorLoadingData(to hasError: Bool) {
-        viewModel.hasErrorLoadingData = hasError
     }
 
     /// Sets the current top banner in the table view header

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -96,22 +96,9 @@ final class OrderListViewController: UIViewController {
 
     private let siteID: Int64
 
-    /// Top banner that shows an error if there is a problem loading orders data
+    /// Current top banner that is displayed.
     ///
-    private lazy var topBannerView: TopBannerView = {
-        ErrorTopBannerFactory.createTopBanner(isExpanded: false,
-                                              expandedStateChangeHandler: { [weak self] in
-                                                self?.tableView.updateHeaderHeight()
-                                              },
-                                              onTroubleshootButtonPressed: { [weak self] in
-                                                let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-                                                self?.present(safariViewController, animated: true, completion: nil)
-                                              },
-                                              onContactSupportButtonPressed: { [weak self] in
-                                                guard let self = self else { return }
-                                                ZendeskManager.shared.showNewRequestIfPossible(from: self, with: nil)
-                                              })
-    }()
+    private var topBannerView: TopBannerView?
 
     // MARK: - View Lifecycle
 
@@ -345,20 +332,17 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
         ServiceLocator.stores.dispatch(action)
     }
 
-    /// Sets `hasErrorLoadingData` in the view model and shows or hides the banner view accordingly
+    /// Sets `hasErrorLoadingData` in the view model.
     ///
     private func setErrorLoadingData(to hasError: Bool) {
         viewModel.hasErrorLoadingData = hasError
-        if hasError {
-            showTopBannerView()
-        } else {
-            hideTopBannerView()
-        }
     }
 
-    /// Display the error banner in the table view header
+    /// Sets the current top banner in the table view header
     ///
     private func showTopBannerView() {
+        guard let topBannerView = topBannerView else { return }
+
         // Configure header container view
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
         headerContainer.addSubview(topBannerView)
@@ -371,7 +355,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     /// Hide the top banner from the table view header
     ///
     private func hideTopBannerView() {
-        topBannerView.removeFromSuperview()
+        topBannerView?.removeFromSuperview()
         tableView.tableHeaderView = nil
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -205,11 +205,11 @@ private extension OrderListViewController {
                 case .none:
                     self.hideTopBannerView()
                 case .error:
-                    break
+                    self.setErrorTopBanner()
                 case .quickPayEnabled:
-                    break
+                    self.setQuickPayEnabledTopBanner()
                 case .quickPayDisabled:
-                    break
+                    self.setQuickPayDisabledTopBanner()
                 }
             }
             .store(in: &cancellables)
@@ -590,6 +590,49 @@ extension OrderListViewController: IndicatorInfoProvider {
     }
 }
 
+// MARK: Top Banner Factories
+private extension OrderListViewController {
+    /// Sets the `topBannerView` property to an error banner.
+    ///
+    func setErrorTopBanner() {
+        topBannerView = ErrorTopBannerFactory.createTopBanner(isExpanded: false, expandedStateChangeHandler: { [weak self] in
+            self?.tableView.updateHeaderHeight()
+        },
+        onTroubleshootButtonPressed: { [weak self] in
+            let safariViewController = SFSafariViewController(url: WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            self?.present(safariViewController, animated: true, completion: nil)
+        },
+        onContactSupportButtonPressed: { [weak self] in
+            guard let self = self else { return }
+            ZendeskManager.shared.showNewRequestIfPossible(from: self, with: nil)
+        })
+        showTopBannerView()
+    }
+
+    /// Sets the `topBannerView` property to a quick pay disabled banner.
+    ///
+    func setQuickPayDisabledTopBanner() {
+        topBannerView = QuickPayTopBannerFactory.createFeatureDisabledBanner(onTopButtonPressed: { [weak self] in
+            self?.tableView.updateHeaderHeight()
+        }, onDismissButtonPressed: {
+            // TODO: Hide top banner
+        })
+        showTopBannerView()
+    }
+
+    /// Sets the `topBannerView` property to a quick pay enabled banner.
+    ///
+    func setQuickPayEnabledTopBanner() {
+        topBannerView = QuickPayTopBannerFactory.createFeatureEnabledBanner(onTopButtonPressed: { [weak self] in
+            self?.tableView.updateHeaderHeight()
+        }, onDismissButtonPressed: {
+            // TODO: Hide top banner
+        }, onGiveFeedbackButtonPressed: {
+            // TODO: Show feedback survey
+        })
+        showTopBannerView()
+    }
+}
 
 // MARK: - Nested Types
 //

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -71,6 +71,18 @@ final class OrderListViewModel {
     ///
     var hasErrorLoadingData: Bool = false
 
+    /// Tracks if the store is ready to receive payments.
+    ///
+    private let inPersonPaymentsReadyUseCase = CardPresentPaymentsOnboardingUseCase()
+
+    /// Tracks if the merchant has enabled the Quick Pay experimental feature toggle
+    ///
+    private var isQuickPayEnabled = false
+
+    /// Tracks if the Quick Pay feature is ready to be released to the public
+    ///
+    private let isQuickPayDevelopmentComplete = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.quickPayPrototype)
+
     init(siteID: Int64,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
@@ -230,5 +242,17 @@ extension OrderListViewModel {
     /// Returns the corresponding section title for the given identifier.
     func sectionTitleFor(sectionIdentifier: String) -> String? {
         Age(rawValue: sectionIdentifier)?.description
+    }
+}
+
+// MARK: Definitions
+extension OrderListViewModel {
+    /// Possible top banners this view model can show.
+    ///
+    enum TopBanner {
+        case error
+        case quickPayEnabled
+        case quickPayDisabled
+        case none
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -83,7 +83,7 @@ final class OrderListViewModel {
 
     /// Tracks if the merchant has enabled the Quick Pay experimental feature toggle
     ///
-    private var isQuickPayEnabled = false
+    @Published private var isQuickPayEnabled = false
 
     /// Tracks if the Quick Pay feature is ready to be released to the public
     ///
@@ -242,8 +242,9 @@ extension OrderListViewModel {
     private func bindTopBannerState() {
         let enrolledState = inPersonPaymentsReadyUseCase.$state.removeDuplicates()
         let errorState = $hasErrorLoadingData.removeDuplicates()
-        Publishers.CombineLatest(enrolledState, errorState)
-            .map { [weak self] state, hasError -> TopBanner in
+        let experimentalState = $isQuickPayEnabled.removeDuplicates()
+        Publishers.CombineLatest3(enrolledState, errorState, experimentalState)
+            .map { [weak self] enrolledState, hasError, isQuickPayEnabled -> TopBanner in
                 guard let self = self else { return .none }
 
                 guard !hasError else {
@@ -254,7 +255,7 @@ extension OrderListViewModel {
                     return .none
                 }
 
-                switch (state, self.isQuickPayEnabled) {
+                switch (enrolledState, isQuickPayEnabled) {
                 case (.completed, false):
                     return .quickPayDisabled
                 case (.completed, true):

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -71,6 +71,10 @@ final class OrderListViewModel {
     ///
     var hasErrorLoadingData: Bool = false
 
+    /// Determines what top banner should be shown
+    ///
+    @Published private(set) var topBanner: TopBanner = .none
+
     /// Tracks if the store is ready to receive payments.
     ///
     private let inPersonPaymentsReadyUseCase = CardPresentPaymentsOnboardingUseCase()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -79,7 +79,7 @@ final class OrderListViewModel {
 
     /// Tracks if the store is ready to receive payments.
     ///
-    private let inPersonPaymentsReadyUseCase = CardPresentPaymentsOnboardingUseCase()
+    private let inPersonPaymentsReadyUseCase: CardPresentPaymentsOnboardingUseCaseProtocol
 
     /// Tracks if the merchant has enabled the Quick Pay experimental feature toggle
     ///
@@ -94,13 +94,15 @@ final class OrderListViewModel {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
-         statusFilter: OrderStatus?) {
+         statusFilter: OrderStatus?,
+         inPersonPaymentsReadyUseCase: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase()) {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
         self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
         self.statusFilter = statusFilter
+        self.inPersonPaymentsReadyUseCase = inPersonPaymentsReadyUseCase
     }
 
     deinit {
@@ -240,7 +242,7 @@ extension OrderListViewModel {
     /// Figures out what top banner should be shown based on the view model internal state.
     ///
     private func bindTopBannerState() {
-        let enrolledState = inPersonPaymentsReadyUseCase.$state.removeDuplicates()
+        let enrolledState = inPersonPaymentsReadyUseCase.statePublisher.removeDuplicates()
         let errorState = $hasErrorLoadingData.removeDuplicates()
         let experimentalState = $isQuickPayEnabled.removeDuplicates()
         Publishers.CombineLatest3(enrolledState, errorState, experimentalState)

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayTopBannerFactory.swift
@@ -1,0 +1,54 @@
+import Yosemite
+
+/// Factory for the QuickPay top banners
+///
+struct QuickPayTopBannerFactory {
+
+    /// Creates a banner to be shown when the quick pay has not been enabled in the beta features screen
+    ///
+    static func createFeatureDisabledBanner(onTopButtonPressed: @escaping () -> Void,
+                                            onDismissButtonPressed: @escaping () -> Void) -> TopBannerView {
+        let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss, action: { _ in onDismissButtonPressed() })
+        let viewModel = TopBannerViewModel(title: Localization.title,
+                                           infoText: Localization.disabledInfo,
+                                           icon: .megaphoneIcon,
+                                           isExpanded: false,
+                                           topButton: .chevron(handler: onTopButtonPressed),
+                                           actionButtons: [dismissAction])
+        let topBannerView = TopBannerView(viewModel: viewModel)
+        topBannerView.translatesAutoresizingMaskIntoConstraints = false
+        return topBannerView
+    }
+
+    /// Creates a banner to be shown when the quick pay has been enabled in the beta features screen
+    ///
+    static func createFeatureEnabledBanner(onTopButtonPressed: @escaping () -> Void,
+                                           onDismissButtonPressed: @escaping () -> Void,
+                                           onGiveFeedbackButtonPressed: @escaping () -> Void) -> TopBannerView {
+        let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss, action: { _ in onDismissButtonPressed() })
+        let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback, action: { _ in onGiveFeedbackButtonPressed() })
+        let viewModel = TopBannerViewModel(title: Localization.title,
+                                           infoText: Localization.enabledInfo,
+                                           icon: .megaphoneIcon,
+                                           isExpanded: false,
+                                           topButton: .chevron(handler: onTopButtonPressed),
+                                           actionButtons: [giveFeedbackAction, dismissAction])
+        let topBannerView = TopBannerView(viewModel: viewModel)
+        topBannerView.translatesAutoresizingMaskIntoConstraints = false
+        return topBannerView
+    }
+}
+
+private extension QuickPayTopBannerFactory {
+    enum Localization {
+        static let title = NSLocalizedString("Take payments from your device!", comment: "Title of the banner notice in the Quick Pay feature")
+        static let disabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
+                                                    "Enable it from the Experimental Features section.",
+                                                    comment: "Content of the top banner to announce the quick pay feature.")
+        static let enabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
+                                                   "For now, tap on the \"+\" button and you’ll be able to create an order with the amount you want to collect",
+                                                   comment: "Content of the banner notice in the Quick Pay view")
+        static let dismiss = NSLocalizedString("Dismiss", comment: "The title of the button to dismiss the QuickPay top banner")
+        static let giveFeedback = NSLocalizedString("Give feedback", comment: "Title of the button to give feedback about the Quick Pay feature")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/QuickPay/QuickPayTopBannerFactory.swift
@@ -43,7 +43,7 @@ private extension QuickPayTopBannerFactory {
     enum Localization {
         static let title = NSLocalizedString("Take payments from your device!", comment: "Title of the banner notice in the Quick Pay feature")
         static let disabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
-                                                    "Enable it from the Experimental Features section.",
+                                                    "Enable Quick Order in Settings > Experimental Features.",
                                                     comment: "Content of the top banner to announce the quick pay feature.")
         static let enabledInfo = NSLocalizedString("We are working on making it easier for you to take payments from your device! " +
                                                    "For now, tap on the \"+\" button and you’ll be able to create an order with the amount you want to collect",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
 		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
+		26100B1E2721BAD800473045 /* QuickPayTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1D2721BAD800473045 /* QuickPayTopBannerFactory.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
@@ -1824,6 +1825,7 @@
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
 		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
+		26100B1D2721BAD800473045 /* QuickPayTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPayTopBannerFactory.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
@@ -3937,6 +3939,7 @@
 			children = (
 				2678897B270E6E8B00BD249E /* QuickPayAmount.swift */,
 				262AF386271114CC00E39AFF /* QuickPayAmountViewModel.swift */,
+				26100B1D2721BAD800473045 /* QuickPayTopBannerFactory.swift */,
 			);
 			path = QuickPay;
 			sourceTree = "<group>";
@@ -7619,6 +7622,7 @@
 				023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */,
 				2664210326F40FB1001FC5B4 /* View+ScrollModifiers.swift in Sources */,
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
+				26100B1E2721BAD800473045 /* QuickPayTopBannerFactory.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,
 				4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -229,8 +229,8 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_having_no_error_and_no_quick_pay_does_not_show_banner() {
         // Given
-        // TODO: Set onboard state to incomplete
-        let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil)
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
+        let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
 
         // When
         viewModel.activate()
@@ -267,7 +267,8 @@ final class OrderListViewModelTests: XCTestCase {
             }
         }
 
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
 
         // When
         viewModel.activate()
@@ -292,8 +293,8 @@ final class OrderListViewModelTests: XCTestCase {
             }
         }
 
-        // TODO: Onboard store explicitly
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
 
         // When
         viewModel.activate()
@@ -317,8 +318,8 @@ final class OrderListViewModelTests: XCTestCase {
             }
         }
 
-        // TODO: Onboard store explicitly
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
 
         // When
         viewModel.activate()
@@ -342,8 +343,8 @@ final class OrderListViewModelTests: XCTestCase {
             }
         }
 
-        // TODO: Set store to not onboarded explicitly
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .wcpayNotInstalled)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
 
         // When
         viewModel.activate()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -226,6 +226,134 @@ final class OrderListViewModelTests: XCTestCase {
         // Assert
         XCTAssertFalse(resynchronizeRequested)
     }
+
+    func test_having_no_error_and_no_quick_pay_does_not_show_banner() {
+        // Given
+        // TODO: Set onboard state to incomplete
+        let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .none
+        }
+    }
+
+    func test_storing_error_shows_error_banner() {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.hasErrorLoadingData = true
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .error
+        }
+    }
+
+    func test_storing_error_shows_error_banner_with_precedence_over_other_state() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadQuickPaySwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                XCTFail("Unsupported action: \(action)")
+            }
+        }
+
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.reloadQuickPayExperimentalFeatureState()
+        viewModel.hasErrorLoadingData = true
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .error
+        }
+    }
+
+    func test_having_store_onboarded_and_quick_pay_disabled_shows_disabled_top_banner() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadQuickPaySwitchState(let onCompletion):
+                onCompletion(.success(false))
+            default:
+                XCTFail("Unsupported action: \(action)")
+            }
+        }
+
+        // TODO: Onboard store explicitly
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.reloadQuickPayExperimentalFeatureState()
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .quickPayDisabled
+        }
+    }
+
+    func test_having_store_onboarded_and_quick_pay_enabled_shows_enabled_top_banner() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadQuickPaySwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                XCTFail("Unsupported action: \(action)")
+            }
+        }
+
+        // TODO: Onboard store explicitly
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.reloadQuickPayExperimentalFeatureState()
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .quickPayEnabled
+        }
+    }
+
+    func test_having_store_not_onboarded_and_quick_pay_enabled_shows_no_banner() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadQuickPaySwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                XCTFail("Unsupported action: \(action)")
+            }
+        }
+
+        // TODO: Set store to not onboarded explicitly
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.reloadQuickPayExperimentalFeatureState()
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .none
+        }
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
# Why

In order to give the feature more discoverability and to allow merchants to give early feedback, this PR adds two quick pay banners on the order list screen.

The first banner will be shown when the store is IPP eligible but the merchant hasn't enabled the experimental feature

<img width="397" alt="disabled" src="https://user-images.githubusercontent.com/562080/138725365-cb532afe-03b2-4d47-8c21-e36a8fc38741.png">


The second banner will be shown when the store is IPP eligible and the merchant has enabled the experimental feature.

<img width="391" alt="enabled" src="https://user-images.githubusercontent.com/562080/138725394-b194ffc1-ee1e-4bfa-87d0-6af80f0671d3.png">

**Note** Button actions will be done in the next PR. (This was getting quite big already)

# How

The order list screen already has a top banner set up when there is an error loading data, for this reason, this PR is refactoring that code in order to show a banner depending on the various states of the app.

The general rules are:

- If there is any error, show the error banner

- If there is no error, the store is IPP eligible and quick pay is disabled, show the quick pay disabled banner.

- If there is no error, the store is IPP eligible and quick pay is enabled, show the quick pay enabled banner.


To accomplish that, the main changes are:

- Created a `QuickPayTopBannerFactory` to create the new quick pay banners

- Updated `OrderListViewModel` to make the VM the one in charge of telling the VC what is the banner should be shown. I have turned some of the variables into published properties in order to combine those state streams.

- Updated `OrderListViewController` to not have a fixed top banner but have a dynamic one, that is driven by the view model content.

# Demo

https://user-images.githubusercontent.com/562080/138724892-0a9d9fe1-6e50-41ff-a9c3-6f04426437d4.mov

# Testing Steps

- Make sure you are in an IPP eligible store
- Go the exp features screen and make sure the quick pay toggle is off.
- Go to the order list and see a banner announcing the feature
- Toggle the quick pay exp feature
- Go back to the order list and see the banner with a "Give Feedback" button
- Turn of internet, and reload the order list
- See the error banner.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
