### PR TITLE
Update product name text field keyboard type to allow all keyboard inputs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix: after disconnecting a site or connecting to a new site, the sites in site picker (Settings > Switch Store) should be updated accordingly. The only exception is when the newly disconnected site is the currently selected site. [https://github.com/woocommerce/woocommerce-ios/pull/5241]
 - [*] Order Details: Show a button on the "Product" section of Order Details screen to allow recreating shipping labels. [https://github.com/woocommerce/woocommerce-ios/pull/5255]
 - [*] Edit Order Address - Enable `Done` button when `Use as {Shipping/Billing} Address` toggle is turned on. [https://github.com/woocommerce/woocommerce-ios/pull/5254]
+- [*] Add/Edit Product: fix an issue where the product name keyboard is English only. [https://github.com/woocommerce/woocommerce-ios/pull/5288]
 
 7.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -149,7 +149,6 @@ private extension ProductFormTableViewDataSource {
                                                                    productStatus: productStatus,
                                                                    placeholder: placeholder,
                                                                    textViewMinimumHeight: 10.0,
-                                                                   keyboardType: .default,
                                                                    onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
                                                                    style: .headline)
         cell.configure(with: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -149,7 +149,7 @@ private extension ProductFormTableViewDataSource {
                                                                    productStatus: productStatus,
                                                                    placeholder: placeholder,
                                                                    textViewMinimumHeight: 10.0,
-                                                                   keyboardType: .alphabet,
+                                                                   keyboardType: .default,
                                                                    onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
                                                                    style: .headline)
         cell.configure(with: cellViewModel)


### PR DESCRIPTION
Fixes #5282 

## Why

In a previous update that introduced `LabeledTextViewTableViewCell`, the keyboard type in the view model for product name cell was updated to `.alphabet` which only allows English characters. Since the product name could be in any language(s), this PR updated the keyboard type back to `.default` to allow switching keyboard inputs.

## Changes

Updated the product name view model's keyboard type from `.alphabet` to `.default` to allow switching keyboard inputs

## Testing

Prerequisite: the simulator/device has more than one keyboard input, which you can set in Settings > General > Keyboard > Keyboards in a simulator

- Launch the app in logged-in state
- Go to the products tab
- Create a product or tap on a product in the list
- Tap on the product name row --> the keyboard should have a way to switch inputs

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2021-10-27 at 12 13 59](https://user-images.githubusercontent.com/1945542/138999464-e2f470d8-6d29-49b1-b91c-3218134f5197.png) | ![Simulator Screen Shot - iPhone 11 - 2021-10-27 at 12 16 11](https://user-images.githubusercontent.com/1945542/138999471-a7d24fa2-de3c-43e0-9897-fbd41f1521d3.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
