### PR TITLE
What's New: Hide decorative icons from VoiceOver

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -35,6 +35,7 @@ struct IconListItem: View {
         HStack(alignment: .center, spacing: Layout.contentSpacing) {
             icon?.getImage()
                 .frame(width: Layout.iconSize.width, height: Layout.iconSize.height)
+                .accessibility(hidden: true)
             VStack(alignment: .leading, spacing: Layout.innerSpacing) {
                 Text(title)
                     .headlineStyle()


### PR DESCRIPTION
Fixes: #5274

## Description

An accessibility review of the What's New component turned up a small accessibility issue:

The icons next to each feature on the What's New screen are just decorative, so they should be hidden from VoiceOver. That way VoiceOver won't identify the icons (by saying "image"); instead, it just skips them to read the content only.

## Changes

Adds `accessibility(hidden: true)` to the image icon in the `IconListItem` component.

https://user-images.githubusercontent.com/8658164/138726521-4223662c-e81b-4105-a9ed-54f5cb9a8c19.mov


## Testing

⚠️ **Prerequisite** ⚠️ 
Make the following changes to display the test announcement:

<img width="562" alt="Screen Shot 2021-10-20 at 12 00 39 PM" src="https://user-images.githubusercontent.com/8658164/138081225-97e8bbf4-983d-4f58-b35f-f7ad3e512746.png">

<img width="1171" alt="Screen Shot 2021-10-20 at 12 00 06 PM" src="https://user-images.githubusercontent.com/8658164/138081226-8b274895-1981-40ef-9b0c-2c84dd9f49e3.png">

1. Build the app in debug mode (to ensure the feature flag is enabled) on a device.
2. What's New component should be displayed upon app launch. (If not, you can go to Settings > What's New in WooCommerce to view it.)
3. Enable VoiceOver on the device.
4. Navigate through the elements on the What's New screen with VoiceOver and confirm that it can access all of the text but skips the decorative icons.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
