### PR TITLE
What's New: Display base64 icons in feature announcements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -27,7 +27,7 @@ struct WhatsNewFactory {
     /// Get IconListItem.Icon from a Feature
     private static func icon(for feature: Feature) -> IconListItem.Icon? {
         var icon: IconListItem.Icon?
-        if let base64String = feature.iconBase64,
+        if let base64String = feature.iconBase64?.components(separatedBy: ";base64,")[safe: 1],
            let imageData = Data(base64Encoded: base64String),
            let image = UIImage(data: imageData) {
             icon = .base64(image)

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewFactory.swift
@@ -27,8 +27,9 @@ struct WhatsNewFactory {
     /// Get IconListItem.Icon from a Feature
     private static func icon(for feature: Feature) -> IconListItem.Icon? {
         var icon: IconListItem.Icon?
-        if let base64String = feature.iconBase64?.components(separatedBy: ";base64,")[safe: 1],
-           let imageData = Data(base64Encoded: base64String),
+        if let base64string = feature.iconBase64,
+           let imageURL = URL(string: base64string),
+           let imageData = try? Data(contentsOf: imageURL),
            let image = UIImage(data: imageData) {
             icon = .base64(image)
         } else if let url = URL(string: feature.iconUrl) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/WhatsNew/WhatsNewFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/WhatsNew/WhatsNewFactoryTests.swift
@@ -15,12 +15,40 @@ final class WhatsNewFactoryTests: XCTestCase {
         XCTAssertEqual(viewController?.rootView.viewModel.items.count, 1)
         XCTAssertEqual(viewController?.modalPresentationStyle, .formSheet)
     }
+
+    func test_announcement_with_iconUrl_contains_icon() throws {
+        // Given
+        let announcement = try makeWordPressAnnouncement(with: .iconUrl)
+
+        // When
+        let viewController = WhatsNewFactory.whatsNew(announcement, onDismiss: {}) as? WhatsNewHostingController
+        let announcementIcon = viewController?.rootView.viewModel.items.first?.icon
+
+        // Then
+        XCTAssertNotNil(announcementIcon)
+    }
+
+    func test_announcement_with_iconBase64_contains_icon() throws {
+        // Given
+        let announcement = try makeWordPressAnnouncement(with: .iconBase64)
+
+        // When
+        let viewController = WhatsNewFactory.whatsNew(announcement, onDismiss: {}) as? WhatsNewHostingController
+        let announcementIcon = viewController?.rootView.viewModel.items.first?.icon
+
+        // Then
+        XCTAssertNotNil(announcementIcon)
+    }
 }
 
 // MARK: - Mocks
 //
 private extension WhatsNewFactoryTests {
-    func makeWordPressAnnouncement() throws -> WordPressKit.Announcement {
+    func makeWordPressAnnouncement(with iconType: IconType = .iconUrl) throws -> WordPressKit.Announcement {
+        // swiftlint:disable line_length
+        let iconBase64String = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAPXSURBVHgBzZk9bNNAFMffOZ92EtHA0A5ITSkDCzSMSEhNBALBUhBiYaB0YaWdGJusSNB2YICFLGUssCCVpWFALEikG0i0GImhRYgU5cNO2/h4z/lQkjrJOQlJflLry/kl/ufvd+d3FwYdkslkIoyxsCRJ04BHzvkIvh6hc9jeY5KkgmGo2N40DCMZCASS0AHMTnAaRbh1/QEqmK+IsYHKAZL7APGgLKuibxISSMI8hcIiCYMegEITokLbCszm8/MYtNiBY+1QjWIx7vf7E62CWgrM6/pSr1xrhsH5sl9RFpqdtxRo3lJdf4XNCPQDxlIFjycaZGzvyCmreHTuMzoXhv6SVGQ52tgpNXaUb2u/xRERzPelxs46B7PZ7D3J4XgBAwRzcgFzcrnyuiowrWkhD8AGNkMwQGiS35fliUo+Vm+xyzBiMGBxBE1nLk1brL6mf2X3vsMQUfB6g+Si6WDZvaHCiQ8IOpoO5jWN3Au1esPaFw2+pYvQC6ZGXXD1lKdlDOWiT1GCTNO0CC8NjpZcWv0NvcLvZvDm9om2ccXDw6iEpVAEumTUJ9mKz+5zoTjmcIQlquWgC55dG4GXN47D8+v1tcTdcwo8vnwMuoFxHpGwsBwXCbZyaczngNPHnWZ7MuisxpC42bMKvNvWhT/LUqAkTUncMEIiweTSE3SE8qfCTq4IW+lDs03H3ZxRFffoYwbWtwt1n+FzMdNV+iwRzCodR7BYQpR5+ikHa1+1uj5ypJ044gqO3IcXAmAHe9mN5A6Ofh8rcVa30e+2fTmQaL4RDd7cPYAPP4860yiu2cChnKykhAikjTL8L/61LefvvP5jOtVOnNXAqbyPppf7b/dgzO+A1ZkgCKCS5ymRSCtxxMWT7rqcsxo4jexkBZ9InP9w0lIQx+UMdAg5YtVX61wXpCQHrgdEImunFxF6IA5owW9eNZfPp9stK9e3dNj8JZ7grZgMOuDWGbldmIprlImSQE2L0doXhgjUk5Blea5UsJaWmWkYIlDYBAo0RzFQ5YqLlRUYEsruqeV2CXNjCAvX/7DFYRcVRUUrAqvPHnIRq4c4DBgc+3G5ZlOp7uGoeL3Lg7zVdG2/LCdq+ywnN1wGbPB+7ctUlbAUGnS+sduyvNC93psgOIH3BM7fy7h5ZHXKUiDlI32bftxuuoaiKLSdbFlVtSzQcI9kHpN2Dpsq9Bgqpcr7MC33H4UesJiTIXwuxnCUz0IPINd8shxr5lottiqAGqHTYHMfxyyMGVuhmUJEWEcCa6EFf3lNHcYLh/A4XvszBFAhzHmKM5akignntiR0wD80jb4Ye7HEOwAAAABJRU5ErkJggg=="
+        // swiftlint:enable line_length
+
         let jsonData = try JSONSerialization.data(withJSONObject: [
             "appVersionName": "1",
             "minimumAppVersion": "",
@@ -30,8 +58,8 @@ private extension WhatsNewFactoryTests {
             "features": [[
                 "title": "foo",
                 "subtitle": "bar",
-                "iconBase64": "",
-                "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
+                "iconBase64": iconType == .iconBase64 ? iconBase64String : "",
+                "iconUrl": iconType == .iconUrl ? "https://s0.wordpress.com/i/store/mobile/plans-premium.png" : ""
             ]],
             "announcementVersion": "2",
             "isLocalized": true,
@@ -39,5 +67,10 @@ private extension WhatsNewFactoryTests {
         ])
 
         return try JSONDecoder().decode(Announcement.self, from: jsonData)
+    }
+
+    enum IconType {
+        case iconBase64
+        case iconUrl
     }
 }


### PR DESCRIPTION
Fixes: #5291

## Description

The "What's New" screen displays feature announcements that include an icon either from a URL or base 64 encoded. Icons that are base 64 encoded include the data URI scheme `data:image/png;base64,` in the string with the image data. This PR makes sure that data URI is removed before decoding the image data, so that those images can be displayed in the app.

## Changes

* Handles the `feature.iconBase64` string as a URL before decoding it, so the data URI scheme is handled as part of the URL.
* Adds unit tests to check that feature announcements contain the expected icon from either a URL or base 64 encoded data.

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2021-10-27 at 12 33 08](https://user-images.githubusercontent.com/8658164/139066794-0d6f5815-609e-45d5-8ebd-f189405270f2.png)|![Simulator Screen Shot - iPhone 13 Pro - 2021-10-27 at 12 48 38](https://user-images.githubusercontent.com/8658164/139066806-fd4bbf9b-385b-4dd4-8200-bc3661c50c90.png)

## Testing

⚠️ **Prerequisite** ⚠️ 
Make the following changes to display the test announcement:

<img width="562" alt="Screen Shot 2021-10-20 at 12 00 39 PM" src="https://user-images.githubusercontent.com/8658164/138081225-97e8bbf4-983d-4f58-b35f-f7ad3e512746.png">

<img width="1171" alt="Screen Shot 2021-10-20 at 12 00 06 PM" src="https://user-images.githubusercontent.com/8658164/138081226-8b274895-1981-40ef-9b0c-2c84dd9f49e3.png">

1. Build the app in debug mode (to ensure the feature flag is enabled) on a device.
2. What's New component should be displayed upon app launch. (If not, you can go to Settings > What's New in WooCommerce to view it.)
3. Confirm you see icons appear next to each of the items in the list.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
