### PR TITLE
What's New: Enable feature flag to release the feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -19,8 +19,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .shippingLabelsMultiPackage:
             return true
-        case .whatsNewOnWooCommerce:
-            return true
         case .pushNotificationsForAllStores:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .quickOrderPrototype:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -20,7 +20,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .shippingLabelsMultiPackage:
             return true
         case .whatsNewOnWooCommerce:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pushNotificationsForAllStores:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .quickOrderPrototype:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -38,10 +38,6 @@ public enum FeatureFlag: Int {
     ///
     case shippingLabelsMultiPackage
 
-    /// Display "What's new on WooCommerce" on App Launch and App Settings
-    ///
-    case whatsNewOnWooCommerce
-
     /// Push notifications for all stores
     ///
     case pushNotificationsForAllStores

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -62,8 +62,6 @@ private extension AppCoordinator {
     /// Synchronize announcements and present What's New Screen if needed
     ///
     func synchronizeAndShowWhatsNew() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.whatsNewOnWooCommerce) else { return }
-
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -467,7 +467,7 @@ private extension SettingsViewController {
     }
 
     func shouldShowWhatsNew() -> Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.whatsNewOnWooCommerce) && announcement != nil
+        announcement != nil
     }
 }
 


### PR DESCRIPTION
⚠️ Merge after #5292 ⚠️ 

## Description

This releases the "What's New" component, so we can display "What's New on WooCommerce" announcements. There are no scheduled announcements for upcoming releases yet, so this won't have any visible changes in the app yet.

## Changes

Enables the `whatsNewOnWooCommerce` feature flag to release the feature.

<img src="https://user-images.githubusercontent.com/8658164/139069138-e934d97a-4cfa-4094-a693-1fd67dffad6a.png" width="300px">

## Testing

1. If you have tested the What's New screen before, delete the app from your simulator/device to clear out any saved announcements from past testing.
2. Build and launch the app. Log in and confirm there are no visible changes on app launch or in Settings (since there are no scheduled announcements for upcoming releases yet).
3. Change the prerequisites noted below (to fake a different release) and confirm the test announcement displays on app launch.
4. Open Settings > What's New in WooCommerce and confirm the test announcement appears.

⚠️ **Prerequisites** ⚠️ 
Make the following changes to display the test announcement:

<img width="562" alt="Screen Shot 2021-10-20 at 12 00 39 PM" src="https://user-images.githubusercontent.com/8658164/138081225-97e8bbf4-983d-4f58-b35f-f7ad3e512746.png">

<img width="1171" alt="Screen Shot 2021-10-20 at 12 00 06 PM" src="https://user-images.githubusercontent.com/8658164/138081226-8b274895-1981-40ef-9b0c-2c84dd9f49e3.png">

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
