### PR TITLE
Quick Order: Add analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -370,3 +370,37 @@ extension WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .featureAnnouncementShown, properties: [Source.key: source.rawValue])
     }
 }
+
+// MARK: - Quick Order
+//
+extension WooAnalyticsEvent {
+    // Namespace
+    enum QuickOrder {
+        /// Common event keys
+        ///
+        private enum Keys {
+            static let state = "state"
+            static let amount = "amount"
+        }
+
+        static func quickOrderFlowStarted() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .quickOrderFlowStarted, properties: [:])
+        }
+
+        static func quickOrderFlowCompleted(amount: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .quickOrderFlowCompleted, properties: [Keys.amount: amount])
+        }
+
+        static func quickOrderFlowCanceled() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .quickOrderFlowCanceled, properties: [:])
+        }
+
+        static func quickOrderFlowFailed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .quickOrderFlowFailed, properties: [:])
+        }
+
+        static func settingsBetaFeaturesQuickOrderToggled(isOn: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .quickOrderFlowStarted, properties: [Keys.state: isOn ? "on" : "off"])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -400,7 +400,7 @@ extension WooAnalyticsEvent {
         }
 
         static func settingsBetaFeaturesQuickOrderToggled(isOn: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .quickOrderFlowStarted, properties: [Keys.state: isOn ? "on" : "off"])
+            WooAnalyticsEvent(statName: .settingsBetaFeaturesQuickOrderToggled, properties: [Keys.state: isOn ? "on" : "off"])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -130,6 +130,7 @@ public enum WooAnalyticsStat: String {
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"
     case settingsBetaFeaturesOrderAddOnsToggled = "settings_beta_features_order_addons_toggled"
+    case settingsBetaFeaturesQuickOrderToggled = "settings_beta_features_quick_order_toggled"
 
     case settingsPrivacySettingsTapped = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled = "privacy_settings_collect_info_toggled"
@@ -511,7 +512,7 @@ public enum WooAnalyticsStat: String {
     //
     case featureAnnouncementShown = "feature_announcement_shown"
 
-    // MARK: Quick Order Prototype events
+    // MARK: Quick Order events
     //
     case quickOrderFlowStarted = "quick_order_flow_started"
     case quickOrderFlowCompleted = "quick_order_flow_completed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -510,6 +510,13 @@ public enum WooAnalyticsStat: String {
     // MARK: What's New Component events
     //
     case featureAnnouncementShown = "feature_announcement_shown"
+
+    // MARK: Quick Order Prototype events
+    //
+    case quickOrderFlowStarted = "quick_order_flow_started"
+    case quickOrderFlowCompleted = "quick_order_flow_completed"
+    case quickOrderFlowCanceled = "quick_order_flow_canceled"
+    case quickOrderFlowFailed = "quick_order_flow_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -180,7 +180,7 @@ private extension BetaFeaturesViewController {
 
         // Change switch's state stored value
         cell.onChange = { isSwitchOn in
-            // TODO: Add analytics
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.QuickOrder.settingsBetaFeaturesQuickOrderToggled(isOn: isSwitchOn))
 
             let action = AppSettingsAction.setQuickOrderFeatureSwitchState(isEnabled: isSwitchOn, onCompletion: { result in
                 // Roll back toggle if an error occurred

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersTabbedViewController.swift
@@ -146,6 +146,8 @@ final class OrdersTabbedViewController: ButtonBarPagerTabStripViewController {
         let viewController = QuickOrderAmountHostingController(viewModel: viewModel)
         let navigationController = WooNavigationController(rootViewController: viewController)
         present(navigationController, animated: true)
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowStarted())
     }
 
     // MARK: - ButtonBarPagerTabStripViewController Conformance

--- a/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmount.swift
@@ -43,9 +43,17 @@ final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmo
                 viewModel.presentNotice = nil
             }
             .store(in: &subscriptions)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
         // Set presentation delegate to track the user dismiss flow event
-        presentationController?.delegate = self
+        if let navigationController = navigationController {
+            navigationController.presentationController?.delegate = self
+        } else {
+            presentationController?.delegate = self
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmount.swift
@@ -43,10 +43,21 @@ final class QuickOrderAmountHostingController: UIHostingController<QuickOrderAmo
                 viewModel.presentNotice = nil
             }
             .store(in: &subscriptions)
+
+        // Set presentation delegate to track the user dismiss flow event
+        presentationController?.delegate = self
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Intercepts to the dismiss drag gesture.
+///
+extension QuickOrderAmountHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        rootView.viewModel.userDidCancelFlow()
     }
 }
 
@@ -97,6 +108,7 @@ struct QuickOrderAmount: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button(Localization.cancelTitle, action: {
                     dismiss()
+                    viewModel.userDidCancelFlow()
                 })
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmountViewModel.swift
@@ -61,15 +61,21 @@ final class QuickOrderAmountViewModel: ObservableObject {
     ///
     private let storeCurrencySymbol: String
 
+    /// Analytics tracker.
+    ///
+    private let analytics: Analytics
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          locale: Locale = Locale.autoupdatingCurrent,
-         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.userLocale = locale
         self.storeCurrencySettings = storeCurrencySettings
         self.storeCurrencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
+        self.analytics = analytics
     }
 
     /// Called when the view taps the done button.
@@ -84,9 +90,11 @@ final class QuickOrderAmountViewModel: ObservableObject {
             switch result {
             case .success(let order):
                 self.onOrderCreated(order)
+                self.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowCompleted(amount: order.total))
 
             case .failure(let error):
                 self.presentNotice = .error
+                self.analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowFailed())
                 DDLogError("⛔️ Error creating quick order order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Quick Order/QuickOrderAmountViewModel.swift
@@ -100,6 +100,12 @@ final class QuickOrderAmountViewModel: ObservableObject {
         }
         stores.dispatch(action)
     }
+
+    /// Track the flow cancel scenario.
+    ///
+    func userDidCancelFlow() {
+        analytics.track(event: WooAnalyticsEvent.QuickOrder.quickOrderFlowCanceled())
+    }
 }
 
 // MARK: Helpers


### PR DESCRIPTION
# Why

Following the quick order development, this PR tracks the following events from the quick order flow.

- quick_order_flow_started
- quick_order_flow_completed
- quick_order_flow_canceled
- quick_order_flow_failed
- settings_beta_features_quick_order_toggled

# Registration

- https://github.com/Automattic/tracks-events-registration/pull/614
- https://github.com/Automattic/tracks-events-registration/pull/615
- https://github.com/Automattic/tracks-events-registration/pull/616
- https://github.com/Automattic/tracks-events-registration/pull/617
- https://github.com/Automattic/tracks-events-registration/pull/618

# Spreadsheet

<img width="1308" alt="Screen Shot 2021-10-27 at 8 02 13 AM" src="https://user-images.githubusercontent.com/562080/139070923-5651b7d8-04de-4e5d-aa36-f63a3a2eeb7c.png">

# Testing Steps
**Make sure the store is IPP eligible and the quick order experimental toggle is on.**

See the appropriate tracks when:
- Tapping the + button in the order list screen
- Cancelling or dismissing the quick order screen
- Successfully creating a quick order
- Failing to create a quick order (eg: no internet)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
