### PR TITLE
Quick Pay: Add banners button actions

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -64,6 +64,8 @@ extension WooAnalyticsEvent {
         case shippingLabelsRelease3 = "shipping_labels_m3"
         /// Shown in beta feature banner for order add-ons.
         case addOnsI1 = "add-ons_i1"
+        /// Shown in beta feature banner for quick pay prototype.
+        case quickPayPrototype = "quick_order_prototype"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -123,6 +123,12 @@ extension WooConstants {
         ///
         case addPaymentMethodWCShip = "https://wordpress.com/me/purchases/add-payment-method"
 
+#if DEBUG
+        case quickPayPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-testing"
+#else
+        case quickPayPrototypeFeedback = "https://automattic.survey.fm/woo-app-quick-order-production"
+#endif
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -614,8 +614,8 @@ private extension OrderListViewController {
     func setQuickPayDisabledTopBanner() {
         topBannerView = QuickPayTopBannerFactory.createFeatureDisabledBanner(onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
-        }, onDismissButtonPressed: {
-            // TODO: Hide top banner
+        }, onDismissButtonPressed: { [weak self] in
+            self?.viewModel.hideQuickPayBanners = true
         })
         showTopBannerView()
     }
@@ -625,8 +625,8 @@ private extension OrderListViewController {
     func setQuickPayEnabledTopBanner() {
         topBannerView = QuickPayTopBannerFactory.createFeatureEnabledBanner(onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
-        }, onDismissButtonPressed: {
-            // TODO: Hide top banner
+        }, onDismissButtonPressed: { [weak self] in
+            self?.viewModel.hideQuickPayBanners = true
         }, onGiveFeedbackButtonPressed: {
             // TODO: Show feedback survey
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -627,8 +627,9 @@ private extension OrderListViewController {
             self?.tableView.updateHeaderHeight()
         }, onDismissButtonPressed: { [weak self] in
             self?.viewModel.hideQuickPayBanners = true
-        }, onGiveFeedbackButtonPressed: {
-            // TODO: Show feedback survey
+        }, onGiveFeedbackButtonPressed: { [weak self] in
+            let surveyNavigation = SurveyCoordinatingController(survey: .quickPayPrototype)
+            self?.present(surveyNavigation, animated: true, completion: nil)
         })
         showTopBannerView()
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -66,6 +66,7 @@ extension SurveyViewController {
         case productsVariationsFeedback
         case shippingLabelsRelease3Feedback
         case addOnsI1
+        case quickPayPrototype
 
         fileprivate var url: URL {
             switch self {
@@ -91,6 +92,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .quickPayPrototype:
+                return WooConstants.URLs.quickPayPrototypeFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -98,7 +104,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1:
+            case .productsVariationsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .quickPayPrototype:
                 return Localization.giveFeedback
             }
         }
@@ -114,6 +120,8 @@ extension SurveyViewController {
                 return .shippingLabelsRelease3
             case .addOnsI1:
                 return .addOnsI1
+            case .quickPayPrototype:
+                return .quickPayPrototype
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -356,7 +356,7 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test__does_not_show_banners() {
+    func test_dismissing_quick_order_banners_does_not_show_banners() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -355,6 +355,47 @@ final class OrderListViewModelTests: XCTestCase {
             viewModel.topBanner == .none
         }
     }
+
+    func test__does_not_show_banners() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case .loadQuickPaySwitchState(let onCompletion):
+                onCompletion(.success(true))
+            default:
+                XCTFail("Unsupported action: \(action)")
+            }
+        }
+
+        let onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed)
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, statusFilter: nil, inPersonPaymentsReadyUseCase: onboardingUseCase)
+
+        // When
+        viewModel.activate()
+        viewModel.reloadQuickPayExperimentalFeatureState()
+        viewModel.hideQuickPayBanners = true
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .none
+        }
+    }
+
+    func test_hiding_quickPay_banners_still_shows_error_banner() {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, statusFilter: nil)
+
+        // When
+        viewModel.activate()
+        viewModel.hasErrorLoadingData = true
+        viewModel.hideQuickPayBanners = true
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .error
+        }
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
# Why

#5276 introduced a couple of top banners for the quick pay prototype. This PR adds concrete actions to those banner buttons.

Actions added are:

- Dismiss: Closes the banner for this session
- Give Feedback: Launches a survey that allows merchants to give feedback about the prototype.

# How

- Added all the necessary cases to properly present the quick pay feedback survey.

- Update `OrderListViewController` to launch the survey when the user taps on the "Give Feedback" button.

- Update `OrderListViewModel` to expose a new published property `hideQuickPayBanners` to allow the view controller to hide the quick pay banners.

# Demo

https://user-images.githubusercontent.com/562080/138784401-9b1b0cbe-9187-4464-9c69-cdae2261397a.mov

# Testing Steps

- Make sure you are in an IPP eligible store.
- Go to the exp features screen and make sure the quick pay toggle is on.
- Go the the order list screen, expand the quick pay banner, and provide some feedback
- Tap on the dismiss button of the banner and see that it gets dismissed.

Note: Dismissing a banner in the "processing orders" tab won't dismiss it in the "all orders" tab.
As the solution is not that trivial, I'm still analyzing the best way to work around that.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
