### PR TITLE
UI Tests: Disable analytics for UI testing

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -18,8 +18,9 @@ public class WooAnalytics: Analytics {
     ///
     var userHasOptedIn: Bool {
         get {
+            let isUITesting: Bool = CommandLine.arguments.contains("-ui_testing")
             let optedIn: Bool? = UserDefaults.standard.object(forKey: .userOptedInAnalytics)
-            return optedIn ?? true // analytics tracking on by default
+            return ( optedIn ?? true ) && !isUITesting // analytics tracking on by default, but disabled for UI tests
         }
         set {
             UserDefaults.standard.set(newValue, forKey: .userOptedInAnalytics)

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -8,7 +8,7 @@ final class LoginTests: XCTestCase {
 
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
-        app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api"]
+        app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
     }
 


### PR DESCRIPTION
## Description

We're seeing a lot of unique users recording Tracks events on the Debug build configuration (internal ref: p91TBi-6kH-p2#comment-6885). These are likely coming from UI test runs on CI. Although we decided at one point not to disable analytics entirely on Debug builds, we intended to disable them for UI testing (internal ref: paaHJt-Ru-p2#comment-1969). We did this for WordPress UI tests but missed it here.

This PR disables analytics tracking for UI test runs using the same approach as in https://github.com/wordpress-mobile/WordPress-iOS/pull/16283.

## Changes

* Adds the launch argument `-ui_testing` to UI test runs. (This is the same argument already used in the [Screenshots test helper](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift#L127).)
* In `WooAnalytics`, checks for that launch argument and only sets `userHasOptedIn` to true if that launch argument is not present.

## Testing

1. Put a breakpoint [here](https://github.com/woocommerce/woocommerce-ios/commit/5c18fd79ba971617f5dd6cda03132870bca733ed#diff-bd712d233b2b5ae9f58daf06fa14c71989990ffefd4fb9e523e8617d14dd2a16R21).
2. Verify tracking is enabled for WooCommerce app when building and running as usual.
3. Verify tracking is disabled when [running the UI tests](https://github.com/woocommerce/woocommerce-ios/blob/develop/docs/UI-TESTS.md#running-tests).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.